### PR TITLE
Rust: Break cyclic ownerships

### DIFF
--- a/lib/everest/framework/everestrs/everestrs-build/jinja/client.jinja2
+++ b/lib/everest/framework/everestrs/everestrs-build/jinja/client.jinja2
@@ -84,7 +84,7 @@ use super::errors;
 #[derive(Clone)]
 pub(crate) struct {{trait.name | title }}ClientPublisher {
    pub(super) implementation_id: &'static str,
-   pub(super) runtime: ::std::pin::Pin<::std::sync::Arc<::everestrs::Runtime>>,
+   pub(super) runtime: ::std::sync::Weak<::everestrs::Runtime>,
    pub(super) index: usize,
 }
 
@@ -114,7 +114,12 @@ impl {{trait.name | title }}ClientPublisher {
             "{{arg.name}}": {{arg.name | identifier}},
 {%- endfor %}
         });
-        self.runtime.call_command(self.implementation_id, self.index, "{{ cmd.name }}", &args)
+        let rt = self.runtime.upgrade().ok_or_else(|| {
+            ::everestrs::Error::HandlerException(
+                "publisher used after Module was dropped".into(),
+            )
+        })?;
+        rt.call_command(self.implementation_id, self.index, "{{ cmd.name }}", &args)
       }
 {% endfor %}
 

--- a/lib/everest/framework/everestrs/everestrs-build/jinja/module.jinja2
+++ b/lib/everest/framework/everestrs/everestrs-build/jinja/module.jinja2
@@ -144,6 +144,11 @@ impl Module {
     ) -> &ModulePublisher {
         let runtime = &self.runtime;
         let connections = runtime.get_module_connections();
+        // Publishers hold a Weak<Runtime> so ModuleInner -> publishers ->
+        // Runtime -> sub_impl -> ModuleInner is not a cycle. Drop of the
+        // Module deterministically tears down Runtime, ModuleInner, and the
+        // mock subscribers inside it.
+        let runtime_weak = ::std::sync::Arc::downgrade(&::std::pin::Pin::into_inner(runtime.clone()));
         let inner = self.inner.get_or_init(|| {
             ::std::sync::Arc::new(ModuleInner {
                 on_ready,
@@ -163,27 +168,27 @@ impl Module {
                 publisher: ModulePublisher {
 {% for provide in provides %}
    {{ provide.implementation_id | identifier }}: {{provide.interface | title}}ServicePublisher {
-      implementation_id: "{{ provide.implementation_id }}",
-      runtime: runtime.clone(),
+        implementation_id: "{{ provide.implementation_id }}",
+        runtime: runtime_weak.clone(),
     },
 {% endfor %}
 {% for require in requires %}
     {% if require.min_connections == 1 and require.max_connections == 1 %}
         {{ require.implementation_id | identifier }}: {{require.interface | title}}ClientPublisher {
             implementation_id: "{{ require.implementation_id }}",
-            runtime: runtime.clone(),
+            runtime: runtime_weak.clone(),
             index: 0,
         },
     {% elif require.min_connections == require.max_connections %}
         {{ require.implementation_id | identifier }}_slots: ::core::array::from_fn(|i| {{require.interface | title}}ClientPublisher{
             implementation_id: "{{ require.implementation_id }}",
-            runtime: runtime.clone(),
+            runtime: runtime_weak.clone(),
             index: i,
         }),
     {% else %}
         {{ require.implementation_id | identifier }}_slots: (0..connections.get("{{require.implementation_id}}").cloned().unwrap_or(0)).map(|i| {{require.interface | title}}ClientPublisher{
             implementation_id: "{{ require.implementation_id }}",
-            runtime: runtime.clone(),
+            runtime: runtime_weak.clone(),
             index: i,
         }).collect(),
     {% endif %}

--- a/lib/everest/framework/everestrs/everestrs-build/jinja/service.jinja2
+++ b/lib/everest/framework/everestrs/everestrs-build/jinja/service.jinja2
@@ -78,28 +78,36 @@ use super::errors;
 #[derive(Clone)]
 pub(crate) struct {{trait.name | title }}ServicePublisher {
    pub(super) implementation_id: &'static str,
-   pub(super) runtime: ::std::pin::Pin<::std::sync::Arc<::everestrs::Runtime>>,
+   pub(super) runtime: ::std::sync::Weak<::everestrs::Runtime>,
 }
 
 impl {{trait.name | title }}ServicePublisher {
 {% for var in trait.vars %}
    pub(crate) fn {{ var.name | identifier }}(&self, value: {{ var.data_type.name }}) -> ::everestrs::Result<()> {
-      self.runtime.publish_variable(self.implementation_id, "{{ var.name }}", &value);
-      Ok(())
+        if let Some(runtime) = self.runtime.upgrade() {
+            runtime.publish_variable(self.implementation_id, "{{ var.name }}", &value)
+        }
+        Ok(())
    }
 {% endfor %}
 
 {%- if trait.errors %}
     pub(crate) fn raise_error(&self, error: ::everestrs::ErrorType<errors::{{ trait.name | snake }}::Error>) {
-        self.runtime.raise_error(self.implementation_id, error);
+        if let Some(runtime) = self.runtime.upgrade() {
+            runtime.raise_error(self.implementation_id, error);
+        }
     }
 
     pub(crate) fn clear_error(&self, error: errors::{{ trait.name | snake }}::Error) {
-        self.runtime.clear_error(self.implementation_id, error, true);
+        if let Some(runtime) = self.runtime.upgrade() {
+            runtime.clear_error(self.implementation_id, error, true);
+        }
     }
 
     pub(crate) fn clear_all_errors(&self) {
-        self.runtime.clear_error(self.implementation_id, "", true);
+        if let Some(runtime) = self.runtime.upgrade() {
+            runtime.clear_error(self.implementation_id, "", true);
+        }
     }
 {%- endif %}
 }

--- a/lib/everest/framework/everestrs/everestrs/src/everestrs_sys.cpp
+++ b/lib/everest/framework/everestrs/everestrs/src/everestrs_sys.cpp
@@ -109,6 +109,15 @@ Module::Module(const std::string& module_id, const std::string& prefix, const Ev
     handle_->spawn_main_loop_thread();
 }
 
+Module::~Module() {
+    // MQTTAbstractionImpl spawns a main loop thread whose only exit condition
+    // is `disconnect_event` being notified. Without this call the `Thread`
+    // member destructor joins a thread that will never exit.
+    if (handle_) {
+        handle_->disconnect();
+    }
+}
+
 JsonBlob Module::get_interface(rust::Str interface_name) const {
     const auto& interface_def = config_->get_interface_definition(std::string(interface_name));
     return json2blob(interface_def);

--- a/lib/everest/framework/everestrs/everestrs/src/everestrs_sys.hpp
+++ b/lib/everest/framework/everestrs/everestrs/src/everestrs_sys.hpp
@@ -28,6 +28,11 @@ public:
     /// In order to create the Module use the `create_module` function.
     Module(const std::string& module_id, const std::string& prefix, const Everest::MQTTSettings& mqtt_settings);
 
+    /// Stops the MQTT main loop before member destruction so the
+    /// `mqtt_mainloop_thread` join inside `~MQTTAbstractionImpl` doesn't
+    /// deadlock.
+    ~Module();
+
     JsonBlob get_manifest() const;
     JsonBlob get_interface(rust::Str interface_name) const;
     rust::Vec<RsModuleConfig> get_module_configs(rust::Str module_name) const;

--- a/lib/everest/framework/everestrs/tests/modules/RsExample/rs_tests/mocked_test.rs
+++ b/lib/everest/framework/everestrs/tests/modules/RsExample/rs_tests/mocked_test.rs
@@ -60,7 +60,7 @@ mod some_module {
 
     #[everestrs::test(config = "config_probe.yaml", module = "example_1")]
     #[should_panic]
-    fn test_mocked_with_panic(module: &Module) {
+    fn test_mocked_with_panic_handler(module: &Module) {
         let mock_service = Arc::new(MockExampleServiceSubscriber::new());
 
         let (tx, rx) = std::sync::mpsc::channel();
@@ -82,5 +82,23 @@ mod some_module {
         // Wait for RsExample's on_ready to publish max_current(123.0).
         rx.recv_timeout(std::time::Duration::from_secs(5))
             .expect("Timed out waiting for on_max_current");
+    }
+
+    #[everestrs::test(config = "config_probe.yaml", module = "example_1")]
+    #[should_panic]
+    fn test_mocked_with_panic_mocks(module: &Module) {
+        let mock_service = Arc::new(MockExampleServiceSubscriber::new());
+
+        let mut mock_client = MockExampleClientSubscriber::new();
+        mock_client
+            .expect_on_max_current()
+            .times(2..) // No one will call us twice.
+            .return_const(());
+        let mock_client = Arc::new(mock_client);
+
+        let mut mock_on_ready = MockOnReadySubscriber::new();
+        mock_on_ready.expect_on_ready().times(1).return_once(|_| ());
+
+        let _pub = module.start(Arc::new(mock_on_ready), mock_service, mock_client);
     }
 }

--- a/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
+++ b/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
@@ -84,7 +84,6 @@ private:
     std::vector<std::string> retained_topics;
     std::unordered_set<std::string> subscribed_topics;
 
-    Thread mqtt_mainloop_thread;
     std::shared_future<void> main_loop_future;
 
     std::string mqtt_server_socket_path;
@@ -96,6 +95,9 @@ private:
     std::unique_ptr<everest::lib::io::mqtt::mqtt_client> mqtt_client;
     everest::lib::io::event::event_fd disconnect_event;
     everest::lib::io::event::fd_event_handler ev_handler;
+
+    // This must be destroyed first.
+    Thread mqtt_mainloop_thread;
 
     void on_mqtt_message(const Message& message);
     void on_mqtt_connect();


### PR DESCRIPTION
## Describe your changes

Currently we have a cycling ownership of the runtime, where the ModuleInner would own the publishers and the publishers would own the runtime and the runtime would own the ModuleInner. This prevented us from dropping the runtime and the ModuleInner. 

This would prevent mockall test assertion evaluate their checkpoints. 

We break the cycle by using weak in the Publishers code
