### PR TITLE
Integrate profile based allow-write for CustomDisplayCostAndPrice

### DIFF
--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration.hpp
@@ -23,6 +23,7 @@ private:
     json config;
     json custom_schema;
     json internal_schema;
+    json cost_and_price_schema;
     bool core_schema_unlock_connector_on_ev_side_disconnect_ro_value;
     fs::path user_config_path;
 
@@ -475,7 +476,8 @@ public:
 
     // California Pricing Requirements
     bool getCustomDisplayCostAndPriceEnabled() override;
-    KeyValue getCustomDisplayCostAndPriceEnabledKeyValue() override;
+    std::optional<KeyValue> getCustomDisplayCostAndPriceEnabledKeyValue();
+    ConfigurationStatus setCustomDisplayCostAndPrice(const bool& value);
 
     std::optional<std::uint32_t> getPriceNumberOfDecimalsForCostValues() override;
     std::optional<KeyValue> getPriceNumberOfDecimalsForCostValuesKeyValue() override;

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration.hpp
@@ -24,6 +24,7 @@ private:
     json config;
     json custom_schema;
     json internal_schema;
+    json cost_and_price_schema;
     bool core_schema_unlock_connector_on_ev_side_disconnect_ro_value;
     fs::path user_config_path;
 
@@ -489,7 +490,8 @@ public:
 
     // California Pricing Requirements
     bool getCustomDisplayCostAndPriceEnabled() override;
-    KeyValue getCustomDisplayCostAndPriceEnabledKeyValue() override;
+    std::optional<KeyValue> getCustomDisplayCostAndPriceEnabledKeyValue();
+    ConfigurationStatus setCustomDisplayCostAndPrice(const bool& value);
 
     std::optional<std::uint32_t> getPriceNumberOfDecimalsForCostValues() override;
     std::optional<KeyValue> getPriceNumberOfDecimalsForCostValuesKeyValue() override;

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
@@ -464,7 +464,7 @@ public:
     std::optional<std::int32_t> getWaitForSetUserPriceTimeout() override;
     std::optional<std::uint32_t> getPriceNumberOfDecimalsForCostValues() override;
 
-    KeyValue getCustomDisplayCostAndPriceEnabledKeyValue() override;
+    std::optional<KeyValue> getCustomDisplayCostAndPriceEnabledKeyValue() override;
     KeyValue getDefaultPriceTextKeyValue(const std::string& language) override;
 
     std::optional<KeyValue> getCustomIdleFeeAfterStopKeyValue() override;

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
@@ -38,6 +38,7 @@ protected:
     SetResult setInternalCompositeScheduleDefaultLimitWatts(const std::string& value);
     SetResult setInternalCompositeScheduleDefaultNumberPhases(const std::string& value);
     SetResult setInternalConnectorEvseIds(const std::string& value);
+    SetResult setInternalCustomDisplayCostAndPrice(const std::string& value);
     SetResult setInternalIgnoredProfilePurposesOffline(const std::string& value);
     SetResult setInternalOcspRequestInterval(const std::string& value);
     SetResult setInternalRejectRemoteStartTransactionWithoutConnectorId(const std::string& value);

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
@@ -489,7 +489,7 @@ public:
     std::optional<std::int32_t> getWaitForSetUserPriceTimeout() override;
     std::optional<std::uint32_t> getPriceNumberOfDecimalsForCostValues() override;
 
-    KeyValue getCustomDisplayCostAndPriceEnabledKeyValue() override;
+    std::optional<KeyValue> getCustomDisplayCostAndPriceEnabledKeyValue() override;
     KeyValue getDefaultPriceTextKeyValue(const std::string& language) override;
 
     std::optional<KeyValue> getCustomIdleFeeAfterStopKeyValue() override;

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_interface.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_interface.hpp
@@ -384,8 +384,8 @@ public:
     virtual std::optional<std::int32_t> getWaitForSetUserPriceTimeout() = 0;
     virtual std::optional<std::uint32_t> getPriceNumberOfDecimalsForCostValues() = 0;
 
-    virtual KeyValue getCustomDisplayCostAndPriceEnabledKeyValue() = 0;
     virtual KeyValue getDefaultPriceTextKeyValue(const std::string& language) = 0;
+    virtual std::optional<KeyValue> getCustomDisplayCostAndPriceEnabledKeyValue() = 0;
 
     virtual std::optional<KeyValue> getCustomIdleFeeAfterStopKeyValue() = 0;
     virtual std::optional<KeyValue> getCustomMultiLanguageMessagesEnabledKeyValue() = 0;

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_interface.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_interface.hpp
@@ -394,8 +394,8 @@ public:
     virtual std::optional<std::int32_t> getWaitForSetUserPriceTimeout() = 0;
     virtual std::optional<std::uint32_t> getPriceNumberOfDecimalsForCostValues() = 0;
 
-    virtual KeyValue getCustomDisplayCostAndPriceEnabledKeyValue() = 0;
     virtual KeyValue getDefaultPriceTextKeyValue(const std::string& language) = 0;
+    virtual std::optional<KeyValue> getCustomDisplayCostAndPriceEnabledKeyValue() = 0;
 
     virtual std::optional<KeyValue> getCustomIdleFeeAfterStopKeyValue() = 0;
     virtual std::optional<KeyValue> getCustomMultiLanguageMessagesEnabledKeyValue() = 0;

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
@@ -2973,7 +2973,7 @@ bool ChargePointConfiguration::setMeterPublicKey(const std::int32_t connector_id
 }
 
 ConfigurationStatus ChargePointConfiguration::setCustomDisplayCostAndPrice(const bool& value) {
-    auto status = ConfigurationStatus::NotSupported;
+    auto status = ConfigurationStatus::Rejected;
 
     if (!this->cost_and_price_schema["properties"]["CustomDisplayCostAndPrice"]["readOnly"]) {
         this->config["CostAndPrice"]["CustomDisplayCostAndPrice"] = value;

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
@@ -70,6 +70,19 @@ ChargePointConfiguration::ChargePointConfiguration(const std::string& config, co
     }
 
     try {
+        const auto cost_schema_path = schemas_path / "CostAndPrice.json";
+        if (fs::exists(cost_schema_path)) {
+            std::ifstream ifs(cost_schema_path.c_str());
+            std::string cost_schema_file((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
+            const auto cost_schema = json::parse(cost_schema_file);
+            this->cost_and_price_schema = json::parse(cost_schema_file);
+        }
+    } catch (const json::parse_error& e) {
+        EVLOG_error << "Error while parsing CostAndPrice.json file.";
+        EVLOG_AND_THROW(e);
+    }
+
+    try {
         auto patch = schemas.get_validator()->validate(this->config);
         if (patch.is_null()) {
             // no defaults substituted
@@ -2383,13 +2396,17 @@ bool ChargePointConfiguration::getCustomDisplayCostAndPriceEnabled() {
     return false;
 }
 
-KeyValue ChargePointConfiguration::getCustomDisplayCostAndPriceEnabledKeyValue() {
-    const bool enabled = getCustomDisplayCostAndPriceEnabled();
-    KeyValue kv;
-    kv.key = "CustomDisplayCostAndPrice";
-    kv.value = ocpp::conversions::bool_to_string(enabled);
-    kv.readonly = true;
-    return kv;
+std::optional<KeyValue> ChargePointConfiguration::getCustomDisplayCostAndPriceEnabledKeyValue() {
+    if (this->config.contains("CostAndPrice") and this->config["CostAndPrice"].contains("CustomDisplayCostAndPrice")) {
+        const bool enabled = getCustomDisplayCostAndPriceEnabled();
+        KeyValue kv;
+        kv.key = "CustomDisplayCostAndPrice";
+        kv.value = ocpp::conversions::bool_to_string(enabled);
+        kv.readonly = this->cost_and_price_schema["properties"]["CustomDisplayCostAndPrice"]["readOnly"];
+        return kv;
+    }
+
+    return std::nullopt;
 }
 
 std::optional<std::uint32_t> ChargePointConfiguration::getPriceNumberOfDecimalsForCostValues() {
@@ -2953,6 +2970,18 @@ bool ChargePointConfiguration::setMeterPublicKey(const std::int32_t connector_id
 
     this->setInUserConfig("Internal", "MeterPublicKeys", this->config["Internal"]["MeterPublicKeys"]);
     return true;
+}
+
+ConfigurationStatus ChargePointConfiguration::setCustomDisplayCostAndPrice(const bool& value) {
+    auto status = ConfigurationStatus::NotSupported;
+
+    if (!this->cost_and_price_schema["properties"]["CustomDisplayCostAndPrice"]["readOnly"]) {
+        this->config["CostAndPrice"]["CustomDisplayCostAndPrice"] = value;
+        this->setInUserConfig("CostAndPrice", "CustomDisplayCostAndPrice", value);
+        status = ConfigurationStatus::Accepted;
+    }
+
+    return status;
 }
 
 void ChargePointConfiguration::setLanguage(const std::string& language) {
@@ -3980,6 +4009,12 @@ std::optional<ConfigurationStatus> ChargePointConfiguration::set(const CiString<
             this->setAllowChargingProfileWithoutStartSchedule(ocpp::conversions::string_to_bool(value.get()));
         } else {
             return ConfigurationStatus::NotSupported;
+        }
+    } else if (key == "CustomDisplayCostAndPrice") {
+        const ConfigurationStatus result =
+            this->setCustomDisplayCostAndPrice(ocpp::conversions::string_to_bool(value.get()));
+        if (result != ConfigurationStatus::Accepted) {
+            return result;
         }
     } else if (key.get().find("DefaultPriceText") == 0) {
         const ConfigurationStatus result = this->setDefaultPriceText(key, value);

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
@@ -74,7 +74,6 @@ ChargePointConfiguration::ChargePointConfiguration(const std::string& config, co
         if (fs::exists(cost_schema_path)) {
             std::ifstream ifs(cost_schema_path.c_str());
             std::string cost_schema_file((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
-            const auto cost_schema = json::parse(cost_schema_file);
             this->cost_and_price_schema = json::parse(cost_schema_file);
         }
     } catch (const json::parse_error& e) {

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
@@ -71,6 +71,19 @@ ChargePointConfiguration::ChargePointConfiguration(const std::string& config, co
     }
 
     try {
+        const auto cost_schema_path = schemas_path / "CostAndPrice.json";
+        if (fs::exists(cost_schema_path)) {
+            std::ifstream ifs(cost_schema_path.c_str());
+            std::string cost_schema_file((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
+            const auto cost_schema = json::parse(cost_schema_file);
+            this->cost_and_price_schema = json::parse(cost_schema_file);
+        }
+    } catch (const json::parse_error& e) {
+        EVLOG_error << "Error while parsing CostAndPrice.json file.";
+        EVLOG_AND_THROW(e);
+    }
+
+    try {
         auto patch = schemas.get_validator()->validate(this->config);
         if (patch.is_null()) {
             // no defaults substituted
@@ -2468,13 +2481,17 @@ bool ChargePointConfiguration::getCustomDisplayCostAndPriceEnabled() {
     return false;
 }
 
-KeyValue ChargePointConfiguration::getCustomDisplayCostAndPriceEnabledKeyValue() {
-    const bool enabled = getCustomDisplayCostAndPriceEnabled();
-    KeyValue kv;
-    kv.key = "CustomDisplayCostAndPrice";
-    kv.value = ocpp::conversions::bool_to_string(enabled);
-    kv.readonly = true;
-    return kv;
+std::optional<KeyValue> ChargePointConfiguration::getCustomDisplayCostAndPriceEnabledKeyValue() {
+    if (this->config.contains("CostAndPrice") and this->config["CostAndPrice"].contains("CustomDisplayCostAndPrice")) {
+        const bool enabled = getCustomDisplayCostAndPriceEnabled();
+        KeyValue kv;
+        kv.key = "CustomDisplayCostAndPrice";
+        kv.value = ocpp::conversions::bool_to_string(enabled);
+        kv.readonly = this->cost_and_price_schema["properties"]["CustomDisplayCostAndPrice"]["readOnly"];
+        return kv;
+    }
+
+    return std::nullopt;
 }
 
 std::optional<std::uint32_t> ChargePointConfiguration::getPriceNumberOfDecimalsForCostValues() {
@@ -3078,6 +3095,18 @@ bool ChargePointConfiguration::setMeterPublicKey(const std::int32_t connector_id
 
     this->setInUserConfig("Internal", "MeterPublicKeys", this->config["Internal"]["MeterPublicKeys"]);
     return true;
+}
+
+ConfigurationStatus ChargePointConfiguration::setCustomDisplayCostAndPrice(const bool& value) {
+    auto status = ConfigurationStatus::NotSupported;
+
+    if (!this->cost_and_price_schema["properties"]["CustomDisplayCostAndPrice"]["readOnly"]) {
+        this->config["CostAndPrice"]["CustomDisplayCostAndPrice"] = value;
+        this->setInUserConfig("CostAndPrice", "CustomDisplayCostAndPrice", value);
+        status = ConfigurationStatus::Accepted;
+    }
+
+    return status;
 }
 
 void ChargePointConfiguration::setLanguage(const std::string& language) {
@@ -4190,6 +4219,12 @@ std::optional<ConfigurationStatus> ChargePointConfiguration::set(const CiString<
             this->setRemoteStartTransactionWithoutConnectorIdFindFirst(ocpp::conversions::string_to_bool(value.get()));
         } else {
             return ConfigurationStatus::Rejected;
+        }
+    } else if (key == "CustomDisplayCostAndPrice") {
+        const ConfigurationStatus result =
+            this->setCustomDisplayCostAndPrice(ocpp::conversions::string_to_bool(value.get()));
+        if (result != ConfigurationStatus::Accepted) {
+            return result;
         }
     } else if (key.get().find("DefaultPriceText") == 0) {
         const ConfigurationStatus result = this->setDefaultPriceText(key, value);

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
@@ -75,7 +75,6 @@ ChargePointConfiguration::ChargePointConfiguration(const std::string& config, co
         if (fs::exists(cost_schema_path)) {
             std::ifstream ifs(cost_schema_path.c_str());
             std::string cost_schema_file((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
-            const auto cost_schema = json::parse(cost_schema_file);
             this->cost_and_price_schema = json::parse(cost_schema_file);
         }
     } catch (const json::parse_error& e) {
@@ -3098,7 +3097,7 @@ bool ChargePointConfiguration::setMeterPublicKey(const std::int32_t connector_id
 }
 
 ConfigurationStatus ChargePointConfiguration::setCustomDisplayCostAndPrice(const bool& value) {
-    auto status = ConfigurationStatus::NotSupported;
+    auto status = ConfigurationStatus::Rejected;
 
     if (!this->cost_and_price_schema["properties"]["CustomDisplayCostAndPrice"]["readOnly"]) {
         this->config["CostAndPrice"]["CustomDisplayCostAndPrice"] = value;
@@ -4221,6 +4220,9 @@ std::optional<ConfigurationStatus> ChargePointConfiguration::set(const CiString<
             return ConfigurationStatus::Rejected;
         }
     } else if (key == "CustomDisplayCostAndPrice") {
+        if (!isBool(value.get())) {
+            return ConfigurationStatus::Rejected;
+        }
         const ConfigurationStatus result =
             this->setCustomDisplayCostAndPrice(ocpp::conversions::string_to_bool(value.get()));
         if (result != ConfigurationStatus::Accepted) {

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
@@ -2631,8 +2631,8 @@ std::optional<std::uint32_t> ChargePointConfigurationDeviceModel::getPriceNumber
     return get_optional<std::int32_t>(*storage, keys::valid_keys::NumberOfDecimalsForCostValues);
 }
 
-KeyValue ChargePointConfigurationDeviceModel::getCustomDisplayCostAndPriceEnabledKeyValue() {
-    return get_key_value(*storage, keys::valid_keys::CustomDisplayCostAndPrice);
+std::optional<KeyValue> ChargePointConfigurationDeviceModel::getCustomDisplayCostAndPriceEnabledKeyValue() {
+    return get_key_value_optional(*storage, keys::valid_keys::CustomDisplayCostAndPrice);
 }
 
 KeyValue ChargePointConfigurationDeviceModel::getDefaultPriceTextKeyValue(const std::string& language) {

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
@@ -147,6 +147,16 @@ inline std::optional<bool> isReadOnly(DeviceModelInterface& storage, const v2::R
     return isReadOnly(storage, component, variable, attribute);
 }
 
+/// readonly when the device model mutability is ReadOnly (or unknown)
+bool isReadOnly(DeviceModelInterface& storage, v16::keys::valid_keys key) {
+    const auto cv = v16::keys::convert_v2(key);
+    if (cv) {
+        const auto mutability = storage.get_mutability(cv->first, cv->second, v2::AttributeEnum::Actual);
+        return mutability.value_or(v2::MutabilityEnum::ReadOnly) == v2::MutabilityEnum::ReadOnly;
+    }
+    return true;
+}
+
 inline bool is_same(const ocpp::v2::RequiredComponentVariable& var, const ocpp::v2::Component& component,
                     const ocpp::v2::Variable& variable) {
     return ((var.component == component) && (var.variable == variable));
@@ -277,7 +287,7 @@ std::optional<v16::KeyValue> get_key_value_optional(DeviceModelInterface& storag
     if (get_result) {
         v16::KeyValue kv;
         kv.key = std::move(std::string{v16::keys::convert(key)});
-        kv.readonly = v16::keys::is_readonly(key);
+        kv.readonly = v16::keys::is_readonly(key) || isReadOnly(storage, key);
         kv.value = std::move(get_result.value());
         result = kv;
     }
@@ -555,6 +565,15 @@ ChargePointConfigurationDeviceModel::setInternalRemoteStartTransactionWithoutCon
         return SetResult::Rejected;
     }
     return set_value_check(*storage, keys::valid_keys::RemoteStartTransactionWithoutConnectorIdFindFirst, value);
+}
+
+ChargePointConfigurationDeviceModel::SetResult
+ChargePointConfigurationDeviceModel::setInternalCustomDisplayCostAndPrice(const std::string& value) {
+    if (not isBool(value)) {
+        return SetResult::Rejected;
+    }
+    // the configured device model mutability is enforced by set_value()
+    return set_value_check(*storage, keys::valid_keys::CustomDisplayCostAndPrice, value);
 }
 
 ChargePointConfigurationDeviceModel::SetResult
@@ -3352,6 +3371,9 @@ std::optional<ConfigurationStatus> ChargePointConfigurationDeviceModel::set(cons
         case keys::valid_keys::ConnectorEvseIds:
             result = convert(setInternalConnectorEvseIds(value_str));
             break;
+        case keys::valid_keys::CustomDisplayCostAndPrice:
+            result = convert(setInternalCustomDisplayCostAndPrice(value_str));
+            break;
         case keys::valid_keys::IgnoredProfilePurposesOffline:
             result = convert(setInternalIgnoredProfilePurposesOffline(value_str));
             break;
@@ -3564,7 +3586,6 @@ std::optional<ConfigurationStatus> ChargePointConfigurationDeviceModel::set(cons
         case keys::valid_keys::StopTxnSampledDataMaxLength:
         case keys::valid_keys::SupportedFeatureProfiles:
         case keys::valid_keys::SupportedFeatureProfilesMaxLength:
-        case keys::valid_keys::CustomDisplayCostAndPrice:
         case keys::valid_keys::CustomMultiLanguageMessages:
         case keys::valid_keys::NumberOfDecimalsForCostValues:
         case keys::valid_keys::SupportedLanguages:

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
@@ -3083,8 +3083,8 @@ std::optional<std::uint32_t> ChargePointConfigurationDeviceModel::getPriceNumber
     return get_optional<std::int32_t>(*storage, keys::valid_keys::NumberOfDecimalsForCostValues);
 }
 
-KeyValue ChargePointConfigurationDeviceModel::getCustomDisplayCostAndPriceEnabledKeyValue() {
-    return get_key_value(*storage, keys::valid_keys::CustomDisplayCostAndPrice);
+std::optional<KeyValue> ChargePointConfigurationDeviceModel::getCustomDisplayCostAndPriceEnabledKeyValue() {
+    return get_key_value_optional(*storage, keys::valid_keys::CustomDisplayCostAndPrice);
 }
 
 KeyValue ChargePointConfigurationDeviceModel::getDefaultPriceTextKeyValue(const std::string& language) {

--- a/lib/everest/ocpp/lib/ocpp/v16/known_keys.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/known_keys.cpp
@@ -77,7 +77,6 @@ using ocpp::v16::keys::valid_keys;
     key(CertificateStoreMaxLength) \
     key(LocalAuthListMaxLength) \
     key(SendLocalListMaxLength) \
-    key(CustomDisplayCostAndPrice) \
     key(NumberOfDecimalsForCostValues) \
     key(CustomMultiLanguageMessages) \
     key(SupportedLanguages) \

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/memory_storage.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/memory_storage.cpp
@@ -278,7 +278,6 @@ MemoryStorage::MemoryStorage() {
     vars_custom = required_vars_custom;
 
     vars_additional.clear();
-    read_only.clear();
 }
 
 void MemoryStorage::apply_full_config() {
@@ -380,12 +379,28 @@ MemoryStorage::SetVariableStatusEnum MemoryStorage::set_v16_custom(const std::st
 }
 
 void MemoryStorage::set_readonly(const std::string& key) {
-    read_only.insert(key);
+    configured_mutability[key] = MutabilityEnum::ReadOnly;
+}
+
+void MemoryStorage::set_readwrite(const std::string& key) {
+    configured_mutability[key] = MutabilityEnum::ReadWrite;
+}
+
+std::optional<MemoryStorage::MutabilityEnum>
+MemoryStorage::get_configured_mutability(const std::string& key_str) const {
+    if (const auto it = configured_mutability.find(key_str); it != configured_mutability.end()) {
+        return it->second;
+    }
+    return std::nullopt;
 }
 
 std::optional<MemoryStorage::MutabilityEnum> MemoryStorage::get_mutability(const std::string& key_str) {
-    std::optional<MutabilityEnum> result;
+    std::optional<MutabilityEnum> result = get_configured_mutability(key_str);
+    if (result) {
+        return result;
+    }
 
+    // fallback: derive the mutability from the known_keys readonly list
     const auto sv_key_opt = keys::convert(key_str);
     if (sv_key_opt) {
         const auto sv_key = sv_key_opt.value();
@@ -396,14 +411,10 @@ std::optional<MemoryStorage::MutabilityEnum> MemoryStorage::get_mutability(const
                                                  : MemoryStorage::MutabilityEnum::ReadWrite;
         }
     } else {
-        if (const auto it = read_only.find(key_str); it == read_only.end()) {
-            // check if key exists (not in the read only list)
-            auto found = locate_v16(key_str);
-            if (found) {
-                result = MemoryStorage::MutabilityEnum::ReadWrite;
-            }
-        } else {
-            result = MemoryStorage::MutabilityEnum::ReadOnly;
+        // check if key exists
+        auto found = locate_v16(key_str);
+        if (found) {
+            result = MemoryStorage::MutabilityEnum::ReadWrite;
         }
     }
 
@@ -597,6 +608,11 @@ MemoryStorage::SetVariableStatusEnum MemoryStorage::set_value(const Component& c
     const auto key_str = enhanced_convert(component_id, variable_id, attribute_enum);
     MemoryStorage::SetVariableStatusEnum result;
     if (!key_str.empty()) {
+        // mirror DeviceModel::set_value(): Reject writes when the configured
+        // mutability is ReadOnly
+        if (!allow_read_only && get_configured_mutability(key_str) == MutabilityEnum::ReadOnly) {
+            return MemoryStorage::SetVariableStatusEnum::Rejected;
+        }
         const auto key_opt = v16::keys::convert(key_str);
         std::string store_value = value;
         result = MemoryStorage::SetVariableStatusEnum::Accepted;
@@ -617,7 +633,7 @@ MemoryStorage::SetVariableStatusEnum MemoryStorage::set_read_only_value(const Co
                                                                         const AttributeEnum& attribute_enum,
                                                                         const std::string& value,
                                                                         const std::string& source) {
-    return set_value(component_id, variable_id, attribute_enum, value, source);
+    return set_value(component_id, variable_id, attribute_enum, value, source, true);
 }
 
 MemoryStorage::SetVariableStatusEnum MemoryStorage::clear_value(const Component& component_id,

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/memory_storage.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/memory_storage.hpp
@@ -11,7 +11,6 @@
 #include <ocpp/v2/ocpp_types.hpp>
 
 #include <map>
-#include <set>
 #include <string>
 #include <string_view>
 
@@ -48,7 +47,9 @@ public:
     static std::optional<std::string> get_connector_id(std::int32_t id, const std::string& current);
 
 private:
-    std::set<std::string> read_only;
+    // mutability as configured in the component configs of a real deployment;
+    // empty by default; tests model it via set_readonly()/set_readwrite()
+    std::map<std::string, MutabilityEnum> configured_mutability;
 
     std::optional<MemoryStorage::Storage::iterator> locate_v16(const std::string& name) const;
     std::optional<std::string> get_meter_public_keys_v16() const;
@@ -56,6 +57,7 @@ private:
     std::optional<std::string> get_v16(ocpp::v16::keys::valid_keys key) const;
     SetVariableStatusEnum set_v16(const std::string& name, const std::string& value);
     SetVariableStatusEnum set_v16_custom(const std::string& name, const std::string& value);
+    std::optional<MutabilityEnum> get_configured_mutability(const std::string& key_str) const;
     std::optional<MutabilityEnum> get_mutability(const std::string& key_str);
     void add_supported_measureands_values_list(ocpp::v2::ReportData& data);
     void add_to_report(std::vector<ocpp::v2::ReportData>& report, const std::string_view& name,
@@ -70,6 +72,7 @@ public:
     void apply_full_config();
 
     void set_readonly(const std::string& key);
+    void set_readwrite(const std::string& key);
     void set(const std::string_view& component, const std::string_view& variable, const std::string_view& value);
     std::string get(const std::string_view& component, const std::string_view& variable);
     void clear(const std::string_view& component, const std::string_view& variable);

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_california_pricing.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_california_pricing.cpp
@@ -44,11 +44,11 @@ using namespace ocpp::v16::stubs;
 
 TEST_P(Configuration, CustomDisplayCostAndPriceEnabled) {
     ASSERT_NE(get(), nullptr);
-    EXPECT_FALSE(get()->getCustomDisplayCostAndPriceEnabled());
     auto kv = get()->getCustomDisplayCostAndPriceEnabledKeyValue();
-    EXPECT_EQ(kv.key, "CustomDisplayCostAndPrice");
-    EXPECT_EQ(kv.value, "false");
-    EXPECT_TRUE(kv.readonly);
+    ASSERT_TRUE(kv.has_value());
+    EXPECT_EQ(kv.value().key, "CustomDisplayCostAndPrice");
+    EXPECT_EQ(kv.value().value, "false");
+    EXPECT_TRUE(kv.value().readonly);
 }
 
 TEST_P(Configuration, DefaultTariffMessage) {

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_california_pricing.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_california_pricing.cpp
@@ -3,6 +3,8 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+
 #include "configuration_stub.hpp"
 
 /*
@@ -44,11 +46,84 @@ using namespace ocpp::v16::stubs;
 
 TEST_P(Configuration, CustomDisplayCostAndPriceEnabled) {
     ASSERT_NE(get(), nullptr);
+    // model the ReadOnly default of OCPP16LegacyCtrlr.json in the device model backend
+    device_model->set_readonly("CustomDisplayCostAndPrice");
     auto kv = get()->getCustomDisplayCostAndPriceEnabledKeyValue();
     ASSERT_TRUE(kv.has_value());
     EXPECT_EQ(kv.value().key, "CustomDisplayCostAndPrice");
     EXPECT_EQ(kv.value().value, "false");
     EXPECT_TRUE(kv.value().readonly);
+}
+
+TEST_P(Configuration, CustomDisplayCostAndPriceSetRejectedWhenReadOnly) {
+    ASSERT_NE(get(), nullptr);
+    // by default the key is read-only (CostAndPrice.json / OCPP16LegacyCtrlr.json)
+    device_model->set_readonly("CustomDisplayCostAndPrice");
+    EXPECT_EQ(get()->set("CustomDisplayCostAndPrice", "true"), ocpp::v16::ConfigurationStatus::Rejected);
+    EXPECT_FALSE(get()->getCustomDisplayCostAndPriceEnabled());
+}
+
+TEST_P(Configuration, CustomDisplayCostAndPriceSetAcceptedWhenWritable) {
+    ASSERT_NE(get(), nullptr);
+    if (GetParam() != "sql") {
+        // JSON backend covered by CaliforniaPricingJsonSchema.CustomDisplayCostAndPriceSetAcceptedWhenWritable
+        GTEST_SKIP() << "the CostAndPrice.json schema in CONFIG_DIR_V16 ships read-only";
+    }
+    device_model->set_readwrite("CustomDisplayCostAndPrice");
+
+    auto kv = get()->getCustomDisplayCostAndPriceEnabledKeyValue();
+    ASSERT_TRUE(kv.has_value());
+    EXPECT_FALSE(kv.value().readonly);
+
+    EXPECT_EQ(get()->set("CustomDisplayCostAndPrice", "not-a-bool"), ocpp::v16::ConfigurationStatus::Rejected);
+    EXPECT_EQ(get()->set("CustomDisplayCostAndPrice", "true"), ocpp::v16::ConfigurationStatus::Accepted);
+    EXPECT_TRUE(get()->getCustomDisplayCostAndPriceEnabled());
+}
+
+// JSON backend with a CostAndPrice.json schema that marks CustomDisplayCostAndPrice writable
+TEST(CaliforniaPricingJsonSchema, CustomDisplayCostAndPriceSetAcceptedWhenWritable) {
+    // copy the config directory and patch the schema to readOnly: false
+    const auto timestamp = std::chrono::steady_clock::now().time_since_epoch().count();
+    const fs::path config_dir = fs::temp_directory_path() / ("ocpp16_cost_and_price_" + std::to_string(timestamp));
+    fs::copy(CONFIG_DIR_V16, config_dir, fs::copy_options::recursive);
+
+    const fs::path schema_path = config_dir / "profile_schemas" / "CostAndPrice.json";
+    json schema;
+    {
+        std::ifstream ifs(schema_path);
+        schema = json::parse(ifs);
+    }
+    schema["properties"]["CustomDisplayCostAndPrice"]["readOnly"] = false;
+    {
+        std::ofstream ofs(schema_path);
+        ofs << schema.dump(4);
+    }
+
+    const fs::path user_config_path = config_dir / "user_config.json";
+    std::ofstream(user_config_path) << "{}";
+
+    std::ifstream config_ifs(fs::path{CONFIG_DIR_V16} / "config.json");
+    const std::string config_file((std::istreambuf_iterator<char>(config_ifs)), (std::istreambuf_iterator<char>()));
+    ocpp::v16::ChargePointConfiguration config(config_file, config_dir, user_config_path);
+
+    auto kv = config.getCustomDisplayCostAndPriceEnabledKeyValue();
+    ASSERT_TRUE(kv.has_value());
+    EXPECT_EQ(kv.value().value, "false");
+    EXPECT_FALSE(kv.value().readonly);
+
+    EXPECT_EQ(config.set("CustomDisplayCostAndPrice", "not-a-bool"), ocpp::v16::ConfigurationStatus::Rejected);
+    EXPECT_EQ(config.set("CustomDisplayCostAndPrice", "true"), ocpp::v16::ConfigurationStatus::Accepted);
+    EXPECT_TRUE(config.getCustomDisplayCostAndPriceEnabled());
+
+    // the new value is persisted in the user config
+    json user_config;
+    {
+        std::ifstream ifs(user_config_path);
+        user_config = json::parse(ifs);
+    }
+    EXPECT_EQ(user_config["CostAndPrice"]["CustomDisplayCostAndPrice"], true);
+
+    fs::remove_all(config_dir);
 }
 
 TEST_P(Configuration, DefaultTariffMessage) {


### PR DESCRIPTION
## Describe your changes
The profiles_value of CostAndPrice:CustomDisplayCostAndPrice is used to determine if the value is writeable via CSMS.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

