### PR TITLE
fix(framework): add thread pool exception policy and use Rethrow in message handling

### DIFF
--- a/lib/everest/framework/include/utils/message_handler.hpp
+++ b/lib/everest/framework/include/utils/message_handler.hpp
@@ -109,7 +109,7 @@ private:
     everest::lib::util::monitor<std::thread> ready;
 
     using LatencyScaling = everest::lib::util::LatencyScaling<THREAD_POOL_SCALING_LATENCY_THRESHOLD_MS>;
-    using ThreadPool = everest::lib::util::thread_pool_scaling<LatencyScaling>;
+    using ThreadPool = everest::lib::util::thread_pool_scaling<LatencyScaling, everest::lib::util::RethrowExceptions>;
     std::unique_ptr<ThreadPool> operation_thread_pool;
 
     using MessageQueue = everest::lib::util::thread_safe_queue<ParsedMessage>;

--- a/lib/everest/framework/lib/message_handler.cpp
+++ b/lib/everest/framework/lib/message_handler.cpp
@@ -98,18 +98,6 @@ MessageHandler::SharedTypedHandler copy_shared_handler(MessageHandler::SingleHan
     return handler_copy;
 }
 
-template <class FtorT, class... Args>
-void try_action_and_log(FtorT const& action, std::string const& error_source, std::string const& topic,
-                        Args&&... args) {
-    try {
-        action(topic, std::forward<Args>(args)...);
-    } catch (const std::exception& e) {
-        EVLOG_error << "Exception in " << error_source << " for topic '" << topic << "': " << e.what();
-    } catch (...) {
-        EVLOG_error << "Unknown exception in " << error_source << " for topic '" << topic << "'";
-    }
-}
-
 void warn_on_high_queue_size(everest::lib::util::simple_queue<ParsedMessage> const& queue, std::string const& topic) {
     if (queue.size() >= MAX_PENDING_MESSAGES_PER_TOPIC) {
         EVLOG_warning << "Pending message queue for topic '" << topic << "' has reached the limit ("
@@ -163,7 +151,7 @@ void MessageHandler::add(const ParsedMessage& message) {
                     action = handle->global_ready;
                 }
                 if (action) {
-                    try_action_and_log(*(action->handler), "global_ready", topic_copy, data_copy);
+                    (*action->handler)(topic_copy, data_copy);
                 }
             });
         } // release ready monitor lock before joining
@@ -237,11 +225,13 @@ void MessageHandler::schedule_operation_message(ParsedMessage&& message) {
     auto on_operation_message_done_ftor = bind_obj(&MessageHandler::on_operation_message_done, this);
     auto operation = [handle = std::move(handle_operation_message_ftor),
                       done = std::move(on_operation_message_done_ftor), message = std::move(message)]() {
-        // Wrap in try-catch so that on_operation_message_done is always called: an exception in
-        // the handler must not leave the topic permanently stuck in operation_topics_in_flight,
-        // which would block all subsequent messages for that topic.
-        try_action_and_log(handle, "handling operation message", message.topic, message.data);
-        try_action_and_log(done, "on_operation_message_done", message.topic);
+        try {
+            handle(message.topic, message.data);
+        } catch (...) {
+            done(message.topic);
+            throw;
+        }
+        done(message.topic);
     };
 
     if (operation_thread_pool) {
@@ -284,16 +274,14 @@ void MessageHandler::on_operation_message_done(const std::string& topic) {
 
 void MessageHandler::run_result_message_worker() {
     while (auto message = result_message_queue.wait_and_pop()) {
-        try_action_and_log(bind_obj(&MessageHandler::handle_result_message, this), "result worker", message->topic,
-                           message->data);
+        handle_result_message(message->topic, message->data);
     }
     EVLOG_info << "Cmd result worker thread stopped";
 }
 
 void MessageHandler::run_external_mqtt_worker() {
-    auto callback = bind_obj(&MessageHandler::handle_external_mqtt_message, this);
     while (auto message = external_mqtt_message_queue.wait_and_pop()) {
-        try_action_and_log(callback, "External MQTT worker", message->topic, message->data);
+        handle_external_mqtt_message(message->topic, message->data);
     }
     EVLOG_info << "External MQTT worker thread stopped";
 }

--- a/lib/everest/framework/tests/test_message_handler.cpp
+++ b/lib/everest/framework/tests/test_message_handler.cpp
@@ -812,43 +812,6 @@ TEST_CASE("MessageHandler processes GetConfig messages", "[message_handler][conf
 // Test: Mixed Message Types
 // ============================================================================
 
-// ============================================================================
-// Test: Ordering preserved when a handler throws
-// ============================================================================
-
-TEST_CASE("MessageHandler preserves per-topic ordering after handler exception",
-          "[message_handler][ordering][exception]") {
-    MessageHandlerFixture handler;
-    ExecutionTracker tracker;
-
-    auto handler_func = std::make_shared<Handler>([&](const std::string& topic, const json& data) {
-        int seq = data.value("sequence", 0);
-        if (seq == 1) {
-            throw std::runtime_error("simulated handler failure");
-        }
-        tracker.record(topic, seq);
-    });
-    auto test_handler = std::make_shared<TypedHandler>(HandlerType::Call, handler_func);
-
-    handler->register_handler("test/topic", test_handler);
-
-    // Message 1 throws; messages 2 and 3 must still be processed in order.
-    handler->add(create_cmd_message("test/topic", 1));
-    handler->add(create_cmd_message("test/topic", 2));
-    handler->add(create_cmd_message("test/topic", 3));
-
-    tracker.wait_for_count(2);
-
-    auto events = tracker.get_events();
-    REQUIRE(events.size() == 2);
-    CHECK(events[0].sequence == 2);
-    CHECK(events[1].sequence == 3);
-}
-
-// ============================================================================
-// Test: Mixed Message Types
-// ============================================================================
-
 TEST_CASE("MessageHandler handles mixed message types concurrently", "[message_handler][mixed]") {
     MessageHandlerFixture handler;
     ExecutionTracker cmd_tracker;

--- a/lib/everest/util/include/everest/util/async/thread_pool_scaling.hpp
+++ b/lib/everest/util/include/everest/util/async/thread_pool_scaling.hpp
@@ -108,14 +108,35 @@ template <std::size_t ThresholdMs = 10> struct LatencyScaling {
 // |              |                          | when a specific depth limit is hit.    |
 // +--------------+--------------------------+----------------------------------------+
 
+// --- Exception Handling Policies ---
+
+/**
+ * @brief Exception policy: silently swallow exceptions (fire-and-forget semantics).
+ */
+struct SuppressExceptions {
+    static void handle_exception([[maybe_unused]] std::exception_ptr) noexcept {
+    }
+};
+
+/**
+ * @brief Exception policy: rethrow from the worker thread, terminating the process if uncaught.
+ */
+struct RethrowExceptions {
+    [[noreturn]] static void handle_exception(std::exception_ptr eptr) {
+        std::rethrow_exception(eptr);
+    }
+};
+
 /**
  * @brief A thread pool that dynamically scales its worker count based on a policy.
  * * @details This pool maintains a minimum number of threads and expands up to a maximum
  * when the ScalingPolicy (e.g., LatencyScaling or GreedyScaling) signals that growth
  * is necessary. Idle surplus threads are automatically retired after a specified timeout.
  * * @tparam ScalingPolicy A policy class implementing should_grow(size_t, size_t, std::optional<time_point>).
+ * * @tparam ExceptionPolicy A policy class implementing a static handle_exception() called inside the catch block.
  */
-template <typename ScalingPolicy = LatencyScaling<10>> class thread_pool_scaling {
+template <typename ScalingPolicy = LatencyScaling<10>, typename ExceptionPolicy = SuppressExceptions>
+class thread_pool_scaling {
 public:
     using action = std::function<void()>;
 
@@ -265,8 +286,7 @@ private:
                     try {
                         task_opt->func();
                     } catch (...) {
-                        // Suppress exception to prevent thread termination.
-                        // Fire-and-forget tasks are responsible for their own error handling.
+                        ExceptionPolicy::handle_exception(std::current_exception());
                     }
                     // Steal the zombie deque under the lock, then join outside it.
                     // Joining while holding the lock is safe in practice (the zombie has already


### PR DESCRIPTION

## Describe your changes

Add ExceptionPolicy to thread_pool_scaling with Suppress and Rethrow modes. Initialize the MessageHandler operation thread pool with Rethrow to preserve pre-extension behavior. Keep exception handling decisions in everest.cpp handler wrappers, where forwarding policy is already defined. This avoids silently swallowed handler exceptions and lets modules terminate on unhandled failures.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

