### PR TITLE
Improve devcontainer test reliability for parallel runs

### DIFF
--- a/.devcontainer/general-devcontainer/Dockerfile
+++ b/.devcontainer/general-devcontainer/Dockerfile
@@ -19,6 +19,7 @@ USER root
 RUN apt-get update && apt-get install -y \
     protobuf-compiler \
     libsystemd-dev \
+    libboost-log-dev \
     tmux \
     chrpath \
     cpio \
@@ -28,6 +29,7 @@ RUN apt-get update && apt-get install -y \
     zstd \
     liblz4-tool \
     file \
+    iproute2 \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y locales \
     && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
     && dpkg-reconfigure --frontend=noninteractive locales  \
@@ -39,7 +41,8 @@ ENV LANG en_US.UTF-8
 
 # EVerest Development Tool - Dependencies
 RUN pip install --break-system-packages \
-    nanopb
+    nanopb \
+    pytest
 
 # EVerest Development Tool
 

--- a/.devcontainer/general-devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/general-devcontainer/docker-compose.devcontainer.yml
@@ -1,6 +1,10 @@
 networks:
   docker-proxy-network:
     internal: true
+  devcontainer-ipv6:
+    enable_ipv6: true
+    driver_opts:
+      com.docker.network.endpoint.sysctls: "net.ipv6.conf.eth0.disable_ipv6=0"
 
 volumes:
   cpm-source-cache:
@@ -55,6 +59,8 @@ services:
         source: ${SSH_AUTH_SOCK}
         target: /ssh-agent
     command: sleep infinity
+    cap_add:
+      - NET_ADMIN
     environment:
       MQTT_SERVER_ADDRESS: mqtt-server
       MQTT_SERVER_PORT: 1883
@@ -65,8 +71,11 @@ services:
     networks:
       - docker-proxy-network
       - default
+      - devcontainer-ipv6
     sysctls:
       - net.ipv6.conf.all.disable_ipv6=0
+      - net.ipv6.conf.default.disable_ipv6=0
+      - net.ipv6.conf.lo.disable_ipv6=0
     profiles:
       - all
       - ocpp

--- a/applications/devrd/devrd
+++ b/applications/devrd/devrd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tests/ocpp_tests/test_sets/everest-aux/install_certs.sh
+++ b/tests/ocpp_tests/test_sets/everest-aux/install_certs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
     echo "Usage: $0 <EVerest-installation-directory>"

--- a/tests/ocpp_tests/test_sets/everest-aux/install_configs.sh
+++ b/tests/ocpp_tests/test_sets/everest-aux/install_configs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
     echo "Usage: $0 <EVerest-installation-directory>"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Unified test runner for E2E tests of EVerest.

--- a/tests/setup-network-isolation.sh
+++ b/tests/setup-network-isolation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Pionix GmbH and Contributors to EVerest
 #


### PR DESCRIPTION
Enable IPv6 and NET_ADMIN support in the devcontainer, add missing runtime/test dependencies, and standardize bash shebangs across test helper scripts. This makes containerized parallel test execution more predictable and fixes environment issues encountered when running the EVerest test suites.

## Describe your changes
Multiple scripts shebang have been changed to improve diverse OS support. Those are not a must but increase compatibility. 

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

