### PR TITLE
fix(tls): StatusFlags get/set correct flag enum for trusted_ca_keys extension

### DIFF
--- a/lib/everest/tls/include/everest/tls/tls_types.hpp
+++ b/lib/everest/tls/include/everest/tls/tls_types.hpp
@@ -36,7 +36,7 @@ public:
         flags.set(flags_t::status_request_v2);
     }
     void trusted_ca_keys_received() {
-        flags.set(flags_t::status_request_v2);
+        flags.set(flags_t::trusted_ca_keys);
     }
     [[nodiscard]] bool has_status_request() const {
         return flags.is_set(flags_t::status_request);
@@ -45,7 +45,7 @@ public:
         return flags.is_set(flags_t::status_request_v2);
     }
     [[nodiscard]] bool has_trusted_ca_keys() const {
-        return flags.is_set(flags_t::status_request_v2);
+        return flags.is_set(flags_t::trusted_ca_keys);
     }
 };
 


### PR DESCRIPTION
## Describe your changes

Fixes the StatusFlags class to set/get the correct flag enum value for the trusted_ca_keys extension.

## Issue ticket number and link

#2059

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

