### PR TITLE
RsPaymentTerminal: Do not authorize bank cards in backoffice

### DIFF
--- a/modules/HardwareDrivers/Payment/RsPaymentTerminal/src/main.rs
+++ b/modules/HardwareDrivers/Payment/RsPaymentTerminal/src/main.rs
@@ -146,7 +146,10 @@ impl ProvidedIdToken {
             parent_id_token: None,
             id_token: IdToken {
                 value: id_token,
-                r#type: IdTokenType::Local,
+                r#type: match authorization_type {
+                    AuthorizationType::BankCard => IdTokenType::NoAuthorization,
+                    _ => IdTokenType::Local,
+                },
                 additional_info: None,
             },
             authorization_type,


### PR DESCRIPTION
## Describe your changes

When using OCPP to communicate with backoffice, the Authorize message contains only IdTokenType and Value which makes it impossible to distinguish between RFID and BankCards on the backoffice. 
The solution for that is to set IdTokenType to NoAuthorization when the provided token was already authorized by the station itself

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

