### PR TITLE
Bazel: Support bazel test ... and bazel run ... for the everest_env

### DIFF
--- a/lib/everest/framework/bazel/everest_env.bzl
+++ b/lib/everest/framework/bazel/everest_env.bzl
@@ -134,7 +134,11 @@ exec bin/manager_impl --prefix . --config {0} --check
         """.format(config_path)
     else:
         script_content += """
-exec bin/manager_impl "$@"
+if [ $# -gt 0 ]; then
+    exec bin/manager_impl "$@"
+else
+    exec bin/manager_impl --prefix . --config {0}
+fi
 """.format(config_path)
     ctx.actions.write(script, script_content, is_executable = True)
     symlinks.update({"bin/manager": script})


### PR DESCRIPTION
## Describe your changes

If the caller passes arguments to the manager wrapper (tests do that) we use them. otherwise we default to the current prefix and config
