### PR TITLE
fix(mqtt): fix TOCTOU race causing messages to be silently dropped

### DIFF
--- a/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
+++ b/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
@@ -82,6 +82,7 @@ private:
     };
 
     bool mqtt_is_connected;
+    std::atomic_bool mqtt_is_connected;
     std::atomic_bool running;
     MessageHandler message_handler;
     everest::lib::util::simple_queue<Message> message_queue;

--- a/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
+++ b/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
@@ -81,7 +81,6 @@ private:
         std::unordered_set<std::string> subscribed_topics;
     };
 
-    bool mqtt_is_connected;
     std::atomic_bool mqtt_is_connected;
     std::atomic_bool running;
     MessageHandler message_handler;

--- a/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
+++ b/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
@@ -165,10 +165,12 @@ void MQTTAbstractionImpl::publish(const std::string& topic, const std::string& d
         }
     }
 
-    if (!this->mqtt_is_connected) {
+    {
         auto handle = messages_before_connected.handle();
-        handle->push_back(std::make_shared<MessageWithQOS>(topic, data, qos, retain));
-        return;
+        if (!this->mqtt_is_connected) {
+            handle->push_back(std::make_shared<MessageWithQOS>(topic, data, qos, retain));
+            return;
+        }
     }
 
     const auto error = this->mqtt_client->publish(topic, data, mqtt_qos, retain, {});
@@ -393,17 +395,17 @@ void MQTTAbstractionImpl::on_mqtt_connect() {
 
     EVLOG_debug << "Connected to MQTT broker";
 
-    // Drain the messages_before_connected queue under the lock, then publish outside it.
-    // publish() itself acquires messages_before_connected_mutex, so calling it
-    // while holding the mutex would deadlock
-    std::vector<std::shared_ptr<MessageWithQOS>> to_publish;
+    // Drain the messages_before_connected under the lock, then publish outside it.
+    // publish() itself acquires the same monitor lock, so calling it
+    // while holding the handle would deadlock
+    shared_messages to_publish;
     {
         auto handle = messages_before_connected.handle();
         this->mqtt_is_connected = true;
-        for (auto& message : *handle) {
-            this->publish(message->topic, message->payload, message->qos, message->retain);
-        }
-        handle->clear();
+        to_publish = std::move(*handle);
+    }
+    for (auto& message : to_publish) {
+        this->publish(message->topic, message->payload, message->qos, message->retain);
     }
 }
 

--- a/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
+++ b/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
@@ -393,7 +393,10 @@ void MQTTAbstractionImpl::on_mqtt_connect() {
 
     EVLOG_debug << "Connected to MQTT broker";
 
-    // this will allow new handlers to subscribe directly, if needed
+    // Drain the messages_before_connected queue under the lock, then publish outside it.
+    // publish() itself acquires messages_before_connected_mutex, so calling it
+    // while holding the mutex would deadlock
+    std::vector<std::shared_ptr<MessageWithQOS>> to_publish;
     {
         auto handle = messages_before_connected.handle();
         this->mqtt_is_connected = true;


### PR DESCRIPTION


## Describe your changes

publish() checked `mqtt_is_connected` outside the mutex before queuing, so on_mqtt_connect() could drain and clear `messages_before_connected` between the check and the push, losing mqtt messages and potentially causing modules to time out on startup.

Fix by moving the check inside the mutex in publish(), draining the queue under the lock in on_mqtt_connect() before publishing outside it and making mqtt_is_connected atomic to eliminate remaining unsynchronised reads.

Should fix issue of E2E tests occasionally failing at startup.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

