### PR TITLE
fix: prevent crash when running in environments without O_DIRECT pipe support

### DIFF
--- a/lib/everest/framework/src/system_unix.cpp
+++ b/lib/everest/framework/src/system_unix.cpp
@@ -206,8 +206,21 @@ std::string set_user_and_capabilities(const std::string& run_as_user, const std:
 SubProcess SubProcess::create(const std::string& run_as_user, const std::vector<std::string>& capabilities) {
     std::array<int, 2> pipefd{};
 
-    if (pipe2(pipefd.data(), O_CLOEXEC | O_DIRECT)) {
-        throw std::runtime_error(fmt::format("Syscall pipe2() failed ({}), exiting", strerror(errno)));
+    const auto flags = O_CLOEXEC;
+    // First, try to create a pipe with O_DIRECT
+    if (pipe2(pipefd.data(), flags | O_DIRECT)) {
+        auto errored = true;
+
+        // pipe2 returns EINVAL if the kernel does not support O_DIRECT. We retry without it and see if it still fails
+        if (errno == EINVAL) {
+            if (pipe2(pipefd.data(), flags) == 0) {
+                errored = false;
+            }
+        }
+
+        if (errored) {
+            throw std::runtime_error(fmt::format("Syscall pipe2() failed ({}), exiting", strerror(errno)));
+        }
     }
 
     const auto reading_end_fd = pipefd[0];


### PR DESCRIPTION
## Describe your changes

According to [its man page](https://man7.org/linux/man-pages/man2/pipe.2.html), the pipe2 syscall returns `EINVAL` (via errno) if the `O_DIRECT` flag is used on a kernel that does not support it.
In addition to old versions of the Linux kernel, this is also the case with some sandbox implementations.
This PR introduces a fallback where it is attempted to create the pipe without `O_DIRECT` if the original call results in `EINVAL`

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

