### PR TITLE
EvseV2G: Do not stay long in authorization loop

### DIFF
--- a/modules/EvseV2G/EvseV2G.hpp
+++ b/modules/EvseV2G/EvseV2G.hpp
@@ -31,6 +31,8 @@ struct Conf {
     bool tls_key_logging;
     std::string tls_key_logging_path;
     bool verify_contract_cert_chain;
+    int auth_timeout_pnc;
+    int auth_timeout_eim;
 };
 
 class EvseV2G : public Everest::ModuleBase {

--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -66,6 +66,9 @@ void ISO15118_chargerImpl::init() {
 
     /* Configure if the contract certificate chain should be verified locally */
     v2g_ctx->session.verify_contract_cert_chain = mod->config.verify_contract_cert_chain;
+
+    v2g_ctx->session.auth_timeout_eim = mod->config.auth_timeout_eim;
+    v2g_ctx->session.auth_timeout_pnc = mod->config.auth_timeout_pnc;
 }
 
 void ISO15118_chargerImpl::ready() {
@@ -195,6 +198,8 @@ void ISO15118_chargerImpl::handle_set_Auth_Okay_EIM(bool& auth_okay_eim) {
 
 void ISO15118_chargerImpl::handle_set_Auth_Okay_PnC(types::authorization::AuthorizationStatus& status,
                                                     types::authorization::CertificateStatus& certificateStatus) {
+    v2g_ctx->session.certificate_status = certificateStatus;
+
     if (status == types::authorization::AuthorizationStatus::Accepted &&
         certificateStatus == types::authorization::CertificateStatus::Accepted) {
         v2g_ctx->evse_v2g_data.evse_processing[PHASE_AUTH] = (uint8_t)iso1EVSEProcessingType_Finished;

--- a/modules/EvseV2G/manifest.yaml
+++ b/modules/EvseV2G/manifest.yaml
@@ -61,6 +61,20 @@ config:
       chain locally.
     type: boolean
     default: false
+  auth_timeout_pnc:
+    description: >-
+      Defines how many seconds the EVSE should wait for authorization in PnC case,
+      before the charging session is aborted.
+      Write 0 if the EVSE should wait indefinitely for PnC authorization.
+    type: integer
+    default: 55
+  auth_timeout_eim:
+    description: >-
+      Defines how many seconds the EVSE should wait for authorization in EIM case,
+      before the charging session is aborted.
+      Write 0 if the EVSE should wait indefinitely for EIM authorization.
+    type: integer
+    default: 300
 provides:
   charger:
     interface: ISO15118_charger

--- a/modules/EvseV2G/v2g.hpp
+++ b/modules/EvseV2G/v2g.hpp
@@ -298,8 +298,12 @@ struct v2g_context {
     struct {
         /* V2G session values */
         iso1paymentOptionType iso_selected_payment_option;
-        uint8_t gen_challenge[16]; // for PnC
-        bool verify_contract_cert_chain; // for PnC
+        long long int auth_start_timeout;
+        int auth_timeout_eim;
+        int auth_timeout_pnc;                                       // for PnC
+        uint8_t gen_challenge[16];                                  // for PnC
+        bool verify_contract_cert_chain;                            // for PnC
+        types::authorization::CertificateStatus certificate_status; // for PnC
 
         struct {
             bool valid_crt;


### PR DESCRIPTION
An optional timeout is added to prevent an authorziation loop. Timeouts can be ignored if set to zero.

For PnC, 55 seconds is the default value for timeout according to V2G_SECC_Ongoing_Performance_Time.

For EIM, the 5 minutes value is not derived from ISO standard.