### PR TITLE
Fix(EvseV2G): Fixing buffer overflow in handle_cert_installation

### DIFF
--- a/modules/EVSE/EvseV2G/iso_server.cpp
+++ b/modules/EVSE/EvseV2G/iso_server.cpp
@@ -8,6 +8,7 @@
 #include <cbv2g/iso_2/iso2_msgDefEncoder.h>
 #include <everest/tls/openssl_util.hpp>
 
+#include <algorithm>
 #include <cstdint>
 #include <inttypes.h>
 #include <math.h>
@@ -648,10 +649,8 @@ static enum v2g_event handle_iso_service_discovery(struct v2g_connection* conn) 
              "PnC is not allowed without TLS-communication. Correcting value to '1' (ExternalPayment)");
     }
 
-    const auto payment_option_length =
-        conn->ctx->evse_v2g_data.payment_option_list.size() > iso2_paymentOptionType_2_ARRAY_SIZE
-            ? iso2_paymentOptionType_2_ARRAY_SIZE
-            : conn->ctx->evse_v2g_data.payment_option_list.size();
+    const auto payment_option_length = std::min(conn->ctx->evse_v2g_data.payment_option_list.size(),
+                                                static_cast<size_t>(iso2_paymentOptionType_2_ARRAY_SIZE));
 
     memcpy(res->PaymentOptionList.PaymentOption.array, conn->ctx->evse_v2g_data.payment_option_list.data(),
            payment_option_length * sizeof(iso2_paymentOptionType));

--- a/modules/EVSE/EvseV2G/iso_server.cpp
+++ b/modules/EVSE/EvseV2G/iso_server.cpp
@@ -27,7 +27,6 @@ using namespace crypto::openssl;
 
 #define MQTT_MAX_PAYLOAD_SIZE         268435455
 #define V2G_SECC_MSG_CERTINSTALL_TIME 4500
-#define GEN_CHALLENGE_SIZE            16
 
 constexpr uint16_t SAE_V2H = 28472;
 constexpr uint16_t SAE_V2G = 28473;
@@ -589,6 +588,7 @@ static enum v2g_event handle_iso_session_setup(struct v2g_connection* conn) {
 
     /* TODO: publish EVCCID to MQTT */
 
+    // An overflow check is already done in ISO15118_chargerImpl.cpp
     res->EVSEID.charactersLen = conn->ctx->evse_v2g_data.evse_id.bytesLen;
     memcpy(res->EVSEID.characters, conn->ctx->evse_v2g_data.evse_id.bytes, conn->ctx->evse_v2g_data.evse_id.bytesLen);
 
@@ -648,9 +648,14 @@ static enum v2g_event handle_iso_service_discovery(struct v2g_connection* conn) 
              "PnC is not allowed without TLS-communication. Correcting value to '1' (ExternalPayment)");
     }
 
+    const auto payment_option_length =
+        conn->ctx->evse_v2g_data.payment_option_list.size() > iso2_paymentOptionType_2_ARRAY_SIZE
+            ? iso2_paymentOptionType_2_ARRAY_SIZE
+            : conn->ctx->evse_v2g_data.payment_option_list.size();
+
     memcpy(res->PaymentOptionList.PaymentOption.array, conn->ctx->evse_v2g_data.payment_option_list.data(),
-           conn->ctx->evse_v2g_data.payment_option_list.size() * sizeof(iso2_paymentOptionType));
-    res->PaymentOptionList.PaymentOption.arrayLen = conn->ctx->evse_v2g_data.payment_option_list.size();
+           payment_option_length * sizeof(iso2_paymentOptionType));
+    res->PaymentOptionList.PaymentOption.arrayLen = payment_option_length;
 
     // ensure a "clean" service list
     res->ServiceList.Service.arrayLen = 0;
@@ -1853,7 +1858,7 @@ static enum v2g_event handle_iso_certificate_installation(struct v2g_connection*
         (conn->ctx->evse_v2g_data.cert_install_status == true)) {
         const auto data = openssl::base64_decode(conn->ctx->evse_v2g_data.cert_install_res_b64_buffer.data(),
                                                  conn->ctx->evse_v2g_data.cert_install_res_b64_buffer.size());
-        if (data.empty() || (data.size() > DEFAULT_BUFFER_SIZE)) {
+        if (data.empty() || (data.size() > DEFAULT_BUFFER_SIZE - V2GTP_HEADER_LENGTH)) {
             dlog(DLOG_LEVEL_ERROR, "Failed to decode base64 stream");
             goto exit;
         } else {

--- a/modules/EVSE/EvseV2G/v2g.hpp
+++ b/modules/EVSE/EvseV2G/v2g.hpp
@@ -63,6 +63,8 @@
 #define FORCE_PUB_MSG           25 // max msg cycles when topics values must be udpated
 #define MAX_PCID_LEN            17
 
+#define GEN_CHALLENGE_SIZE 16
+
 #define DEFAULT_BUFFER_SIZE 8192
 
 #define DEBUG 1
@@ -330,7 +332,7 @@ struct v2g_context {
         long long int auth_start_timeout;
         int auth_timeout_eim;
         int auth_timeout_pnc;                                                   // for PnC
-        uint8_t gen_challenge[16];                                              // for PnC
+        uint8_t gen_challenge[GEN_CHALLENGE_SIZE];                              // for PnC
         bool verify_contract_cert_chain;                                        // for PnC
         types::authorization::CertificateStatus certificate_status;             // for PnC
         bool authorization_rejected;                                            // for PnC


### PR DESCRIPTION
## Describe your changes
When checking whether the base64 fits in the buffer, the 8 bytes from the `V2GTP_HEADER` are subtracted.
In addition, the payment option vector is now checked to see if it contains more than two elements. If so, only the first two elements are copied into the response message.

## Issue ticket number and link
Previously, a buffer overflow could occur if, in the CertInstall state, a Base64 string was larger than `DEFAULT_BUFFER_SIZE-8`

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

