### PR TITLE
Adaptation of the README.md file for Fedora 37 and 38

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ zypper install -y --type pattern devel_basis
 zypper install -y git rsync wget cmake doxygen graphviz clang-tools cppcheck boost-devel libboost_filesystem-devel libboost_log-devel libboost_program_options-devel libboost_system-devel libboost_thread-devel maven java-11-openjdk java-11-openjdk-devel nodejs nodejs-devel npm python3-pip gcc-c++ libopenssl-devel sqlite3-devel libpcap-devel libevent-devel
 ```
 
-#### Fedora 36
+#### Fedora 36, 37 & 38
 ```bash
 sudo dnf update
-sudo dnf install make automake gcc gcc-c++ kernel-devel python3-pip git rsync wget cmake doxygen graphviz clang-tools-extra cppcheck maven java-11-openjdk java-11-openjdk-devel boost-devel nodejs nodejs-devel npm openssl-devel libsqlite3x-devel curl rfkill libpcap-devel libevent-devel
+sudo dnf install make automake gcc gcc-c++ kernel-devel python3-pip python3-devel git rsync wget cmake doxygen graphviz clang-tools-extra cppcheck maven java-17-openjdk java-17-openjdk-devel boost-devel nodejs nodejs-devel npm openssl openssl-devel libsqlite3x-devel curl rfkill libpcap-devel libevent-devel
 ```
 
 ### Build & Install:


### PR DESCRIPTION
EVerest has been successfully built and tested on the latest Fedora versions 37 and 38.