### PR TITLE
fix(e2e-tests):Use one EXI JVM once per session

### DIFF
--- a/tests/ocpp_tests/conftest.py
+++ b/tests/ocpp_tests/conftest.py
@@ -49,6 +49,12 @@ def pytest_sessionfinish(session, exitstatus):
     pass
 
 
+@pytest.fixture(scope="session")
+def exi_generator():
+    certs_path = str(Path(__file__).parent / "test_sets" / "everest-aux" / "certs")
+    return everest_test_utils.EXIGenerator(certs_path)
+
+
 @pytest.fixture
 def test_config() -> OcppTestConfiguration:
     return everest_test_utils.load_test_config()

--- a/tests/ocpp_tests/test_sets/everest_test_utils.py
+++ b/tests/ocpp_tests/test_sets/everest_test_utils.py
@@ -87,39 +87,17 @@ class EXIGenerator:
         self.certs_path = certs_path
         EXI().set_exi_codec(ExificientEXICodec())
 
-    def generate_certificate_installation_res(
-        self, base64_encoded_cert_installation_req: str, namespace: str
-    ) -> str:
-
-        cert_install_req_exi = base64.b64decode(
-            base64_encoded_cert_installation_req)
-        cert_install_req = EXI().from_exi(cert_install_req_exi, namespace)
-        try:
-            dh_pub_key, encrypted_priv_key_bytes = encrypt_priv_key(
-                oem_prov_cert=load_cert(
-                    os.path.join(self.certs_path, CertPath.OEM_LEAF_DER)
-                ),
-                priv_key_to_encrypt=load_priv_key(
-                    os.path.join(self.certs_path, KeyPath.CONTRACT_LEAF_PEM),
-                    KeyEncoding.PEM,
-                    os.path.join(
-                        self.certs_path, KeyPasswordPath.CONTRACT_LEAF_KEY_PASSWORD
-                    ),
-                ),
-            )
-        except EncryptionError:
-            raise EncryptionError(
-                "EncryptionError while trying to encrypt the private key for the "
-                "contract certificate"
-            )
-        except PrivateKeyReadError as exc:
-            raise PrivateKeyReadError(
-                f"Can't read private key to encrypt for CertificateInstallationRes:"
-                f" {exc}"
-            )
-
-        # The elements that need to be part of the signature
-        contract_cert_chain = CertificateChain(
+        self.oem_leaf_der = load_cert(
+            os.path.join(self.certs_path, CertPath.OEM_LEAF_DER)
+        )
+        self.contract_leaf_key = load_priv_key(
+            os.path.join(self.certs_path, KeyPath.CONTRACT_LEAF_PEM),
+            KeyEncoding.PEM,
+            os.path.join(
+                self.certs_path, KeyPasswordPath.CONTRACT_LEAF_KEY_PASSWORD
+            ),
+        )
+        self.contract_cert_chain = CertificateChain(
             id="id1",
             certificate=load_cert(
                 os.path.join(self.certs_path, CertPath.CONTRACT_LEAF_DER)
@@ -133,18 +111,14 @@ class EXIGenerator:
                 ]
             ),
         )
-        encrypted_priv_key = EncryptedPrivateKey(
-            id="id2", value=encrypted_priv_key_bytes
-        )
-        dh_public_key = DHPublicKey(id="id3", value=dh_pub_key)
-        emaid = EMAID(
+        self.emaid = EMAID(
             id="id4",
             value=get_cert_cn(
                 load_cert(os.path.join(self.certs_path,
                           CertPath.CONTRACT_LEAF_DER))
             ),
         )
-        cps_certificate_chain = CertificateChain(
+        self.cps_certificate_chain = CertificateChain(
             certificate=load_cert(os.path.join(
                 self.certs_path, CertPath.CPS_LEAF_DER)),
             sub_certificates=SubCertificates(
@@ -156,54 +130,67 @@ class EXIGenerator:
                 ]
             ),
         )
+        self.signature_key = load_priv_key(
+            os.path.join(self.certs_path, KeyPath.CPS_LEAF_PEM),
+            KeyEncoding.PEM,
+            os.path.join(self.certs_path,
+                         KeyPasswordPath.CPS_LEAF_KEY_PASSWORD),
+        )
+        self.contract_cert_chain_exi = EXI().to_exi(
+            self.contract_cert_chain, Namespace.ISO_V2_MSG_DEF
+        )
+        self.emaid_exi = EXI().to_exi(
+            self.emaid, Namespace.ISO_V2_MSG_DEF
+        )
+
+    def generate_certificate_installation_res(
+        self, base64_encoded_cert_installation_req: str, namespace: str
+    ) -> str:
+
+        cert_install_req_exi = base64.b64decode(base64_encoded_cert_installation_req)
+        cert_install_req = EXI().from_exi(cert_install_req_exi, namespace)
+        try:
+            dh_pub_key, encrypted_priv_key_bytes = encrypt_priv_key(
+                oem_prov_cert=self.oem_leaf_der,
+                priv_key_to_encrypt=self.contract_leaf_key,
+            )
+        except EncryptionError:
+            raise EncryptionError(
+                "EncryptionError while trying to encrypt the private key for the "
+                "contract certificate"
+            )
+        except PrivateKeyReadError as exc:
+            raise PrivateKeyReadError(
+                f"Can't read private key to encrypt for CertificateInstallationRes:"
+                f" {exc}"
+            )
+
+        encrypted_priv_key = EncryptedPrivateKey(id="id2", value=encrypted_priv_key_bytes)
+        dh_public_key = DHPublicKey(id="id3", value=dh_pub_key)
 
         cert_install_res = CertificateInstallationRes(
             response_code=ResponseCode.OK,
-            cps_cert_chain=cps_certificate_chain,
-            contract_cert_chain=contract_cert_chain,
+            cps_cert_chain=self.cps_certificate_chain,
+            contract_cert_chain=self.contract_cert_chain,
             encrypted_private_key=encrypted_priv_key,
             dh_public_key=dh_public_key,
-            emaid=emaid,
+            emaid=self.emaid,
         )
 
         try:
-            # Elements to sign, containing its id and the exi encoded stream
-            contract_cert_tuple = (
-                cert_install_res.contract_cert_chain.id,
-                EXI().to_exi(
-                    cert_install_res.contract_cert_chain, Namespace.ISO_V2_MSG_DEF
-                ),
-            )
-            encrypted_priv_key_tuple = (
-                cert_install_res.encrypted_private_key.id,
-                EXI().to_exi(
-                    cert_install_res.encrypted_private_key, Namespace.ISO_V2_MSG_DEF
-                ),
-            )
-            dh_public_key_tuple = (
-                cert_install_res.dh_public_key.id,
-                EXI().to_exi(cert_install_res.dh_public_key, Namespace.ISO_V2_MSG_DEF),
-            )
-            emaid_tuple = (
-                cert_install_res.emaid.id,
-                EXI().to_exi(cert_install_res.emaid, Namespace.ISO_V2_MSG_DEF),
-            )
-
             elements_to_sign = [
-                contract_cert_tuple,
-                encrypted_priv_key_tuple,
-                dh_public_key_tuple,
-                emaid_tuple,
+                (cert_install_res.contract_cert_chain.id, self.contract_cert_chain_exi),
+                (
+                    cert_install_res.encrypted_private_key.id,
+                    EXI().to_exi(cert_install_res.encrypted_private_key, Namespace.ISO_V2_MSG_DEF),
+                ),
+                (
+                    cert_install_res.dh_public_key.id,
+                    EXI().to_exi(cert_install_res.dh_public_key, Namespace.ISO_V2_MSG_DEF),
+                ),
+                (cert_install_res.emaid.id, self.emaid_exi),
             ]
-            # The private key to be used for the signature
-            signature_key = load_priv_key(
-                os.path.join(self.certs_path, KeyPath.CPS_LEAF_PEM),
-                KeyEncoding.PEM,
-                os.path.join(self.certs_path,
-                             KeyPasswordPath.CPS_LEAF_KEY_PASSWORD),
-            )
-
-            signature = create_signature(elements_to_sign, signature_key)
+            signature = create_signature(elements_to_sign, self.signature_key)
 
         except PrivateKeyReadError as exc:
             raise Exception(
@@ -217,18 +204,14 @@ class EXIGenerator:
             session_id=cert_install_req.header.session_id,
             signature=signature,
         )
-        body = Body.parse_obj(
-            {"CertificateInstallationRes": cert_install_res.dict()})
+        body = Body.parse_obj({"CertificateInstallationRes": cert_install_res.dict()})
         to_be_exi_encoded = V2GMessageV2(header=header, body=body)
         exi_encoded_cert_installation_res = EXI().to_exi(
             to_be_exi_encoded, Namespace.ISO_V2_MSG_DEF
         )
 
-        base64_encode_cert_install_res = base64.b64encode(
-            exi_encoded_cert_installation_res
-        ).decode("utf-8")
+        return base64.b64encode(exi_encoded_cert_installation_res).decode("utf-8")
 
-        return base64_encode_cert_install_res
 
 
 def certificate_signed_response(csr: crypto.X509Req):
@@ -268,7 +251,7 @@ def certificate_signed_response(csr: crypto.X509Req):
     return crypto.dump_certificate(crypto.FILETYPE_PEM, signed_cert).decode("utf-8")
 
 
-def on_data_transfer(accept_pnc_authorize, **kwargs):
+def on_data_transfer(accept_pnc_authorize, exi_generator: EXIGenerator, **kwargs):
     req = call.DataTransfer(**kwargs)
     if req.vendor_id == "org.openchargealliance.iso15118pnc":
         if req.message_id == "Authorize":
@@ -295,11 +278,9 @@ def on_data_transfer(accept_pnc_authorize, **kwargs):
                 status=DataTransferStatus.unknown_message_id, data="Please implement me"
             )
         elif req.message_id == "Get15118EVCertificate":
-            certs_path: str = Path(
-                __file__).parent.resolve() / "everest-aux/certs/"
-            generator: EXIGenerator = EXIGenerator(certs_path)
-            exi_request = json.loads(kwargs["data"])["exiRequest"]
-            namespace = json.loads(kwargs["data"])["iso15118SchemaVersion"]
+            data_payload = json.loads(kwargs["data"])
+            exi_request = data_payload["exiRequest"]
+            namespace = data_payload["iso15118SchemaVersion"]
             return call_result.DataTransfer(
                 status=DataTransferStatus.accepted,
                 data=json.dumps(
@@ -308,7 +289,7 @@ def on_data_transfer(accept_pnc_authorize, **kwargs):
                             asdict(
                                 call_result201.Get15118EVCertificate(
                                     status=Iso15118EVCertificateStatusEnumType.accepted,
-                                    exi_response=generator.generate_certificate_installation_res(
+                                    exi_response=exi_generator.generate_certificate_installation_res(
                                         exi_request, namespace
                                     ),
                                 )
@@ -364,28 +345,31 @@ def on_data_transfer(accept_pnc_authorize, **kwargs):
         )
 
 
-@on(Action.data_transfer)
-def on_data_transfer_accept_authorize(**kwargs):
-    return on_data_transfer(accept_pnc_authorize=True, **kwargs)
+def make_on_data_transfer_accept_authorize(exi_generator: EXIGenerator):
+    @on(Action.data_transfer)
+    def handler(**kwargs):
+        return on_data_transfer(accept_pnc_authorize=True, exi_generator=exi_generator, **kwargs)
+    return handler
 
 
-@on(Action.data_transfer)
-def on_data_transfer_reject_authorize(**kwargs):
-    return on_data_transfer(accept_pnc_authorize=False, **kwargs)
+def make_on_data_transfer_reject_authorize(exi_generator: EXIGenerator):
+    @on(Action.data_transfer)
+    def handler(**kwargs):
+        return on_data_transfer(accept_pnc_authorize=False, exi_generator=exi_generator, **kwargs)
+    return handler
 
 
-@on(Action201.get_15118_ev_certificate)
-def on_get_15118_ev_certificate(**kwargs):
-    certs_path: str = Path(__file__).parent.resolve() / "everest-aux/certs/"
-    generator: EXIGenerator = EXIGenerator(certs_path)
-    payload = call201.Get15118EVCertificate(**kwargs)
-
-    return call_result201.Get15118EVCertificate(
-        status=GenericStatusEnumType.accepted,
-        exi_response=generator.generate_certificate_installation_res(
-            payload.exi_request, payload.iso15118_schema_version
-        ),
-    )
+def make_on_get_15118_ev_certificate(exi_generator: EXIGenerator):
+    @on(Action201.get_15118_ev_certificate)
+    def handler(**kwargs):
+        payload = call201.Get15118EVCertificate(**kwargs)
+        return call_result201.Get15118EVCertificate(
+            status=GenericStatusEnumType.accepted,
+            exi_response=exi_generator.generate_certificate_installation_res(
+                payload.exi_request, payload.iso15118_schema_version
+            ),
+        )
+    return handler
 
 
 def get_everest_config_path_str(config_name):

--- a/tests/ocpp_tests/test_sets/ocpp16/plug_and_charge_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/plug_and_charge_tests.py
@@ -45,6 +45,7 @@ class TestPlugAndCharge:
     async def test_contract_installation_and_authorization_01(
         self,
         request,
+        exi_generator,
         central_system_v16: CentralSystem,
         charge_point_v16: ChargePoint16,
         test_controller: TestController,
@@ -56,7 +57,7 @@ class TestPlugAndCharge:
         """
 
         setattr(charge_point_v16, "on_data_transfer",
-                on_data_transfer_accept_authorize)
+                make_on_data_transfer_accept_authorize(exi_generator))
         central_system_v16.chargepoint.route_map = create_route_map(
             central_system_v16.chargepoint
         )
@@ -132,6 +133,7 @@ class TestPlugAndCharge:
     async def test_contract_installation_and_authorization_02(
         self,
         request,
+        exi_generator,
         central_system_v16: CentralSystem,
         charge_point_v16: ChargePoint16,
         test_controller: TestController,
@@ -142,7 +144,7 @@ class TestPlugAndCharge:
         """
 
         setattr(charge_point_v16, "on_data_transfer",
-                on_data_transfer_reject_authorize)
+                make_on_data_transfer_reject_authorize(exi_generator))
         central_system_v16.chargepoint.route_map = create_route_map(
             central_system_v16.chargepoint
         )
@@ -194,6 +196,7 @@ class TestPlugAndCharge:
     async def test_contract_installation_and_authorization_03(
         self,
         request,
+        exi_generator,
         central_system_v16: CentralSystem,
         charge_point_v16: ChargePoint16,
         test_controller: TestController,
@@ -229,7 +232,7 @@ class TestPlugAndCharge:
             "status": "Accepted"}
 
         setattr(charge_point_v16, "on_data_transfer",
-                on_data_transfer_accept_authorize)
+                make_on_data_transfer_accept_authorize(exi_generator))
         central_system_v16.chargepoint.route_map = create_route_map(
             central_system_v16.chargepoint
         )
@@ -292,6 +295,7 @@ class TestPlugAndCharge:
     async def test_contract_installation_and_authorization_04(
         self,
         request,
+        exi_generator,
         central_system_v16: CentralSystem,
         charge_point_v16: ChargePoint16,
         test_controller: TestController,
@@ -327,7 +331,7 @@ class TestPlugAndCharge:
             "status": "Accepted"}
 
         setattr(charge_point_v16, "on_data_transfer",
-                on_data_transfer_accept_authorize)
+                make_on_data_transfer_accept_authorize(exi_generator))
         central_system_v16.chargepoint.route_map = create_route_map(
             central_system_v16.chargepoint
         )
@@ -355,6 +359,7 @@ class TestPlugAndCharge:
     async def test_contract_installation_and_authorization_04(
         self,
         request,
+        exi_generator,
         central_system_v16: CentralSystem,
         charge_point_v16: ChargePoint16,
         test_controller: TestController,
@@ -390,7 +395,7 @@ class TestPlugAndCharge:
             "status": "Accepted"}
 
         setattr(charge_point_v16, "on_data_transfer",
-                on_data_transfer_accept_authorize)
+                make_on_data_transfer_accept_authorize(exi_generator))
         central_system_v16.chargepoint.route_map = create_route_map(
             central_system_v16.chargepoint
         )
@@ -530,6 +535,7 @@ class TestPlugAndCharge:
     @pytest.mark.asyncio
     async def test_pnc_reject(
         self,
+        exi_generator,
         test_config,
         central_system_v16: CentralSystem,
         charge_point_v16: ChargePoint16,
@@ -542,7 +548,7 @@ class TestPlugAndCharge:
         """
 
         setattr(charge_point_v16, "on_data_transfer",
-                on_data_transfer_reject_authorize)
+                make_on_data_transfer_reject_authorize(exi_generator))
         central_system_v16.chargepoint.route_map = create_route_map(
             central_system_v16.chargepoint
         )

--- a/tests/ocpp_tests/test_sets/ocpp201/plug_and_charge_tests201.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/plug_and_charge_tests201.py
@@ -56,6 +56,7 @@ class TestPlugAndCharge:
     async def test_contract_installation_and_authorization_01(
         self,
         request,
+        exi_generator,
         central_system: CentralSystem,
         charge_point: ChargePoint201,
         test_controller: TestController,
@@ -67,7 +68,7 @@ class TestPlugAndCharge:
         """
 
         setattr(
-            charge_point, "on_get_15118_ev_certificate", on_get_15118_ev_certificate
+            charge_point, "on_get_15118_ev_certificate", make_on_get_15118_ev_certificate(exi_generator)
         )
         central_system.chargepoint.route_map = create_route_map(
             central_system.chargepoint
@@ -116,6 +117,7 @@ class TestPlugAndCharge:
     async def test_contract_installation_and_authorization_02(
         self,
         request,
+        exi_generator,
         central_system: CentralSystem,
         charge_point: ChargePoint201,
         test_controller: TestController,
@@ -134,7 +136,7 @@ class TestPlugAndCharge:
             )
 
         setattr(
-            charge_point, "on_get_15118_ev_certificate", on_get_15118_ev_certificate
+            charge_point, "on_get_15118_ev_certificate", make_on_get_15118_ev_certificate(exi_generator)
         )
         setattr(charge_point, "on_authorize", on_authorize)
 
@@ -198,6 +200,7 @@ class TestPlugAndCharge:
     async def test_contract_installation_and_authorization_03(
         self,
         request,
+        exi_generator,
         central_system: CentralSystem,
         charge_point: ChargePoint201,
         test_controller: TestController,
@@ -209,7 +212,7 @@ class TestPlugAndCharge:
         """
 
         setattr(
-            charge_point, "on_get_15118_ev_certificate", on_get_15118_ev_certificate
+            charge_point, "on_get_15118_ev_certificate", make_on_get_15118_ev_certificate(exi_generator)
         )
         central_system.chargepoint.route_map = create_route_map(
             central_system.chargepoint
@@ -304,6 +307,7 @@ class TestPlugAndCharge:
     async def test_contract_installation_and_authorization_04(
         self,
         request,
+        exi_generator,
         central_system: CentralSystem,
         charge_point: ChargePoint201,
         test_controller: TestController,
@@ -315,7 +319,7 @@ class TestPlugAndCharge:
         """
 
         setattr(
-            charge_point, "on_get_15118_ev_certificate", on_get_15118_ev_certificate
+            charge_point, "on_get_15118_ev_certificate", make_on_get_15118_ev_certificate(exi_generator)
         )
         central_system.chargepoint.route_map = create_route_map(
             central_system.chargepoint
@@ -400,6 +404,7 @@ class TestPlugAndCharge:
     async def test_contract_revoked(
         self,
         request,
+        exi_generator,
         central_system: CentralSystem,
         charge_point: ChargePoint201,
         test_controller: TestController,
@@ -418,7 +423,7 @@ class TestPlugAndCharge:
             )
 
         setattr(
-            charge_point, "on_get_15118_ev_certificate", on_get_15118_ev_certificate
+            charge_point, "on_get_15118_ev_certificate", make_on_get_15118_ev_certificate(exi_generator)
         )
         setattr(charge_point, "on_authorize", on_authorize)
 
@@ -532,6 +537,7 @@ class TestPlugAndCharge:
     )
     async def test_no_tls_after_secc_leaf_deleted(
         self,
+        exi_generator,
         central_system: CentralSystem,
         charge_point: ChargePoint201,
         test_controller: TestController,
@@ -543,7 +549,7 @@ class TestPlugAndCharge:
         """
 
         setattr(
-            charge_point, "on_get_15118_ev_certificate", on_get_15118_ev_certificate
+            charge_point, "on_get_15118_ev_certificate", make_on_get_15118_ev_certificate(exi_generator)
         )
         central_system.chargepoint.route_map = create_route_map(
             central_system.chargepoint


### PR DESCRIPTION

## Describe your changes

Lately sometimes some PlugAndCharge e2e tests are failing because the ISO15118-2 timeout for CertificateInstallationRes (4.5s) triggers because the Exi generation process is too slow.  

EXIGenerator was instantiated on every Get15118EVCertificate message, spawning a new JVM each time and potentially exceeding the CertificateInstallationRes timeout. Move cert/key loading and static EXI encoding into __init__, expose EXIGenerator via a session-scoped fixture and inject it into OCPP handler factories rather than constructing it inside handlers.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

