### PR TITLE
Rust: Adds support for #[tokio::main] and #[tokio::test]

### DIFF
--- a/lib/everest/framework/everestrs/Cargo.lock
+++ b/lib/everest/framework/everestrs/Cargo.lock
@@ -273,6 +273,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -437,6 +438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "predicates"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +602,27 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/everest/framework/everestrs/everestrs-derive/src/lib.rs
+++ b/lib/everest/framework/everestrs/everestrs-derive/src/lib.rs
@@ -8,7 +8,9 @@ use syn::{parse_macro_input, spanned::Spanned, ItemFn, ItemMod, Type};
 /// it cannot be dropped prematurely. After the user function returns, the
 /// `Module` is dropped deterministically before process exit.
 ///
-/// # Example
+/// # Basics
+///
+/// The basic usage is demonstated below
 ///
 /// ```ignore
 /// #[everestrs::main]
@@ -18,6 +20,18 @@ use syn::{parse_macro_input, spanned::Spanned, ItemFn, ItemMod, Type};
 ///     loop { std::thread::sleep(std::time::Duration::from_secs(1)); }
 /// }
 /// ```
+///
+/// # Async
+///
+/// You can also use async for your code. The pattern is quite similar:
+///
+/// ```ignore
+/// #[everestrs::main]
+/// #[tokio::main]
+/// async fn main(module: &Module) {
+///     let class = Arc::new(MyModule {});
+///     ...
+/// }
 #[proc_macro_attribute]
 pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
     if !attr.is_empty() {
@@ -37,6 +51,10 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
     let param = &sig.inputs[0];
     let body = &input.block;
     let ret = &sig.output;
+    let maybe_async = &sig.asyncness;
+    let maybe_await = maybe_async.as_ref().map(|_| quote! {.await});
+    let ident = &sig.ident;
+    let attrs = &input.attrs;
 
     // Extract the parameter name and inner type from `name: &Type`.
     let (param_name, inner_ty) = match param {
@@ -51,12 +69,13 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let expanded = quote! {
-        fn main() #ret {
+        #(#attrs)*
+        #maybe_async fn #ident() #ret {
             let #param_name = #inner_ty::new();
             let __everest_result = {
-                fn __everest_main(#param_name: &#inner_ty) #ret
+                #maybe_async fn __everest_main(#param_name: &#inner_ty) #ret
                     #body
-                __everest_main(&#param_name)
+                __everest_main(&#param_name) #maybe_await
             };
             __everest_result
         }
@@ -66,20 +85,6 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 fn main_validate(input: &ItemFn) -> Result<(), syn::Error> {
-    if input.sig.ident != "main" {
-        return Err(syn::Error::new(
-            input.sig.ident.span(),
-            "#[everestrs::main] can only be applied to `fn main`",
-        ));
-    }
-
-    if input.sig.asyncness.is_some() {
-        return Err(syn::Error::new(
-            input.sig.asyncness.span(),
-            "#[everestrs::main] does not support async functions",
-        ));
-    }
-
     if !input.sig.generics.params.is_empty() {
         return Err(syn::Error::new(
             input.sig.generics.span(),
@@ -180,6 +185,8 @@ impl syn::parse::Parse for TestAttr {
 /// body. Each test gets a unique MQTT prefix so tests can run in parallel
 /// without topic collisions.
 ///
+/// # Basics
+///
 /// Both `config` and `module` are required.
 ///
 /// It can either be applied inside a module tagged with `everestrs::harness`.
@@ -203,12 +210,34 @@ impl syn::parse::Parse for TestAttr {
 /// #[everestrs::test(config = "config.yaml", module = "example_1", harness = true)]
 /// fn test_a(module: &Module) { ... }
 /// ```
+///
+/// # Other macros
+///
 /// The macro can be combined with other commonly used macros, for example
+///
 /// ```ignore
 /// #[everestrs::test(config = "config.yaml", module = "example_1", harness = true)]
 /// #[should_panic]
 /// fn test_a(module: &Module) {
 ///     assert!(false);
+/// }
+/// ```
+///
+/// You can also combine it with #[tokio::test]. The ordering does not matter
+///
+/// ```ignore
+/// #[everestrs::test(config = "config.yaml", module = "example_1", harness = true)]
+/// #[tokio::test]
+/// async fn my_test(module: &Module) {
+/// }
+/// ```
+///
+/// works same as
+///
+/// ```ignore
+/// #[tokio::test]
+/// #[everestrs::test(config = "config.yaml", module = "example_1", harness = true)]
+/// async fn my_test(module: &Module) {
 /// }
 /// ```
 #[proc_macro_attribute]
@@ -225,13 +254,6 @@ pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 fn test_validate(input: &ItemFn) -> Result<(), syn::Error> {
-    if input.sig.asyncness.is_some() {
-        return Err(syn::Error::new(
-            input.sig.asyncness.span(),
-            "#[everestrs::test] does not support async functions",
-        ));
-    }
-
     if !input.sig.generics.params.is_empty() {
         return Err(syn::Error::new(
             input.sig.generics.span(),
@@ -281,13 +303,31 @@ fn test_impl(attr: &TestAttr, item_fn: ItemFn) -> Result<proc_macro2::TokenStrea
 
     // Forward all attributes from the user function to the generated #[test] fn
     // (e.g. #[should_panic], #[ignore], #[allow(...)]).
-    let forwarded_attrs = &item_fn.attrs;
+    let attrs = &item_fn.attrs;
 
     let sig = &item_fn.sig;
     let ident = &sig.ident;
     let param = &sig.inputs[0];
     let ret = &sig.output;
     let body = &item_fn.block;
+    // Check if someone else after us might emit #[test]. `rstest` does
+    // something similar to prevent reemit this. We match any attribute whose
+    // last path segment is `test` — covers `#[test]`, `#[tokio::test]`,
+    // `#[async_std::test]`, etc.
+    // See https://github.com/la10736/rstest/blob/master/rstest_macros/src/utils.rs#L38
+    // and https://github.com/la10736/rstest/blob/master/rstest_macros/src/parse/rstest/test_attr.rs#L25
+    let maybe_test = if attrs.iter().any(|a| {
+        a.path()
+            .segments
+            .last()
+            .map_or(false, |s| s.ident == "test")
+    }) {
+        quote! {}
+    } else {
+        quote! { #[test] }
+    };
+    let maybe_async = &sig.asyncness;
+    let maybe_await = maybe_async.as_ref().map(|_| quote! {.await});
     let module = &attr.module_name;
 
     // Extract the parameter name and inner type from `name: &Type`.
@@ -312,9 +352,9 @@ fn test_impl(attr: &TestAttr, item_fn: ItemFn) -> Result<proc_macro2::TokenStrea
 
     // The function we would like to emit
     let test_fn = quote! {
-        #[test]
-        #(#forwarded_attrs)*
-        fn #ident() #ret {
+        #maybe_test
+        #(#attrs)*
+        #maybe_async fn #ident() #ret {
             let prefix = std::env::current_dir().expect("Failed to get current directory");
             let config = prefix.join(format!("etc/everest/{}", #config_basename));
 
@@ -344,9 +384,9 @@ fn test_impl(attr: &TestAttr, item_fn: ItemFn) -> Result<proc_macro2::TokenStrea
 
             let #param_name = #inner_ty::new_with_args(args);
             let __everest_result = {
-                fn __everest_test(#param_name: &#inner_ty) #ret
+                #maybe_async fn __everest_test(#param_name: &#inner_ty) #ret
                     #body
-                __everest_test(&#param_name)
+                __everest_test(&#param_name) #maybe_await
             };
             drop(#param_name);
             __everest_result
@@ -438,8 +478,6 @@ fn generate_harness_tokens(attr: &TestAttr) -> Result<proc_macro2::TokenStream, 
 /// Applied to a `mod` to share generated types across multiple tests and
 /// fixtures. For single test functions, use
 /// `#[everestrs::test(config = "...", module = "...")]` instead.
-///
-/// # Example
 ///
 /// ```ignore
 /// #[everestrs::harness(config = "config.yaml", module = "example_1")]

--- a/lib/everest/framework/everestrs/everestrs/Cargo.toml
+++ b/lib/everest/framework/everestrs/everestrs/Cargo.toml
@@ -24,3 +24,5 @@ build_bazel = []
 [dev-dependencies]
 mockall = "0.13.0"
 mockall_double = "0.3.1"
+# For tests
+tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros", "sync", "time"] }

--- a/lib/everest/framework/everestrs/tests/modules/RsAsync/BUILD.bazel
+++ b/lib/everest/framework/everestrs/tests/modules/RsAsync/BUILD.bazel
@@ -1,0 +1,96 @@
+load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//applications/utils:requirements.bzl", "requirement")
+load("//lib/everest/framework/bazel:everest_env.bzl", "everest_env", "everest_test")
+load("//lib/everest/framework/bazel:modules_def.bzl", "rs_everest_module")
+load("//third-party/bazel/toolchains:defs.bzl", "CROSS_PYTHON_INCOMPATIBLE")
+
+cargo_build_script(
+    name = "build_script",
+    srcs = ["build.rs"],
+    build_script_env = {
+        "EVEREST_CORE_ROOT": "../..",
+    },
+    data = [
+        "manifest.yaml",
+        "//lib/everest/framework/everestrs/tests/errors",
+        "//lib/everest/framework/everestrs/tests/interfaces",
+        "//lib/everest/framework/everestrs/tests/types",
+    ],
+    edition = "2021",
+    deps = [
+        "//lib/everest/framework/everestrs/everestrs-build",
+    ],
+)
+
+rust_binary(
+    name = "RsAsyncBinary",
+    srcs = glob(["src/**/*.rs"]),
+    edition = "2021",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":build_script",
+        "//lib/everest/framework/everestrs/everestrs",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_bridge",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_sys",
+        "@everest_framework_crate_index//:log",
+        "@everest_framework_crate_index//:tokio",
+    ],
+)
+
+rs_everest_module(
+    name = "RsAsync",
+    binary = ":RsAsyncBinary",
+    manifest = "manifest.yaml",
+)
+
+everest_env(
+    name = "config_env",
+    config_file = "config.yaml",
+    modules = [
+        ":RsAsync",
+    ],
+)
+
+sh_test(
+    name = "integration_test",
+    srcs = ["//lib/everest/framework/everestrs/tests/modules:smoke_test.sh"],
+    data = [":config_env"],
+    tags = ["exclusive"],
+)
+
+# Integration tests for RsAsync. Will launch EVerest with a ProbeModule and
+# validate calls to our trait mocks.
+rust_test(
+    name = "RsAsyncMockedTestBinary",
+    srcs = ["rs_tests/tests.rs"],
+    compile_data = [
+        "config.yaml",
+        "manifest.yaml",
+        "//lib/everest/framework/everestrs/tests/errors",
+        "//lib/everest/framework/everestrs/tests/interfaces",
+        "//lib/everest/framework/everestrs/tests/types",
+    ],
+    crate_features = [
+        "mockall",
+        "trait",
+    ],
+    data = ["config_env"],
+    edition = "2021",
+    proc_macro_deps = [
+        "//lib/everest/framework/everestrs/everestrs-derive",
+        "@everest_framework_crate_index//:mockall_double",
+    ],
+    rustc_env = {
+        "CARGO_MANIFEST_DIR": "lib/everest/framework/everestrs/tests/modules/RsAsync",
+        "EVEREST_CORE_ROOT": "lib/everest/framework/everestrs/tests",
+    },
+    tags = ["exclusive"],
+    deps = [
+        "//lib/everest/framework/everestrs/everestrs",
+        "@everest_framework_crate_index//:mockall",
+        "@everest_framework_crate_index//:tokio",
+    ],
+)

--- a/lib/everest/framework/everestrs/tests/modules/RsAsync/build.rs
+++ b/lib/everest/framework/everestrs/tests/modules/RsAsync/build.rs
@@ -1,0 +1,13 @@
+use everestrs_build::Builder;
+
+pub fn main() {
+    Builder::new(
+        "manifest.yaml",
+        vec![std::env::var("EVEREST_CORE_ROOT").unwrap_or("../../..".to_string())],
+    )
+    .generate()
+    .unwrap();
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=manifest.yaml");
+}

--- a/lib/everest/framework/everestrs/tests/modules/RsAsync/config.yaml
+++ b/lib/everest/framework/everestrs/tests/modules/RsAsync/config.yaml
@@ -1,0 +1,14 @@
+# Test config for regression tests for the framework.
+active_modules:
+  example_0:
+    module: RsAsync
+    connections:
+      receiver:
+        - module_id: example_1
+          implementation_id: sender
+  example_1:
+    module: RsAsync
+    connections:
+      receiver:
+        - module_id: example_0
+          implementation_id: sender

--- a/lib/everest/framework/everestrs/tests/modules/RsAsync/manifest.yaml
+++ b/lib/everest/framework/everestrs/tests/modules/RsAsync/manifest.yaml
@@ -1,0 +1,14 @@
+description: Simple Example
+provides:
+  sender:
+    interface: example
+    description: An example interface.
+requires:
+  receiver:
+    interface: example
+    ignore:
+      errors: true
+metadata:
+  license: https://opensource.org/licenses/Apache-2.0
+  authors:
+    - Everest authors

--- a/lib/everest/framework/everestrs/tests/modules/RsAsync/rs_tests/tests.rs
+++ b/lib/everest/framework/everestrs/tests/modules/RsAsync/rs_tests/tests.rs
@@ -1,0 +1,60 @@
+#![allow(non_snake_case)]
+
+use std::sync::Arc;
+use tokio::sync::oneshot;
+
+#[tokio::test]
+#[everestrs::test(config = "config.yaml", module = "example_1", harness = true)]
+async fn test_tokio_everest(module: &Module) {
+    use super::*;
+    use generated::*;
+
+    let mock_service = Arc::new(MockExampleServiceSubscriber::new());
+
+    let (tx, rx) = oneshot::channel();
+    let mut mock_client = MockExampleClientSubscriber::new();
+    mock_client
+        .expect_on_max_current()
+        .withf(|_, value| *value == 123.0)
+        .times(1)
+        .return_once(move |_, _| {
+            tx.send(()).unwrap();
+        });
+    let mock_client = Arc::new(mock_client);
+
+    let mut mock_on_ready = MockOnReadySubscriber::new();
+    mock_on_ready.expect_on_ready().times(1).return_once(|_| ());
+
+    let _pub = module.start(Arc::new(mock_on_ready), mock_service, mock_client);
+
+    // Wait for RsExample's on_ready to publish max_current(123.0).
+    rx.await.expect("Timed out waiting for on_max_current");
+}
+
+#[everestrs::test(config = "config.yaml", module = "example_1", harness = true)]
+#[tokio::test]
+async fn test_everest_tokio(module: &Module) {
+    use super::*;
+    use generated::*;
+
+    let mock_service = Arc::new(MockExampleServiceSubscriber::new());
+
+    let (tx, rx) = oneshot::channel();
+    let mut mock_client = MockExampleClientSubscriber::new();
+    mock_client
+        .expect_on_max_current()
+        .withf(|_, value| *value == 123.0)
+        .times(1)
+        .return_once(move |_, _| {
+            tx.send(()).unwrap();
+        });
+    let mock_client = Arc::new(mock_client);
+
+    let mut mock_on_ready = MockOnReadySubscriber::new();
+    mock_on_ready.expect_on_ready().times(1).return_once(|_| ());
+
+    let _pub = module.start(Arc::new(mock_on_ready), mock_service, mock_client);
+
+    // Wait for RsExample's on_ready to publish max_current(123.0).
+    rx.await.expect("Timed out waiting for on_max_current");
+}

--- a/lib/everest/framework/everestrs/tests/modules/RsAsync/src/main.rs
+++ b/lib/everest/framework/everestrs/tests/modules/RsAsync/src/main.rs
@@ -1,0 +1,77 @@
+#![allow(non_snake_case)]
+include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+
+use generated::{
+    Context, ExampleClientSubscriber, ExampleServiceSubscriber, Module, ModulePublisher,
+    OnReadySubscriber,
+};
+use std::sync::{Arc, Mutex};
+// Just to use async.
+use tokio::sync::oneshot;
+use tokio::time::sleep;
+
+pub struct OneClass {
+    tx: Mutex<Option<oneshot::Sender<String>>>,
+}
+
+impl ExampleServiceSubscriber for OneClass {
+    fn uses_something(&self, _context: &Context, key: String) -> ::everestrs::Result<bool> {
+        log::info!("Received {key}");
+        let tx = self.tx.lock().unwrap().take();
+        if let Some(tx) = tx {
+            tx.send(key).unwrap();
+        }
+        Ok(true)
+    }
+}
+
+impl ExampleClientSubscriber for OneClass {
+    fn on_max_current(&self, context: &Context, value: f64) {
+        log::info!("Received {value}");
+        context
+            .publisher
+            .receiver
+            .uses_something(format!("{value}"))
+            .unwrap();
+    }
+}
+
+impl OnReadySubscriber for OneClass {
+    fn on_ready(&self, _publishers: &ModulePublisher) {
+        log::info!("Ready");
+    }
+}
+
+/// Example how to use async with Everest. Everything in EVerest (all traits)
+/// remain strictly sync because of the underlying c++ runtime. However, you can
+/// combine your async code with sync EVerest.
+///
+/// You can combine the `everestrs::main` macro with `tokio::main` macro. The
+/// ordering does not really matter, so for non-main function (functions which
+/// can receive input args), you can also write
+/// ```ignore
+/// #[tokio::main]
+/// #[everestrs::main]
+/// async fn my_fun(module: &Module) {}
+/// ```
+#[everestrs::main]
+#[tokio::main]
+async fn main(module: &Module) {
+    let config = module.get_config();
+    log::info!("Received the config {config:?}");
+    let (tx, rx) = oneshot::channel();
+    let one_class = Arc::new(OneClass {
+        tx: Mutex::new(Some(tx)),
+    });
+    let publishers = module.start(one_class.clone(), one_class.clone(), one_class.clone());
+
+    publishers.sender.max_current(123.).unwrap();
+
+    // Simulate some async steps...
+    let result = rx.await.unwrap();
+    log::info!("Done {result}");
+
+    loop {
+        sleep(std::time::Duration::from_secs(1)).await;
+    }
+}

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -526,6 +526,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -962,13 +963,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1408,12 +1409,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1537,15 +1538,15 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1562,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1824,7 +1825,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1839,7 +1840,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1848,16 +1849,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1875,31 +1867,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1909,22 +1884,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1933,22 +1896,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1957,22 +1908,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1981,22 +1920,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "yore"


### PR DESCRIPTION
## Describe your changes

Adds support for `#[tokio::main]` and `#[tokio::test]` macros allowing to combine sync EVerest and async 3rd party code.

You can write now to launch your async code
```rs
#[everestrs::main]
#[tokio::main]
async fn main(module: &Module) {
    let class = Arc::new(MyModule {});
    ...
}
```

For tests you can use 
```rs
#[everestrs::test(config = "config.yaml", module = "example_1", harness = true)]
#[tokio::test]
async fn my_test(module: &Module) {
}
```
