### PR TITLE
conformance: add handing of charge params in accordance with v2g2-477

### DIFF
--- a/lib/everest/cbv2g/include/cbv2g/iso_2/iso2_msgDefDatatypes.h
+++ b/lib/everest/cbv2g/include/cbv2g/iso_2/iso2_msgDefDatatypes.h
@@ -28,6 +28,7 @@ extern "C" {
 
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "cbv2g/common/exi_basetypes.h"
 
@@ -575,6 +576,128 @@ struct iso2_PhysicalValueType {
     int16_t Value;
 
 };
+
+// Enum for PhysicalValueType element names from ISO 15118-2 Table 68
+ typedef enum
+ {
+    iso2_ChargingProfileEntryMaxPower,
+    iso2_EAmount,
+    iso2_EVEnergyCapacity,
+    iso2_EVEnergyRequest,
+    iso2_EVMaxCurrent,
+    iso2_EVMaximumCurrentLimit,
+    iso2_EVMaximumPowerLimit,
+    iso2_EVMaximumVoltageLimit,
+    iso2_EVMaxVoltage,
+    iso2_EVMinCurrent,
+    iso2_EVSECurrentRegulationTolerance,
+    iso2_EVSEEnergyToBeDelivered,
+    iso2_EVSEMaxCurrent,
+    iso2_EVSEMaximumCurrentLimit,
+    iso2_EVSEMaximumPowerLimit,
+    iso2_EVSEMaximumVoltageLimit,
+    iso2_EVSENominalVoltage,
+    iso2_EVSEMinimumCurrentLimit,
+    iso2_EVSEMinimumVoltageLimit,
+    iso2_EVSEPeakCurrentRipple,
+    iso2_EVSEPresentCurrent,
+    iso2_EVSEPresentVoltage,
+    iso2_EVTargetCurrent,
+    iso2_EVTargetVoltage,
+    iso2_PMax,
+    iso2_RemainingTimeToBulkSoC,
+    iso2_RemainingTimeToFullSoC,
+    iso2_StartValue,
+    // Sentinel value
+    iso2_PhysicalValueElementCount
+} iso2_PhysicalValueElement;
+
+inline const char *iso2_PhysicalValueElementToString(iso2_PhysicalValueElement element)
+{
+    static const char *const strings[iso2_PhysicalValueElementCount] = {
+        [iso2_ChargingProfileEntryMaxPower]   = "ChargingProfileEntryMaxPower",
+        [iso2_EAmount]                        = "EAmount",
+        [iso2_EVEnergyCapacity]               = "EVEnergyCapacity",
+        [iso2_EVEnergyRequest]                = "EVEnergyRequest",
+        [iso2_EVMaxCurrent]                   = "EVMaxCurrent",
+        [iso2_EVMaximumCurrentLimit]          = "EVMaximumCurrentLimit",
+        [iso2_EVMaximumPowerLimit]            = "EVMaximumPowerLimit",
+        [iso2_EVMaximumVoltageLimit]          = "EVMaximumVoltageLimit",
+        [iso2_EVMaxVoltage]                   = "EVMaxVoltage",
+        [iso2_EVMinCurrent]                   = "EVMinCurrent",
+        [iso2_EVSECurrentRegulationTolerance] = "EVSECurrentRegulationTolerance",
+        [iso2_EVSEEnergyToBeDelivered]        = "EVSEEnergyToBeDelivered",
+        [iso2_EVSEMaxCurrent]                 = "EVSEMaxCurrent",
+        [iso2_EVSEMaximumCurrentLimit]        = "EVSEMaximumCurrentLimit",
+        [iso2_EVSEMaximumPowerLimit]          = "EVSEMaximumPowerLimit",
+        [iso2_EVSEMaximumVoltageLimit]        = "EVSEMaximumVoltageLimit",
+        [iso2_EVSENominalVoltage]             = "EVSENominalVoltage",
+        [iso2_EVSEMinimumCurrentLimit]        = "EVSEMinimumCurrentLimit",
+        [iso2_EVSEMinimumVoltageLimit]        = "EVSEMinimumVoltageLimit",
+        [iso2_EVSEPeakCurrentRipple]          = "EVSEPeakCurrentRipple",
+        [iso2_EVSEPresentCurrent]             = "EVSEPresentCurrent",
+        [iso2_EVSEPresentVoltage]             = "EVSEPresentVoltage",
+        [iso2_EVTargetCurrent]                = "EVTargetCurrent",
+        [iso2_EVTargetVoltage]                = "EVTargetVoltage",
+        [iso2_PMax]                           = "PMax",
+        [iso2_RemainingTimeToBulkSoC]         = "RemainingTimeToBulkSoC",
+        [iso2_RemainingTimeToFullSoC]         = "RemainingTimeToFullSoC",
+        [iso2_StartValue]                     = "StartValue",
+    };
+
+    if (element < 0 || element >= iso2_PhysicalValueElementCount)
+    {
+        return "Unknown";
+    }
+
+    return strings[element];
+}
+
+struct iso2_PhysicalValueRange {
+    int16_t min;
+    int32_t max;
+};
+
+// Table 68 — Value range and unit definition for message elements using PhysicalValueType
+// ISO 15118-2:2014(E)
+static const struct iso2_PhysicalValueRange kPhysicalValueTypeRanges[] = {
+    {.min = 0,.max = 200000},  // ChargingProfileEntryMaxPower
+    {.min = 0,.max = 200000},  // EAmount
+    {.min = 0,.max = 200000},  // EVEnergyCapacity
+    {.min = 0,.max = 200000},  // EVEnergyRequest
+    {.min = 0,.max = 400},     // EVMaxCurrent
+    {.min = 0,.max = 400},     // EVMaximumCurrentLimit
+    {.min = 0,.max = 200000},  // EVMaximumPowerLimit
+    {.min = 0,.max = 1000},    // EVMaximumVoltageLimit
+    {.min = 0,.max = 1000},    // EVMaxVoltage
+    {.min = 0,.max = 400},     // EVMinCurrent
+    {.min = 0,.max = 400},     // EVSECurrentRegulationTolerance
+    {.min = 0,.max = 200000},  // EVSEEnergyToBeDelivered
+    {.min = 0,.max = 400},     // EVSEMaxCurrent
+    {.min = 0,.max = 400},     // EVSEMaximumCurrentLimit
+    {.min = 0,.max = 200000},  // EVSEMaximumPowerLimit
+    {.min = 0,.max = 1000},    // EVSEMaximumVoltageLimit
+    {.min = 0,.max = 1000},    // EVSENominalVoltage
+    {.min = 0,.max = 400},     // EVSEMinimumCurrentLimit
+    {.min = 0,.max = 1000},    // EVSEMinimumVoltageLimit
+    {.min = 0,.max = 400},     // EVSEPeakCurrentRipple
+    {.min = 0,.max = 400},     // EVSEPresentCurrent
+    {.min = 0,.max = 1000},    // EVSEPresentVoltage
+    {.min = 0,.max = 400},     // EVTargetCurrent
+    {.min = 0,.max = 1000},    // EVTargetVoltage
+    {.min = 0,.max = 200000},  // PMax
+    {.min = 0,.max = 172800},  // RemainingTimeToBulkSoC
+    {.min = 0,.max = 172800},  // RemainingTimeToFullSoC
+    {.min = 0,.max = 200000},  // StartValue
+};
+
+// Helper function for lookup
+inline const struct iso2_PhysicalValueRange* GetPhysicalValueRange(iso2_PhysicalValueElement element) {
+    if (element < iso2_PhysicalValueElementCount) {
+        return &kPhysicalValueTypeRanges[element];
+    }
+    return NULL;
+}
 
 // Element: definition=complex; name={urn:iso:15118:2:2013:MsgDataTypes}ConsumptionCost; type={urn:iso:15118:2:2013:MsgDataTypes}ConsumptionCostType; base type=; content type=ELEMENT-ONLY;
 //          abstract=False; final=False;

--- a/modules/EVSE/EvseV2G/iso_server.cpp
+++ b/modules/EVSE/EvseV2G/iso_server.cpp
@@ -1265,6 +1265,13 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
     int64_t pmax{0};
 
     if (conn->ctx->is_dc_charger == false) {
+        // check all values defined in AC_EVChargeParameterType
+        if (!IsPhysicalValueValid(iso2_EAmount, &req->AC_EVChargeParameter.EAmount) ||
+            !IsPhysicalValueValid(iso2_EVMaxVoltage, &req->AC_EVChargeParameter.EVMaxVoltage) ||
+            !IsPhysicalValueValid(iso2_EVMaxCurrent, &req->AC_EVChargeParameter.EVMaxCurrent) ||
+            !IsPhysicalValueValid(iso2_EVMinCurrent, &req->AC_EVChargeParameter.EVMinCurrent)) {
+                res->ResponseCode = iso2_responseCodeType_FAILED_WrongChargeParameter; // [V2G2-477]
+            }
         /* Determin max current and nominal voltage */
         /* Setup default params (before the departure time overrides) */
         float max_current = conn->ctx->basic_config.evse_ac_nominal_current;

--- a/modules/EVSE/EvseV2G/tools.cpp
+++ b/modules/EVSE/EvseV2G/tools.cpp
@@ -242,3 +242,30 @@ void strncpy_to_v2g(char* characters, size_t size_of_characters, uint16_t* chara
 
     *characters_len = len;
 }
+
+PhysicalValueValidationResult ValidatePhysicalValue(iso2_PhysicalValueElement element, const struct iso2_PhysicalValueType* physical_value) {
+
+    const struct iso2_PhysicalValueRange* range = GetPhysicalValueRange(element);
+    if (!range) {
+        dlog(DLOG_LEVEL_ERROR, "Null pointer for element: %s", iso2_PhysicalValueElementToString(element));
+        return InvalidElement;
+    }
+
+    double actual_physical_value = calc_physical_value(physical_value->Value, physical_value->Multiplier);
+
+    if (actual_physical_value < range->min) {
+        dlog(DLOG_LEVEL_ERROR, "%s actual physical value less than minimum: %f, min: %d", iso2_PhysicalValueElementToString(element), actual_physical_value, range->min);
+        return BelowMinimum;
+    }
+
+    if (actual_physical_value > range->max) {
+        dlog(DLOG_LEVEL_ERROR, "%s actual physical value more than max: %f, max: %d", iso2_PhysicalValueElementToString(element), actual_physical_value, range->max);
+        return AboveMaximum;
+    }
+
+    return Valid;
+}
+
+bool IsPhysicalValueValid( iso2_PhysicalValueElement element, const struct iso2_PhysicalValueType* physical_value) {
+    return ValidatePhysicalValue(element, physical_value) == Valid;
+}

--- a/modules/EVSE/EvseV2G/tools.hpp
+++ b/modules/EVSE/EvseV2G/tools.hpp
@@ -15,6 +15,7 @@
 #include <sys/time.h>
 #include <time.h>
 #include <vector>
+#include <cbv2g/iso_2/iso2_msgDefDatatypes.h>
 
 #define MAX_FILE_NAME_LENGTH 100
 #define MAX_PKI_CA_LENGTH    4 /* leaf up to root certificate */
@@ -89,5 +90,28 @@ std::string to_mac_address_str(const uint8_t* ptr, size_t len);
  * \param src The source string to use.
  */
 void strncpy_to_v2g(char* characters, size_t size_of_characters, uint16_t* characters_len, const std::string& src);
+
+ // An enum used for checking if the physical value is within spec
+typedef enum {
+    Valid,
+    BelowMinimum,
+    AboveMaximum,
+    InvalidElement
+} PhysicalValueValidationResult;
+
+/** 
+ * \brief  Helper function to validate PhysicalValueType against Table 68 iso-2 ranges
+ * \param element physical value element from Table 68 iso-2
+ * \param physical_value value struct 
+ * \return PhysicalValueValidationResult
+ */
+PhysicalValueValidationResult ValidatePhysicalValue(iso2_PhysicalValueElement element, const struct iso2_PhysicalValueType* physical_value);
+/**
+ * \brief Convenience function that returns true if valid, false if violates
+ * \param element physical value element from Table 68 iso-2
+ * \param physical_value physical value according to table 67 in iso15118-2
+ * \return bool true - valid, false - not valid
+*/
+bool IsPhysicalValueValid( iso2_PhysicalValueElement element, const struct iso2_PhysicalValueType* physical_value);
 
 #endif /* TOOLS_H */


### PR DESCRIPTION
## Describe your changes

To conform with the conformance test `TC_SECC_AC_VTB_ChargeParameterDiscovery_005` and the requirement `V2G2_477` add checking of `ChargingParameterDiscovery` parameters are within defined range.

Tested using conformance testing equipment running `TC_SECC_AC_VTB_ChargeParameterDiscovery_005`

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #2214 
- <kbd>&nbsp;1&nbsp;</kbd> #2049 👈 
<!-- GitButler Footer Boundary Bottom -->

