### PR TITLE
ocpp: emit NotifyEvent for connector AvailabilityState on OCPP 2.1 (G01)

### DIFF
--- a/lib/everest/ocpp/include/ocpp/v2/charge_point.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/charge_point.hpp
@@ -13,6 +13,7 @@
 
 #include <ocpp/v2/average_meter_values.hpp>
 #include <ocpp/v2/charge_point_callbacks.hpp>
+#include <ocpp/v2/event_id_generator.hpp>
 #include <ocpp/v2/ocpp_enums.hpp>
 #include <ocpp/v2/ocpp_types.hpp>
 #include <ocpp/v2/ocsp_updater.hpp>
@@ -376,6 +377,7 @@ private:
     std::atomic<RegistrationStatusEnum> registration_status;
     std::atomic<OcppProtocolVersion> ocpp_version =
         OcppProtocolVersion::Unknown; // version that is currently in use, selected by CSMS in websocket handshake
+    EventIdGenerator event_id_generator;
     std::atomic<UploadLogStatusEnum> upload_log_status;
     std::atomic<std::int32_t> upload_log_status_id;
     BootReasonEnum bootreason;

--- a/lib/everest/ocpp/include/ocpp/v2/event_id_generator.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/event_id_generator.hpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+namespace ocpp::v2 {
+
+/// Monotonic source for `EventData.eventId` values.
+///
+/// A single instance is owned by `ChargePoint` and shared via
+/// `FunctionalBlockContext` so that all NotifyEvent emitters
+/// (MonitoringUpdater, Availability::availability_state_notify_event_req,
+/// future ones) draw from one namespace and never collide.
+class EventIdGenerator {
+public:
+    EventIdGenerator() = default;
+
+    EventIdGenerator(const EventIdGenerator&) = delete;
+    EventIdGenerator& operator=(const EventIdGenerator&) = delete;
+
+    /// Returns the next eventId. Thread-safe.
+    std::int32_t next() {
+        return counter.fetch_add(1, std::memory_order_relaxed);
+    }
+
+private:
+    std::atomic<std::int32_t> counter{0};
+};
+
+} // namespace ocpp::v2

--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/availability.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/availability.hpp
@@ -95,6 +95,15 @@ public:
     void status_notification_req(const std::int32_t evse_id, const std::int32_t connector_id,
                                  const ConnectorStatusEnum status,
                                  const bool initiated_by_trigger_message = false) override;
+
+    /// \brief Send the OCPP 2.1 G01 NotifyEvent for a connector AvailabilityState change.
+    ///
+    /// Used in place of StatusNotificationRequest on OCPP 2.1+ sessions; see G01 worked
+    /// example. Component is `Connector` with the EVSE/connector ids; variable is
+    /// `AvailabilityState`; actualValue is the stringified ConnectorStatusEnum.
+    void availability_state_notify_event_req(std::int32_t evse_id, std::int32_t connector_id,
+                                             ConnectorStatusEnum status, bool initiated_by_trigger_message);
+
     void heartbeat_req(const bool initiated_by_trigger_message = false) override;
 
     void handle_scheduled_change_availability_requests(const std::int32_t evse_id) override;

--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/functional_block_context.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/functional_block_context.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <ocpp/common/message_dispatcher.hpp>
+#include <ocpp/v2/event_id_generator.hpp>
 #include <ocpp/v2/types.hpp>
 
 namespace ocpp {
@@ -29,12 +30,13 @@ struct FunctionalBlockContext {
     EvseSecurity& evse_security;
     ComponentStateManagerInterface& component_state_manager;
     std::atomic<OcppProtocolVersion>& ocpp_version;
+    EventIdGenerator& event_id_generator;
 
     FunctionalBlockContext(MessageDispatcherInterface<MessageType>& message_dispatcher,
                            DeviceModelAbstract& device_model, ConnectivityManagerInterface& connectivity_manager,
                            EvseManagerInterface& evse_manager, DatabaseHandlerInterface& database_handler,
                            EvseSecurity& evse_security, ComponentStateManagerInterface& component_state_manager,
-                           std::atomic<OcppProtocolVersion>& ocpp_version) :
+                           std::atomic<OcppProtocolVersion>& ocpp_version, EventIdGenerator& event_id_generator) :
         message_dispatcher(message_dispatcher),
         device_model(device_model),
         connectivity_manager(connectivity_manager),
@@ -42,7 +44,8 @@ struct FunctionalBlockContext {
         database_handler(database_handler),
         evse_security(evse_security),
         component_state_manager(component_state_manager),
-        ocpp_version(ocpp_version) {
+        ocpp_version(ocpp_version),
+        event_id_generator(event_id_generator) {
     }
 };
 } // namespace v2

--- a/lib/everest/ocpp/include/ocpp/v2/monitoring_updater.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/monitoring_updater.hpp
@@ -8,6 +8,7 @@
 #include <everest/timer.hpp>
 
 #include <ocpp/v2/enums.hpp>
+#include <ocpp/v2/event_id_generator.hpp>
 #include <ocpp/v2/ocpp_enums.hpp>
 #include <ocpp/v2/ocpp_types.hpp>
 
@@ -101,11 +102,12 @@ public:
 
     /// \brief Constructs a new variable monitor updater
     /// \param device_model Currently used variable device model
+    /// \param event_id_generator Shared source for EventData.eventId values
     /// \param notify_csms_events Function that can be invoked with a number of alert events
     /// \param is_chargepoint_offline Function that can be invoked in order to retrieve the
     /// status of the charging station connection to the CSMS
-    MonitoringUpdater(DeviceModelAbstract& device_model, notify_events notify_csms_events,
-                      is_offline is_chargepoint_offline);
+    MonitoringUpdater(DeviceModelAbstract& device_model, EventIdGenerator& event_id_generator,
+                      notify_events notify_csms_events, is_offline is_chargepoint_offline);
     ~MonitoringUpdater();
 
     /// \brief Starts monitoring the variables, kicking the timer
@@ -169,8 +171,7 @@ private:
     DeviceModelAbstract& device_model;
     Everest::SteadyTimer monitors_timer;
 
-    // Charger to CSMS message unique ID for EventData
-    std::int32_t unique_id;
+    EventIdGenerator& event_id_generator;
 
     notify_events notify_csms_events;
     is_offline is_chargepoint_offline;

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
@@ -550,7 +550,8 @@ void ChargePoint::initialize(const std::map<std::int32_t, std::int32_t>& evse_co
     // Construct functional blocks.
     functional_block_context = std::make_unique<FunctionalBlockContext>(
         *this->message_dispatcher, *this->device_model, *this->connectivity_manager, *this->evse_manager,
-        *this->database_handler, *this->evse_security, *this->component_state_manager, this->ocpp_version);
+        *this->database_handler, *this->evse_security, *this->component_state_manager, this->ocpp_version,
+        this->event_id_generator);
 
     this->data_transfer = std::make_unique<DataTransfer>(
         *this->functional_block_context, this->callbacks.data_transfer_callback, DEFAULT_WAIT_FOR_FUTURE_TIMEOUT);

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/availability.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/availability.cpp
@@ -9,6 +9,7 @@
 #include <ocpp/v2/functional_blocks/functional_block_context.hpp>
 
 #include <ocpp/v2/messages/Heartbeat.hpp>
+#include <ocpp/v2/messages/NotifyEvent.hpp>
 #include <ocpp/v2/messages/StatusNotification.hpp>
 
 namespace ocpp::v2 {
@@ -43,6 +44,11 @@ void Availability::handle_message(const ocpp::EnhancedMessage<MessageType>& mess
 
 void Availability::status_notification_req(const std::int32_t evse_id, const std::int32_t connector_id,
                                            const ConnectorStatusEnum status, const bool initiated_by_trigger_message) {
+    if (this->context.ocpp_version.load() == OcppProtocolVersion::v21) {
+        this->availability_state_notify_event_req(evse_id, connector_id, status, initiated_by_trigger_message);
+        return;
+    }
+
     StatusNotificationRequest req;
     req.connectorId = connector_id;
     req.evseId = evse_id;
@@ -50,6 +56,37 @@ void Availability::status_notification_req(const std::int32_t evse_id, const std
     req.connectorStatus = status;
 
     const ocpp::Call<StatusNotificationRequest> call(req);
+    this->context.message_dispatcher.dispatch_call(call, initiated_by_trigger_message);
+}
+
+void Availability::availability_state_notify_event_req(const std::int32_t evse_id, const std::int32_t connector_id,
+                                                       const ConnectorStatusEnum status,
+                                                       const bool initiated_by_trigger_message) {
+    EventData event;
+    event.eventId = this->context.event_id_generator.next();
+    event.timestamp = DateTime();
+    event.trigger = EventTriggerEnum::Delta;
+    event.eventNotificationType = EventNotificationEnum::HardWiredNotification;
+    event.actualValue = CiString<2500>(conversions::connector_status_enum_to_string(status));
+
+    Component component;
+    component.name = "Connector";
+    EVSE evse;
+    evse.id = evse_id;
+    evse.connectorId = connector_id;
+    component.evse = evse;
+    event.component = component;
+
+    Variable variable;
+    variable.name = "AvailabilityState";
+    event.variable = variable;
+
+    NotifyEventRequest req;
+    req.generatedAt = DateTime();
+    req.seqNo = 0;
+    req.eventData = {event};
+
+    const ocpp::Call<NotifyEventRequest> call(req);
     this->context.message_dispatcher.dispatch_call(call, initiated_by_trigger_message);
 }
 

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/diagnostics.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/diagnostics.cpp
@@ -34,7 +34,8 @@ Diagnostics::Diagnostics(const FunctionalBlockContext& context, AuthorizationInt
     context(context),
     authorization(authorization),
     monitoring_updater(
-        context.device_model, [this](const std::vector<EventData>& events) { this->notify_event_req(events); },
+        context.device_model, context.event_id_generator,
+        [this](const std::vector<EventData>& events) { this->notify_event_req(events); },
         [this]() { return !this->context.connectivity_manager.is_websocket_connected(); }),
     get_log_request_callback(get_log_request_callback),
     get_customer_information_callback(get_customer_information_callback),

--- a/lib/everest/ocpp/lib/ocpp/v2/monitoring_updater.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/monitoring_updater.cpp
@@ -134,11 +134,11 @@ EventData create_notify_event(std::int32_t unique_id, const std::string& reporte
 }
 } // namespace
 
-MonitoringUpdater::MonitoringUpdater(DeviceModelAbstract& device_model, notify_events notify_csms_events,
-                                     is_offline is_chargepoint_offline) :
+MonitoringUpdater::MonitoringUpdater(DeviceModelAbstract& device_model, EventIdGenerator& event_id_generator,
+                                     notify_events notify_csms_events, is_offline is_chargepoint_offline) :
     device_model(device_model),
     monitors_timer([this]() { this->process_monitors_internal(true, true); }),
-    unique_id(0),
+    event_id_generator(event_id_generator),
     notify_csms_events(std::move(notify_csms_events)),
     is_chargepoint_offline(std::move(is_chargepoint_offline)) {
 }
@@ -510,8 +510,8 @@ void MonitoringUpdater::process_monitor_meta_internal(UpdaterMonitorMeta& update
             const auto current_value = this->device_model.get_value<std::string>(comp_var);
 
             EventData notify_event =
-                std::move(create_notify_event(this->unique_id++, current_value, updater_meta_data.component,
-                                              updater_meta_data.variable, monitor_meta));
+                std::move(create_notify_event(this->event_id_generator.next(), current_value,
+                                              updater_meta_data.component, updater_meta_data.variable, monitor_meta));
 
             // Generate one event that will either be sent now, or later based on the offline state
             updater_meta_data.generated_monitor_events.push_back(std::move(notify_event));
@@ -529,9 +529,9 @@ void MonitoringUpdater::process_monitor_meta_internal(UpdaterMonitorMeta& update
                 reported_value = updater_meta_data.value_current;
             }
 
-            EventData notify_event =
-                std::move(create_notify_event(unique_id++, reported_value, updater_meta_data.component,
-                                              updater_meta_data.variable, updater_meta_data.monitor_meta));
+            EventData notify_event = std::move(
+                create_notify_event(this->event_id_generator.next(), reported_value, updater_meta_data.component,
+                                    updater_meta_data.variable, updater_meta_data.monitor_meta));
 
             // N07.FR.18 - the cleared attribute does not apply to deltas
             // N07.FR.19

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(libocpp_unit_tests PRIVATE
         test_database_handler.cpp
         test_database_migration_files.cpp
         test_device_model_storage_sqlite.cpp
+        test_event_id_generator.cpp
         test_notify_report_requests_splitter.cpp
         test_ocsp_updater.cpp
         test_component_state_manager.cpp

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/CMakeLists.txt
@@ -72,6 +72,7 @@ set(TEST_AVAILABILITY_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../device_model_test_h
             ${LIBOCPP_LIB_PATH}/ocpp/v2/ctrlr_component_variables.cpp
             ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/ChangeAvailability.cpp
             ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/Heartbeat.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/NotifyEvent.cpp
             ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/StatusNotification.cpp
             ${LIBOCPP_TEST_INCLUDE_COMMON_SOURCES}
             ${LIBOCPP_TEST_INCLUDE_V2_SOURCES}

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_authorization.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_authorization.cpp
@@ -8,6 +8,7 @@
 
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/device_model.hpp>
+#include <ocpp/v2/event_id_generator.hpp>
 #include <ocpp/v2/functional_blocks/functional_block_context.hpp>
 
 #include "component_state_manager_mock.hpp"
@@ -44,6 +45,7 @@ protected: // Members
     EvseManagerFake evse_manager;
     ComponentStateManagerMock component_state_manager;
     std::atomic<ocpp::OcppProtocolVersion> ocpp_version;
+    EventIdGenerator event_id_generator;
     FunctionalBlockContext functional_block_context;
 
     std::unique_ptr<Authorization> authorization;
@@ -67,7 +69,8 @@ protected: // Functions
         ocpp_version(ocpp::OcppProtocolVersion::v201),
         functional_block_context{
             this->mock_dispatcher,       *this->device_model, this->connectivity_manager,    this->evse_manager,
-            this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version},
+            this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version,
+            this->event_id_generator},
         authorization(std::make_unique<Authorization>(functional_block_context)) {
     }
 
@@ -343,7 +346,8 @@ TEST_F(AuthorizationTest, is_auth_cache_ctrlr_enabled) {
     this->device_model = this->device_model_test_helper.get_device_model();
     FunctionalBlockContext context = {
         this->mock_dispatcher,       *this->device_model, this->connectivity_manager,    this->evse_manager,
-        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version};
+        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version,
+        this->event_id_generator};
     this->authorization = std::make_unique<Authorization>(context);
     EXPECT_FALSE(authorization->is_auth_cache_ctrlr_enabled());
 }
@@ -1780,7 +1784,8 @@ TEST_F(AuthorizationTest, cache_cleanup_handler_exceeds_max_storage) {
     this->authorization = nullptr;
     FunctionalBlockContext context = {
         this->mock_dispatcher,       *this->device_model, this->connectivity_manager,    this->evse_manager,
-        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version};
+        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version,
+        this->event_id_generator};
     this->authorization = std::make_unique<Authorization>(context);
     auto meta_data =
         this->device_model->get_variable_meta_data(component_variable.component, component_variable.variable.value());
@@ -1843,7 +1848,8 @@ TEST_F(AuthorizationTest, cache_cleanup_handler_exceeds_max_storage_database_exc
 
     FunctionalBlockContext context = {
         this->mock_dispatcher,       *this->device_model, this->connectivity_manager,    this->evse_manager,
-        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version};
+        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version,
+        this->event_id_generator};
     this->authorization = std::make_unique<Authorization>(context);
 
     auto meta_data =

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_availability.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_availability.cpp
@@ -8,9 +8,11 @@
 
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/device_model.hpp>
+#include <ocpp/v2/event_id_generator.hpp>
 #include <ocpp/v2/functional_blocks/functional_block_context.hpp>
 
 #include <ocpp/v2/messages/Heartbeat.hpp>
+#include <ocpp/v2/messages/NotifyEvent.hpp>
 #include <ocpp/v2/messages/StatusNotification.hpp>
 
 #include "component_state_manager_mock.hpp"
@@ -43,6 +45,7 @@ protected: // Members
     EvseManagerFake evse_manager;
     ComponentStateManagerMock component_state_manager;
     std::atomic<ocpp::OcppProtocolVersion> ocpp_version;
+    EventIdGenerator event_id_generator;
     FunctionalBlockContext functional_block_context;
     MockFunction<void(const ocpp::DateTime& currentTime)> time_sync_callback;
     MockFunction<void()> all_connectors_unavailable_callback;
@@ -63,7 +66,8 @@ protected: // Functions
         ocpp_version(ocpp::OcppProtocolVersion::v201),
         functional_block_context{
             this->mock_dispatcher,       *this->device_model, this->connectivity_manager,    this->evse_manager,
-            this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version},
+            this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version,
+            this->event_id_generator},
         evse_1(evse_manager.get_mock(1)),
         evse_2(evse_manager.get_mock(2)),
         availability(std::make_unique<Availability>(functional_block_context, time_sync_callback.AsStdFunction(),
@@ -121,6 +125,43 @@ TEST_F(AvailabilityTest, status_notification_req) {
         EXPECT_FALSE(triggered);
     }));
 
+    availability->status_notification_req(1, 2, ConnectorStatusEnum::Unavailable, false);
+}
+
+TEST_F(AvailabilityTest, availability_state_notify_event_req_emits_g01_payload) {
+    EXPECT_CALL(mock_dispatcher, dispatch_call(_, _)).WillOnce(Invoke([](const json& call, bool /*triggered*/) {
+        const auto message = call[ocpp::CALL_PAYLOAD].get<NotifyEventRequest>();
+        ASSERT_EQ(message.eventData.size(), 1u);
+        const auto& ev = message.eventData[0];
+        EXPECT_EQ(ev.trigger, EventTriggerEnum::Delta);
+        EXPECT_EQ(ev.eventNotificationType, EventNotificationEnum::HardWiredNotification);
+        EXPECT_EQ(ev.component.name, "Connector");
+        ASSERT_TRUE(ev.component.evse.has_value());
+        EXPECT_EQ(ev.component.evse->id, 1);
+        EXPECT_EQ(ev.component.evse->connectorId.value_or(-1), 2);
+        EXPECT_EQ(ev.variable.name, "AvailabilityState");
+        EXPECT_EQ(ev.actualValue.get(), conversions::connector_status_enum_to_string(ConnectorStatusEnum::Unavailable));
+        EXPECT_FALSE(ev.variableMonitoringId.has_value());
+    }));
+    availability->availability_state_notify_event_req(1, 2, ConnectorStatusEnum::Unavailable, false);
+}
+
+TEST_F(AvailabilityTest, status_notification_req_dispatches_notify_event_on_v21) {
+    this->ocpp_version.store(ocpp::OcppProtocolVersion::v21);
+    EXPECT_CALL(mock_dispatcher, dispatch_call(_, _)).WillOnce(Invoke([](const json& call, bool /*triggered*/) {
+        const auto message = call[ocpp::CALL_PAYLOAD].get<NotifyEventRequest>();
+        ASSERT_EQ(message.eventData.size(), 1u);
+        EXPECT_EQ(message.eventData[0].variable.name, "AvailabilityState");
+    }));
+    availability->status_notification_req(1, 2, ConnectorStatusEnum::Unavailable, false);
+}
+
+TEST_F(AvailabilityTest, status_notification_req_keeps_status_notification_on_v201) {
+    this->ocpp_version.store(ocpp::OcppProtocolVersion::v201);
+    EXPECT_CALL(mock_dispatcher, dispatch_call(_, _)).WillOnce(Invoke([](const json& call, bool /*triggered*/) {
+        const auto message = call[ocpp::CALL_PAYLOAD].get<StatusNotificationRequest>();
+        EXPECT_EQ(message.connectorStatus, ConnectorStatusEnum::Unavailable);
+    }));
     availability->status_notification_req(1, 2, ConnectorStatusEnum::Unavailable, false);
 }
 

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_data_transfer.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_data_transfer.cpp
@@ -14,6 +14,7 @@
 #include "mocks/database_handler_mock.hpp"
 #include <ocpp/common/constants.hpp>
 #include <ocpp/v2/device_model.hpp>
+#include <ocpp/v2/event_id_generator.hpp>
 #include <ocpp/v2/functional_blocks/data_transfer.hpp>
 #include <ocpp/v2/functional_blocks/functional_block_context.hpp>
 #include <ocpp/v2/messages/DataTransfer.hpp>
@@ -42,6 +43,7 @@ protected: // Members
     EvseManagerFake evse_manager;
     ComponentStateManagerMock component_state_manager;
     std::atomic<ocpp::OcppProtocolVersion> ocpp_version;
+    EventIdGenerator event_id_generator;
     FunctionalBlockContext functional_block_context;
 
     DataTransferTest() :
@@ -55,7 +57,8 @@ protected: // Members
         ocpp_version(ocpp::OcppProtocolVersion::v201),
         functional_block_context{
             this->mock_dispatcher,       *this->device_model, this->connectivity_manager,    this->evse_manager,
-            this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version} {
+            this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version,
+            this->event_id_generator} {
     }
 };
 

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_reservation.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_reservation.cpp
@@ -17,6 +17,7 @@
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/device_model.hpp>
 #include <ocpp/v2/device_model_storage_sqlite.hpp>
+#include <ocpp/v2/event_id_generator.hpp>
 #include <ocpp/v2/functional_blocks/functional_block_context.hpp>
 #include <ocpp/v2/init_device_model_db.hpp>
 
@@ -42,7 +43,8 @@ protected: // Functions
         this->device_model = create_device_model();
         this->functional_block_context = std::make_unique<FunctionalBlockContext>(
             this->mock_dispatcher, *this->device_model, this->connectivity_manager, this->evse_manager,
-            this->database_handler, this->evse_security, this->component_state_manager, this->ocpp_version);
+            this->database_handler, this->evse_security, this->component_state_manager, this->ocpp_version,
+            this->event_id_generator);
         this->reservation = std::make_unique<Reservation>(
             *functional_block_context, reserve_now_callback_mock.AsStdFunction(),
             cancel_reservation_callback_mock.AsStdFunction(), is_reservation_for_token_callback_mock.AsStdFunction());
@@ -188,6 +190,7 @@ protected: // Members
                                               const std::optional<ocpp::CiString<255>> groupIdToken)>
         is_reservation_for_token_callback_mock;
     std::atomic<ocpp::OcppProtocolVersion> ocpp_version;
+    EventIdGenerator event_id_generator;
     std::unique_ptr<FunctionalBlockContext> functional_block_context;
     // Make reservation a unique ptr so we can create it after creating the device model.
     std::unique_ptr<Reservation> reservation;
@@ -543,7 +546,7 @@ TEST_F(ReservationTest, handle_reserve_now_no_evses) {
 
     const FunctionalBlockContext b{this->mock_dispatcher,         *this->device_model,    this->connectivity_manager,
                                    evse_manager_no_evses,         this->database_handler, this->evse_security,
-                                   this->component_state_manager, this->ocpp_version};
+                                   this->component_state_manager, this->ocpp_version,     this->event_id_generator};
     this->functional_block_context = std::make_unique<FunctionalBlockContext>(b);
 
     Reservation r{*this->functional_block_context, reserve_now_callback_mock.AsStdFunction(),

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_security.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_security.cpp
@@ -6,6 +6,7 @@
 
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/device_model.hpp>
+#include <ocpp/v2/event_id_generator.hpp>
 #include <ocpp/v2/functional_blocks/functional_block_context.hpp>
 
 #define private public // Make everything in security.hpp public so we can trigger the timer.
@@ -49,6 +50,7 @@ protected: // Members
     MockFunction<void(const ocpp::CiString<50>& event_type, const std::optional<ocpp::CiString<255>>& tech_info)>
         security_event_callback_mock;
     std::atomic<ocpp::OcppProtocolVersion> ocpp_version;
+    EventIdGenerator event_id_generator;
     FunctionalBlockContext functional_block_context;
     Security security;
 
@@ -64,7 +66,8 @@ protected: // Functions
         ocpp_version(ocpp::OcppProtocolVersion::v201),
         functional_block_context{
             this->mock_dispatcher,       *this->device_model, this->connectivity_manager,    this->evse_manager,
-            this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version},
+            this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version,
+            this->event_id_generator},
         security(functional_block_context, logging, ocsp_updater, security_event_callback_mock.AsStdFunction()) {
     }
 
@@ -401,7 +404,8 @@ TEST_F(SecurityTest, sign_certificate_request_no_organization_name) {
     device_model = device_model_test_helper.get_device_model();
     const FunctionalBlockContext b{
         this->mock_dispatcher,       *this->device_model, this->connectivity_manager,    this->evse_manager,
-        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version};
+        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version,
+        this->event_id_generator};
     Security s(b, logging, ocsp_updater, security_event_callback_mock.AsStdFunction());
 
     this->device_model->set_value(ControllerComponentVariables::ChargeBoxSerialNumber.component,
@@ -430,7 +434,8 @@ TEST_F(SecurityTest, sign_certificate_request_no_serial_number) {
 
     const FunctionalBlockContext b{
         this->mock_dispatcher,       *this->device_model, this->connectivity_manager,    this->evse_manager,
-        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version};
+        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version,
+        this->event_id_generator};
     Security s(b, logging, ocsp_updater, security_event_callback_mock.AsStdFunction());
 
     this->device_model->set_value(ControllerComponentVariables::OrganizationName.component,
@@ -458,7 +463,8 @@ TEST_F(SecurityTest, sign_certificate_request_no_country) {
     device_model = device_model_test_helper.get_device_model();
     const FunctionalBlockContext b{
         this->mock_dispatcher,       *this->device_model, this->connectivity_manager,    this->evse_manager,
-        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version};
+        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version,
+        this->event_id_generator};
     Security s(b, logging, ocsp_updater, security_event_callback_mock.AsStdFunction());
 
     this->device_model->set_value(ControllerComponentVariables::OrganizationName.component,
@@ -560,7 +566,8 @@ TEST_F(SecurityTest, sign_certificate_request_v2g_no_common_name) {
     device_model = device_model_test_helper.get_device_model();
     const FunctionalBlockContext b{
         this->mock_dispatcher,       *this->device_model, this->connectivity_manager,    this->evse_manager,
-        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version};
+        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version,
+        this->event_id_generator};
     Security s(b, logging, ocsp_updater, security_event_callback_mock.AsStdFunction());
 
     this->device_model->set_value(ControllerComponentVariables::ISO15118CtrlrOrganizationName.component,
@@ -588,7 +595,8 @@ TEST_F(SecurityTest, sign_certificate_request_v2g_no_organization) {
     device_model = device_model_test_helper.get_device_model();
     const FunctionalBlockContext b{
         this->mock_dispatcher,       *this->device_model, this->connectivity_manager,    this->evse_manager,
-        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version};
+        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version,
+        this->event_id_generator};
     Security s(b, logging, ocsp_updater, security_event_callback_mock.AsStdFunction());
 
     this->device_model->set_value(ControllerComponentVariables::ISO15118CtrlrSeccId.component,
@@ -616,7 +624,8 @@ TEST_F(SecurityTest, sign_certificate_request_v2g_no_country) {
     device_model = device_model_test_helper.get_device_model();
     const FunctionalBlockContext b{
         this->mock_dispatcher,       *this->device_model, this->connectivity_manager,    this->evse_manager,
-        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version};
+        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version,
+        this->event_id_generator};
     Security s(b, logging, ocsp_updater, security_event_callback_mock.AsStdFunction());
 
     this->device_model->set_value(ControllerComponentVariables::ISO15118CtrlrSeccId.component,
@@ -729,7 +738,8 @@ TEST_F(SecurityTest, security_event_notification_no_callback) {
     // Trigger a critical security event, but there is no callback to call.
     const FunctionalBlockContext b{
         this->mock_dispatcher,       *this->device_model, this->connectivity_manager,    this->evse_manager,
-        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version};
+        this->database_handler_mock, this->evse_security, this->component_state_manager, this->ocpp_version,
+        this->event_id_generator};
     Security s(b, logging, ocsp_updater, nullptr);
 
     // This will send a security event notification to the CSMS.

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_smart_charging.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_smart_charging.cpp
@@ -9,6 +9,7 @@
 #include "ocpp/common/types.hpp"
 #include "ocpp/v2/ctrlr_component_variables.hpp"
 #include "ocpp/v2/device_model.hpp"
+#include "ocpp/v2/event_id_generator.hpp"
 #include "ocpp/v2/functional_blocks/functional_block_context.hpp"
 #include "ocpp/v2/functional_blocks/smart_charging.hpp"
 #include "ocpp/v2/ocpp_types.hpp"
@@ -90,7 +91,8 @@ protected:
         device_model = device_model_test_helper.get_device_model();
         this->functional_block_context = std::make_unique<FunctionalBlockContext>(
             this->mock_dispatcher, *this->device_model, this->connectivity_manager, *this->evse_manager,
-            *this->database_handler, this->evse_security, this->component_state_manager, this->ocpp_version);
+            *this->database_handler, this->evse_security, this->component_state_manager, this->ocpp_version,
+            this->event_id_generator);
         // Defaults
         const auto& charging_rate_unit_cv = ControllerComponentVariables::ChargingScheduleChargingRateUnit;
         device_model->set_value(charging_rate_unit_cv.component, charging_rate_unit_cv.variable.value(),
@@ -150,6 +152,7 @@ protected:
     TestSmartCharging smart_charging = create_smart_charging();
     boost::uuids::random_generator uuid_generator = boost::uuids::random_generator();
     std::atomic<OcppProtocolVersion> ocpp_version = OcppProtocolVersion::v201;
+    EventIdGenerator event_id_generator;
 };
 
 TEST_F(SmartChargingTest, K01FR03_IfTxProfileIsMissingTransactionId_ThenProfileIsInvalid) {

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_tariff_and_cost.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_tariff_and_cost.cpp
@@ -8,6 +8,7 @@
 
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/device_model.hpp>
+#include <ocpp/v2/event_id_generator.hpp>
 #include <ocpp/v2/functional_blocks/functional_block_context.hpp>
 #include <ocpp/v2/functional_blocks/tariff_and_cost.hpp>
 #include <ocpp/v2/messages/CostUpdated.hpp>
@@ -48,6 +49,7 @@ protected:
     EvseManagerFake evse_manager;
     ComponentStateManagerMock component_state_manager;
     std::atomic<ocpp::OcppProtocolVersion> ocpp_version;
+    EventIdGenerator event_id_generator;
     FunctionalBlockContext functional_block_context;
     NiceMock<MeterValuesMock> meter_values_mock;
     boost::asio::io_context io_context;
@@ -64,7 +66,8 @@ protected:
         evse_manager(1),
         ocpp_version(ocpp::OcppProtocolVersion::v201),
         functional_block_context{mock_dispatcher,       *device_model, connectivity_manager,    evse_manager,
-                                 database_handler_mock, evse_security, component_state_manager, ocpp_version} {
+                                 database_handler_mock, evse_security, component_state_manager, ocpp_version,
+                                 event_id_generator} {
     }
 
     std::unique_ptr<TariffAndCost> make_tariff_and_cost() {

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/smart_charging_test_utils.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/smart_charging_test_utils.cpp
@@ -448,7 +448,8 @@ CompositeScheduleTestFixtureV2::create_smart_charging_handler(const OcppProtocol
     database_handler->open_connection();
     this->functional_block_context = std::make_unique<FunctionalBlockContext>(
         this->mock_dispatcher, *this->device_model, this->connectivity_manager, *this->evse_manager,
-        *this->database_handler, this->evse_security, this->component_state_manager, this->ocpp_version);
+        *this->database_handler, this->evse_security, this->component_state_manager, this->ocpp_version,
+        this->event_id_generator);
     return std::make_unique<TestSmartCharging>(*functional_block_context,
                                                set_charging_profiles_callback_mock.AsStdFunction(),
                                                stop_transaction_callback_mock.AsStdFunction());
@@ -458,7 +459,8 @@ void CompositeScheduleTestFixtureV2::reconfigure_for_nr_of_evses(std::int32_t nr
     this->evse_manager = std::make_unique<EvseManagerFake>(nr_of_evses);
     this->functional_block_context = std::make_unique<FunctionalBlockContext>(
         this->mock_dispatcher, *this->device_model, this->connectivity_manager, *this->evse_manager,
-        *this->database_handler, this->evse_security, this->component_state_manager, this->ocpp_version);
+        *this->database_handler, this->evse_security, this->component_state_manager, this->ocpp_version,
+        this->event_id_generator);
     this->handler = std::make_unique<TestSmartCharging>(*functional_block_context,
                                                         set_charging_profiles_callback_mock.AsStdFunction(),
                                                         stop_transaction_callback_mock.AsStdFunction());

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/smart_charging_test_utils.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/smart_charging_test_utils.hpp
@@ -25,6 +25,7 @@
 #include <evse_mock.hpp>
 #include <evse_security_mock.hpp>
 #include <gmock/gmock.h>
+#include <ocpp/v2/event_id_generator.hpp>
 #include <ocpp/v2/functional_blocks/functional_block_context.hpp>
 
 #include <boost/uuid/uuid_generators.hpp>
@@ -167,6 +168,7 @@ public:
     std::unique_ptr<TestSmartCharging> handler;
     boost::uuids::random_generator uuid_generator;
     std::atomic<OcppProtocolVersion> ocpp_version = OcppProtocolVersion::v201;
+    EventIdGenerator event_id_generator;
 };
 
 class CompositeScheduleTestFixtureV21 : public CompositeScheduleTestFixtureV2 {

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_event_id_generator.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_event_id_generator.cpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gtest/gtest.h>
+
+#include <ocpp/v2/event_id_generator.hpp>
+
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+using ocpp::v2::EventIdGenerator;
+
+TEST(EventIdGeneratorTest, starts_at_zero_and_monotonic) {
+    EventIdGenerator gen;
+    EXPECT_EQ(gen.next(), 0);
+    EXPECT_EQ(gen.next(), 1);
+    EXPECT_EQ(gen.next(), 2);
+}
+
+TEST(EventIdGeneratorTest, ids_are_unique_under_concurrency) {
+    EventIdGenerator gen;
+    constexpr int threads = 8;
+    constexpr int per_thread = 1000;
+
+    std::vector<std::vector<std::int32_t>> buckets(threads);
+    std::vector<std::thread> workers;
+    workers.reserve(threads);
+    for (int t = 0; t < threads; ++t) {
+        workers.emplace_back([&, t]() {
+            buckets[t].reserve(per_thread);
+            for (int i = 0; i < per_thread; ++i) {
+                buckets[t].push_back(gen.next());
+            }
+        });
+    }
+    for (auto& w : workers) {
+        w.join();
+    }
+
+    std::unordered_set<std::int32_t> seen;
+    for (const auto& b : buckets) {
+        for (auto id : b) {
+            EXPECT_TRUE(seen.insert(id).second) << "duplicate id: " << id;
+        }
+    }
+    EXPECT_EQ(seen.size(), static_cast<std::size_t>(threads * per_thread));
+}

--- a/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_smart_charging.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_smart_charging.cpp
@@ -19,6 +19,7 @@
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/database_handler.hpp>
 #include <ocpp/v2/device_model.hpp>
+#include <ocpp/v2/event_id_generator.hpp>
 #include <ocpp/v2/evse.hpp>
 #include <ocpp/v2/functional_blocks/functional_block_context.hpp>
 #include <ocpp/v2/ocpp_enums.hpp>
@@ -68,7 +69,8 @@ protected:
         device_model = device_model_test_helper.get_device_model();
         this->functional_block_context = std::make_unique<FunctionalBlockContext>(
             this->mock_dispatcher, *this->device_model, this->connectivity_manager, *this->evse_manager,
-            *this->database_handler, this->evse_security, this->component_state_manager, this->ocpp_version);
+            *this->database_handler, this->evse_security, this->component_state_manager, this->ocpp_version,
+            this->event_id_generator);
         return TestSmartCharging(*functional_block_context, set_charging_profiles_callback_mock.AsStdFunction(),
                                  stop_transaction_callback_mock.AsStdFunction());
     }
@@ -88,6 +90,7 @@ protected:
     std::unique_ptr<FunctionalBlockContext> functional_block_context;
     TestSmartCharging smart_charging = create_smart_charging();
     std::atomic<OcppProtocolVersion> ocpp_version = OcppProtocolVersion::v21;
+    EventIdGenerator event_id_generator;
 };
 
 TEST_F(SmartChargingTestV21,

--- a/tests/ocpp_tests/test_sets/ocpp21/availability_notify_event.py
+++ b/tests/ocpp_tests/test_sets/ocpp21/availability_notify_event.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Pionix GmbH and Contributors to EVerest
+
+"""OCPP 2.1 G01: connector AvailabilityState reported via NotifyEventRequest."""
+
+import logging
+import pytest
+
+# fmt: off
+from everest.testing.core_utils._configuration.libocpp_configuration_helper import GenericOCPP2XConfigAdjustment
+from everest.testing.core_utils.controller.test_controller_interface import TestController
+from everest.testing.ocpp_utils.charge_point_utils import TestUtility, wait_for_and_validate
+from everest.testing.ocpp_utils.fixtures import *
+from everest_test_utils import *
+from ocpp.v21.enums import ConnectorStatusEnumType
+# fmt: on
+
+log = logging.getLogger("availabilityNotifyEventTest")
+
+
+def _validate_notify_event_for_availability_state(meta_data, msg, exp_payload):
+    payload = msg.payload
+    for ev in payload.get("eventData", []):
+        component = ev.get("component", {})
+        variable = ev.get("variable", {})
+        if component.get("name") == "Connector" and variable.get("name") == "AvailabilityState":
+            assert ev["trigger"] == "Delta"
+            assert ev["eventNotificationType"] == "HardWiredNotification"
+            assert ev["actualValue"] in {s.value for s in ConnectorStatusEnumType}
+            return True
+    return False
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.1")
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-ocpp201.yaml")
+)
+@pytest.mark.ocpp_config_adaptions(
+    GenericOCPP2XConfigAdjustment(
+        [
+            (
+                OCPP2XConfigVariableIdentifier(
+                    "InternalCtrlr", "SupportedOcppVersions", "Actual"
+                ),
+                "ocpp2.1",
+            )
+        ]
+    )
+)
+async def test_g01_connector_status_emits_notify_event(
+    central_system_v21: CentralSystem,
+    test_controller: TestController,
+    test_utility: TestUtility,
+):
+    """G01: When the charging station boots up on OCPP 2.1, the connector
+    AvailabilityState transition shall be reported via NotifyEventRequest
+    (component=Connector, variable=AvailabilityState). The deprecated
+    StatusNotificationRequest path must not be used on 2.1+."""
+
+    test_controller.start()
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint()
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v21,
+        "NotifyEvent",
+        {},
+        _validate_notify_event_for_availability_state,
+    )

--- a/tests/ocpp_tests/test_sets/ocpp21/bidirectional.py
+++ b/tests/ocpp_tests/test_sets/ocpp21/bidirectional.py
@@ -18,7 +18,7 @@ from ocpp.routing import on, create_route_map
 from everest.testing.ocpp_utils.fixtures import *
 from everest_test_utils import * # Needs to be before the datatypes below since it overrides the v21 Action enum with the v16 one
 from ocpp.v21.enums import (Action, ConnectorStatusEnumType, AuthorizationStatusEnumType, EnergyTransferModeEnumType, AttributeEnumType, GetVariableStatusEnumType, NotifyEVChargingNeedsStatusEnumType, NotifyAllowedEnergyTransferStatusEnumType)
-from validations import validate_status_notification_201
+from validations import validate_notify_event_connector_availability_21
 from everest.testing.core_utils._configuration.libocpp_configuration_helper import GenericOCPP2XConfigAdjustment
 from everest.testing.ocpp_utils.charge_point_utils import wait_for_and_validate, TestUtility
 # fmt: on
@@ -81,11 +81,11 @@ async def test_q01(
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v21,
-        "StatusNotification",
+        "NotifyEvent",
         call21.StatusNotification(
             1,  ConnectorStatusEnumType.available, 1, datetime.now().isoformat()
         ),
-        validate_status_notification_201,
+        validate_notify_event_connector_availability_21,
     )
 
     iso_enabled = GetVariableDataType(component=ComponentType(name="ISO15118Ctrlr", evse=EVSEType(id=1)),
@@ -124,11 +124,11 @@ async def test_q01(
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v21,
-        "StatusNotification",
+        "NotifyEvent",
         call21.StatusNotification(
             1,  ConnectorStatusEnumType.occupied, 1, datetime.now().isoformat()
         ),
-        validate_status_notification_201,
+        validate_notify_event_connector_availability_21,
     )
 
     @on(Action.authorize)
@@ -258,11 +258,11 @@ async def test_rejected_q01(
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v21,
-        "StatusNotification",
+        "NotifyEvent",
         call21.StatusNotification(
             1,  ConnectorStatusEnumType.available, 1, datetime.now().isoformat()
         ),
-        validate_status_notification_201,
+        validate_notify_event_connector_availability_21,
     )
 
     iso_enabled = GetVariableDataType(component=ComponentType(name="ISO15118Ctrlr", evse=EVSEType(id=1)),
@@ -300,11 +300,11 @@ async def test_rejected_q01(
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v21,
-        "StatusNotification",
+        "NotifyEvent",
         call21.StatusNotification(
             1,  ConnectorStatusEnumType.occupied, 1, datetime.now().isoformat()
         ),
-        validate_status_notification_201,
+        validate_notify_event_connector_availability_21,
     )
 
     @on(Action.authorize)
@@ -436,11 +436,11 @@ async def test_q02_no_service_renegotiation(
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v21,
-        "StatusNotification",
+        "NotifyEvent",
         call21.StatusNotification(
             1,  ConnectorStatusEnumType.available, 1, datetime.now().isoformat()
         ),
-        validate_status_notification_201,
+        validate_notify_event_connector_availability_21,
     )
     test_controller.plug_in_dc_iso()
 

--- a/tests/ocpp_tests/test_sets/validations.py
+++ b/tests/ocpp_tests/test_sets/validations.py
@@ -242,6 +242,31 @@ def validate_status_notification_201(meta_data, msg, exp_payload):
     )
 
 
+def validate_notify_event_connector_availability_21(meta_data, msg, exp_payload):
+    """OCPP 2.1 G01 equivalent of validate_status_notification_201.
+
+    Accepts an expected StatusNotificationRequest-shaped payload (evse_id,
+    connector_id, connector_status) and verifies the corresponding
+    NotifyEventRequest carries the same fields under the G01 shape:
+    component.name == "Connector", variable.name == "AvailabilityState",
+    component.evse.{id, connectorId}, and actualValue == stringified
+    connector_status.
+    """
+    for ev in msg.payload.get("eventData", []):
+        component = ev.get("component", {})
+        variable = ev.get("variable", {})
+        evse = component.get("evse", {}) or {}
+        if (
+            component.get("name") == "Connector"
+            and variable.get("name") == "AvailabilityState"
+            and evse.get("id") == exp_payload.evse_id
+            and evse.get("connectorId") == exp_payload.connector_id
+            and ev.get("actualValue") == exp_payload.connector_status.value
+        ):
+            return True
+    return False
+
+
 def validate_notify_report_data_201(meta_data, msg, exp_payload):
     found_items = 0
 


### PR DESCRIPTION
Route connector-availability transitions through NotifyEventRequest on OCPP 2.1+ sessions, keeping the deprecated StatusNotificationRequest path for OCPP 2.0.1. Introduces a shared EventIdGenerator so all NotifyEvent emitters draw from one eventId namespace.

## Motivation

Per OCPP 2.1 G01 (connector AvailabilityState reporting), StatusNotificationRequest is deprecated in favor of NotifyEventRequest carrying component=Connector /
variable=AvailabilityState. This change implements that pivot inside libocpp without any module-side surface change.

Because multiple functional blocks will emit NotifyEventRequest and EventDataType.cause is an inter-event reference, eventId collisions across emitters would be semantically harmful. MonitoringUpdater currently owns its own unique_id counter; the new availability path would otherwise introduce a second, overlapping namespace. Hence the EventIdGenerator infrastructure that precedes the feature itself.

## Changes — infrastructure

- lib/everest/ocpp/include/ocpp/v2/event_id_generator.hpp — new EventIdGenerator class: default-constructed, non-copyable, thread-safe next() backed by std::atomic<std::int32_t> with relaxed memory order.
- FunctionalBlockContext gains an EventIdGenerator& member so every block can reach it without new cross-block dependencies.
- ChargePoint owns the single instance and passes it through when constructing the FunctionalBlockContext.
- MonitoringUpdater constructor takes EventIdGenerator& in place of its private unique_id; both emission paths call this->event_id_generator.next().
- Diagnostics (which owns the MonitoringUpdater) wires the shared generator through at construction.

## Changes — feature

- New Availability::availability_state_notify_event_req(evse_id, connector_id, status, initiated_by_trigger_message) builds the G01 payload and dispatches directly via context.message_dispatcher, drawing the eventId from the shared EventIdGenerator.
- Availability::status_notification_req gains a version branch: on context.ocpp_version == v21 it delegates to the new method; otherwise the existing StatusNotificationRequest path is preserved verbatim.
- CMakeLists.txt for libocpp_test_availability adds NotifyEvent.cpp to the test binary's source list so the to_json for NotifyEventRequest resolves at link time.

No module-side changes — the ComponentStateManager callback signature in charge_point.cpp is untouched; the version switch lives one layer down in Availability.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

