### PR TITLE
fix(libocpp & framework): fix build on platforms which require libatomic

### DIFF
--- a/lib/everest/framework/lib/CMakeLists.txt
+++ b/lib/everest/framework/lib/CMakeLists.txt
@@ -85,6 +85,7 @@ target_link_libraries(framework
         Boost::program_options
         everest::io
         ryml::ryml
+        ${ATOMIC_LIBS}
 )
 
 collect_migration_files(

--- a/lib/everest/ocpp/lib/CMakeLists.txt
+++ b/lib/everest/ocpp/lib/CMakeLists.txt
@@ -201,6 +201,11 @@ if(LIBOCPP_USE_BOOST_FILESYSTEM)
     )
 endif()
 
+target_link_libraries(ocpp
+    PUBLIC
+        ${ATOMIC_LIBS}
+)
+
 # FIXME (aw): right now nlohmann_json and boost::optional don't compile
 #             with gcc 10.x and C++11/14, so we need to publish the
 #             C++17 standard


### PR DESCRIPTION
Same topic as already addressed in 21930bb5ad73:
On some platforms, e.g. armel or mipsel, std::atomic<...> requires linking with -latomic since such platforms do not support lock-free instruction sequences.

This commit fixes this for libocpp and framework by adding the conditional set variable.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

