### PR TITLE
Add check of number of certificates

### DIFF
--- a/lib/everest/evse_security/lib/evse_security/evse_security.cpp
+++ b/lib/everest/evse_security/lib/evse_security/evse_security.cpp
@@ -376,6 +376,12 @@ InstallCertificateResult EvseSecurity::install_ca_certificate(const std::string&
 
         X509CertificateBundle existing_certs(ca_bundle_path, EncodingFormat::PEM);
 
+        if (existing_certs.get_certificate_count() > max_fs_certificate_store_entries) {
+            EVLOG_error << "Max number of certificates " << max_fs_certificate_store_entries
+                        << " reached, install not possible!";
+            return InstallCertificateResult::CertificateStoreMaxLengthExceeded;
+        }
+
         if (existing_certs.is_using_directory()) {
             const std::string filename = conversions::ca_certificate_type_to_string(certificate_type) + "_ROOT_" +
                                          filesystem_utils::get_random_file_name(PEM_EXTENSION.string());

--- a/lib/everest/evse_security/lib/evse_security/evse_security.cpp
+++ b/lib/everest/evse_security/lib/evse_security/evse_security.cpp
@@ -376,7 +376,18 @@ InstallCertificateResult EvseSecurity::install_ca_certificate(const std::string&
 
         X509CertificateBundle existing_certs(ca_bundle_path, EncodingFormat::PEM);
 
-        if (existing_certs.get_certificate_count() > max_fs_certificate_store_entries) {
+        std::uintmax_t total_v2g_mo_ca_count = 0;
+        for (const auto ca_type : {CaCertificateType::V2G, CaCertificateType::MO}) {
+            const auto ca_path = this->ca_bundle_path_map.at(ca_type);
+            if (!fs::is_directory(ca_path)) {
+                filesystem_utils::create_file_if_nonexistent(ca_path);
+            }
+
+            X509CertificateBundle ca_certs(ca_path, EncodingFormat::PEM);
+            total_v2g_mo_ca_count += ca_certs.get_certificate_count();
+        }
+
+        if (total_v2g_mo_ca_count > max_fs_certificate_store_entries) {
             EVLOG_error << "Max number of certificates " << max_fs_certificate_store_entries
                         << " reached, install not possible!";
             return InstallCertificateResult::CertificateStoreMaxLengthExceeded;


### PR DESCRIPTION
## Describe your changes

The InstallCertificate command is extended to check if the max number of certificates is reached.
If so, an error is returned.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

