### PR TITLE
EvseManager: re-issue SessionStart if Ev is still plugged in at Sessi…

### DIFF
--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -964,6 +964,29 @@ void Charger::run_state_machine() {
                 break;
             }
 
+            // Cable still attached and the stop was user/CSMS-initiated: end
+            // the transaction, refresh the session, and route back to
+            // WaitingForAuthentication so a new RFID swipe can start a new
+            // transaction without requiring a replug. Fatal stops (errors,
+            // emergency, plug-out, etc.) fall through to Finished below and
+            // continue to require a replug, as documented there.
+            if (shared_context.flag_ev_plugged_in and not stop_charging_on_fatal_error_internal() and
+                shared_context.last_stop_transaction_reason.has_value()) {
+                using StopReason = types::evse_manager::StopTransactionReason;
+                const auto reason = shared_context.last_stop_transaction_reason.value();
+                const bool soft_restartable = reason == StopReason::Local or reason == StopReason::Remote or
+                                              reason == StopReason::MasterPass or reason == StopReason::DeAuthorized;
+                if (soft_restartable) {
+                    if (shared_context.flag_transaction_active) {
+                        stop_transaction();
+                    }
+                    bsp->allow_power_on(false, types::evse_board_support::Reason::PowerOff);
+                    stop_session();
+                    set_state(EvseState::WaitingForAuthentication);
+                    break;
+                }
+            }
+
             // Those are fatal, so we can not recover without replugging.
             if (not shared_context.flag_transaction_active or not shared_context.flag_ev_plugged_in or
                 not shared_context.flag_authorized) {
@@ -1317,6 +1340,14 @@ void Charger::stop_session() {
     shared_context.flag_paused_by_evse = false;
     signal_simple_event(types::evse_manager::SessionEventEnum::SessionFinished);
     shared_context.session_uuid.clear();
+
+    // If the EV is still physically connected, immediately open a new session
+    // so downstream consumers (e.g. Auth's plug_in_queue) treat this as a
+    // fresh plug-in event and don't require the customer to replug to start
+    // a new transaction.
+    if (shared_context.flag_ev_plugged_in) {
+        start_session(false);
+    }
 }
 
 bool Charger::start_transaction() {

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -964,6 +964,32 @@ void Charger::run_state_machine() {
                 break;
             }
 
+            // Cable still attached and the stop was user/CSMS-initiated: end
+            // the transaction, refresh the session, and route back to
+            // WaitingForAuthentication so a new RFID swipe can start a new
+            // transaction without requiring a replug. Fatal stops (errors,
+            // emergency, plug-out, etc.) fall through to Finished below and
+            // continue to require a replug, as documented there.
+            if (shared_context.flag_ev_plugged_in and not stop_charging_on_fatal_error_internal() and
+                shared_context.last_stop_transaction_reason.has_value()) {
+                using StopReason = types::evse_manager::StopTransactionReason;
+                const auto reason = shared_context.last_stop_transaction_reason.value();
+                const bool soft_restartable = reason == StopReason::Local or reason == StopReason::Remote or
+                                              reason == StopReason::MasterPass or reason == StopReason::DeAuthorized;
+                if (soft_restartable) {
+                    if (shared_context.flag_transaction_active) {
+                        stop_transaction();
+                    }
+                    if (config_context.charge_mode == ChargeMode::DC) {
+                        signal_dc_supply_off();
+                    }                    
+                    bsp->allow_power_on(false, types::evse_board_support::Reason::PowerOff);
+                    stop_session();
+                    set_state(EvseState::WaitingForAuthentication);
+                    break;
+                }
+            }
+
             // Those are fatal, so we can not recover without replugging.
             if (not shared_context.flag_transaction_active or not shared_context.flag_ev_plugged_in or
                 not shared_context.flag_authorized) {

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -1037,6 +1037,32 @@ void Charger::run_state_machine() {
                 break;
             }
 
+            // Cable still attached and the stop was user/CSMS-initiated: end
+            // the transaction, refresh the session, and route back to
+            // WaitingForAuthentication so a new RFID swipe can start a new
+            // transaction without requiring a replug. Fatal stops (errors,
+            // emergency, plug-out, etc.) fall through to Finished below and
+            // continue to require a replug, as documented there.
+            if (shared_context.flag_ev_plugged_in and not stop_charging_on_fatal_error_internal() and
+                shared_context.last_stop_transaction_reason.has_value()) {
+                using StopReason = types::evse_manager::StopTransactionReason;
+                const auto reason = shared_context.last_stop_transaction_reason.value();
+                const bool soft_restartable = reason == StopReason::Local or reason == StopReason::Remote or
+                                              reason == StopReason::MasterPass or reason == StopReason::DeAuthorized;
+                if (soft_restartable) {
+                    if (shared_context.flag_transaction_active) {
+                        stop_transaction();
+                    }
+                    if (config_context.charge_mode == ChargeMode::DC) {
+                        signal_dc_supply_off();
+                    }
+                    bsp->allow_power_on(false, types::evse_board_support::Reason::PowerOff);
+                    stop_session();
+                    set_state(EvseState::WaitingForAuthentication);
+                    break;
+                }
+            }
+
             // Those are fatal, so we can not recover without replugging.
             if (not shared_context.flag_transaction_active or not shared_context.flag_ev_plugged_in or
                 not shared_context.flag_authorized or shared_context.flag_disable_requested) {

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -675,6 +675,65 @@ TEST_F(ChargerTest, DelayedAuthorizeAfterCancelTransactionIsIgnored) {
     EXPECT_TRUE(ctx.flag_externally_cancelled);
 }
 
+// tests for stop_session() refreshing the session when the EV is still plugged in.
+// Driven via the public authorize(false, ...) entry point because stop_session is private.
+struct StopSessionRefreshTest : public ChargerTest {
+    int session_started_count{0};
+    int session_finished_count{0};
+    types::evse_manager::StartSessionReason last_start_reason{};
+
+    void SetUp() override {
+        ChargerTest::SetUp();
+        charger->signal_session_started_event.connect([this](types::evse_manager::StartSessionReason reason,
+                                                             std::optional<types::authorization::ProvidedIdToken>) {
+            session_started_count++;
+            last_start_reason = reason;
+        });
+        charger->signal_simple_event.connect([this](SessionEventEnum event) {
+            if (event == SessionEventEnum::SessionFinished) {
+                session_finished_count++;
+            }
+        });
+    }
+
+    static types::authorization::ProvidedIdToken make_token() {
+        types::authorization::ProvidedIdToken token;
+        token.id_token.value = "TOKEN";
+        token.id_token.type = types::authorization::IdTokenType::Central;
+        token.authorization_type = types::authorization::AuthorizationType::OCPP;
+        return token;
+    }
+};
+
+TEST_F(StopSessionRefreshTest, DeauthWhilePluggedInReopensSession) {
+    auto& ctx = charger->get_shared_context();
+    ctx.session_active = true;
+    ctx.flag_ev_plugged_in = true;
+
+    types::authorization::ValidationResult result;
+    result.authorization_status = types::authorization::AuthorizationStatus::Accepted;
+    charger->authorize(false, make_token(), result);
+
+    EXPECT_EQ(session_finished_count, 1) << "SessionFinished should fire once";
+    EXPECT_EQ(session_started_count, 1) << "Still-plugged EV should get a fresh SessionStarted";
+    EXPECT_EQ(last_start_reason, types::evse_manager::StartSessionReason::EVConnected);
+    EXPECT_TRUE(ctx.session_active) << "start_session should re-arm session_active";
+}
+
+TEST_F(StopSessionRefreshTest, DeauthAfterUnplugDoesNotReopenSession) {
+    auto& ctx = charger->get_shared_context();
+    ctx.session_active = true;
+    ctx.flag_ev_plugged_in = false;
+
+    types::authorization::ValidationResult result;
+    result.authorization_status = types::authorization::AuthorizationStatus::Accepted;
+    charger->authorize(false, make_token(), result);
+
+    EXPECT_EQ(session_finished_count, 1);
+    EXPECT_EQ(session_started_count, 0) << "No fresh session when EV is gone";
+    EXPECT_FALSE(ctx.session_active);
+}
+
 } // namespace
 
 // ----------------------------------------------------------------------------

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -675,6 +675,50 @@ TEST_F(ChargerTest, DelayedAuthorizeAfterCancelTransactionIsIgnored) {
     EXPECT_TRUE(ctx.flag_externally_cancelled);
 }
 
+// tests for stop_session() refreshing the session when the EV is still plugged in.
+// Driven via the public authorize(false, ...) entry point because stop_session is private.
+struct StopSessionRefreshTest : public ChargerTest {
+    int session_started_count{0};
+    int session_finished_count{0};
+    types::evse_manager::StartSessionReason last_start_reason{};
+
+    void SetUp() override {
+        ChargerTest::SetUp();
+        charger->signal_session_started_event.connect([this](types::evse_manager::StartSessionReason reason,
+                                                             std::optional<types::authorization::ProvidedIdToken>) {
+            session_started_count++;
+            last_start_reason = reason;
+        });
+        charger->signal_simple_event.connect([this](SessionEventEnum event) {
+            if (event == SessionEventEnum::SessionFinished) {
+                session_finished_count++;
+            }
+        });
+    }
+
+    static types::authorization::ProvidedIdToken make_token() {
+        types::authorization::ProvidedIdToken token;
+        token.id_token.value = "TOKEN";
+        token.id_token.type = types::authorization::IdTokenType::Central;
+        token.authorization_type = types::authorization::AuthorizationType::OCPP;
+        return token;
+    }
+};
+
+TEST_F(StopSessionRefreshTest, DeauthAfterUnplugDoesNotReopenSession) {
+    auto& ctx = charger->get_shared_context();
+    ctx.session_active = true;
+    ctx.flag_ev_plugged_in = false;
+
+    types::authorization::ValidationResult result;
+    result.authorization_status = types::authorization::AuthorizationStatus::Accepted;
+    charger->authorize(false, make_token(), result);
+
+    EXPECT_EQ(session_finished_count, 1);
+    EXPECT_EQ(session_started_count, 0) << "No fresh session when EV is gone";
+    EXPECT_FALSE(ctx.session_active);
+}
+
 } // namespace
 
 // ----------------------------------------------------------------------------

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -761,6 +761,50 @@ TEST_F(ChargerTest, DisableDuringIdle) {
     EXPECT_EQ(last_event, SessionEventEnum::Disabled);
 }
 
+// tests for stop_session() refreshing the session when the EV is still plugged in.
+// Driven via the public authorize(false, ...) entry point because stop_session is private.
+struct StopSessionRefreshTest : public ChargerTest {
+    int session_started_count{0};
+    int session_finished_count{0};
+    types::evse_manager::StartSessionReason last_start_reason{};
+
+    void SetUp() override {
+        ChargerTest::SetUp();
+        charger->signal_session_started_event.connect([this](types::evse_manager::StartSessionReason reason,
+                                                             std::optional<types::authorization::ProvidedIdToken>) {
+            session_started_count++;
+            last_start_reason = reason;
+        });
+        charger->signal_simple_event.connect([this](SessionEventEnum event) {
+            if (event == SessionEventEnum::SessionFinished) {
+                session_finished_count++;
+            }
+        });
+    }
+
+    static types::authorization::ProvidedIdToken make_token() {
+        types::authorization::ProvidedIdToken token;
+        token.id_token.value = "TOKEN";
+        token.id_token.type = types::authorization::IdTokenType::Central;
+        token.authorization_type = types::authorization::AuthorizationType::OCPP;
+        return token;
+    }
+};
+
+TEST_F(StopSessionRefreshTest, DeauthAfterUnplugDoesNotReopenSession) {
+    auto& ctx = charger->get_shared_context();
+    ctx.session_active = true;
+    ctx.flag_ev_plugged_in = false;
+
+    types::authorization::ValidationResult result;
+    result.authorization_status = types::authorization::AuthorizationStatus::Accepted;
+    charger->authorize(false, make_token(), result);
+
+    EXPECT_EQ(session_finished_count, 1);
+    EXPECT_EQ(session_started_count, 0) << "No fresh session when EV is gone";
+    EXPECT_FALSE(ctx.session_active);
+}
+
 } // namespace
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Currently the auth module would not consider an Ev as connected if the session stops and the customer is not unplugging. We reissue the SessionStart here to allow users to re-authenticate without unplugging

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

