### PR TITLE
Ocpp201: Convert the ResetType from Ocpp to EVerest

### DIFF
--- a/modules/EVSE/OCPP201/OCPP201.cpp
+++ b/modules/EVSE/OCPP201/OCPP201.cpp
@@ -510,12 +510,12 @@ void OCPP201::ready() {
 
     ocpp::v2::Callbacks callbacks;
     callbacks.is_reset_allowed_callback = [this](const std::optional<const int32_t> evse_id,
-                                                 const ocpp::v2::ResetEnum&) {
+                                                 const ocpp::v2::ResetEnum& type) {
         if (evse_id.has_value()) {
             return false; // Reset of EVSE is currently not supported
         }
         try {
-            return this->r_system->call_is_reset_allowed(types::system::ResetType::NotSpecified);
+            return this->r_system->call_is_reset_allowed(conversions::to_everest_system_reset_type_enum(type));
         } catch (std::out_of_range& e) {
             EVLOG_warning << "Could not convert OCPP ResetEnum to EVerest ResetType while executing "
                              "is_reset_allowed_callback.";
@@ -533,7 +533,7 @@ void OCPP201::ready() {
         // small delay before stopping the charge point to make sure all responses are received
         std::this_thread::sleep_for(std::chrono::seconds(this->config.ResetStopDelay));
         try {
-            this->r_system->call_reset(types::system::ResetType::NotSpecified, scheduled);
+            this->r_system->call_reset(conversions::to_everest_system_reset_type_enum(type), scheduled);
         } catch (std::out_of_range& e) {
             EVLOG_warning << "Could not convert OCPP ResetEnum to EVerest ResetType while executing reset_callack. No "
                              "reset will be executed.";

--- a/modules/EVSE/OCPP201/conversions.cpp
+++ b/modules/EVSE/OCPP201/conversions.cpp
@@ -1820,5 +1820,17 @@ std::vector<types::iso15118::EnergyTransferMode> to_everest_allowed_energy_trans
     return value;
 }
 
+types::system::ResetType to_everest_system_reset_type_enum(const ocpp::v2::ResetEnum& from) {
+    switch (from) {
+    case ocpp::v2::ResetEnum::OnIdle:
+        return types::system::ResetType::Soft;
+    case ocpp::v2::ResetEnum::Immediate:
+        [[fallthrough]];
+    case ocpp::v2::ResetEnum::ImmediateAndResume:
+        return types::system::ResetType::Hard;
+    }
+    return types::system::ResetType::NotSpecified;
+}
+
 } // namespace conversions
 } // namespace module

--- a/modules/EVSE/OCPP201/conversions.hpp
+++ b/modules/EVSE/OCPP201/conversions.hpp
@@ -19,6 +19,7 @@
 #include <ocpp/v2/messages/GetDisplayMessages.hpp>
 #include <ocpp/v2/messages/GetLog.hpp>
 #include <ocpp/v2/messages/NotifyEVChargingNeeds.hpp>
+#include <ocpp/v2/messages/Reset.hpp>
 #include <ocpp/v2/messages/SetDisplayMessage.hpp>
 #include <ocpp/v2/messages/TransactionEvent.hpp>
 #include <ocpp/v2/messages/UpdateFirmware.hpp>
@@ -281,6 +282,9 @@ to_everest_allowed_energy_transfer_mode(const ocpp::v2::EnergyTransferModeEnum& 
 /// std::vector<types::iso15118::EnergyTransferMode>
 std::vector<types::iso15118::EnergyTransferMode> to_everest_allowed_energy_transfer_modes(
     const std::vector<ocpp::v2::EnergyTransferModeEnum>& allowed_energy_transfer_modes);
+
+/// \brief Converts the ocpp ResetEnum to the everest counterpart.
+types::system::ResetType to_everest_system_reset_type_enum(const ocpp::v2::ResetEnum& from);
 } // namespace conversions
 } // namespace module
 


### PR DESCRIPTION
## Describe your changes

forwards the real ocpp reset type to the everest interface - has no real effect on the current system module -> the system module always triggers the same action for now