### PR TITLE
fix(ocpp): remove printability check from isHexNotation for AuthorizationKey

### DIFF
--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_base.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_base.cpp
@@ -416,30 +416,24 @@ std::string ChargePointConfigurationBase::hexToString(const std::string& s) {
 }
 
 bool ChargePointConfigurationBase::isHexNotation(const std::string& s) {
-    // TODO(james-ctc): this check is problematic
-    // need to identify what is considered valid
-    // e.g. what can the first two characters be?
-    // why are they not ignored in hexToString()?
-    // the size should be a multiple of 2 …
+    // Per OCPP 1.6 spec errata E05, AuthorizationKey values SHALL be represented
+    // as hexadecimal notation. A valid hex string must have even length (each byte
+    // is two hex digits) and contain only hex characters.
     //
-    // consider combining isHexNotation and hexToString to avoid reparsing
-    // the string
+    // The previous implementation had two problems:
+    // 1. It skipped the first 2 characters in the hex-validity check (offset 2 in
+    //    find_first_not_of), allowing non-hex chars at positions 0-1.
+    // 2. It checked whether every decoded byte was a printable ASCII character.
+    //    This caused identical hex-format strings to be treated differently based
+    //    on whether their decoded bytes happened to be printable, leading to
+    //    authentication failures with spec-compliant CSMSes.
+    //    See: https://github.com/EVerest/everest-core/issues/2034
 
-    bool result = s.size() > 2 and s.find_first_not_of("0123456789abcdefABCDEF", 2) == std::string::npos;
-    if (result) {
-        // check if every char is printable
-        for (size_t i = 0; i < s.length(); i += 2) {
-            std::string byte = s.substr(i, 2);
-            char chr = (char)(int)strtol(byte.c_str(), NULL, 16);
-            // ignoring check for \n (0x0a) because find_first_not_of() has not
-            // found one
-            if (!std::isprint(chr)) {
-                result = false;
-                break;
-            }
-        }
+    if (s.size() < 2 || s.size() % 2 != 0) {
+        return false;
     }
-    return result;
+
+    return s.find_first_not_of("0123456789abcdefABCDEF") == std::string::npos;
 }
 
 } // namespace ocpp::v16

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_security.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_security.cpp
@@ -72,6 +72,35 @@ TEST_P(Configuration, AuthorizationKey) {
     EXPECT_FALSE(kv.value().readonly);
 }
 
+TEST_P(Configuration, AuthorizationKeyHexDecoded) {
+    // Per OCPP 1.6 spec errata E05, AuthorizationKey SHALL be hex-encoded.
+    // Hex strings (even length, all hex chars) must be decoded consistently
+    // regardless of whether the decoded bytes are printable.
+    // See: https://github.com/EVerest/everest-core/issues/2034
+
+    ASSERT_NE(get(), nullptr);
+
+    // "746869735f69735f615f70617373776f72645f21" decodes to "this_is_a_password_!"
+    // All decoded bytes are printable ASCII.
+    get()->setAuthorizationKey("746869735f69735f615f70617373776f72645f21");
+    EXPECT_EQ(get()->getAuthorizationKey(), "this_is_a_password_!");
+
+    // "746869735f69735f615f70617373776f72645f01" decodes to "this_is_a_password_\x01"
+    // The last byte (0x01) is non-printable. The old isHexNotation() rejected this
+    // due to the printability check, storing the raw hex string instead of decoding.
+    // Both keys use the same hex format and must be handled identically.
+    std::string expected = std::string("this_is_a_password_") + '\x01';
+    get()->setAuthorizationKey("746869735f69735f615f70617373776f72645f01");
+    EXPECT_EQ(get()->getAuthorizationKey(), expected);
+}
+
+TEST_P(Configuration, AuthorizationKeyOddLengthNotHex) {
+    // A string with odd length cannot be valid hex notation (each byte needs 2 chars)
+    ASSERT_NE(get(), nullptr);
+    get()->setAuthorizationKey("abcdef123");
+    EXPECT_EQ(get()->getAuthorizationKey(), "abcdef123");
+}
+
 TEST_P(Configuration, CpoName) {
     ASSERT_NE(get(), nullptr);
     // initial values are from the JSON unit test config files


### PR DESCRIPTION
## Describe your changes

Fixes #2034

The `isHexNotation()` function used for AuthorizationKey processing had two bugs:

1. **Skipped first 2 characters in hex validation**: The call to `find_first_not_of("0123456789abcdefABCDEF", 2)` started checking at offset 2, allowing arbitrary non-hex characters at positions 0-1. This meant a string like `"XX0123456789abcdef"` would incorrectly pass validation.

2. **Printability check caused inconsistent hex decoding**: After validating hex characters, the function decoded each byte pair and checked `std::isprint()`. If any decoded byte was non-printable, the string was rejected as "not hex" and stored as-is. This means two identically formatted hex strings could be treated differently depending on whether their decoded bytes happened to be printable ASCII — leading to authentication failures with spec-compliant CSMSes that send hex-encoded keys per OCPP 1.6 errata E05.

The fix simplifies `isHexNotation()` to only check what matters: even length (>= 2) and all hex characters. The printability of decoded bytes is irrelevant to whether a string is valid hex notation.

I also updated the existing AuthorizationKey test to use a non-hex key (since the old test key happened to be all-hex and relied on the broken printability behavior), and added two new test cases:
- `AuthorizationKeyHexDecoded`: verifies consistent decoding for both printable and non-printable decoded bytes
- `AuthorizationKeyOddLengthNotHex`: verifies odd-length all-hex strings are correctly rejected

## Issue ticket number and link

Closes #2034

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements