### PR TITLE
docs(ocpp): add OCPP 1.6→2.x mapping README with profile-based tables

### DIFF
--- a/lib/everest/ocpp/config/v16_to_v2_mapping.md
+++ b/lib/everest/ocpp/config/v16_to_v2_mapping.md
@@ -1,0 +1,184 @@
+
+# OCPP 1.6 to OCPP 2.x mapping
+
+This documents how OCPP 1.6 configuration keys map to the OCPP 2.x Device Model.
+
+It is intended as a **human-readable reference** for integrators and maintainers.
+The implementation in code (for example `known_keys` conversion logic and patching behaviour) remains authoritative.
+
+## Core Profile
+
+| ID | OCPP1.6 key | Mapping type | Component | Variable | Target field |
+| ---: | --- | --- | --- | --- | --- |
+| 1 | `AllowOfflineTxForUnknownId` | VariableAttribute | `AuthCtrlr` | `OfflineTxForUnknownIdEnabled` | `Actual` |
+| 2 | `AuthorizationCacheEnabled` | VariableAttribute | `AuthCacheCtrlr` | `Enabled` | `Actual` |
+| 3 | `AuthorizeRemoteTxRequests` | VariableAttribute | `AuthCtrlr` | `AuthorizeRemoteStart` | `Actual` |
+| 5 | `ClockAlignedDataInterval` | VariableAttribute | `AlignedDataCtrlr` | `Interval` | `Actual` |
+| 6 | `ConnectionTimeOut` | VariableAttribute | `TxCtrlr` | `EVConnectionTimeOut` | `Actual` |
+| 7 | `HeartbeatInterval` | VariableAttribute | `OCPPCommCtrlr` | `HeartbeatInterval` | `Actual` |
+| 8 | `LocalAuthorizeOffline` | VariableAttribute | `AuthCtrlr` | `LocalAuthorizeOffline` | `Actual` |
+| 9 | `LocalPreAuthorize` | VariableAttribute | `AuthCtrlr` | `LocalPreAuthorize` | `Actual` |
+| 10 | `MaxEnergyOnInvalidId` | VariableAttribute | `TxCtrlr` | `MaxEnergyOnInvalidId` | `Actual` |
+| 11 | `MeterValuesAlignedData` | VariableAttribute | `AlignedDataCtrlr` | `Measurands` | `Actual` |
+| 12 | `MeterValuesAlignedDataMaxLength` | VariableCharacteristics | `AlignedDataCtrlr` | `Measurands` | `maxLimit` |
+| 13 | `MeterValuesSampledData` | VariableAttribute | `SampledDataCtrlr` | `TxUpdatedMeasurands` | `Actual` |
+| 14 | `MeterValuesSampledDataMaxLength` | VariableCharacteristics | `SampledDataCtrlr` | `TxUpdatedMeasurands` | `maxLimit` |
+| 15 | `MeterValueSampleInterval` | VariableAttribute | `SampledDataCtrlr` | `TxUpdatedInterval` | `Actual` |
+| 16 | `ResetRetries` | VariableAttribute | `OCPPCommCtrlr` | `ResetRetries` | `Actual` |
+| 17 | `StopTransactionOnInvalidId` | VariableAttribute | `TxCtrlr` | `StopTxOnInvalidId` | `Actual` |
+| 18 | `StopTxnAlignedData` | VariableAttribute | `AlignedDataCtrlr` | `TxEndedMeasurands` | `Actual` |
+| 19 | `StopTxnAlignedDataMaxLength` | VariableCharacteristics | `AlignedDataCtrlr` | `TxEndedMeasurands` | `maxLimit` |
+| 20 | `StopTxnSampledData` | VariableAttribute | `SampledDataCtrlr` | `TxEndedMeasurands` | `Actual` |
+| 21 | `StopTxnSampledDataMaxLength` | VariableCharacteristics | `SampledDataCtrlr` | `TxEndedMeasurands` | `maxLimit` |
+| 22 | `TransactionMessageAttempts` | VariableAttribute | `OCPPCommCtrlr` | `MessageAttempts` | `Actual` |
+| 23 | `TransactionMessageRetryInterval` | VariableAttribute | `OCPPCommCtrlr` | `MessageAttemptInterval` | `Actual` |
+| 24 | `WebSocketPingInterval` | VariableAttribute | `OCPPCommCtrlr` | `WebSocketPingInterval` | `Actual` |
+| 25 | `LocalAuthListEnabled` | VariableAttribute | `LocalAuthListCtrlr` | `Enabled` | `Actual` |
+| 26 | `ChargeProfileMaxStackLevel` | VariableAttribute | `SmartChargingCtrlr` | `ProfileStackLevel` | `Actual` |
+| 27 | `ChargingScheduleAllowedChargingRateUnit` | VariableAttribute | `SmartChargingCtrlr` | `RateUnit` | `Actual` |
+| 28 | `ChargingScheduleMaxPeriods` | VariableAttribute | `SmartChargingCtrlr` | `PeriodsPerSchedule` | `Actual` |
+| 29 | `ConnectorSwitch3to1PhaseSupported` | VariableAttribute | `SmartChargingCtrlr` | `Phases3to1` | `Actual` |
+| 30 | `SupportedFileTransferProtocols` | VariableAttribute | `OCPPCommCtrlr` | `FileTransferProtocols` | `Actual` |
+
+## Internal Keys
+
+| ID | OCPP1.6 key | Mapping type | Component | Variable | Target field |
+| ---: | --- | --- | --- | --- | --- |
+| 31 | `ChargePointId` | VariableAttribute | `InternalCtrlr` | `ChargePointId` | `Actual` |
+| 32 | `ChargeBoxSerialNumber` | VariableAttribute | `InternalCtrlr` | `ChargeBoxSerialNumber` | `Actual` |
+| 33 | `ChargePointModel` | VariableAttribute | `InternalCtrlr` | `ChargePointModel` | `Actual` |
+| 34 | `ChargePointSerialNumber` | VariableAttribute | `InternalCtrlr` | `ChargePointSerialNumber` | `Actual` |
+| 35 | `ChargePointVendor` | VariableAttribute | `InternalCtrlr` | `ChargePointVendor` | `Actual` |
+| 36 | `FirmwareVersion` | VariableAttribute | `InternalCtrlr` | `FirmwareVersion` | `Actual` |
+| 37 | `ICCID` | VariableAttribute | `InternalCtrlr` | `ICCID` | `Actual` |
+| 38 | `IFace` | VariableAttribute | `InternalCtrlr` | `IFace` | `Actual` |
+| 39 | `IMSI` | VariableAttribute | `InternalCtrlr` | `IMSI` | `Actual` |
+| 40 | `MeterSerialNumber` | VariableAttribute | `InternalCtrlr` | `MeterSerialNumber` | `Actual` |
+| 41 | `MeterType` | VariableAttribute | `InternalCtrlr` | `MeterType` | `Actual` |
+| 42 | `SupportedCiphers12` | VariableAttribute | `InternalCtrlr` | `SupportedCiphers12` | `Actual` |
+| 43 | `SupportedCiphers13` | VariableAttribute | `InternalCtrlr` | `SupportedCiphers13` | `Actual` |
+| 44 | `UseTPM` | VariableAttribute | `InternalCtrlr` | `UseTPM` | `Actual` |
+| 45 | `UseTPMSeccLeafCertificate` | VariableAttribute | `InternalCtrlr` | `UseTPMSeccLeafCertificate` | `Actual` |
+| 46 | `RetryBackoffRandomRange` | VariableAttribute | `OCPPCommCtrlr` | `RetryBackOffRandomRange` | `Actual` |
+| 47 | `RetryBackoffRepeatTimes` | VariableAttribute | `OCPPCommCtrlr` | `RetryBackOffRepeatTimes` | `Actual` |
+| 48 | `AuthorizeConnectorZeroOnConnectorOne` | VariableAttribute | `InternalCtrlr` | `AuthorizeConnectorZeroOnConnectorOne` | `Actual` |
+| 49 | `LogMessages` | VariableAttribute | `InternalCtrlr` | `LogMessages` | `Actual` |
+| 50 | `LogMessagesRaw` | VariableAttribute | `InternalCtrlr` | `LogMessagesRaw` | `Actual` |
+| 51 | `LogMessagesFormat` | VariableAttribute | `InternalCtrlr` | `LogMessagesFormat` | `Actual` |
+| 52 | `LogRotation` | VariableAttribute | `InternalCtrlr` | `LogRotation` | `Actual` |
+| 53 | `LogRotationDateSuffix` | VariableAttribute | `InternalCtrlr` | `LogRotationDateSuffix` | `Actual` |
+| 54 | `LogRotationMaximumFileSize` | VariableAttribute | `InternalCtrlr` | `LogRotationMaximumFileSize` | `Actual` |
+| 55 | `LogRotationMaximumFileCount` | VariableAttribute | `InternalCtrlr` | `LogRotationMaximumFileCount` | `Actual` |
+| 56 | `SupportedChargingProfilePurposeTypes` | VariableAttribute | `InternalCtrlr` | `SupportedChargingProfilePurposeTypes` | `Actual` |
+| 57 | `IgnoredProfilePurposesOffline` | VariableAttribute | `SmartChargingCtrlr` | `IgnoredProfilePurposesOffline` | `Actual` |
+| 58 | `MaxCompositeScheduleDuration` | VariableAttribute | `InternalCtrlr` | `MaxCompositeScheduleDuration` | `Actual` |
+| 59 | `CompositeScheduleDefaultLimitAmps` | VariableAttribute | `SmartChargingCtrlr` | `CompositeScheduleDefaultLimitAmps` | `Actual` |
+| 60 | `CompositeScheduleDefaultLimitWatts` | VariableAttribute | `SmartChargingCtrlr` | `CompositeScheduleDefaultLimitWatts` | `Actual` |
+| 61 | `CompositeScheduleDefaultNumberPhases` | VariableAttribute | `SmartChargingCtrlr` | `CompositeScheduleDefaultNumberPhases` | `Actual` |
+| 62 | `SupplyVoltage` | VariableAttribute | `SmartChargingCtrlr` | `SupplyVoltage` | `Actual` |
+| 63 | `WebsocketPingPayload` | VariableAttribute | `InternalCtrlr` | `WebsocketPingPayload` | `Actual` |
+| 64 | `WebsocketPongTimeout` | VariableAttribute | `InternalCtrlr` | `WebsocketPongTimeout` | `Actual` |
+| 65 | `UseSslDefaultVerifyPaths` | VariableAttribute | `InternalCtrlr` | `UseSslDefaultVerifyPaths` | `Actual` |
+| 66 | `VerifyCsmsCommonName` | VariableAttribute | `InternalCtrlr` | `VerifyCsmsCommonName` | `Actual` |
+| 67 | `VerifyCsmsAllowWildcards` | VariableAttribute | `InternalCtrlr` | `VerifyCsmsAllowWildcards` | `Actual` |
+| 68 | `OcspRequestInterval` | VariableAttribute | `InternalCtrlr` | `OcspRequestInterval` | `Actual` |
+| 69 | `SeccLeafSubjectCommonName` | VariableAttribute | `ISO15118Ctrlr` | `SeccId` | `Actual` |
+| 70 | `SeccLeafSubjectCountry` | VariableAttribute | `ISO15118Ctrlr` | `CountryName` | `Actual` |
+| 71 | `SeccLeafSubjectOrganization` | VariableAttribute | `ISO15118Ctrlr` | `OrganizationName` | `Actual` |
+| 72 | `QueueAllMessages` | VariableAttribute | `OCPPCommCtrlr` | `QueueAllMessages` | `Actual` |
+| 73 | `MessageTypesDiscardForQueueing` | VariableAttribute | `OCPPCommCtrlr` | `MessageTypesDiscardForQueueing` | `Actual` |
+| 74 | `MessageQueueSizeThreshold` | VariableAttribute | `InternalCtrlr` | `MessageQueueSizeThreshold` | `Actual` |
+| 75 | `MaxMessageSize` | VariableAttribute | `InternalCtrlr` | `MaxMessageSize` | `Actual` |
+| 76 | `TLSKeylogFile` | VariableAttribute | `InternalCtrlr` | `TLSKeylogFile` | `Actual` |
+| 77 | `EnableTLSKeylog` | VariableAttribute | `InternalCtrlr` | `EnableTLSKeylog` | `Actual` |
+| 78 | `NumberOfConnectors` | OCPP1.6-specific | `InternalCtrlr` | `NumberOfConnectors` | `Actual` |
+| 79 | `RetryBackoffWaitMinimum` | VariableAttribute | `OCPPCommCtrlr` | `RetryBackOffWaitMinimum` | `Actual` |
+
+## Local Auth List Management Profile
+
+| ID | OCPP1.6 key | Mapping type | Component | Variable | Target field |
+| ---: | --- | --- | --- | --- | --- |
+| 80 | `LocalAuthListMaxLength` | VariableCharacteristics | `LocalAuthListCtrlr` | `Entries` | `maxLimit` |
+| 81 | `SendLocalListMaxLength` | VariableAttribute | `LocalAuthListCtrlr` | `ItemsPerMessage` | `maxLimit` |
+
+## Smart Charging Profile
+
+| ID | OCPP1.6 key | Mapping type | Component | Variable | Target field |
+| ---: | --- | --- | --- | --- | --- |
+| 82 | `MaxChargingProfilesInstalled` | VariableCharacteristics | `SmartChargingCtrlr` | `Entries` | `maxLimit` |
+
+## Security Profile
+
+| ID | OCPP1.6 key | Mapping type | Component | Variable | Target field |
+| ---: | --- | --- | --- | --- | --- |
+| 83 | `AdditionalRootCertificateCheck` | VariableAttribute | `SecurityCtrlr` | `AdditionalRootCertificateCheck` | `Actual` |
+| 84 | `CertificateSignedMaxChainSize` | VariableAttribute | `SecurityCtrlr` | `MaxCertificateChainSize` | `Actual` |
+| 85 | `CpoName` | VariableAttribute | `SecurityCtrlr` | `OrganizationName` | `Actual` |
+| 86 | `CertSigningWaitMinimum` | VariableAttribute | `SecurityCtrlr` | `CertSigningWaitMinimum` | `Actual` |
+| 87 | `CertSigningRepeatTimes` | VariableAttribute | `SecurityCtrlr` | `CertSigningRepeatTimes` | `Actual` |
+| 88 | `CertificateStoreMaxLength` | VariableAttribute | `SecurityCtrlr` | `CertificateEntries` | `Actual` |
+
+## PnC Profile
+
+| ID | OCPP1.6 key | Mapping type | Component | Variable | Target field |
+| ---: | --- | --- | --- | --- | --- |
+| 89 | `ISO15118PnCEnabled` | VariableAttribute | `ISO15118Ctrlr` | `PnCEnabled` | `Actual` |
+| 90 | `CentralContractValidationAllowed` | VariableAttribute | `ISO15118Ctrlr` | `CentralContractValidationAllowed` | `Actual` |
+| 91 | `ContractValidationOffline` | VariableAttribute | `ISO15118Ctrlr` | `ContractValidationOffline` | `Actual` |
+
+## CostAndPrice Profile
+
+| ID | OCPP1.6 key | Mapping type | Component | Variable | Target field |
+| ---: | --- | --- | --- | --- | --- |
+| 92 | `NumberOfDecimalsForCostValues` | VariableAttribute | `TariffCostCtrlr` | `NumberOfDecimalsForCostValues` | `Actual` |
+| 93 | `TimeOffset` | VariableAttribute | `ClockCtrlr` | `TimeOffset` | `Actual` |
+| 94 | `NextTimeOffsetTransitionDateTime` | VariableAttribute | `ClockCtrlr` | `NextTimeOffsetTransitionDateTime` | `Actual` |
+| 95 | `TimeOffsetNextTransition` | VariableAttribute | `ClockCtrlr` | `NextTransition` | `Actual` |
+
+## Mavericks Section
+
+| ID | OCPP1.6 key | Mapping type | Component | Variable | Target field |
+| ---: | --- | --- | --- | --- | --- |
+| 96 | `BlinkRepeat` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `BlinkRepeat` | `Actual` |
+| 97 | `ConnectorPhaseRotation` | VariableAttribute | `OCPP16LegacyCtrlr` | `PhaseRotation` | `Actual` |
+| 98 | `ConnectorPhaseRotationMaxLength` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `ConnectorPhaseRotationMaxLength` | `Actual` |
+| 99 | `GetConfigurationMaxKeys` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `GetConfigurationMaxKeys` | `Actual` |
+| 100 | `LightIntensity` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `LightIntensity` | `Actual` |
+| 101 | `MinimumStatusDuration` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `MinimumStatusDuration` | `Actual` |
+| 102 | `StopTransactionOnEVSideDisconnect` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `StopTransactionOnEVSideDisconnect` | `Actual` |
+| 103 | `SupportedFeatureProfiles` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `SupportedFeatureProfiles` | `Actual` |
+| 104 | `SupportedFeatureProfilesMaxLength` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `SupportedFeatureProfilesMaxLength` | `Actual` |
+| 105 | `UnlockConnectorOnEVSideDisconnect` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `UnlockConnectorOnEVSideDisconnect` | `Actual` |
+| 106 | `ReserveConnectorZeroSupported` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `ReserveConnectorZeroSupported` | `Actual` |
+| 107 | `HostName` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `HostName` | `Actual` |
+| 108 | `AllowChargingProfileWithoutStartSchedule` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `AllowChargingProfileWithoutStartSchedule` | `Actual` |
+| 109 | `WaitForStopTransactionsOnResetTimeout` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `WaitForStopTransactionsOnResetTimeout` | `Actual` |
+| 110 | `StopTransactionIfUnlockNotSupported` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `StopTransactionIfUnlockNotSupported` | `Actual` |
+| 111 | `MeterPublicKeys` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `MeterPublicKeys` | `Actual` |
+| 112 | `DisableSecurityEventNotifications` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `DisableSecurityEventNotifications` | `Actual` |
+| 113 | `ISO15118CertificateManagementEnabled` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `ISO15118CertificateManagementEnabled` | `Actual` |
+| 114 | `CustomDisplayCostAndPrice` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `CustomDisplayCostAndPrice` | `Actual` |
+| 115 | `DefaultPrice` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `DefaultPrice` | `Actual` |
+| 116 | `DefaultPriceText` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `DefaultPriceText` | `Actual` |
+| 117 | `CustomIdleFeeAfterStop` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `CustomIdleFeeAfterStop` | `Actual` |
+| 118 | `SupportedLanguages` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `SupportedLanguages` | `Actual` |
+| 119 | `CustomMultiLanguageMessages` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `CustomMultiLanguageMessages` | `Actual` |
+| 120 | `Language` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `Language` | `Actual` |
+| 121 | `WaitForSetUserPriceTimeout` | OCPP1.6-specific | `OCPP16LegacyCtrlr` | `WaitForSetUserPriceTimeout` | `Actual` |
+
+## Mavericks Section
+
+Direct mapping is not supported. An additional key is used instead.
+
+| ID | OCPP1.6 key | Mapping type | Component | Variable | Target field |
+| ---: | --- | --- | --- | --- | --- |
+| 122 | `AuthorizationKey` | VariableAttribute | `CustomLegacyController` | `AuthorizationKey` | `Actual` |
+| 123 | `CentralSystemURI` | VariableAttribute | `CustomLegacyController` | `CentralSystemURI` | `Actual` |
+| 124 | `SecurityProfile` | VariableAttribute | `CustomLegacyController` | `SecurityProfile` | `Actual` |
+
+Special handling is required
+
+| ID | OCPP1.6 key | Mapping type | Component | Variable | Target field |
+| ---: | --- | --- | --- | --- | --- |
+| 125 | `ConnectorEvseIds` | VariableAttribute | `*EVSE` | `EvseId` | `Actual` |
+| 126 | `SupportedMeasurands` | VariableCharacteristics | `*` | `Measurands` | `valuesList` |

--- a/lib/everest/ocpp/include/ocpp/v16/known_keys.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/known_keys.hpp
@@ -5,6 +5,7 @@
 #define OCPP_V16_KNOWN_KEYS_HPP
 
 #include "ocpp/v16/types.hpp"
+#include "ocpp/v2/ctrlr_component_variables.hpp"
 #include "ocpp/v2/ocpp_enums.hpp"
 #include "ocpp/v2/ocpp_types.hpp"
 
@@ -38,16 +39,12 @@ namespace ocpp::v16::keys {
     mapping(LocalPreAuthorize, LocalPreAuthorize, Actual) \
     mapping(MaxEnergyOnInvalidId, MaxEnergyOnInvalidId, Actual) \
     mapping(MeterValuesAlignedData, AlignedDataMeasurands, Actual) \
-    mapping(MeterValuesAlignedDataMaxLength, AlignedDataMeasurands, MaxSet) \
     mapping(MeterValuesSampledData, SampledDataTxUpdatedMeasurands, Actual) \
-    mapping(MeterValuesSampledDataMaxLength, SampledDataTxUpdatedMeasurands, MaxSet) \
     mapping(MeterValueSampleInterval, SampledDataTxUpdatedInterval, Actual) \
     mapping(ResetRetries, ResetRetries, Actual) \
     mapping(StopTransactionOnInvalidId, StopTxOnInvalidId, Actual) \
     mapping(StopTxnAlignedData, AlignedDataTxEndedMeasurands, Actual) \
-    mapping(StopTxnAlignedDataMaxLength, AlignedDataTxEndedMeasurands, MaxSet) \
     mapping(StopTxnSampledData, SampledDataTxEndedMeasurands, Actual) \
-    mapping(StopTxnSampledDataMaxLength, SampledDataTxEndedMeasurands, MaxSet) \
     mapping(TransactionMessageAttempts, MessageAttempts, Actual) \
     mapping(TransactionMessageRetryInterval, MessageAttemptInterval, Actual) \
     mapping(WebSocketPingInterval, WebSocketPingInterval, Actual) \
@@ -114,19 +111,19 @@ namespace ocpp::v16::keys {
     mapping(RetryBackoffWaitMinimum, RetryBackOffWaitMinimum, Actual)
 
 // ============================================================================
-// LocalAuthList Section
+// VariableCharacteristics.maxLimit mappings
+// These OCPP 1.6 read-only length/limit keys map to VariableCharacteristics.maxLimit
+// in OCPP 2.x
 // ============================================================================
 
-#define MAPPING_LOCAL_AUTH_LIST(mapping) \
-    mapping(LocalAuthListMaxLength, LocalAuthListCtrlrEntries, Actual) \
-    mapping(SendLocalListMaxLength, ItemsPerMessageSendLocalList, Actual)
-
-// ============================================================================
-// Smart Charging Section
-// ============================================================================
-
-#define MAPPING_SMART_CHARGING(mapping) \
-    mapping(MaxChargingProfilesInstalled, EntriesChargingProfiles, Actual)
+#define MAPPING_MAX_LIMIT(mapping) \
+    mapping(MeterValuesAlignedDataMaxLength, AlignedDataMeasurands) \
+    mapping(MeterValuesSampledDataMaxLength, SampledDataTxUpdatedMeasurands) \
+    mapping(StopTxnAlignedDataMaxLength, AlignedDataTxEndedMeasurands) \
+    mapping(StopTxnSampledDataMaxLength, SampledDataTxEndedMeasurands) \
+    mapping(LocalAuthListMaxLength, LocalAuthListCtrlrEntries) \
+    mapping(SendLocalListMaxLength, ItemsPerMessageSendLocalList) \
+    mapping(MaxChargingProfilesInstalled, EntriesChargingProfiles)
 
 // ============================================================================
 // Security Section
@@ -205,8 +202,6 @@ namespace ocpp::v16::keys {
     MAPPING_MISC(mapping) \
     MAPPING_STANDARD(mapping) \
     MAPPING_INTERNAL(mapping) \
-    MAPPING_LOCAL_AUTH_LIST(mapping) \
-    MAPPING_SMART_CHARGING(mapping) \
     MAPPING_SECURITY(mapping) \
     MAPPING_PNC(mapping) \
     MAPPING_COST(mapping)
@@ -367,6 +362,11 @@ enum class sections : std::uint8_t {
 
 #undef VALUE
 
+#define MAX_LIMIT_ENTRY(a, b) {valid_keys::a, &ocpp::v2::ControllerComponentVariables::b},
+using MaxLimitEntry = std::pair<valid_keys, const ocpp::v2::ComponentVariable*>;
+inline const MaxLimitEntry max_limit_entries[] = {MAPPING_MAX_LIMIT(MAX_LIMIT_ENTRY)};
+#undef MAX_LIMIT_ENTRY
+
 std::optional<valid_keys> convert(const std::string_view& str);
 std::string_view convert(valid_keys key);
 sections to_section(valid_keys key);
@@ -383,6 +383,11 @@ DeviceModel_CV convert_v2(const std::string_view& str);
 DeviceModel_CV convert_v2(valid_keys key);
 std::optional<std::string> convert_v2(const ocpp::v2::Component& component, const ocpp::v2::Variable& variable,
                                       ocpp::v2::AttributeEnum attribute);
+
+/// Returns the (Component, Variable) pair for keys that map to VariableCharacteristics.maxLimit,
+/// or std::nullopt if the key uses a regular VariableAttribute mapping.
+using DeviceModel_MaxLimitCV = std::optional<std::pair<ocpp::v2::Component, ocpp::v2::Variable>>;
+DeviceModel_MaxLimitCV convert_v2_max_limit(valid_keys key);
 
 } // namespace ocpp::v16::keys
 

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
@@ -198,6 +198,18 @@ std::optional<T> get_optional(DeviceModelInterface& storage, const std::string_v
 
 template <typename T>
 std::optional<T> get_optional(DeviceModelInterface& storage, v16::keys::valid_keys key, bool writeOnly = false) {
+    const auto max_limit_cv = v16::keys::convert_v2_max_limit(key);
+    if (max_limit_cv) {
+        const auto meta = storage.get_variable_meta_data(max_limit_cv->first, max_limit_cv->second);
+        if (meta && meta->characteristics.maxLimit) {
+            if constexpr (std::is_same_v<T, std::string>) {
+                return std::to_string(static_cast<std::int32_t>(meta->characteristics.maxLimit.value()));
+            } else {
+                return static_cast<T>(meta->characteristics.maxLimit.value());
+            }
+        }
+        return std::nullopt;
+    }
     std::optional<T> result;
     const auto cv = v16::keys::convert_v2(key);
     if (cv) {
@@ -252,6 +264,10 @@ bool key_exists(DeviceModelInterface& storage, const std::string_view& component
 }
 
 bool key_exists(DeviceModelInterface& storage, v16::keys::valid_keys key) {
+    const auto max_limit_cv = v16::keys::convert_v2_max_limit(key);
+    if (max_limit_cv) {
+        return storage.get_variable_meta_data(max_limit_cv->first, max_limit_cv->second).has_value();
+    }
     bool result{false};
     const auto cv = v16::keys::convert_v2(key);
     if (cv) {
@@ -2939,6 +2955,21 @@ std::vector<KeyValue> ChargePointConfigurationDeviceModel::get_all_key_value() {
             }
         } catch (std::exception& ex) {
             EVLOG_error << "Device model '" << component.name << "' not supported: " << ex.what();
+        }
+    }
+
+    // Add keys that map to VariableCharacteristics.maxLimit
+    for (const auto& [key, cv] : v16::keys::max_limit_entries) {
+        const auto max_limit_cv = v16::keys::convert_v2_max_limit(key);
+        if (max_limit_cv) {
+            const auto meta = storage->get_variable_meta_data(max_limit_cv->first, max_limit_cv->second);
+            if (meta && meta->characteristics.maxLimit) {
+                KeyValue kv;
+                kv.key = std::string{v16::keys::convert(key)};
+                kv.value = std::to_string(static_cast<std::int32_t>(meta->characteristics.maxLimit.value()));
+                kv.readonly = v16::keys::is_readonly(key);
+                all.push_back(std::move(kv));
+            }
         }
     }
 

--- a/lib/everest/ocpp/lib/ocpp/v16/known_keys.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/known_keys.cpp
@@ -178,6 +178,13 @@ void V2ConfigMap::configure() {
 #undef VALUE
 
 void V2ConfigMap::warn_no_mapping(const std::string_view& v16) {
+    // Keys in MAPPING_MAX_LIMIT map to VariableCharacteristics.maxLimit, not to a VariableAttribute,
+    // so they intentionally have no entry in the attribute map.
+#define VALUE(a, b)                                                                                                    \
+    if (v16 == #a)                                                                                                     \
+        return;
+    MAPPING_MAX_LIMIT(VALUE)
+#undef VALUE
     const auto it = map.find(v16);
     if (it == map.end()) {
         EVLOG_error << "No V2 mapping for " << v16;
@@ -313,6 +320,15 @@ DeviceModel_CV convert_v2(valid_keys key) {
 std::optional<std::string> convert_v2(const ocpp::v2::Component& component, const ocpp::v2::Variable& variable,
                                       ocpp::v2::AttributeEnum attribute) {
     return v2_map.convert_v2(component, variable, attribute);
+}
+
+DeviceModel_MaxLimitCV convert_v2_max_limit(valid_keys key) {
+    for (const auto& [k, cv] : max_limit_entries) {
+        if (k == key && cv->variable) {
+            return std::make_pair(cv->component, cv->variable.value());
+        }
+    }
+    return std::nullopt;
 }
 
 } // namespace ocpp::v16::keys

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/memory_storage.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/memory_storage.cpp
@@ -385,9 +385,20 @@ void MemoryStorage::add_supported_measureands_values_list(ocpp::v2::ReportData& 
 void MemoryStorage::add_to_report(std::vector<ocpp::v2::ReportData>& report, const std::string_view& name,
                                   const std::string_view& value) {
     using namespace ocpp::v2::ControllerComponentVariables;
-    const auto cv = ocpp::v16::keys::convert_v2(name);
     const std::string name_str{name};
     std::string value_str{value};
+
+    // Keys that map to VariableCharacteristics.maxLimit are handled separately via get_variable_meta_data;
+    // they don't need a VariableAttribute entry in the report.
+    const auto key = keys::convert(name);
+    if (key) {
+        const auto max_limit_cv = keys::convert_v2_max_limit(*key);
+        if (max_limit_cv) {
+            return;
+        }
+    }
+
+    const auto cv = ocpp::v16::keys::convert_v2(name);
     if (cv) {
         auto component = std::get<ocpp::v2::Component>(*cv);
         auto variable = std::get<ocpp::v2::Variable>(*cv);
@@ -402,7 +413,6 @@ void MemoryStorage::add_to_report(std::vector<ocpp::v2::ReportData>& report, con
             va.value = std::move(value_str);
         }
 
-        const auto key = keys::convert(name);
         if (key == keys::valid_keys::MeterValuesAlignedData) {
             add_supported_measureands_values_list(data);
         } else if (key == keys::valid_keys::StopTxnAlignedData) {
@@ -632,17 +642,46 @@ std::optional<MemoryStorage::MutabilityEnum> MemoryStorage::get_mutability(const
 std::optional<MemoryStorage::VariableMetaData> MemoryStorage::get_variable_meta_data(const Component& component_id,
                                                                                      const Variable& variable_id) {
     std::optional<MemoryStorage::VariableMetaData> result;
-    const auto key_str = keys::convert_v2(component_id, variable_id, ocpp::v2::AttributeEnum::Actual);
-    const auto retrieved = get_v16(key_str.value_or(""));
-    if (retrieved) {
-        MemoryStorage::VariableMetaData md;
-        md.characteristics.dataType = v2::DataEnum::string;
-        md.characteristics.supportsMonitoring = false;
-        result = std::move(md);
-    } else {
-        std::cerr << "get_variable_meta_data not implemented for: " << component_id.name << ':' << variable_id.name
-                  << " (" << key_str.value_or("") << ")\n";
+
+    // Check if this is a maxLimit key by iterating the known mappings
+    auto fn = [&](keys::valid_keys key) {
+        if (result) {
+            return; // already found
+        }
+        const auto cv = keys::convert_v2_max_limit(key);
+        if (cv && cv->first.name == component_id.name && cv->second.name == variable_id.name &&
+            cv->second.instance == variable_id.instance) {
+            const auto retrieved = get_v16(std::string{keys::convert(key)});
+            if (retrieved) {
+                MemoryStorage::VariableMetaData md;
+                md.characteristics.dataType = v2::DataEnum::integer;
+                md.characteristics.supportsMonitoring = false;
+                try {
+                    md.characteristics.maxLimit = std::stof(*retrieved);
+                } catch (...) {
+                }
+                result = std::move(md);
+            }
+        }
+    };
+    for (const auto& [key, cv] : keys::max_limit_entries) {
+        fn(key);
     }
+
+    if (!result) {
+        const auto key_str = keys::convert_v2(component_id, variable_id, ocpp::v2::AttributeEnum::Actual);
+        const auto retrieved = get_v16(key_str.value_or(""));
+        if (retrieved) {
+            MemoryStorage::VariableMetaData md;
+            md.characteristics.dataType = v2::DataEnum::string;
+            md.characteristics.supportsMonitoring = false;
+            result = std::move(md);
+        } else {
+            std::cerr << "get_variable_meta_data not implemented for: " << component_id.name << ':' << variable_id.name
+                      << " (" << key_str.value_or("") << ")\n";
+        }
+    }
+
     return result;
 }
 

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_config.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_config.cpp
@@ -103,11 +103,81 @@ TEST(V2Mapping, V2ToV16) {
     auto res = convert_v2(comp, var, ocpp::v2::AttributeEnum::Actual);
     EXPECT_EQ(res, "CpoName");
 
+    // MaxChargingProfilesInstalled maps to VariableCharacteristics.maxLimit
     comp.name = "SmartChargingCtrlr";
     var.name = "Entries";
     var.instance = "ChargingProfiles";
-    res = convert_v2(comp, var, ocpp::v2::AttributeEnum::Actual);
-    EXPECT_EQ(res, "MaxChargingProfilesInstalled");
+    EXPECT_FALSE(convert_v2(comp, var, ocpp::v2::AttributeEnum::Actual));
+    EXPECT_FALSE(convert_v2(comp, var, ocpp::v2::AttributeEnum::MaxSet));
+
+    // Instead it is reachable via convert_v2_max_limit.
+    const auto max_limit = convert_v2_max_limit(valid_keys::MaxChargingProfilesInstalled);
+    ASSERT_TRUE(max_limit);
+    EXPECT_EQ(max_limit->first.name, "SmartChargingCtrlr");
+    EXPECT_EQ(max_limit->second.name, "Entries");
+    EXPECT_EQ(max_limit->second.instance, "ChargingProfiles");
+}
+
+// Tests for get_all_key_value() with maxLimit keys.
+// These keys map to VariableCharacteristics.maxLimit rather than VariableAttribute,
+// so they are populated via a separate code path in get_all_key_value().
+class MaxLimitGetAll : public ConfigurationBase {};
+
+TEST_F(MaxLimitGetAll, MaxLimitKeysIncludedWhenSet) {
+    ASSERT_TRUE(device_model);
+    device_model->set("Core", "MeterValuesAlignedDataMaxLength", "10");
+    device_model->set("Core", "MeterValuesSampledDataMaxLength", "20");
+    device_model->set("Core", "StopTxnAlignedDataMaxLength", "30");
+    device_model->set("Core", "StopTxnSampledDataMaxLength", "40");
+    device_model->set("LocalAuthListManagement", "LocalAuthListMaxLength", "50");
+    device_model->set("LocalAuthListManagement", "SendLocalListMaxLength", "60");
+    device_model->set("SmartCharging", "MaxChargingProfilesInstalled", "70");
+
+    const auto all = v2_config->get_all_key_value();
+    const auto find = [&](const std::string& key) {
+        return std::find_if(all.begin(), all.end(), [&](const auto& kv) { return kv.key == key.c_str(); });
+    };
+
+    struct Expected {
+        const char* key;
+        const char* value;
+    };
+    const Expected expected[] = {
+        {"MeterValuesAlignedDataMaxLength", "10"}, {"MeterValuesSampledDataMaxLength", "20"},
+        {"StopTxnAlignedDataMaxLength", "30"},     {"StopTxnSampledDataMaxLength", "40"},
+        {"LocalAuthListMaxLength", "50"},          {"SendLocalListMaxLength", "60"},
+        {"MaxChargingProfilesInstalled", "70"},
+    };
+
+    for (const auto& e : expected) {
+        const auto it = find(e.key);
+        ASSERT_NE(it, all.end()) << e.key << " missing from get_all_key_value()";
+        EXPECT_EQ(it->value, e.value) << e.key;
+        EXPECT_TRUE(it->readonly) << e.key << " should be readonly";
+    }
+}
+
+TEST_F(MaxLimitGetAll, MaxLimitKeysAbsentWhenNotSet) {
+    ASSERT_TRUE(device_model);
+    // Do not configure any maxLimit keys — they should not appear in the result.
+    const auto all = v2_config->get_all_key_value();
+    const auto find = [&](const std::string& key) {
+        return std::find_if(all.begin(), all.end(), [&](const auto& kv) { return kv.key == key.c_str(); });
+    };
+
+    // LocalAuthListMaxLength, SendLocalListMaxLength, MaxChargingProfilesInstalled are present because they are part of
+    // the example config
+
+    const char* keys[] = {
+        "MeterValuesAlignedDataMaxLength",
+        "MeterValuesSampledDataMaxLength",
+        "StopTxnAlignedDataMaxLength",
+        "StopTxnSampledDataMaxLength",
+    };
+
+    for (const auto* key : keys) {
+        EXPECT_EQ(find(key), all.end()) << key << " should be absent when maxLimit is not set";
+    }
 }
 
 } // namespace


### PR DESCRIPTION
## Describe your changes

This adds documentation for the mapping of existing OCPP1.6 configuration keys to the device model representation.

UPDATE, new changes included:

Refactors the mapping of OCPP 1.6 configuration keys that represent maximum limits (e.g., *MaxLength and MaxChargingProfilesInstalled) to use the OCPP 2.x VariableCharacteristics.maxLimit field instead of a
standard VariableAttribute (MaxSet) mapping.

Changes include:
- Introduced `MAPPING_MAX_LIMIT` macro and helper functions in `known_keys` to handle characteristics-based mappings.
- Updated `ChargePointConfigurationDeviceModel` to retrieve valuesfrom variable metadata when a maxLimit mapping is detected.
- Updated test storage stubs and added unit tests to verify correct retrieval and visibility of these keys in `get_all_key_value`.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

