### PR TITLE
iso15118: add DC charge parameter discovery compatibility check

### DIFF
--- a/lib/everest/iso15118/include/iso15118/d20/context.hpp
+++ b/lib/everest/iso15118/include/iso15118/d20/context.hpp
@@ -157,6 +157,8 @@ public:
     std::optional<UpdateDynamicModeParameters> cache_dynamic_mode_parameters;
     std::optional<AcTargetPower> cache_ac_target_power;
     std::optional<AcPresentPower> cache_ac_present_power;
+    bool dc_limits_locked_after_charge_param{false};
+    std::optional<DcTransferLimits> dc_limits_after_charge_param_bounds;
 
 private:
     const std::optional<ControlEvent>& current_control_event;

--- a/lib/everest/iso15118/include/iso15118/detail/d20/state/dc_charge_parameter_discovery.hpp
+++ b/lib/everest/iso15118/include/iso15118/detail/d20/state/dc_charge_parameter_discovery.hpp
@@ -9,6 +9,11 @@
 
 namespace iso15118::d20::state {
 
+bool handle_compatibility_check(const d20::DcTransferLimits& evse_dc_limits,
+                                const std::variant<message_20::datatypes::DC_CPDReqEnergyTransferMode,
+                                                   message_20::datatypes::BPT_DC_CPDReqEnergyTransferMode>& ev_limits,
+                                d20::DcTransferLimits& out_limits);
+
 message_20::DC_ChargeParameterDiscoveryResponse
 handle_request(const message_20::DC_ChargeParameterDiscoveryRequest& req, const d20::Session& session,
                const d20::DcTransferLimits& dc_limits);

--- a/lib/everest/iso15118/src/iso15118/d20/state/dc_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/dc_charge_parameter_discovery.cpp
@@ -242,6 +242,7 @@ Result DC_ChargeParameterDiscovery::feed(Event ev) {
         // Save adapted limits for later states (e.g. charge loop)
         m_ctx.session_config.dc_limits = checked_limits;
         m_ctx.dc_limits_locked_after_charge_param = true;
+        m_ctx.dc_limits_after_charge_param_bounds = checked_limits;
         res = handle_request(*req, m_ctx.session, checked_limits);
         m_ctx.respond(res);
 

--- a/lib/everest/iso15118/src/iso15118/d20/state/dc_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/dc_charge_parameter_discovery.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
+#include <algorithm>
+
 #include <iso15118/d20/state/dc_charge_parameter_discovery.hpp>
 #include <iso15118/d20/state/schedule_exchange.hpp>
 
@@ -40,6 +42,108 @@ template <> void convert(BPT_DC_ModeRes& out, const d20::DcTransferLimits& in) {
         out.max_discharge_current = discharge_limits.current.max;
         out.min_discharge_current = discharge_limits.current.min;
     }
+}
+
+bool handle_compatibility_check(const d20::DcTransferLimits& evse_dc_limits,
+                                const std::variant<DC_ModeReq, BPT_DC_ModeReq>& ev_limits,
+                                d20::DcTransferLimits& out_limits) {
+    // In IEC 61851-23-3 a compatibility check is required
+    constexpr float MAX_VOLTAGE_OFFSET = 50.f;
+    constexpr float MAX_VOLTAGE_THRESHOLD = 500.f;
+    constexpr float MAX_VOLTAGE_FACTOR = 1.1f;
+    constexpr float DEFAULT_MAX_POWER_IF_UNSET = 200000.f;
+    bool compatibility_flag = true;
+
+    float ev_max_power, ev_max_current, ev_max_voltage;
+
+    // Start with a copy for output
+    out_limits = evse_dc_limits;
+
+    // Extract EV values
+    if (const auto* mode = std::get_if<DC_ModeReq>(&ev_limits)) {
+        ev_max_power = dt::from_RationalNumber(mode->max_charge_power);
+        ev_max_current = dt::from_RationalNumber(mode->max_charge_current);
+        ev_max_voltage = dt::from_RationalNumber(mode->max_voltage);
+    } else if (const auto* mode = std::get_if<BPT_DC_ModeReq>(&ev_limits)) {
+        ev_max_power = dt::from_RationalNumber(mode->max_charge_power);
+        ev_max_current = dt::from_RationalNumber(mode->max_charge_current);
+        ev_max_voltage = dt::from_RationalNumber(mode->max_voltage);
+    } else {
+        return false;
+    }
+
+    // CC.5.6 f-h) Checks are handled by the EV - not relevant here
+    // CC.5.6 1) not relevant here is just a note that CPD and RATED limits are the same sent by EV
+
+    // CC.5.6.2 a) Max voltage
+    auto& out_max_voltage = out_limits.voltage.max;
+    float evse_max_voltage = dt::from_RationalNumber(out_max_voltage);
+    if (ev_max_voltage <= MAX_VOLTAGE_THRESHOLD) {
+        float new_evse_max_voltage = std::min({ev_max_voltage + MAX_VOLTAGE_OFFSET, MAX_VOLTAGE_THRESHOLD});
+        if (evse_max_voltage > new_evse_max_voltage) {
+            logf_info("Compatibility check: max voltage changed (EVSE: %.1f V → adjusted value: %.1f V)",
+                      evse_max_voltage, new_evse_max_voltage);
+            out_max_voltage = dt::from_float(new_evse_max_voltage);
+        }
+    } else {
+        float new_evse_max_voltage = ev_max_voltage * MAX_VOLTAGE_FACTOR;
+        if (evse_max_voltage > new_evse_max_voltage) {
+            logf_info("Compatibility check: max voltage changed (EVSE: %.1f V → adjusted value: %.1f V)",
+                      evse_max_voltage, new_evse_max_voltage);
+            out_max_voltage = dt::from_float(new_evse_max_voltage);
+        }
+    }
+
+    // CC.5.6.2 b) Max current
+    auto& out_max_current = out_limits.charge_limits.current.max;
+    float evse_max_current = dt::from_RationalNumber(out_max_current);
+    if (evse_max_current > ev_max_current) {
+        logf_info("Compatibility check: max current changed (EVSE: %.1f A → adjusted value: %.1f A)", evse_max_current,
+                  ev_max_current);
+        out_max_current = dt::from_float(ev_max_current);
+    }
+
+    // CC.5.6.2 c) Max power
+    auto& out_max_power = out_limits.charge_limits.power.max;
+    float evse_max_power = dt::from_RationalNumber(out_max_power);
+    float ev_power_max =
+        ev_max_power > 0 ? ev_max_power : std::max(ev_max_voltage * ev_max_current, DEFAULT_MAX_POWER_IF_UNSET);
+    if (evse_max_power > ev_power_max) {
+        logf_info("Compatibility check: max power changed (EVSE: %.1f W → adjusted value: %.1f W)", evse_max_power,
+                  ev_power_max);
+        out_max_power = dt::from_float(ev_power_max);
+    }
+
+    // CC.5.6.2 d-f) Is not relevant here because EVerest makes no different between RATED and CPD up to now
+
+    // CC.5.6.2 g.i) If any of the below checks fail, the EVSE shall reject the request with response code
+    // FAILED_WrongChargeParameter CC.5.6.2 g) Relation between EVSE min and EV max voltage
+    auto& out_min_voltage = out_limits.voltage.min;
+    float evse_min_voltage = dt::from_RationalNumber(out_min_voltage);
+    if (evse_min_voltage >= ev_max_voltage) {
+        logf_error("EVSE min voltage %.1f V >= EV max voltage %.1f V", evse_min_voltage, ev_max_voltage);
+        compatibility_flag = false;
+    }
+
+    // CC.5.6 g) Relation between EVSE min current and EV max current
+    auto& out_min_current = out_limits.charge_limits.current.min;
+    float evse_min_current = dt::from_RationalNumber(out_min_current);
+    if (evse_min_current >= ev_max_current) {
+        logf_error("EVSE min current %.1f A >= EV max current %.1f A", evse_min_current, ev_max_current);
+        compatibility_flag = false;
+    }
+
+    // CC.5.6 g) Relation between EVSE min power and EV max power
+    auto& out_min_power = out_limits.charge_limits.power.min;
+    float evse_min_power = dt::from_RationalNumber(out_min_power);
+    if (evse_min_power >= ev_power_max) {
+        logf_error("EVSE min power %.1f W >= EV max power %.1f W", evse_min_power, ev_power_max);
+        compatibility_flag = false;
+    }
+
+    // CC.5.6 3-5) Are EV checks and not relevant here
+
+    return compatibility_flag;
 }
 
 message_20::DC_ChargeParameterDiscoveryResponse
@@ -122,8 +226,23 @@ Result DC_ChargeParameterDiscovery::feed(Event ev) {
             m_ctx.session_ev_info.ev_transfer_limits.emplace<BPT_DC_ModeReq>(*mode);
         }
 
-        const auto res = handle_request(*req, m_ctx.session, m_ctx.session_config.powersupply_limits);
-
+        // Compatibility check and use of new limits
+        d20::DcTransferLimits checked_limits;
+        bool compatible =
+            handle_compatibility_check(m_ctx.session_config.powersupply_limits, req->transfer_mode, checked_limits);
+        message_20::DC_ChargeParameterDiscoveryResponse res;
+        if (!compatible) {
+            res = handle_request(*req, m_ctx.session, checked_limits);
+            res.response_code = dt::ResponseCode::FAILED_WrongChargeParameter;
+            m_ctx.respond(res);
+            m_ctx.feedback.dc_max_limits(dc_max_limits);
+            m_ctx.session_stopped = true;
+            return {};
+        }
+        // Save adapted limits for later states (e.g. charge loop)
+        m_ctx.session_config.dc_limits = checked_limits;
+        m_ctx.dc_limits_locked_after_charge_param = true;
+        res = handle_request(*req, m_ctx.session, checked_limits);
         m_ctx.respond(res);
 
         m_ctx.feedback.dc_max_limits(dc_max_limits);

--- a/lib/everest/iso15118/src/iso15118/d20/state/session_setup.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/session_setup.cpp
@@ -116,6 +116,8 @@ Result SessionSetup::feed(Event ev) {
         }
 
         if (new_session) {
+            m_ctx.dc_limits_locked_after_charge_param = false;
+            m_ctx.dc_limits_after_charge_param_bounds.reset();
             logf_info("New session created with session_id: %s", session_id_to_string(m_ctx.session.get_id()).c_str());
             if (vehicle_cert_hash) {
                 auto& pause_ctx = m_ctx.pause_ctx.emplace();

--- a/lib/everest/iso15118/src/iso15118/session/iso.cpp
+++ b/lib/everest/iso15118/src/iso15118/session/iso.cpp
@@ -17,6 +17,35 @@ namespace iso15118 {
 
 static constexpr auto SESSION_IDLE_TIMEOUT_MS = 5000;
 
+static void clamp_dc_limits(const d20::DcTransferLimits& upper_bound, d20::DcTransferLimits& candidate) {
+    namespace dt = message_20::datatypes;
+
+    const auto clamp_rational_max = [](const dt::RationalNumber& bound, dt::RationalNumber& value) {
+        if (dt::from_RationalNumber(value) > dt::from_RationalNumber(bound)) {
+            value = bound;
+        }
+    };
+    const auto clamp_rational_min = [](const dt::RationalNumber& bound, dt::RationalNumber& value) {
+        if (dt::from_RationalNumber(value) < dt::from_RationalNumber(bound)) {
+            value = bound;
+        }
+    };
+
+    clamp_rational_max(upper_bound.voltage.max, candidate.voltage.max);
+    clamp_rational_max(upper_bound.charge_limits.current.max, candidate.charge_limits.current.max);
+    clamp_rational_max(upper_bound.charge_limits.power.max, candidate.charge_limits.power.max);
+    clamp_rational_min(upper_bound.voltage.min, candidate.voltage.min);
+    clamp_rational_min(upper_bound.charge_limits.current.min, candidate.charge_limits.current.min);
+    clamp_rational_min(upper_bound.charge_limits.power.min, candidate.charge_limits.power.min);
+
+    if (upper_bound.discharge_limits.has_value() and candidate.discharge_limits.has_value()) {
+        clamp_rational_max(upper_bound.discharge_limits->current.max, candidate.discharge_limits->current.max);
+        clamp_rational_max(upper_bound.discharge_limits->power.max, candidate.discharge_limits->power.max);
+        clamp_rational_min(upper_bound.discharge_limits->current.min, candidate.discharge_limits->current.min);
+        clamp_rational_min(upper_bound.discharge_limits->power.min, candidate.discharge_limits->power.min);
+    }
+}
+
 static void log_sdp_packet(const iso15118::io::SdpPacket& sdp) {
     static constexpr auto ESCAPED_BYTE_CHAR_COUNT = 4;
     auto payload_string_buffer = std::make_unique<char[]>(sdp.get_payload_length() * ESCAPED_BYTE_CHAR_COUNT + 1);
@@ -160,7 +189,12 @@ TimePoint const& Session::poll() {
     while ((active_control_event = control_event_queue.pop()) != std::nullopt) {
 
         if (const auto control_data = ctx.get_control_event<d20::DcTransferLimits>()) {
-            ctx.session_config.dc_limits = *control_data;
+            auto updated_limits = *control_data;
+            if (ctx.dc_limits_locked_after_charge_param) {
+                const auto& bounds = ctx.dc_limits_after_charge_param_bounds.value_or(ctx.session_config.dc_limits);
+                clamp_dc_limits(bounds, updated_limits);
+            }
+            ctx.session_config.dc_limits = updated_limits;
         } else if (const auto control_data = ctx.get_control_event<d20::EnergyServices>()) {
             ctx.session_config.supported_energy_transfer_services = *control_data;
         } else if (const auto control_data = ctx.get_control_event<d20::SupportedVASs>()) {

--- a/lib/everest/iso15118/test/iso15118/states/dc_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/test/iso15118/states/dc_charge_parameter_discovery.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <iso15118/detail/d20/state/dc_charge_parameter_discovery.hpp>
@@ -455,4 +456,122 @@ SCENARIO("DC charge parameter discovery state handling") {
     // GIVEN("Bad Case - Performance Timeout") {} // TODO(sl): not here
 
     // GIVEN("Bad Case - Sequence Timeout") {} // TODO(sl): not here
+}
+
+SCENARIO("DC charge parameter compatibility check") {
+    d20::DcTransferLimits powersupply_limits;
+    powersupply_limits.charge_limits.power.max = dt::from_float(300000.f);
+    powersupply_limits.charge_limits.power.min = dt::from_float(100000.f);
+    powersupply_limits.charge_limits.current.max = dt::from_float(500.f);
+    powersupply_limits.charge_limits.current.min = dt::from_float(5.f);
+    powersupply_limits.voltage.max = dt::from_float(1000.f);
+    powersupply_limits.voltage.min = dt::from_float(10.f);
+
+    d20::DcTransferLimits checked_limits;
+    std::variant<DC_ModeReq, BPT_DC_ModeReq> ev_limits;
+    auto& ev_mode = ev_limits.emplace<DC_ModeReq>();
+    ev_mode.max_charge_power = dt::from_float(0.f);
+    ev_mode.max_charge_current = dt::from_float(100.f);
+    ev_mode.max_voltage = dt::from_float(400.f);
+
+    GIVEN("Good Case: EV sends max power as 0 and EVSE min power is below fallback") {
+        const auto compatible = d20::state::handle_compatibility_check(powersupply_limits, ev_limits, checked_limits);
+
+        THEN("Compatibility check passes and max power is clamped to fallback (200 kW)") {
+            REQUIRE(compatible == true);
+            REQUIRE(dt::from_RationalNumber(checked_limits.charge_limits.power.max) == Catch::Approx(200000.f));
+        }
+    }
+
+    GIVEN("Bad Case: EV sends max power as 0 and EVSE min power is above fallback") {
+        powersupply_limits.charge_limits.power.min = dt::from_float(210000.f);
+
+        const auto compatible = d20::state::handle_compatibility_check(powersupply_limits, ev_limits, checked_limits);
+
+        THEN("Compatibility check fails because EVSE min power exceeds fallback") {
+            REQUIRE(compatible == false);
+        }
+    }
+
+    GIVEN(
+        "Good Case: EV sends max power as 0 and max current * max voltage is above fallback and above EVSE max power") {
+        ev_mode.max_charge_power = dt::from_float(0.f);
+        ev_mode.max_charge_current = dt::from_float(1000.f);
+        ev_mode.max_voltage = dt::from_float(400.f);
+
+        const auto compatible = d20::state::handle_compatibility_check(powersupply_limits, ev_limits, checked_limits);
+
+        THEN("Compatibility check passes and max power is clamped to fallback (300 kW)") {
+            REQUIRE(compatible == true);
+            REQUIRE(dt::from_RationalNumber(checked_limits.charge_limits.power.max) == Catch::Approx(300000.f));
+        }
+    }
+
+    GIVEN("Good Case: EV max voltage <= 500 V and EVSE max voltage is clamped to EV max + 50 V") {
+        powersupply_limits.voltage.max = dt::from_float(900.f);
+        ev_mode.max_voltage = dt::from_float(400.f);
+        ev_mode.max_charge_current = dt::from_float(300.f);
+        ev_mode.max_charge_power = dt::from_float(250000.f);
+
+        const auto compatible = d20::state::handle_compatibility_check(powersupply_limits, ev_limits, checked_limits);
+
+        THEN("Compatibility check passes and max voltage is clamped to 450 V") {
+            REQUIRE(compatible == true);
+            REQUIRE(dt::from_RationalNumber(checked_limits.voltage.max) == Catch::Approx(450.f));
+        }
+    }
+
+    GIVEN("Good Case: EV max voltage > 500 V and EVSE max voltage is clamped to 1.1 * EV max voltage") {
+        powersupply_limits.voltage.max = dt::from_float(1000.f);
+        ev_mode.max_voltage = dt::from_float(700.f);
+        ev_mode.max_charge_current = dt::from_float(300.f);
+        ev_mode.max_charge_power = dt::from_float(250000.f);
+
+        const auto compatible = d20::state::handle_compatibility_check(powersupply_limits, ev_limits, checked_limits);
+
+        THEN("Compatibility check passes and max voltage is clamped to 770 V") {
+            REQUIRE(compatible == true);
+            REQUIRE(dt::from_RationalNumber(checked_limits.voltage.max) == Catch::Approx(770.f));
+        }
+    }
+
+    GIVEN("Good Case: EVSE max current is above EV max current") {
+        powersupply_limits.charge_limits.current.max = dt::from_float(500.f);
+        ev_mode.max_charge_current = dt::from_float(125.f);
+        ev_mode.max_voltage = dt::from_float(700.f);
+        ev_mode.max_charge_power = dt::from_float(250000.f);
+
+        const auto compatible = d20::state::handle_compatibility_check(powersupply_limits, ev_limits, checked_limits);
+
+        THEN("Compatibility check passes and max current is clamped to EV max current") {
+            REQUIRE(compatible == true);
+            REQUIRE(dt::from_RationalNumber(checked_limits.charge_limits.current.max) == Catch::Approx(125.f));
+        }
+    }
+
+    GIVEN("Bad Case: EVSE min voltage is greater than or equal to EV max voltage") {
+        powersupply_limits.voltage.min = dt::from_float(400.f);
+        ev_mode.max_voltage = dt::from_float(400.f);
+        ev_mode.max_charge_current = dt::from_float(300.f);
+        ev_mode.max_charge_power = dt::from_float(250000.f);
+
+        const auto compatible = d20::state::handle_compatibility_check(powersupply_limits, ev_limits, checked_limits);
+
+        THEN("Compatibility check fails") {
+            REQUIRE(compatible == false);
+        }
+    }
+
+    GIVEN("Bad Case: EVSE min current is greater than or equal to EV max current") {
+        powersupply_limits.charge_limits.current.min = dt::from_float(100.f);
+        ev_mode.max_charge_current = dt::from_float(100.f);
+        ev_mode.max_voltage = dt::from_float(700.f);
+        ev_mode.max_charge_power = dt::from_float(250000.f);
+
+        const auto compatible = d20::state::handle_compatibility_check(powersupply_limits, ev_limits, checked_limits);
+
+        THEN("Compatibility check fails") {
+            REQUIRE(compatible == false);
+        }
+    }
 }


### PR DESCRIPTION
## Describe your changes

This PR adds a DC ChargeParameterDiscovery compatibility check for ISO 15118-20 (aligned with IEC 61851-23  CC.5.6) and ensures negotiated DC limits are not loosened by later external limit updates.

Note: As an initial step, this solution is implemented inside `iso15118` only. The adapted limits after compatibility check the are currently not propagated to other modules by design. This is considered acceptable for now, because EV-side limits should already ensure that requested target setpoints stay within the allowed range.

This PR is based on the [PR that was already opened in the libiso libay repository](https://github.com/EVerest/libiso15118/pull/164) and was closed due to the mono-repo conversion.

Changes:

- Added compatibility validation in DC_ChargeParameterDiscovery for EV/EVSE limits (voltage/current/power).
- Added adaptation of EVSE limits returned to the EV when stricter bounds are required.
- Added fallback handling for EV max power == 0 in min-power validation.
- Persisted adapted DC limits in session context for subsequent states.
- Added locking/clamping of external DcTransferLimits updates to negotiated bounds.
- Added unit tests for compatibility-check behavior in dc_charge_parameter_discovery.

## Issue ticket number and link
--
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements
