### PR TITLE
Introduce EVSE SLAC loglevel

### DIFF
--- a/lib/everest/slac/fsm/ev/include/everest/slac/fsm/ev/context.hpp
+++ b/lib/everest/slac/fsm/ev/include/everest/slac/fsm/ev/context.hpp
@@ -50,7 +50,10 @@ template <typename SlacMessageType> struct MMV {
 struct ContextCallbacks {
     std::function<void(slac::messages::HomeplugMessage&)> send_raw_slac{nullptr};
     std::function<void(const std::string&)> signal_state{nullptr};
-    std::function<void(const std::string&)> log{nullptr};
+    std::function<void(const std::string&)> log_debug{nullptr};
+    std::function<void(const std::string&)> log_info{nullptr};
+    std::function<void(const std::string&)> log_warn{nullptr};
+    std::function<void(const std::string&)> log_error{nullptr};
 };
 
 struct Context {
@@ -77,7 +80,10 @@ struct Context {
     void signal_state(const std::string& state);
 
     // logging util
+    void log_debug(const std::string& text);
     void log_info(const std::string& text);
+    void log_warn(const std::string& text);
+    void log_error(const std::string& text);
 
 private:
     const ContextCallbacks& callbacks;

--- a/lib/everest/slac/fsm/ev/src/context.cpp
+++ b/lib/everest/slac/fsm/ev/src/context.cpp
@@ -12,9 +12,27 @@ void Context::signal_state(const std::string& state) {
     }
 }
 
+void Context::log_debug(const std::string& text) {
+    if (callbacks.log_debug) {
+        callbacks.log_debug(text);
+    }
+}
+
 void Context::log_info(const std::string& text) {
-    if (callbacks.log) {
-        callbacks.log(text);
+    if (callbacks.log_info) {
+        callbacks.log_info(text);
+    }
+}
+
+void Context::log_warn(const std::string& text) {
+    if (callbacks.log_warn) {
+        callbacks.log_warn(text);
+    }
+}
+
+void Context::log_error(const std::string& text) {
+    if (callbacks.log_error) {
+        callbacks.log_error(text);
     }
 }
 

--- a/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/context.hpp
+++ b/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/context.hpp
@@ -144,7 +144,10 @@ struct ContextCallbacks {
     std::function<void()> signal_error_routine_request{nullptr};
     std::function<void(const std::string&)> signal_ev_mac_address_parm_req{nullptr};
     std::function<void(const std::string&)> signal_ev_mac_address_match_cnf{nullptr};
-    std::function<void(const std::string&)> log{nullptr};
+    std::function<void(const std::string&)> log_debug{nullptr};
+    std::function<void(const std::string&)> log_info{nullptr};
+    std::function<void(const std::string&)> log_warn{nullptr};
+    std::function<void(const std::string&)> log_error{nullptr};
 };
 
 struct EvseSlacConfig {
@@ -212,7 +215,10 @@ struct Context {
     void signal_state(const std::string& state);
 
     // logging util
+    void log_debug(const std::string& text);
     void log_info(const std::string& text);
+    void log_warn(const std::string& text);
+    void log_error(const std::string& text);
 
     ModemVendor modem_vendor{ModemVendor::Unknown};
 

--- a/lib/everest/slac/fsm/evse/src/context.cpp
+++ b/lib/everest/slac/fsm/evse/src/context.cpp
@@ -52,9 +52,27 @@ void Context::signal_state(const std::string& state) {
     }
 }
 
+void Context::log_debug(const std::string& text) {
+    if (callbacks.log_debug) {
+        callbacks.log_debug(text);
+    }
+}
+
 void Context::log_info(const std::string& text) {
-    if (callbacks.log) {
-        callbacks.log(text);
+    if (callbacks.log_info) {
+        callbacks.log_info(text);
+    }
+}
+
+void Context::log_warn(const std::string& text) {
+    if (callbacks.log_warn) {
+        callbacks.log_warn(text);
+    }
+}
+
+void Context::log_error(const std::string& text) {
+    if (callbacks.log_error) {
+        callbacks.log_error(text);
     }
 }
 

--- a/lib/everest/slac/fsm/evse/src/states/matching.cpp
+++ b/lib/everest/slac/fsm/evse/src/states/matching.cpp
@@ -102,10 +102,10 @@ FSMSimpleState::CallbackReturnType MatchingState::callback() {
             session.ack_timeout();
 
             if (session.state == MatchingSubState::WAIT_FOR_START_ATTEN_CHAR) {
-                session_log(ctx, session, "Waiting for CM_START_ATTEN_CHAR_IND timed out -> failed");
+                session_log(ctx, session, LogLevel::ERROR, "Waiting for CM_START_ATTEN_CHAR_IND timed out -> failed");
                 session.state = MatchingSubState::FAILED;
             } else if (session.state == MatchingSubState::SOUNDING) {
-                session_log(ctx, session,
+                session_log(ctx, session, LogLevel::WARN,
                             "Sounding not yet complete but timed out, going to sub-state FINALIZE_SOUNDING");
                 session.state = MatchingSubState::FINALIZE_SOUNDING;
                 session.set_next_timeout(FINALIZE_SOUNDING_DELAY_MS);
@@ -115,14 +115,15 @@ FSMSimpleState::CallbackReturnType MatchingState::callback() {
             } else if (session.state == MatchingSubState::WAIT_FOR_ATTEN_CHAR_RSP) {
                 session.num_retries++;
                 if (session.num_retries <= slac::defs::C_EV_MATCH_RETRY) {
-                    session_log(ctx, session, "Waiting for CM_ATTEN_CHAR_RSP timed out -> retry matching");
+                    session_log(ctx, session, LogLevel::WARN,
+                                "Waiting for CM_ATTEN_CHAR_RSP timed out -> retry matching");
                     finalize_sounding(session);
                 } else {
-                    session_log(ctx, session, "Waiting for CM_ATTEN_CHAR_RSP timed out -> failed");
+                    session_log(ctx, session, LogLevel::ERROR, "Waiting for CM_ATTEN_CHAR_RSP timed out -> failed");
                     session.state = MatchingSubState::FAILED;
                 }
             } else if (session.state == MatchingSubState::WAIT_FOR_SLAC_MATCH) {
-                session_log(ctx, session, "Wating for CM_SLAC_MATCH_REQ timed out -> failed");
+                session_log(ctx, session, LogLevel::ERROR, "Wating for CM_SLAC_MATCH_REQ timed out -> failed");
                 session.state = MatchingSubState::FAILED;
             }
         }

--- a/lib/everest/slac/fsm/evse/src/states/matching.cpp
+++ b/lib/everest/slac/fsm/evse/src/states/matching.cpp
@@ -72,7 +72,7 @@ FSMSimpleState::CallbackReturnType MatchingState::callback() {
 
     if (!seen_slac_parm_req) {
         if (now_tp >= timeout_slac_parm_req) {
-            ctx.log_info("CM_SLAC_PARM_REQ timed out -> FAILED");
+            ctx.log_error("CM_SLAC_PARM_REQ timed out -> FAILED");
             return Event::FAILED;
         }
 
@@ -154,7 +154,7 @@ FSMSimpleState::HandleEventReturnType MatchingState::handle_event(AllocatorType&
     } else if (ev == Event::RETRY_MATCHING) {
         num_retries++;
         if (num_retries == slac::defs::C_EV_MATCH_RETRY) {
-            ctx.log_info("Reached retry limit for matching");
+            ctx.log_error("Reached retry limit for matching");
             return sa.create_simple<FailedState>(ctx);
         }
 
@@ -165,7 +165,7 @@ FSMSimpleState::HandleEventReturnType MatchingState::handle_event(AllocatorType&
     } else if (ev == Event::FAILED) {
         failed_count++;
         if (ctx.slac_config.reset_instead_of_fail and failed_count < 2) {
-            ctx.log_info("Resetting MatchingState. Waiting for the next CM_SLAC_PARAM.REQ message.");
+            ctx.log_error("Resetting MatchingState. Waiting for the next CM_SLAC_PARAM.REQ message.");
 
             // Resetting all relevant MatchingState members
             sessions.clear();

--- a/lib/everest/slac/fsm/evse/src/states/matching_handle_slac.cpp
+++ b/lib/everest/slac/fsm/evse/src/states/matching_handle_slac.cpp
@@ -115,7 +115,7 @@ void MatchingState::handle_slac_message(slac::messages::HomeplugMessage& msg) {
         handle_cm_validate_req(msg.get_payload<slac::messages::cm_validate_req>());
         break;
     default:
-        ctx.log_info("Received non-expected SLAC message of type " + format_mmtype(mmtype));
+        ctx.log_warn("Received non-expected SLAC message of type " + format_mmtype(mmtype));
     }
 }
 
@@ -134,7 +134,7 @@ static bool validate_cm_slac_parm_req(const slac::messages::cm_slac_parm_req& ms
 void MatchingState::handle_cm_slac_parm_req(const slac::messages::cm_slac_parm_req& msg) {
 
     if (not validate_cm_slac_parm_req(msg)) {
-        ctx.log_info("Invalid CM_SLAC_PARM.REQ received, ignoring");
+        ctx.log_warn("Invalid CM_SLAC_PARM.REQ received, ignoring");
         return;
     }
 
@@ -186,13 +186,13 @@ static bool validate_cm_start_atten_char_ind(const slac::messages::cm_start_atte
 void MatchingState::handle_cm_start_atten_char_ind(const slac::messages::cm_start_atten_char_ind& msg) {
 
     if (not validate_cm_start_atten_char_ind(msg)) {
-        ctx.log_info("Invalid CM_START_ATTEN_CHAR_IND received, ignoring");
+        ctx.log_warn("Invalid CM_START_ATTEN_CHAR_IND received, ignoring");
         return;
     }
 
     auto session = find_session(sessions, tmp_ev_mac, msg.run_id);
     if (!session) {
-        ctx.log_info("No session found for CM_START_ATTEN_CHAR_IND");
+        ctx.log_warn("No session found for CM_START_ATTEN_CHAR_IND");
         return;
     }
 
@@ -223,13 +223,13 @@ static bool validate_cm_mnbc_sound_ind(const slac::messages::cm_mnbc_sound_ind& 
 void MatchingState::handle_cm_mnbc_sound_ind(const slac::messages::cm_mnbc_sound_ind& msg) {
 
     if (not validate_cm_mnbc_sound_ind(msg)) {
-        ctx.log_info("Invalid CM_MNBC_SOUND_IND received, ignoring");
+        ctx.log_warn("Invalid CM_MNBC_SOUND_IND received, ignoring");
         return;
     }
 
     auto session = find_session(sessions, tmp_ev_mac, msg.run_id);
     if (!session) {
-        ctx.log_info("No session found for CM_MNBC_SOUND_IND");
+        ctx.log_warn("No session found for CM_MNBC_SOUND_IND");
         return;
     }
 
@@ -255,7 +255,7 @@ void MatchingState::handle_cm_atten_profile_ind(const slac::messages::cm_atten_p
     }
 
     if (!session) {
-        ctx.log_info("No session found for CM_ATTEN_PROFILE_IND");
+        ctx.log_warn("No session found for CM_ATTEN_PROFILE_IND");
         return;
     }
 
@@ -305,13 +305,13 @@ static bool validate_cm_atten_char_rsp(const slac::messages::cm_atten_char_rsp& 
 void MatchingState::handle_cm_atten_char_rsp(const slac::messages::cm_atten_char_rsp& msg) {
 
     if (not validate_cm_atten_char_rsp(msg)) {
-        ctx.log_info("Invalid CM_ATTEN_CHAR_RSP received, ignoring");
+        ctx.log_warn("Invalid CM_ATTEN_CHAR_RSP received, ignoring");
         return;
     }
 
     auto session = find_session(sessions, tmp_ev_mac, msg.run_id);
     if (!session) {
-        ctx.log_info("No session found for CM_ATTEN_CHAR_RSP");
+        ctx.log_warn("No session found for CM_ATTEN_CHAR_RSP");
         return;
     }
 
@@ -329,7 +329,7 @@ void MatchingState::handle_cm_atten_char_rsp(const slac::messages::cm_atten_char
 
 void MatchingState::handle_cm_validate_req(const slac::messages::cm_validate_req& msg) {
     // NOTE: CM_VALIDATE.REQ does not specify its session
-    ctx.log_info("Received CM_VALIDATE.REQ / not implemented - will return failure code");
+    ctx.log_warn("Received CM_VALIDATE.REQ / not implemented - will return failure code");
 
     slac::messages::cm_validate_cnf validate_cnf;
     validate_cnf.signal_type = slac::defs::CM_VALIDATE_REQ_SIGNAL_TYPE;
@@ -357,13 +357,13 @@ static bool validate_cm_slac_match_req(const slac::messages::cm_slac_match_req& 
 void MatchingState::handle_cm_slac_match_req(const slac::messages::cm_slac_match_req& msg) {
 
     if (not validate_cm_slac_match_req(msg)) {
-        ctx.log_info("Invalid CM_SLAC_MATCH_REQ received, ignoring");
+        ctx.log_warn("Invalid CM_SLAC_MATCH_REQ received, ignoring");
         return;
     }
 
     auto session = find_session(sessions, tmp_ev_mac, msg.run_id);
     if (!session) {
-        ctx.log_info("No session found for CM_SLAC_MATCH_REQ");
+        ctx.log_warn("No session found for CM_SLAC_MATCH_REQ");
         return;
     }
 

--- a/lib/everest/slac/fsm/evse/src/states/matching_handle_slac.cpp
+++ b/lib/everest/slac/fsm/evse/src/states/matching_handle_slac.cpp
@@ -431,13 +431,13 @@ void MatchingState::finalize_sounding(MatchingSession& session) {
         aag_overall_sum += atten_char.attenuation_profile.aag[i];
     }
     std::ostringstream ss;
-    ss << "Average attenuation: " << std::fixed << std::setprecision(1)
+    ss << "Avg atten.: " << std::fixed << std::setprecision(1)
        << (static_cast<double>(aag_overall_sum) / slac::defs::AAG_LIST_LEN) << " dB";
     if (ctx.slac_config.sounding_atten_adjustment != 0) {
         ss << " plus offset " << std::to_string(ctx.slac_config.sounding_atten_adjustment) << " dB";
     }
     ss << ", from " << std::to_string(slac::defs::AAG_LIST_LEN) << " groups, " << session.captured_sounds << " sounds";
-    ctx.log_info(ss.str());
+    session_log(ctx, session, LogLevel::INFO, ss.str());
 }
 
 } // namespace slac::fsm::evse

--- a/lib/everest/slac/fsm/evse/src/states/matching_handle_slac.hpp
+++ b/lib/everest/slac/fsm/evse/src/states/matching_handle_slac.hpp
@@ -7,8 +7,15 @@
 
 namespace slac::fsm::evse {
 
-void session_log(Context& ctx, MatchingSession& session, const std::string& text);
+enum class LogLevel {
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR
+};
 
-}
+void session_log(Context& ctx, MatchingSession& session, const LogLevel level, const std::string& text);
+
+} // namespace slac::fsm::evse
 
 #endif // EVSE_SLAC_STATES_MATCHING_HANDLE_SLAC_HPP

--- a/lib/everest/slac/fsm/evse/src/states/others.cpp
+++ b/lib/everest/slac/fsm/evse/src/states/others.cpp
@@ -68,7 +68,7 @@ FSMSimpleState::CallbackReturnType ResetState::callback() {
 
         return cfg.set_key_timeout_ms;
     } else {
-        ctx.log_info("CM_SET_KEY_REQ timeout - failed to setup NMK key");
+        ctx.log_error("CM_SET_KEY_REQ timeout - failed to setup NMK key");
         return {};
     }
 }
@@ -78,7 +78,7 @@ bool ResetState::handle_slac_message(slac::messages::HomeplugMessage& message) {
     if (mmtype != (slac::defs::MMTYPE_CM_SET_KEY | slac::defs::MMTYPE_MODE_CNF)) {
         // unexpected message
         // FIXME (aw): need to also deal with CM_VALIDATE.REQ. It is optional in the standard.
-        ctx.log_info("Received non-expected SLAC message of type " + format_mmtype(mmtype));
+        ctx.log_warn("Received non-expected SLAC message of type " + format_mmtype(mmtype));
         return false;
     } else {
         ctx.log_info("Received CM_SET_KEY_CNF");
@@ -131,7 +131,7 @@ FSMSimpleState::CallbackReturnType ResetChipState::callback() {
             ctx.log_info("Chip reset not supported on this chip");
         }
     } else {
-        ctx.log_info("Reset timeout, no response received - failed to reset the chip");
+        ctx.log_error("Reset timeout, no response received - failed to reset the chip");
         return {};
     }
     return {};
@@ -141,7 +141,7 @@ bool ResetChipState::handle_slac_message(slac::messages::HomeplugMessage& messag
     const auto mmtype = message.get_mmtype();
     if (mmtype != (slac::defs::qualcomm::MMTYPE_CM_RESET_DEVICE | slac::defs::MMTYPE_MODE_CNF)) {
         // unexpected message
-        ctx.log_info("Received non-expected SLAC message of type " + format_mmtype(mmtype));
+        ctx.log_warn("Received non-expected SLAC message of type " + format_mmtype(mmtype));
         return false;
     } else {
         ctx.log_info("Received RS_DEV.CNF");
@@ -208,7 +208,7 @@ FSMSimpleState::HandleEventReturnType MatchedState::handle_event(AllocatorType& 
             if (link_ok.value()) {
                 return sa.PASS_ON;
             } else {
-                ctx.log_info("Connection lost in matched state");
+                ctx.log_error("Connection lost in matched state");
                 ctx.signal_error_routine_request();
                 return sa.PASS_ON;
             }
@@ -268,7 +268,7 @@ FSMSimpleState::HandleEventReturnType WaitForLinkState::handle_event(AllocatorTy
             return sa.PASS_ON;
         }
     } else if (ev == Event::RETRY_MATCHING) {
-        ctx.log_info("Link could not be established");
+        ctx.log_error("Link could not be established");
         // Notify higher layers to on CP signal
         return sa.create_simple<FailedState>(ctx);
     } else if (ev == Event::RESET) {

--- a/modules/EV/EvSlac/main/ev_slacImpl.cpp
+++ b/modules/EV/EvSlac/main/ev_slacImpl.cpp
@@ -53,7 +53,10 @@ void ev_slacImpl::run() {
         publish_state(value);
     };
 
-    callbacks.log = [](const std::string& text) { EVLOG_info << "EvSlac: " << text; };
+    callbacks.log_debug = [](const std::string& text) { EVLOG_debug << "EvSlac: " << text; };
+    callbacks.log_info = [](const std::string& text) { EVLOG_info << "EvSlac: " << text; };
+    callbacks.log_warn = [](const std::string& text) { EVLOG_warning << "EvSlac: " << text; };
+    callbacks.log_error = [](const std::string& text) { EVLOG_error << "EvSlac: " << text; };
 
     auto fsm_ctx = slac::fsm::ev::Context(callbacks);
     // fsm_ctx.slac_config.set_key_timeout_ms = config.set_key_timeout_ms;

--- a/modules/EVSE/EvseSlac/main/slacImpl.cpp
+++ b/modules/EVSE/EvseSlac/main/slacImpl.cpp
@@ -61,7 +61,10 @@ void slacImpl::run() {
 
     callbacks.signal_error_routine_request = [this]() { publish_request_error_routine(nullptr); };
 
-    callbacks.log = [](const std::string& text) { EVLOG_info << text; };
+    callbacks.log_debug = [](const std::string& text) { EVLOG_debug << text; };
+    callbacks.log_info = [](const std::string& text) { EVLOG_info << text; };
+    callbacks.log_warn = [](const std::string& text) { EVLOG_warning << text; };
+    callbacks.log_error = [](const std::string& text) { EVLOG_error << text; };
 
     if (config.publish_mac_on_first_parm_req) {
         callbacks.signal_ev_mac_address_parm_req = [this](const std::string& mac) { publish_ev_mac_address(mac); };


### PR DESCRIPTION
## Describe your changes
This pull request introduces more loglevels for the SLAC code and adjusts the level of the EVSE SLAC log messages. The EV SLAC log levels are kept, because of the missing test environment. Additionally it converts the EVSE SLAC attenuation log into a session_log.

## Issue ticket number and link
https://github.com/EVerest/everest-core/issues/1416

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

