### PR TITLE
fix(evse_security): use case-insensitive hash comparison for leaf certificate deletion

### DIFF
--- a/lib/everest/evse_security/include/evse_security/certificate/x509_hierarchy.hpp
+++ b/lib/everest/evse_security/include/evse_security/certificate/x509_hierarchy.hpp
@@ -78,7 +78,8 @@ public:
 
     /// @brief Searches for all the certificates with the provided hash, throwing a NoCertificateFound
     // if none were found. Can be useful when we have SUB-CAs in multiple bundles
-    std::vector<X509Wrapper> find_certificates_multi(const CertificateHashData& hash);
+    std::vector<X509Wrapper> find_certificates_multi(const CertificateHashData& hash,
+                                                     bool case_insensitive_comparison = false);
 
     std::string to_debug_string();
 

--- a/lib/everest/evse_security/lib/evse_security/certificate/x509_hierarchy.cpp
+++ b/lib/everest/evse_security/lib/evse_security/certificate/x509_hierarchy.cpp
@@ -188,12 +188,23 @@ std::optional<X509Wrapper> X509CertificateHierarchy::find_certificate(const Cert
     return std::nullopt;
 }
 
-std::vector<X509Wrapper> X509CertificateHierarchy::find_certificates_multi(const CertificateHashData& hash) {
+std::vector<X509Wrapper> X509CertificateHierarchy::find_certificates_multi(const CertificateHashData& hash,
+                                                                           bool case_insensitive_comparison) {
     std::vector<X509Wrapper> certificates;
 
     for_each([&](X509Node& node) {
-        if (node.hash == hash) {
-            certificates.push_back(node.certificate);
+        if (node.hash.has_value()) {
+            bool matches = false;
+
+            if (case_insensitive_comparison) {
+                matches = node.hash.value().case_insensitive_comparison(hash);
+            } else {
+                matches = (node.hash.value() == hash);
+            }
+
+            if (matches) {
+                certificates.push_back(node.certificate);
+            }
         }
 
         return true;

--- a/lib/everest/evse_security/lib/evse_security/evse_security.cpp
+++ b/lib/everest/evse_security/lib/evse_security/evse_security.cpp
@@ -412,7 +412,7 @@ InstallCertificateResult EvseSecurity::install_ca_certificate(const std::string&
 DeleteResult EvseSecurity::delete_certificate(const CertificateHashData& certificate_hash_data) {
     const std::lock_guard<std::mutex> guard(EvseSecurity::security_mutex);
 
-    EVLOG_info << "Deleteing certificate: " << certificate_hash_data.serial_number;
+    EVLOG_info << "Deleting certificate: " << certificate_hash_data.serial_number;
 
     DeleteResult response;
     response.result = DeleteCertificateResult::NotFound;
@@ -512,7 +512,7 @@ DeleteResult EvseSecurity::delete_certificate(const CertificateHashData& certifi
             std::move(X509CertificateHierarchy::build_hierarchy(base_roots, leaf_bundle.split()));
 
         // Collect all the leafs that we have to delete
-        auto leafs_to_delete = hierarchy.find_certificates_multi(certificate_hash_data);
+        auto leafs_to_delete = hierarchy.find_certificates_multi(certificate_hash_data, true);
 
         leaf_bundle.for_each_chain([&](const fs::path& path, const std::vector<X509Wrapper>& chain) {
             // If any chain element is contained in the leafs to delete, then delete the whole chain
@@ -1092,7 +1092,8 @@ void EvseSecurity::update_ocsp_cache(const CertificateHashData& certificate_hash
         // If we already have the hash, over-write, else create a new one
         try {
             // Find the certificates, can me multiple if we have SUBcas in multiple bundles
-            const std::vector<X509Wrapper> certs = certificate_hierarchy.find_certificates_multi(certificate_hash_data);
+            const std::vector<X509Wrapper> certs =
+                certificate_hierarchy.find_certificates_multi(certificate_hash_data, true);
 
             for (auto& cert : certs) {
                 EVLOG_debug << "Writing OCSP Response to filesystem";

--- a/lib/everest/evse_security/tests/tests.cpp
+++ b/lib/everest/evse_security/tests/tests.cpp
@@ -675,6 +675,30 @@ TEST_F(EvseSecurityTestsCSMS, delete_csms_provided_certs) {
     ASSERT_EQ(cached_secc_chain, read_file_to_string("csms_certs_temp/client/CPO_CERT_SECC_LEAF_CHAIN_A.pem"));
 }
 
+TEST_F(EvseSecurityTestsCSMS, delete_leaf_case_insensitive_hash) {
+    // Verify that delete_certificate matches leaf certificate hashes case-insensitively.
+    // The stored hashes are lowercase hex; using uppercase hex should still find and
+    // delete the leaf certificate. Relates to issue #2027.
+
+    ASSERT_TRUE(fs::exists("csms_certs_temp/client/SECC_LEAF_B.pem"));
+    ASSERT_TRUE(fs::exists("csms_certs_temp/client/SECC_LEAF_B.key"));
+
+    // Same hash data as delete_csms_provided_certs but with uppercase hex values
+    CertificateHashData certificate_hash_data;
+    certificate_hash_data.hash_algorithm = HashAlgorithm::SHA256;
+    certificate_hash_data.issuer_name_hash = "82ADDB4B47026C702B9ED9D482C6E3570BBAE9C49B963EC18B0A3523DFB47FE3";
+    certificate_hash_data.issuer_key_hash = "E9D2A6D245233EDBF5A8319B99087313E16307CA29B388373D951B50E93090AA";
+    certificate_hash_data.serial_number = "4ED698D63C724C6A61A0CCC4FF80B383192DFD7A";
+
+    DeleteResult result = this->evse_security->delete_certificate(certificate_hash_data);
+    ASSERT_EQ(result.result, DeleteCertificateResult::Accepted);
+    ASSERT_TRUE(result.leaf_certificate_type.has_value());
+    ASSERT_EQ(result.leaf_certificate_type.value(), LeafCertificateType::V2G);
+
+    ASSERT_FALSE(fs::exists("csms_certs_temp/client/SECC_LEAF_B.pem"));
+    ASSERT_FALSE(fs::exists("csms_certs_temp/client/SECC_LEAF_B.key"));
+}
+
 TEST_F(EvseSecurityTests, delete_root_ca_01) {
     std::vector<CertificateType> certificate_types;
     certificate_types.push_back(CertificateType::V2GRootCertificate);


### PR DESCRIPTION
The `find_certificates_multi` function used case-sensitive hash comparison (operator==)
while `find_certificate` and `delete_certificate` for root CAs already supported
case-insensitive matching. This meant DeleteCertificate requests with uppercase hex
hashes would succeed for root certificates but silently fail for leaf certificates.

I've added a `case_insensitive_comparison` parameter to `find_certificates_multi`
(matching the existing pattern in `find_certificate` and `contains_certificate_hash`)
and enabled it in the `delete_certificate` and `update_ocsp_cache` call sites.

Also fixed a small typo in the log message ("Deleteing" → "Deleting").

Added a test that uses uppercase hex hashes to verify leaf deletion still works.

Fixes #2027