### PR TITLE
Rust: Support shared linking

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,3 +10,12 @@ build:ci --strip=always
 build:ci --copt=-g0
 build:ci --repository_cache=~/.cache/bazel-repo-cache
 build:ci --disk_cache=~/.cache/bazel-disk-cache
+
+# With our setup Bazel links every binary statically to `libframework.a` If you
+# want to link dynamically to `libframework.so` use `--dynamic_mode=fully`.
+# See https://bazel.build/docs/user-manual#dynamic-mode for more details. If
+# linking dynamically, ensure that `libframework.so` is in the
+# `LD_LIBRARY_PATH`.
+#
+# Not supported on musl targets.
+# --dynamic_mode=default

--- a/lib/everest/framework/BUILD.bazel
+++ b/lib/everest/framework/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_import", "cc_library", "cc_shared_library")
 load("@rules_python//python:py_binary.bzl", "py_binary")
 load("//third-party/bazel/toolchains:defs.bzl", "CROSS_PYTHON_INCOMPATIBLE")
 
@@ -37,8 +37,14 @@ genrule(
   """,
 )
 
+config_setting(
+    name = "_dynamic_mode_fully",
+    values = {"dynamic_mode": "fully"},
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
-    name = "framework",
+    name = "framework_lib",
     srcs = glob(["lib/**/*.cpp"]),
     hdrs = glob(["include/**/*.hpp"]) + [
         ":compile_time_settings",
@@ -68,6 +74,29 @@ cc_library(
         "@com_github_pboettch_json-schema-validator//:json-schema-validator",
         "@rapidyaml",
     ],
+)
+
+cc_shared_library(
+    name = "framework_so",
+    shared_lib_name = "libframework.so",
+    deps = [":framework_lib"],
+    exports_filter = [":framework_lib"],
+)
+
+cc_import(
+    name = "framework_dynamic",
+    shared_library = ":framework_so",
+    deps = [":framework_lib"],
+    linkopts = ["-lframework"],
+)
+
+alias(
+    name = "framework",
+    actual = select({
+        ":_dynamic_mode_fully": ":framework_dynamic",
+        "//conditions:default": ":framework_lib",
+    }),
+    visibility = ["//visibility:public"],
 )
 
 cc_library(

--- a/lib/everest/framework/everestrs/everestrs/src/everestrs_sys.cpp
+++ b/lib/everest/framework/everestrs/everestrs/src/everestrs_sys.cpp
@@ -16,13 +16,6 @@
 #include <type_traits>
 #include <variant>
 
-#include <boost/log/attributes/attribute_value_set.hpp>
-#include <boost/log/attributes/constant.hpp>
-#include <boost/log/expressions/filter.hpp>
-#include <boost/log/utility/setup/filter_parser.hpp>
-#include <boost/log/utility/setup/settings.hpp>
-#include <boost/log/utility/setup/settings_parser.hpp>
-
 namespace {
 
 JsonBlob json2blob(const json& j) {
@@ -280,56 +273,13 @@ rust::Vec<RsModuleConfig> Module::get_module_configs(rust::Str module_id) const 
 }
 
 int init_logging(rust::Str module_id, rust::Str prefix, rust::Str logging_config_file) {
-    using namespace boost::log;
-    using namespace Everest::Logging;
-
     const std::string module_id_cpp{module_id};
-    const std::string prefix_cpp{prefix};
     const std::string logging_config_file_cpp{logging_config_file};
 
-    // Init the CPP logger.
-    init(logging_config_file_cpp, module_id_cpp);
-
-    // Below is something really ugly. Boost's log filter rules may actually be
-    // quite "complex" but the library does not expose any way to check the
-    // already installed filters. We therefore reopen the config and construct
-    // or own filter - and feed it with dummy values to determine its filtering
-    // behaviour (the lowest severity which is accepted by the filter)
-    std::filesystem::path logging_path{logging_config_file_cpp};
-    std::ifstream logging_config(logging_path.c_str());
-    if (!logging_config.is_open()) {
-        return info;
-    }
-    const auto settings = parse_settings(logging_config);
-
-    if (auto core_settings = settings["Core"]) {
-        if (boost::optional<std::string> param = core_settings["Filter"]) {
-
-            const auto filter = parse_filter(param.get());
-            // Check for the severity values - which is the first one to be
-            // accepted by the filter.
-            static_assert(static_cast<int>(verbose) == 0);
-            static_assert(static_cast<int>(error) == 4);
-            for (int ii = static_cast<int>(verbose); ii <= static_cast<int>(error); ++ii) {
-                attribute_set set1, set2, set3;
-                set1["Severity"] = attributes::constant<severity_level>{static_cast<severity_level>(ii)};
-
-                attribute_value_set value_set(set1, set2, set3);
-                value_set.freeze();
-
-                if (filter(value_set)) {
-                    return ii;
-                }
-            }
-        }
-    }
-
-    return info;
+    // // Init the CPP logger.
+    return Everest::Logging::init(logging_config_file_cpp, module_id_cpp);
 }
 
 void log2cxx(int level, int line, rust::Str file, rust::Str message) {
-    const auto logging_level = static_cast<::Everest::Logging::severity_level>(level);
-    BOOST_LOG_SEV(::global_logger::get(), logging_level)
-        << boost::log::BOOST_LOG_VERSION_NAMESPACE::add_value("file", std::string{file})
-        << boost::log::BOOST_LOG_VERSION_NAMESPACE::add_value("line", line) << std::string{message};
+    Everest::Logging::ffi_log(level, line, std::string(file), std::string(message));
 }

--- a/lib/everest/framework/everestrs/everestrs/src/lib.rs
+++ b/lib/everest/framework/everestrs/everestrs/src/lib.rs
@@ -319,6 +319,9 @@ mod logger {
         pub(crate) fn init_logger(module_name: &str, prefix: &str, conf: &str) {
             INIT_LOGGER_ONCE.call_once(|| {
                 let level = match ffi::init_logging(module_name, prefix, conf) {
+                    -1 => {
+                        return;
+                    }
                     0 => log::Level::Trace,
                     1 => log::Level::Debug,
                     2 => log::Level::Info,

--- a/lib/everest/log/include/everest/logging.hpp
+++ b/lib/everest/log/include/everest/logging.hpp
@@ -33,11 +33,11 @@ enum severity_level {
 int init();
 
 /// \brief Initialize logger using the config pointed to by \p logconf
-/// \return minimum accepted severity level (-1=off, 0=verbose .. 4=error)
+/// \return minimum accepted severity level (-1=off, 0=verbose .. 5=critical)
 int init(const std::string& logconf);
 
 /// \brief Initialize logger using the config pointed to by \p logconf additionally setting the \p process_name
-/// \return minimum accepted severity level (-1=off, 0=verbose .. 4=error)
+/// \return minimum accepted severity level (-1=off, 0=verbose .. 5=critical)
 int init(const std::string& logconf, std::string process_name);
 
 /// \brief Logging function for foreign language interfaces.

--- a/lib/everest/log/include/everest/logging.hpp
+++ b/lib/everest/log/include/everest/logging.hpp
@@ -29,13 +29,19 @@ enum severity_level {
 };
 
 /// \brief Initialize a completely silenced logger
-void init();
+/// \return -1 for off.
+int init();
 
 /// \brief Initialize logger using the config pointed to by \p logconf
-void init(const std::string& logconf);
+/// \return minimum accepted severity level (-1=off, 0=verbose .. 4=error)
+int init(const std::string& logconf);
 
 /// \brief Initialize logger using the config pointed to by \p logconf additionally setting the \p process_name
-void init(const std::string& logconf, std::string process_name);
+/// \return minimum accepted severity level (-1=off, 0=verbose .. 4=error)
+int init(const std::string& logconf, std::string process_name);
+
+/// \brief Logging function for foreign language interfaces.
+void ffi_log(int level, int line, const std::string& file, const std::string& message);
 
 void update_process_name(std::string process_name);
 std::string trace();

--- a/lib/everest/log/lib/logging.cpp
+++ b/lib/everest/log/lib/logging.cpp
@@ -206,10 +206,11 @@ int init(const std::string& logconf, std::string process_name) {
     is_initialized = true;
 
     // Probe the installed filter to find the minimum accepted severity level.
-    for (int ii = static_cast<int>(verbose); ii <= static_cast<int>(error); ++ii) {
-        auto rec = global_logger::get().open_record(boost::log::keywords::severity = static_cast<severity_level>(ii));
+    for (int level = static_cast<int>(verbose); level <= static_cast<int>(critical); ++level) {
+        auto rec =
+            global_logger::get().open_record(boost::log::keywords::severity = static_cast<severity_level>(level));
         if (rec) {
-            return ii;
+            return level;
         }
     }
 

--- a/lib/everest/log/lib/logging.cpp
+++ b/lib/everest/log/lib/logging.cpp
@@ -134,16 +134,17 @@ struct escaped_message_formatter_factory : public logging::formatter_factory<cha
     }
 };
 
-void init() {
+int init() {
     logging::core::get()->remove_all_sinks();
     logging::core::get()->set_logging_enabled(false);
+    return -1;
 }
 
-void init(const std::string& logconf) {
-    init(logconf, "");
+int init(const std::string& logconf) {
+    return init(logconf, "");
 }
 
-void init(const std::string& logconf, std::string process_name) {
+int init(const std::string& logconf, std::string process_name) {
     BOOST_LOG_FUNCTION();
 
     if (is_initialized) {
@@ -203,6 +204,16 @@ void init(const std::string& logconf, std::string process_name) {
 
     EVLOG_debug << "Logger " << (is_initialized ? "re" : "") << "initialized (using " << logconf << ")...";
     is_initialized = true;
+
+    // Probe the installed filter to find the minimum accepted severity level.
+    for (int ii = static_cast<int>(verbose); ii <= static_cast<int>(error); ++ii) {
+        auto rec = global_logger::get().open_record(boost::log::keywords::severity = static_cast<severity_level>(ii));
+        if (rec) {
+            return ii;
+        }
+    }
+
+    return -1;
 }
 
 void update_process_name(std::string process_name) {
@@ -213,5 +224,17 @@ void update_process_name(std::string process_name) {
         current_process_name.set(padded_process_name);
     }
 }
+
+void ffi_log(int level, int line, const std::string& file, const std::string& message) {
+    // Logging is off.
+    if (level < 0) {
+        return;
+    }
+    const auto logging_level = static_cast<severity_level>(level);
+    BOOST_LOG_SEV(::global_logger::get(), logging_level)
+        << boost::log::BOOST_LOG_VERSION_NAMESPACE::add_value("file", file)
+        << boost::log::BOOST_LOG_VERSION_NAMESPACE::add_value("line", line) << message;
+}
+
 } // namespace Logging
 } // namespace Everest


### PR DESCRIPTION
## Describe your changes

Bazel by default links everything statically. This change uses `cc_shared_library` in conjunction with `dynamic_mode=fully` to link to `libframework.so` and not to `libframework.a

To make sure that the Rust bindings don't link to boost log symbols we also move the logging registration into liblog. 

TBD: Maybe we should wire the log bindings through libframework to make the dynamic linking more robust
