### PR TITLE
fix(EnergyManager): Race Condition with energy_flow_request

### DIFF
--- a/modules/EnergyManagement/EnergyManager/EnergyManagerImpl.cpp
+++ b/modules/EnergyManagement/EnergyManager/EnergyManagerImpl.cpp
@@ -95,13 +95,13 @@ void EnergyManagerImpl::on_energy_flow_request(const types::energy::EnergyFlowRe
     }
 }
 
-std::vector<types::energy::EnforcedLimits> EnergyManagerImpl::run_optimizer(types::energy::EnergyFlowRequest request,
-                                                                            date::utc_clock::time_point start_time,
-                                                                            const std::string& test_name) {
+std::vector<types::energy::EnforcedLimits>
+EnergyManagerImpl::run_optimizer(const types::energy::EnergyFlowRequest& request,
+                                 date::utc_clock::time_point start_time, const std::string& test_name) {
+    std::scoped_lock lock(energy_mutex);
+
     globals.init(start_time, config.schedule_interval_duration, config.schedule_total_duration, config.slice_ampere,
                  config.slice_watt, config.debug, request);
-
-    std::scoped_lock lock(energy_mutex);
 
     time_probe optimizer_start;
     optimizer_start.start();

--- a/modules/EnergyManagement/EnergyManager/EnergyManagerImpl.hpp
+++ b/modules/EnergyManagement/EnergyManager/EnergyManagerImpl.hpp
@@ -48,7 +48,7 @@ public:
     /// \param request
     /// \param start_time
     /// \return a vector of limits to enforce at the individual nodes of the \p request
-    std::vector<types::energy::EnforcedLimits> run_optimizer(types::energy::EnergyFlowRequest request,
+    std::vector<types::energy::EnforcedLimits> run_optimizer(const types::energy::EnergyFlowRequest& request,
                                                              date::utc_clock::time_point start_time,
                                                              const std::string& test_name = "");
 

--- a/modules/EnergyManagement/EnergyManager/Market.cpp
+++ b/modules/EnergyManagement/EnergyManager/Market.cpp
@@ -384,7 +384,7 @@ void apply_setpoints(ScheduleReq& imp, ScheduleReq& exp, const ScheduleSetpoints
     }
 }
 
-Market::Market(types::energy::EnergyFlowRequest& _energy_flow_request, const float __nominal_ac_voltage,
+Market::Market(const types::energy::EnergyFlowRequest& _energy_flow_request, const float __nominal_ac_voltage,
                Market* __parent) :
     energy_flow_request(_energy_flow_request), _parent(__parent), _nominal_ac_voltage(__nominal_ac_voltage) {
 

--- a/modules/EnergyManagement/EnergyManager/Market.hpp
+++ b/modules/EnergyManagement/EnergyManager/Market.hpp
@@ -54,7 +54,7 @@ private:
 
 class Market {
 public:
-    Market(types::energy::EnergyFlowRequest& _energy_flow_request, const float __nominal_ac_voltage,
+    Market(const types::energy::EnergyFlowRequest& _energy_flow_request, const float __nominal_ac_voltage,
            Market* __parent = nullptr);
 
     void trade(const ScheduleRes& s);
@@ -76,7 +76,7 @@ public:
     float nominal_ac_voltage();
 
     // local request only for this node
-    types::energy::EnergyFlowRequest& energy_flow_request;
+    const types::energy::EnergyFlowRequest& energy_flow_request;
 
 private:
     Market* _parent;


### PR DESCRIPTION
## Describe your changes

Eliminate data race and unnecessary copy in optimizer

Acquire energy_mutex before globals.init() so the entire run_optimizer is protected against concurrent on_energy_flow_request writes. Pass EnergyFlowRequest as const& throughout (run_optimizer, Market constructor and member) to avoid copying a potentially large object on every iteration.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

