### PR TITLE
Fix/InfyPower_BEG1K075G: publish negative current in import mode

### DIFF
--- a/modules/HardwareDrivers/PowerSupplies/InfyPower_BEG1K075G/main/power_supply_DCImpl.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower_BEG1K075G/main/power_supply_DCImpl.cpp
@@ -28,6 +28,11 @@ void power_supply_DCImpl::init() {
 
     mod->acdc.signalVoltageCurrent.connect([this](float voltage, float current) {
         types::power_supply_DC::VoltageCurrent vc;
+        if (last_publish_mode == types::power_supply_DC::Mode::Import) {
+            // According to ISO 15118-20 V2G20-1034 / V2G20-1035,
+            // negative current indicates EV -> EVSE power transfer (discharging).
+            current = -current;
+        }
         vc.current_A = current;
         vc.voltage_V = voltage;
         publish_voltage_current(vc);

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower_BEG1K075G/main/power_supply_DCImpl.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower_BEG1K075G/main/power_supply_DCImpl.cpp
@@ -2,9 +2,28 @@
 // Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
 
 #include "power_supply_DCImpl.hpp"
+#include <cmath>
 
 namespace module {
 namespace main {
+
+namespace {
+constexpr double voltage_log_threshold_v = 0.5;
+constexpr double current_log_threshold_a = 0.2;
+
+bool should_log_setpoint(std::optional<double>& last_voltage, std::optional<double>& last_current, double voltage,
+                         double current) {
+    if (!last_voltage.has_value() || !last_current.has_value() ||
+        std::abs(voltage - *last_voltage) >= voltage_log_threshold_v ||
+        std::abs(current - *last_current) >= current_log_threshold_a) {
+        last_voltage = voltage;
+        last_current = current;
+        return true;
+    }
+
+    return false;
+}
+} // namespace
 
 void power_supply_DCImpl::init() {
     caps.bidirectional = true;
@@ -75,6 +94,13 @@ void power_supply_DCImpl::handle_setMode(types::power_supply_DC::Mode& mode,
                                          types::power_supply_DC::ChargingPhase& phase) {
     std::scoped_lock lock(settings_mutex);
 
+    if (mode != last_publish_mode) {
+        last_logged_export_voltage.reset();
+        last_logged_export_current.reset();
+        last_logged_import_voltage.reset();
+        last_logged_import_current.reset();
+    }
+
     if (mode == types::power_supply_DC::Mode::Off) {
         mod->acdc.switch_on_off(false);
         mod->acdc.set_inverter_mode(false);
@@ -107,7 +133,10 @@ void power_supply_DCImpl::handle_setExportVoltageCurrent(double& voltage, double
     exportVoltage = voltage;
     exportCurrentLimit = current;
 
-    EVLOG_info << "Updating voltage/current via CAN: " << exportVoltage << "V / " << exportCurrentLimit << "A";
+    if (should_log_setpoint(this->last_logged_export_voltage, this->last_logged_export_current, exportVoltage,
+                            exportCurrentLimit)) {
+        EVLOG_info << "Updating voltage/current via CAN: " << exportVoltage << "V / " << exportCurrentLimit << "A";
+    }
     mod->acdc.set_voltage_current(exportVoltage, exportCurrentLimit);
 };
 
@@ -129,7 +158,11 @@ void power_supply_DCImpl::handle_setImportVoltageCurrent(double& voltage, double
         minImportVoltage = voltage;
         importCurrentLimit = current;
 
-        EVLOG_info << "Updating voltage/current via CAN: " << minImportVoltage << "V / " << importCurrentLimit << "A";
+        if (should_log_setpoint(this->last_logged_import_voltage, this->last_logged_import_current, minImportVoltage,
+                                importCurrentLimit)) {
+            EVLOG_info << "Updating voltage/current via CAN: " << minImportVoltage << "V / " << importCurrentLimit
+                       << "A";
+        }
         mod->acdc.set_voltage_current(minImportVoltage, importCurrentLimit);
     }
 }

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower_BEG1K075G/main/power_supply_DCImpl.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower_BEG1K075G/main/power_supply_DCImpl.cpp
@@ -3,6 +3,7 @@
 
 #include "power_supply_DCImpl.hpp"
 #include <cmath>
+#include <iomanip>
 
 namespace module {
 namespace main {
@@ -135,7 +136,8 @@ void power_supply_DCImpl::handle_setExportVoltageCurrent(double& voltage, double
 
     if (should_log_setpoint(this->last_logged_export_voltage, this->last_logged_export_current, exportVoltage,
                             exportCurrentLimit)) {
-        EVLOG_info << "Updating voltage/current via CAN: " << exportVoltage << "V / " << exportCurrentLimit << "A";
+        EVLOG_info << std::fixed << std::setprecision(2) << "Updating voltage/current via CAN: " << exportVoltage
+                   << "V / " << exportCurrentLimit << "A";
     }
     mod->acdc.set_voltage_current(exportVoltage, exportCurrentLimit);
 };
@@ -160,8 +162,8 @@ void power_supply_DCImpl::handle_setImportVoltageCurrent(double& voltage, double
 
         if (should_log_setpoint(this->last_logged_import_voltage, this->last_logged_import_current, minImportVoltage,
                                 importCurrentLimit)) {
-            EVLOG_info << "Updating voltage/current via CAN: " << minImportVoltage << "V / " << importCurrentLimit
-                       << "A";
+            EVLOG_info << std::fixed << std::setprecision(2) << "Updating voltage/current via CAN: " << minImportVoltage
+                       << "V / " << importCurrentLimit << "A";
         }
         mod->acdc.set_voltage_current(minImportVoltage, importCurrentLimit);
     }

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower_BEG1K075G/main/power_supply_DCImpl.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower_BEG1K075G/main/power_supply_DCImpl.hpp
@@ -14,6 +14,7 @@
 
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 // insert your custom include headers here
+#include <optional>
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 
 namespace module {
@@ -59,6 +60,10 @@ private:
     types::power_supply_DC::Capabilities caps;
 
     types::power_supply_DC::Mode last_publish_mode{types::power_supply_DC::Mode::Off};
+    std::optional<double> last_logged_export_voltage;
+    std::optional<double> last_logged_export_current;
+    std::optional<double> last_logged_import_voltage;
+    std::optional<double> last_logged_import_current;
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 


### PR DESCRIPTION
## Describe your changes

This PR contains three changes in InfyPower_BEG1K075G:

Import mode feedback now publishes negative current values.
According to ISO 15118-20 V2G20-1034 / V2G20-1035, positive values for W, Wh and A represent power transfer from EVSE to EV, while negative values represent power transfer from EV to EVSE. A short code comment was added at the sign conversion to document this requirement.

EVLOG_info output for import/export setpoints is now rate-limited and limited the number of decimal places of the log message.
handle_setExportVoltageCurrent() and handle_setImportVoltageCurrent() only log when the requested setpoints change significantly. This reduces log noise during repeated updates with nearly identical voltage/current values.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

