### PR TITLE
Feature/dynamic_ac_config: Refactor AC with SoC feature

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -1,4 +1,5 @@
 generate_config_run_script(CONFIG sil)
+generate_config_run_script(CONFIG sil-ac-soc)
 generate_config_run_script(CONFIG sil-rpcapi)
 generate_config_run_script(CONFIG sil-two-evse)
 generate_config_run_script(CONFIG sil-two-evse-rpcapi)

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -1,6 +1,7 @@
 generate_config_run_script(CONFIG empty)
 generate_config_run_script(CONFIG no-active_modules)
 generate_config_run_script(CONFIG sil)
+generate_config_run_script(CONFIG sil-ac-soc)
 generate_config_run_script(CONFIG sil-rpcapi)
 generate_config_run_script(CONFIG sil-two-evse)
 generate_config_run_script(CONFIG sil-two-evse-rpcapi)

--- a/config/config-sil-ac-soc.yaml
+++ b/config/config-sil-ac-soc.yaml
@@ -1,0 +1,482 @@
+settings:
+  telemetry_enabled: true
+active_modules:
+  api:
+    connections:
+      evse_manager:
+        - implementation_id: evse
+          module_id: connector_1
+      error_history:
+        - module_id: error_history
+          implementation_id: error_history
+      evse_energy_sink:
+        - module_id: grid_connection_point
+          implementation_id: external_limits
+        - module_id: api_sink_1_evsemgr
+          implementation_id: external_limits
+    module: API
+  ev_api:
+    connections:
+      ev_manager:
+        - implementation_id: ev_manager
+          module_id: ev_manager
+    module: EvAPI
+  error_history:
+    module: ErrorHistory
+    config_implementation:
+      error_history:
+        database_path: /tmp/error_history.db
+  auth:
+    config_module:
+      connection_timeout: 10
+      prioritize_authorization_over_stopping_transaction: true
+      selection_algorithm: FindFirst
+      ignore_connector_faults: true
+    connections:
+      evse_manager:
+        - implementation_id: evse
+          module_id: connector_1
+      token_provider:
+        - implementation_id: main
+          module_id: token_provider
+      token_validator:
+        - implementation_id: main
+          module_id: token_validator
+    module: Auth
+  ev_manager:
+    config_module:
+      auto_enable: true
+      auto_exec: false
+      auto_exec_commands: sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 30;unplug
+      connector_id: 1
+    connections:
+      ev:
+        - implementation_id: ev
+          module_id: iso15118_car
+      ev_board_support:
+        - implementation_id: ev_board_support
+          module_id: connector_1_powerpath
+      slac:
+        - implementation_id: ev
+          module_id: slac
+    module: EvManager
+  energy_manager:
+    config_module:
+      switch_3ph1ph_while_charging_mode: Both
+      switch_3ph1ph_max_nr_of_switches_per_session: 5
+      switch_3ph1ph_time_hysteresis_s: 20
+      switch_3ph1ph_power_hysteresis_W: 1000
+      switch_3ph1ph_switch_limit_stickyness: SinglePhase
+      schedule_interval_duration: 60
+      schedule_total_duration: 10
+      debug: false
+    connections:
+      energy_trunk:
+        - implementation_id: energy_grid
+          module_id: grid_connection_point
+    module: EnergyManager
+  api_sink_1_evsemgr:
+    module: EnergyNode
+    mapping:
+      module:
+        evse: 1
+    config_module:
+      fuse_limit_A: 32.0
+      phase_count: 3
+    connections:
+      energy_consumer:
+        - module_id: connector_1
+          implementation_id: energy_grid
+  connector_1:
+    mapping:
+      module:
+        evse: 1
+    config_module:
+      ac_enforce_hlc: true
+      ac_hlc_enabled: true
+      ac_hlc_use_5percent: true
+      ac_nominal_voltage: 230
+      ac_with_soc: true
+      charge_mode: AC
+      connector_id: 1
+      ev_receipt_required: false
+      evse_id: DE*PNX*E12345*1
+      has_ventilation: true
+      payment_enable_contract: true
+      payment_enable_eim: true
+      session_logging: true
+      session_logging_path: /tmp/everest-logs
+      session_logging_xml: false
+      switch_3ph1ph_delay_s: 5
+      switch_3ph1ph_cp_state: F
+      disable_authentication: false
+      reinit_method: CPStateF
+      reinit_duration_ms: 4000
+    connections:
+      bsp:
+        - implementation_id: board_support
+          module_id: connector_1_powerpath
+      hlc:
+        - implementation_id: charger
+          module_id: iso15118_charger
+      powermeter_grid_side:
+        - implementation_id: powermeter
+          module_id: connector_1_powerpath
+      slac:
+        - implementation_id: evse
+          module_id: slac
+      ac_rcd:
+        - implementation_id: rcd
+          module_id: connector_1_powerpath
+      connector_lock:
+        - implementation_id: connector_lock
+          module_id: connector_1_powerpath
+    module: EvseManager
+    telemetry:
+      id: 1
+  grid_connection_point:
+    mapping:
+      module:
+        evse: 0
+    config_module:
+      fuse_limit_A: 40
+      phase_count: 3
+    connections:
+      energy_consumer:
+        - implementation_id: energy_grid
+          module_id: api_sink_1_evsemgr
+    module: EnergyNode
+  iso15118_car:
+    config_module:
+      device: auto
+      supported_ISO15118_2: true
+      supported_DIN70121: true
+    connections: {}
+    module: PyEvJosev
+  iso15118_charger:
+    config_module:
+      device: auto
+      tls_security: allow
+      supported_DIN70121: true # SoC AC requires DIN70121 support
+      terminate_connection_on_failed_response: true
+    module: EvseV2G
+    connections:
+      security:
+        - module_id: evse_security
+          implementation_id: main
+  evse_security:
+    module: EvseSecurity
+    config_module:
+      private_key_password: "123456"
+  persistent_store:
+    config_module:
+      sqlite_db_file_path: everest_persistent_store.db
+    connections: {}
+    module: PersistentStore
+  setup:
+    config_module:
+      initialized_by_default: true
+      localization: true
+      online_check_host: lfenergy.org
+      setup_simulation: true
+      setup_wifi: false
+    connections:
+      store:
+        - implementation_id: main
+          module_id: persistent_store
+    module: Setup
+  slac:
+    module: SlacSimulator
+  token_provider:
+    config_implementation:
+      main:
+        timeout: 10
+        token: DEADBEEF
+    connections:
+      evse:
+        - implementation_id: evse
+          module_id: connector_1
+    module: DummyTokenProvider
+  token_validator:
+    config_implementation:
+      main:
+        sleep: 0.25
+        validation_reason: Token seems valid
+        validation_result: Accepted
+    connections: {}
+    module: DummyTokenValidator
+  connector_1_powerpath:
+    config_module:
+      connector_id: 1
+    connections: {}
+    module: YetiSimulator
+    telemetry:
+      id: 1
+'x-module-layout':
+  api:
+    position:
+      x: 33
+      y: 13
+    terminals:
+      bottom: []
+      left:
+        - id: evse_manager
+          interface: evse_manager
+          type: requirement
+      right:
+        - id: main
+          interface: empty
+          type: provide
+      top: []
+  auth:
+    position:
+      x: 33
+      y: 2
+    terminals:
+      bottom:
+        - id: main
+          interface: auth
+          type: provide
+        - id: reservation
+          interface: reservation
+          type: provide
+      left:
+        - id: evse_manager
+          interface: evse_manager
+          type: requirement
+      right:
+        - id: token_validator
+          interface: auth_token_validator
+          type: requirement
+      top:
+        - id: token_provider
+          interface: auth_token_provider
+          type: requirement
+  ev_manager:
+    position:
+      x: 53
+      y: 33
+    terminals:
+      bottom: []
+      left:
+        - id: simulation_control
+          interface: yeti_simulation_control
+          type: requirement
+        - id: slac
+          interface: slac
+          type: requirement
+      right:
+        - id: main
+          interface: ev_manager
+          type: provide
+      top:
+        - id: ev
+          interface: ISO15118_ev
+          type: requirement
+  connector_1:
+    position:
+      x: 13
+      y: 23
+    terminals:
+      bottom:
+        - id: powersupply_DC
+          interface: power_supply_DC
+          type: requirement
+        - id: imd
+          interface: isolation_monitor
+          type: requirement
+        - id: powermeter_car_side
+          interface: powermeter
+          type: requirement
+        - id: token_provider
+          interface: auth_token_provider
+          type: provide
+        - id: slac
+          interface: slac
+          type: requirement
+      left:
+        - id: hlc
+          interface: ISO15118_charger
+          type: requirement
+      right:
+        - id: bsp
+          interface: board_support_AC
+          type: requirement
+        - id: powermeter_grid_side
+          interface: powermeter
+          type: requirement
+      top:
+        - id: energy_grid
+          interface: energy
+          type: provide
+        - id: evse
+          interface: evse_manager
+          type: provide
+  connector_1_powerpath:
+    position:
+      x: 33
+      y: 23
+    terminals:
+      bottom:
+        - id: debug_keepalive
+          interface: debug_json
+          type: provide
+        - id: debug_powermeter
+          interface: debug_json
+          type: provide
+        - id: debug_yeti
+          interface: debug_json
+          type: provide
+        - id: yeti_extras
+          interface: yeti_extras
+          type: provide
+        - id: debug_state
+          interface: debug_json
+          type: provide
+      left:
+        - id: board_support
+          interface: board_support_AC
+          type: provide
+        - id: powermeter
+          interface: powermeter
+          type: provide
+      right:
+        - id: yeti_simulation_control
+          interface: yeti_simulation_control
+          type: provide
+      top: []
+  energy_manager:
+    position:
+      x: -5
+      y: 2
+    terminals:
+      bottom:
+        - id: energy_trunk
+          interface: energy
+          type: requirement
+      left: []
+      right:
+        - id: main
+          interface: energy_manager
+          type: provide
+      top: []
+  grid_connection_point:
+    position:
+      x: -5
+      y: 13
+    terminals:
+      bottom: []
+      left:
+        - id: price_information
+          interface: energy_price_information
+          type: requirement
+        - id: powermeter
+          interface: powermeter
+          type: requirement
+      right:
+        - id: external_limits
+          interface: external_energy_limits
+          type: provide
+        - id: energy_consumer
+          interface: energy
+          type: requirement
+      top:
+        - id: energy_grid
+          interface: energy
+          type: provide
+  iso15118_car:
+    position:
+      x: 53
+      y: 23
+    terminals:
+      bottom:
+        - id: ev
+          interface: ISO15118_ev
+          type: provide
+      left: []
+      right:
+        - id: main
+          interface: empty
+          type: provide
+      top: []
+  iso15118_charger:
+    position:
+      x: -5
+      y: 23
+    terminals:
+      bottom: []
+      left: []
+      right:
+        - id: charger
+          interface: ISO15118_charger
+          type: provide
+      top: []
+  persistent_store:
+    position:
+      x: -5
+      y: 40
+    terminals:
+      bottom: []
+      left: []
+      right:
+        - id: main
+          interface: kvs
+          type: provide
+      top: []
+  setup:
+    position:
+      x: 13
+      y: 40
+    terminals:
+      bottom: []
+      left:
+        - id: store
+          interface: kvs
+          type: requirement
+      right:
+        - id: main
+          interface: empty
+          type: provide
+      top: []
+  slac:
+    position:
+      x: 33
+      y: 33
+    terminals:
+      bottom: []
+      left:
+        - id: evse
+          interface: slac
+          type: provide
+      right:
+        - id: ev
+          interface: slac
+          type: provide
+      top: []
+  token_provider:
+    position:
+      x: 33
+      y: -9
+    terminals:
+      bottom:
+        - id: main
+          interface: auth_token_provider
+          type: provide
+      left:
+        - id: evse
+          interface: evse_manager
+          type: requirement
+      right: []
+      top: []
+  token_validator:
+    position:
+      x: 51
+      y: 2
+    terminals:
+      bottom: []
+      left:
+        - id: main
+          interface: auth_token_validator
+          type: provide
+      right: []
+      top: []

--- a/config/config-sil-ac-soc.yaml
+++ b/config/config-sil-ac-soc.yaml
@@ -1,0 +1,483 @@
+settings:
+  telemetry_enabled: true
+active_modules:
+  api:
+    connections:
+      evse_manager:
+        - implementation_id: evse
+          module_id: connector_1
+      error_history:
+        - module_id: error_history
+          implementation_id: error_history
+      evse_energy_sink:
+        - module_id: grid_connection_point
+          implementation_id: external_limits
+        - module_id: api_sink_1_evsemgr
+          implementation_id: external_limits
+    module: API
+  ev_api:
+    connections:
+      ev_manager:
+        - implementation_id: ev_manager
+          module_id: ev_manager
+    module: EvAPI
+  error_history:
+    module: ErrorHistory
+    config_implementation:
+      error_history:
+        database_path: /tmp/error_history.db
+  auth:
+    config_module:
+      connection_timeout: 10
+      prioritize_authorization_over_stopping_transaction: true
+      selection_algorithm: FindFirst
+      ignore_connector_faults: true
+    connections:
+      evse_manager:
+        - implementation_id: evse
+          module_id: connector_1
+      token_provider:
+        - implementation_id: main
+          module_id: token_provider
+      token_validator:
+        - implementation_id: main
+          module_id: token_validator
+    module: Auth
+  ev_manager:
+    config_module:
+      auto_enable: true
+      auto_exec: false
+      auto_exec_commands: sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 30;unplug
+      connector_id: 1
+    connections:
+      ev:
+        - implementation_id: ev
+          module_id: iso15118_car
+      ev_board_support:
+        - implementation_id: ev_board_support
+          module_id: connector_1_powerpath
+      slac:
+        - implementation_id: ev
+          module_id: slac
+    module: EvManager
+  energy_manager:
+    config_module:
+      switch_3ph1ph_while_charging_mode: Both
+      switch_3ph1ph_max_nr_of_switches_per_session: 5
+      switch_3ph1ph_time_hysteresis_s: 20
+      switch_3ph1ph_power_hysteresis_W: 1000
+      switch_3ph1ph_switch_limit_stickyness: SinglePhase
+      schedule_interval_duration: 60
+      schedule_total_duration: 10
+      debug: false
+    connections:
+      energy_trunk:
+        - implementation_id: energy_grid
+          module_id: grid_connection_point
+    module: EnergyManager
+  api_sink_1_evsemgr:
+    module: EnergyNode
+    mapping:
+      module:
+        evse: 1
+    config_module:
+      fuse_limit_A: 32.0
+      phase_count: 3
+    connections:
+      energy_consumer:
+        - module_id: connector_1
+          implementation_id: energy_grid
+  connector_1:
+    mapping:
+      module:
+        evse: 1
+    config_module:
+      enable_nodered_interface: true
+      ac_enforce_hlc: true
+      ac_hlc_enabled: true
+      ac_hlc_use_5percent: true
+      ac_nominal_voltage: 230
+      ac_with_soc: true
+      charge_mode: AC
+      connector_id: 1
+      ev_receipt_required: false
+      evse_id: DE*PNX*E12345*1
+      has_ventilation: true
+      payment_enable_contract: true
+      payment_enable_eim: true
+      session_logging: true
+      session_logging_path: /tmp/everest-logs
+      session_logging_xml: false
+      switch_3ph1ph_delay_s: 5
+      switch_3ph1ph_cp_state: F
+      disable_authentication: false
+      reinit_method: CPStateF
+      reinit_duration_ms: 4000
+    connections:
+      bsp:
+        - implementation_id: board_support
+          module_id: connector_1_powerpath
+      hlc:
+        - implementation_id: charger
+          module_id: iso15118_charger
+      powermeter_grid_side:
+        - implementation_id: powermeter
+          module_id: connector_1_powerpath
+      slac:
+        - implementation_id: evse
+          module_id: slac
+      ac_rcd:
+        - implementation_id: rcd
+          module_id: connector_1_powerpath
+      connector_lock:
+        - implementation_id: connector_lock
+          module_id: connector_1_powerpath
+    module: EvseManager
+    telemetry:
+      id: 1
+  grid_connection_point:
+    mapping:
+      module:
+        evse: 0
+    config_module:
+      fuse_limit_A: 40
+      phase_count: 3
+    connections:
+      energy_consumer:
+        - implementation_id: energy_grid
+          module_id: api_sink_1_evsemgr
+    module: EnergyNode
+  iso15118_car:
+    config_module:
+      device: auto
+      supported_ISO15118_2: true
+      supported_DIN70121: true
+    connections: {}
+    module: PyEvJosev
+  iso15118_charger:
+    config_module:
+      device: auto
+      tls_security: allow
+      supported_DIN70121: true # SoC AC requires DIN70121 support
+      terminate_connection_on_failed_response: true
+    module: EvseV2G
+    connections:
+      security:
+        - module_id: evse_security
+          implementation_id: main
+  evse_security:
+    module: EvseSecurity
+    config_module:
+      private_key_password: "123456"
+  persistent_store:
+    config_module:
+      sqlite_db_file_path: everest_persistent_store.db
+    connections: {}
+    module: PersistentStore
+  setup:
+    config_module:
+      initialized_by_default: true
+      localization: true
+      online_check_host: lfenergy.org
+      setup_simulation: true
+      setup_wifi: false
+    connections:
+      store:
+        - implementation_id: main
+          module_id: persistent_store
+    module: Setup
+  slac:
+    module: SlacSimulator
+  token_provider:
+    config_implementation:
+      main:
+        timeout: 10
+        token: DEADBEEF
+    connections:
+      evse:
+        - implementation_id: evse
+          module_id: connector_1
+    module: DummyTokenProvider
+  token_validator:
+    config_implementation:
+      main:
+        sleep: 0.25
+        validation_reason: Token seems valid
+        validation_result: Accepted
+    connections: {}
+    module: DummyTokenValidator
+  connector_1_powerpath:
+    config_module:
+      connector_id: 1
+    connections: {}
+    module: YetiSimulator
+    telemetry:
+      id: 1
+'x-module-layout':
+  api:
+    position:
+      x: 33
+      y: 13
+    terminals:
+      bottom: []
+      left:
+        - id: evse_manager
+          interface: evse_manager
+          type: requirement
+      right:
+        - id: main
+          interface: empty
+          type: provide
+      top: []
+  auth:
+    position:
+      x: 33
+      y: 2
+    terminals:
+      bottom:
+        - id: main
+          interface: auth
+          type: provide
+        - id: reservation
+          interface: reservation
+          type: provide
+      left:
+        - id: evse_manager
+          interface: evse_manager
+          type: requirement
+      right:
+        - id: token_validator
+          interface: auth_token_validator
+          type: requirement
+      top:
+        - id: token_provider
+          interface: auth_token_provider
+          type: requirement
+  ev_manager:
+    position:
+      x: 53
+      y: 33
+    terminals:
+      bottom: []
+      left:
+        - id: simulation_control
+          interface: yeti_simulation_control
+          type: requirement
+        - id: slac
+          interface: slac
+          type: requirement
+      right:
+        - id: main
+          interface: ev_manager
+          type: provide
+      top:
+        - id: ev
+          interface: ISO15118_ev
+          type: requirement
+  connector_1:
+    position:
+      x: 13
+      y: 23
+    terminals:
+      bottom:
+        - id: powersupply_DC
+          interface: power_supply_DC
+          type: requirement
+        - id: imd
+          interface: isolation_monitor
+          type: requirement
+        - id: powermeter_car_side
+          interface: powermeter
+          type: requirement
+        - id: token_provider
+          interface: auth_token_provider
+          type: provide
+        - id: slac
+          interface: slac
+          type: requirement
+      left:
+        - id: hlc
+          interface: ISO15118_charger
+          type: requirement
+      right:
+        - id: bsp
+          interface: board_support_AC
+          type: requirement
+        - id: powermeter_grid_side
+          interface: powermeter
+          type: requirement
+      top:
+        - id: energy_grid
+          interface: energy
+          type: provide
+        - id: evse
+          interface: evse_manager
+          type: provide
+  connector_1_powerpath:
+    position:
+      x: 33
+      y: 23
+    terminals:
+      bottom:
+        - id: debug_keepalive
+          interface: debug_json
+          type: provide
+        - id: debug_powermeter
+          interface: debug_json
+          type: provide
+        - id: debug_yeti
+          interface: debug_json
+          type: provide
+        - id: yeti_extras
+          interface: yeti_extras
+          type: provide
+        - id: debug_state
+          interface: debug_json
+          type: provide
+      left:
+        - id: board_support
+          interface: board_support_AC
+          type: provide
+        - id: powermeter
+          interface: powermeter
+          type: provide
+      right:
+        - id: yeti_simulation_control
+          interface: yeti_simulation_control
+          type: provide
+      top: []
+  energy_manager:
+    position:
+      x: -5
+      y: 2
+    terminals:
+      bottom:
+        - id: energy_trunk
+          interface: energy
+          type: requirement
+      left: []
+      right:
+        - id: main
+          interface: energy_manager
+          type: provide
+      top: []
+  grid_connection_point:
+    position:
+      x: -5
+      y: 13
+    terminals:
+      bottom: []
+      left:
+        - id: price_information
+          interface: energy_price_information
+          type: requirement
+        - id: powermeter
+          interface: powermeter
+          type: requirement
+      right:
+        - id: external_limits
+          interface: external_energy_limits
+          type: provide
+        - id: energy_consumer
+          interface: energy
+          type: requirement
+      top:
+        - id: energy_grid
+          interface: energy
+          type: provide
+  iso15118_car:
+    position:
+      x: 53
+      y: 23
+    terminals:
+      bottom:
+        - id: ev
+          interface: ISO15118_ev
+          type: provide
+      left: []
+      right:
+        - id: main
+          interface: empty
+          type: provide
+      top: []
+  iso15118_charger:
+    position:
+      x: -5
+      y: 23
+    terminals:
+      bottom: []
+      left: []
+      right:
+        - id: charger
+          interface: ISO15118_charger
+          type: provide
+      top: []
+  persistent_store:
+    position:
+      x: -5
+      y: 40
+    terminals:
+      bottom: []
+      left: []
+      right:
+        - id: main
+          interface: kvs
+          type: provide
+      top: []
+  setup:
+    position:
+      x: 13
+      y: 40
+    terminals:
+      bottom: []
+      left:
+        - id: store
+          interface: kvs
+          type: requirement
+      right:
+        - id: main
+          interface: empty
+          type: provide
+      top: []
+  slac:
+    position:
+      x: 33
+      y: 33
+    terminals:
+      bottom: []
+      left:
+        - id: evse
+          interface: slac
+          type: provide
+      right:
+        - id: ev
+          interface: slac
+          type: provide
+      top: []
+  token_provider:
+    position:
+      x: 33
+      y: -9
+    terminals:
+      bottom:
+        - id: main
+          interface: auth_token_provider
+          type: provide
+      left:
+        - id: evse
+          interface: evse_manager
+          type: requirement
+      right: []
+      top: []
+  token_validator:
+    position:
+      x: 51
+      y: 2
+    terminals:
+      bottom: []
+      left:
+        - id: main
+          interface: auth_token_validator
+          type: provide
+      right: []
+      top: []

--- a/config/nodered/config-sil-flow.json
+++ b/config/nodered/config-sil-flow.json
@@ -1869,6 +1869,11 @@
                 "label": "AC ISO15118-2",
                 "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC 86400 0;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session AC 86400 0;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000",
                 "type": "str"
+            },
+            {
+                "label": "AC SoC",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_for_stop 3;iso_stop_charging;sleep 1;iec_wait_pwr_ready;sleep 5;draw_power_regulated 16,3;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 36000;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000",
+                "type": "str"
             }
         ],
         "payload": "",

--- a/interfaces/ISO15118_charger.yaml
+++ b/interfaces/ISO15118_charger.yaml
@@ -48,6 +48,11 @@ cmds:
           Indicates if the vehicle contract may be forwarded to and validated by a CSMS in case
           local validation was not successful
         type: boolean
+      fake_dc_enabled:
+        description: >-
+          If true, the charger will abort an active DC session after receiving the EV SOC value to allow
+          switching to AC basic charging.
+        type: boolean
   bpt_setup:
     description: >-
       At startup, set the bpt setup for ISO15118-20 at least once. May be updated later on.

--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -850,7 +850,8 @@ void ISO15118_chargerImpl::handle_set_charging_parameters(types::iso15118::Setup
 
 void ISO15118_chargerImpl::handle_session_setup(std::vector<types::iso15118::PaymentOption>& payment_options,
                                                 bool& supported_certificate_service,
-                                                [[maybe_unused]] bool& central_contract_validation_allowed) {
+                                                [[maybe_unused]] bool& central_contract_validation_allowed,
+                                                [[maybe_unused]] bool& fake_dc_enabled) {
     std::scoped_lock lock(GEL);
 
     std::vector<dt::Authorization> auth_services;

--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.hpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.hpp
@@ -46,8 +46,8 @@ protected:
                               bool& debug_mode) override;
     virtual void handle_set_charging_parameters(types::iso15118::SetupPhysicalValues& physical_values) override;
     virtual void handle_session_setup(std::vector<types::iso15118::PaymentOption>& payment_options,
-                                      bool& supported_certificate_service,
-                                      bool& central_contract_validation_allowed) override;
+                                      bool& supported_certificate_service, bool& central_contract_validation_allowed,
+                                      bool& fake_dc_enabled) override;
     virtual void handle_bpt_setup(types::iso15118::BptSetup& bpt_config) override;
     virtual void handle_set_powersupply_capabilities(types::power_supply_DC::Capabilities& capabilities) override;
     virtual void handle_authorization_response(types::authorization::AuthorizationStatus& authorization_status,

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -1573,6 +1573,7 @@ void Charger::setup(bool has_ventilation, const ChargeMode _charge_mode, bool _a
                     float _soft_over_current_tolerance_percent, float _soft_over_current_measurement_noise_A,
                     const int _switch_3ph1ph_delay_s, const std::string _switch_3ph1ph_cp_state,
                     const int _soft_over_current_timeout_ms, const int _state_F_after_fault_ms,
+                    const int reinit_duration_ms, const std::string& reinit_method,
                     const bool fail_on_powermeter_errors, const bool raise_mrec9,
                     const int sleep_before_enabling_pwm_hlc_mode_ms, const utils::SessionIdType session_id_type,
                     const int hlc_charge_loop_without_energy_timeout_s) {
@@ -1595,6 +1596,8 @@ void Charger::setup(bool has_ventilation, const ChargeMode _charge_mode, bool _a
     config_context.switch_3ph1ph_cp_state = _switch_3ph1ph_cp_state;
 
     config_context.state_F_after_fault_ms = _state_F_after_fault_ms;
+    config_context.reinit_duration_ms = reinit_duration_ms;
+    config_context.reinit_method = reinit_method;
     config_context.fail_on_powermeter_errors = fail_on_powermeter_errors;
     config_context.raise_mrec9 = raise_mrec9;
     config_context.sleep_before_enabling_pwm_hlc_mode_ms = sleep_before_enabling_pwm_hlc_mode_ms;

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -2201,6 +2201,11 @@ void Charger::dlink_terminate() {
 void Charger::dlink_error() {
     Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_dlink_error);
 
+    if (shared_context.reinit_requested or shared_context.reinit_running) {
+        EVLOG_debug << "Ignoring D-LINK_ERROR.req because reinit is active";
+        return;
+    }
+
     shared_context.hlc_allow_close_contactor = false;
 
     // Is PWM on at the moment?

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -158,6 +158,7 @@ void Charger::run_state_machine() {
     // run over state machine loop until current_state does not change anymore
     do {
         mainloop_runs++;
+        process_pending_reinit_request();
         // If a state change happened or an error recovered during a state we reinitialize the state
         bool initialize_state = (internal_context.last_state_detect_state_change not_eq shared_context.current_state) or
                                 (internal_context.last_shutdown_type not_eq shared_context.shutdown_type);
@@ -669,6 +670,34 @@ void Charger::run_state_machine() {
                     internal_context.pwm_set_last_ampere = internal_context.t_step_EF_return_ampere;
                 }
                 shared_context.current_state = internal_context.t_step_X1_return_state;
+            }
+            break;
+
+        case EvseState::Reinit:
+            if (initialize_state) {
+                session_log.evse(false, fmt::format("Reinit sequence started (method: {}, duration: {} ms)",
+                                                    shared_context.reinit_config.state_transition,
+                                                    shared_context.reinit_config.duration));
+                shared_context.reinit_running = true;
+                shared_context.iec_allow_close_contactor = false;
+                shared_context.hlc_allow_close_contactor = false;
+                apply_configured_reinit_method();
+                if (shared_context.reinit_config.duration > 0) {
+                    internal_context.reinit_timer_active = true;
+                    internal_context.reinit_deadline = std::chrono::steady_clock::now() +
+                                                       std::chrono::milliseconds(shared_context.reinit_config.duration);
+                } else {
+                    internal_context.reinit_timer_active = false;
+                }
+            }
+
+            if (!internal_context.reinit_timer_active or
+                std::chrono::steady_clock::now() >= internal_context.reinit_deadline) {
+                session_log.evse(false, "Exit reinit");
+                shared_context.reinit_running = false;
+                internal_context.reinit_timer_active = false;
+                cp_state_X1();
+                shared_context.current_state = EvseState::WaitingForAuthentication;
             }
             break;
 
@@ -1290,10 +1319,23 @@ void Charger::cp_state_E() {
     bsp->set_cp_state_E();
 }
 
+void Charger::apply_configured_reinit_method() {
+    if (shared_context.reinit_config.state_transition == "CPStateE") {
+        cp_state_E();
+    } else if (shared_context.reinit_config.state_transition == "CPStateX1") {
+        cp_state_X1();
+    } else {
+        cp_state_F();
+    }
+}
+
 void Charger::set_supports_cp_state_E(bool value) {
     supports_cp_state_E = value;
     if (!value and config_context.switch_3ph1ph_cp_state == "E") {
         EVLOG_warning << "Phase switch CP state E configured but BSP does not support CP state E.";
+    }
+    if (!value and config_context.reinit_method == "CPStateE") {
+        EVLOG_warning << "Reinit method CPStateE configured but BSP does not support CP state E.";
     }
 }
 
@@ -1568,6 +1610,53 @@ bool Charger::switch_three_phases_while_charging(bool n) {
     return true;
 }
 
+bool Charger::start_reinit() {
+    Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_start_reinit);
+
+    if (shared_context.current_state == EvseState::Disabled or shared_context.current_state == EvseState::Idle) {
+        EVLOG_warning << "Rejecting reinit request: no EV plugged in or connector disabled";
+        return false;
+    }
+
+    if (config_context.reinit_method == "CPStateE" and !supports_cp_state_E) {
+        EVLOG_warning << "Reinit requested with CP state E but BSP does not support CP state E.";
+        return false;
+    }
+
+    if (shared_context.reinit_running) {
+        EVLOG_warning << "Skip reinit request. Reinit process already running";
+        return false;
+    }
+
+    shared_context.reinit_config = ReinitConfiguration{config_context.reinit_method, config_context.reinit_duration_ms};
+    shared_context.reinit_requested = true;
+    EVLOG_info << fmt::format("Reinit requested (method: {}, duration: {} ms)",
+                              shared_context.reinit_config.state_transition, shared_context.reinit_config.duration);
+    return true;
+}
+
+void Charger::process_pending_reinit_request() {
+    if (!shared_context.reinit_requested) {
+        return;
+    }
+
+    if (shared_context.current_state == EvseState::Charging) {
+        shared_context.current_state = EvseState::StoppingCharging;
+    }
+
+    if (shared_context.slac_matched) {
+        if (!shared_context.reinit_running) {
+            shared_context.reinit_running = true;
+            signal_hlc_stop_charging();
+        }
+        return;
+    }
+
+    shared_context.reinit_requested = false;
+    shared_context.reinit_running = true;
+    shared_context.current_state = EvseState::Reinit;
+}
+
 void Charger::setup(bool has_ventilation, const ChargeMode _charge_mode, bool _ac_hlc_enabled,
                     bool _ac_hlc_use_5percent, bool _ac_enforce_hlc, bool _ac_with_soc_timeout,
                     float _soft_over_current_tolerance_percent, float _soft_over_current_measurement_noise_A,
@@ -1603,6 +1692,12 @@ void Charger::setup(bool has_ventilation, const ChargeMode _charge_mode, bool _a
     config_context.sleep_before_enabling_pwm_hlc_mode_ms = sleep_before_enabling_pwm_hlc_mode_ms;
     config_context.session_id_type = session_id_type;
     config_context.hlc_charge_loop_without_energy_timeout_s = hlc_charge_loop_without_energy_timeout_s;
+
+    if (config_context.charge_mode == ChargeMode::DC) {
+        shared_context.hlc_charging_active = true;
+    } else if (not config_context.ac_hlc_enabled) {
+        shared_context.hlc_charging_active = false;
+    }
 
     if (config_context.charge_mode == ChargeMode::AC and config_context.ac_hlc_enabled)
         EVLOG_info << "AC HLC mode enabled.";
@@ -1924,6 +2019,9 @@ std::string Charger::evse_state_to_string(EvseState s) {
     case EvseState::T_step_X1:
         return ("T_step_X1");
         break;
+    case EvseState::Reinit:
+        return ("Reinit");
+        break;
     case EvseState::PrepareCharging:
         return ("PrepareCharging");
         break;
@@ -2042,6 +2140,12 @@ void Charger::request_error_sequence() {
 void Charger::set_matching_started(bool m) {
     Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_set_matching_started);
     shared_context.matching_started = m;
+}
+
+void Charger::set_slac_matched(bool matched) {
+    Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_set_matching_started);
+    shared_context.slac_matched = matched;
+    shared_context.matching_started = matched or shared_context.matching_started;
 }
 
 void Charger::reset_dc_enforce_target_limits_timer() {

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -581,7 +581,9 @@ void Charger::run_state_machine() {
             if (initialize_state) {
                 session_log.evse(false, "Start switching phases");
                 signal_simple_event(types::evse_manager::SessionEventEnum::SwitchingPhases);
-                if (config_context.switch_3ph1ph_cp_state_F) {
+                if (config_context.switch_3ph1ph_cp_state == "E") {
+                    cp_state_E();
+                } else if (config_context.switch_3ph1ph_cp_state == "F") {
                     cp_state_F();
                 } else {
                     cp_state_X1();
@@ -1273,6 +1275,28 @@ void Charger::cp_state_F() {
     bsp->set_cp_state_F();
 }
 
+void Charger::cp_state_E() {
+    if (!supports_cp_state_E) {
+        EVLOG_warning << "CP state E requested but not supported by hardware. Falling back to CP state X1.";
+        cp_state_X1();
+        return;
+    }
+
+    session_log.evse(false, "Set CP state E");
+    shared_context.pwm_running = false;
+    internal_context.update_pwm_last_duty_cycle = 0.;
+    internal_context.pwm_set_last_ampere = 0.;
+    internal_context.cp_state_F_active = false;
+    bsp->set_cp_state_E();
+}
+
+void Charger::set_supports_cp_state_E(bool value) {
+    supports_cp_state_E = value;
+    if (!value and config_context.switch_3ph1ph_cp_state == "E") {
+        EVLOG_warning << "Phase switch CP state E configured but BSP does not support CP state E.";
+    }
+}
+
 void Charger::run() {
     // spawn new thread and return
     main_thread_handle = std::thread(&Charger::main_thread, this);
@@ -1568,7 +1592,7 @@ void Charger::setup(bool has_ventilation, const ChargeMode _charge_mode, bool _a
     soft_over_current_measurement_noise_A = _soft_over_current_measurement_noise_A;
 
     config_context.switch_3ph1ph_delay_s = _switch_3ph1ph_delay_s;
-    config_context.switch_3ph1ph_cp_state_F = _switch_3ph1ph_cp_state == "F";
+    config_context.switch_3ph1ph_cp_state = _switch_3ph1ph_cp_state;
 
     config_context.state_F_after_fault_ms = _state_F_after_fault_ms;
     config_context.fail_on_powermeter_errors = fail_on_powermeter_errors;

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -69,6 +69,7 @@ Charger::Charger(const std::unique_ptr<IECStateMachine>& bsp, const std::unique_
     internal_context.last_state_detect_state_change = EvseState::Idle;
 
     hlc_use_5percent_current_session = false;
+    hlc_failed = false;
 
     // create thread for processing errors/error clearings
     error_thread_handle = std::thread(&Charger::error_thread, this);
@@ -233,6 +234,7 @@ void Charger::run_state_machine() {
                 shared_context.flag_transaction_active = false;
                 clear_errors_on_unplug();
                 internal_context.dc_statistics_printed = false;
+                hlc_failed = false;
             }
 
             if (shared_context.flag_disable_requested) {
@@ -276,7 +278,7 @@ void Charger::run_state_machine() {
 
                 // switch on HLC if configured. May be switched off later on after retries for this session only.
                 if (config_context.charge_mode == ChargeMode::AC) {
-                    ac_hlc_enabled_current_session = config_context.ac_hlc_enabled;
+                    ac_hlc_enabled_current_session = config_context.ac_hlc_enabled and not hlc_failed;
                     if (ac_hlc_enabled_current_session) {
                         hlc_use_5percent_current_session = config_context.ac_hlc_use_5percent;
                     }
@@ -734,7 +736,7 @@ void Charger::run_state_machine() {
             }
 
             // make sure we are enabling PWM
-            if (not hlc_use_5percent_current_session) {
+            if (config_context.charge_mode == ChargeMode::AC and (not hlc_use_5percent_current_session or hlc_failed)) {
                 update_pwm_now_if_changed_ampere(get_max_current_internal());
             } else {
                 update_pwm_now_if_changed(PWM_5_PERCENT);
@@ -2199,24 +2201,21 @@ void Charger::dlink_terminate() {
 }
 
 void Charger::dlink_error() {
-    Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_dlink_error);
+    {
+        Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_dlink_error);
 
-    if (shared_context.reinit_requested or shared_context.reinit_running) {
-        EVLOG_debug << "Ignoring D-LINK_ERROR.req because reinit is active";
-        return;
-    }
+        if (shared_context.reinit_requested or shared_context.reinit_running) {
+            EVLOG_debug << "Ignoring D-LINK_ERROR.req because reinit is active";
+            return;
+        }
 
-    shared_context.hlc_allow_close_contactor = false;
+        shared_context.hlc_allow_close_contactor = false;
+        hlc_failed = true;
 
-    // Is PWM on at the moment?
-    if (not shared_context.pwm_running) {
-        // [V2G3-M07-04]: With receiving a D-LINK_ERROR.request from HLE in X1 state, the EVSE's
-        // communication node shall perform a state X1 to state E/F to state X1 or X2 transition.
-    } else {
-        // [V2G3-M07-05]: With receiving a D-LINK_ERROR.request in X2 state from HLE, the EVSE's
-        // communication node shall perform a state X2 to X1 to state E/F to state X1 or X2 transition.
+        if (config_context.charge_mode == ChargeMode::AC) {
+            shared_context.hlc_charging_active = false;
+        }
 
-        // Are we in 5% mode or not?
         if (hlc_use_5percent_current_session) {
             // [V2G3-M07-06] Within the control pilot state X1, the communication node shall leave the
             // logical network and change the matching state to "Unmatched". [V2G3-M07-07] With reaching the
@@ -2228,26 +2227,22 @@ void Charger::dlink_error() {
             // Do t_step_X1 with a t_step_EF afterwards
             // [V2G3-M07-08] The state E/F shall be applied at least T_step_EF: This is already handled in
             // the t_step_EF state.
-            internal_context.t_step_X1_return_state = EvseState::T_step_EF;
-            internal_context.t_step_X1_return_pwm = 0.;
-            internal_context.t_step_EF_return_ampere = 0.;
-            shared_context.current_state = EvseState::T_step_X1;
-
-            // After returning from T_step_EF, go to Waiting for Auth (We are restarting the session)
-            internal_context.t_step_EF_return_state = EvseState::WaitingForAuthentication;
-            // [V2G3-M07-09] After applying state E/F, the EVSE shall switch to contol pilot state X1 or X2
-            // as soon as the EVSE is ready control for pilot incoming duty matching cycle requests: This is
-            // already handled in the Auth step.
-
-            // [V2G3-M07-05] says we need to go through X1 at the end of the sequence
-            internal_context.t_step_EF_return_pwm = 0.;
-            internal_context.t_step_EF_return_ampere = 0.;
+            cp_state_X1();
         }
-        // else {
-        // [V2G3-M07-10] Gives us two options for nominal PWM mode and HLC in case of error: We choose
-        // [V2G3-M07-12] (Don't interrupt basic AC charging just because an error in HLC happend) So we
-        // don't do anything here, SLAC will be notified anyway to reset
-        //}
+    }
+
+    // [V2G3-M07-10] Gives us two options for nominal PWM mode and HLC in case of error: We choose [V2G3-M07-12]
+    // [V2G3-M07-12] (Don't interrupt basic AC charging just because an error in HLC happend) So we
+    // don't do anything here, SLAC will be notified anyway to reset
+    // [V2G3-M07-04]: With receiving a D-LINK_ERROR.request from HLE in X1 state, the EVSE's
+    // communication node shall perform a state X1 to state E/F to state X1 or X2 transition.
+    // [V2G3-M07-05]: With receiving a D-LINK_ERROR.request in X2 state from HLC, the EVSE's
+    // communication node shall perform a state X2 to X1 to state E/F to state X1 or X2 transition.
+    // [V2G3-M07-06] Within the control pilot state X1, the communication node shall leave the
+    // logical network and change the matching state to "Unmatched". [V2G3-M07-07] With reaching the
+    // state "Unmatched", the EVSE shall switch to state E/F.
+    if (hlc_use_5percent_current_session) {
+        start_reinit();
     }
 }
 

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -69,6 +69,7 @@ Charger::Charger(const std::unique_ptr<IECStateMachine>& bsp, const std::unique_
     internal_context.last_state_detect_state_change = EvseState::Idle;
 
     hlc_use_5percent_current_session = false;
+    hlc_failed = false;
 
     // create thread for processing errors/error clearings
     error_thread_handle = std::thread(&Charger::error_thread, this);
@@ -165,6 +166,7 @@ void Charger::run_state_machine() {
     // run over state machine loop until current_state does not change anymore
     do {
         mainloop_runs++;
+        process_pending_reinit_request();
         // If a state change happened or an error recovered during a state we reinitialize the state
         bool initialize_state = (internal_context.last_state_detect_state_change not_eq shared_context.current_state) or
                                 (internal_context.last_shutdown_type not_eq shared_context.shutdown_type);
@@ -239,6 +241,7 @@ void Charger::run_state_machine() {
                 shared_context.flag_transaction_active = false;
                 clear_errors_on_unplug();
                 internal_context.dc_statistics_printed = false;
+                hlc_failed = false;
             }
 
             if (shared_context.flag_disable_requested) {
@@ -282,7 +285,7 @@ void Charger::run_state_machine() {
 
                 // switch on HLC if configured. May be switched off later on after retries for this session only.
                 if (config_context.charge_mode == ChargeMode::AC) {
-                    ac_hlc_enabled_current_session = config_context.ac_hlc_enabled;
+                    ac_hlc_enabled_current_session = config_context.ac_hlc_enabled and not hlc_failed;
                     if (ac_hlc_enabled_current_session) {
                         hlc_use_5percent_current_session = config_context.ac_hlc_use_5percent;
                     }
@@ -588,7 +591,9 @@ void Charger::run_state_machine() {
             if (initialize_state) {
                 session_log.evse(false, "Start switching phases");
                 signal_simple_event(types::evse_manager::SessionEventEnum::SwitchingPhases);
-                if (config_context.switch_3ph1ph_cp_state_F) {
+                if (config_context.switch_3ph1ph_cp_state == "E") {
+                    cp_state_E();
+                } else if (config_context.switch_3ph1ph_cp_state == "F") {
                     cp_state_F();
                 } else {
                     cp_state_X1();
@@ -677,6 +682,34 @@ void Charger::run_state_machine() {
             }
             break;
 
+        case EvseState::Reinit:
+            if (initialize_state) {
+                session_log.evse(false, fmt::format("Reinit sequence started (method: {}, duration: {} ms)",
+                                                    shared_context.reinit_config.state_transition,
+                                                    shared_context.reinit_config.duration));
+                shared_context.reinit_running = true;
+                shared_context.iec_allow_close_contactor = false;
+                shared_context.hlc_allow_close_contactor = false;
+                apply_configured_reinit_method();
+                if (shared_context.reinit_config.duration > 0) {
+                    internal_context.reinit_timer_active = true;
+                    internal_context.reinit_deadline = std::chrono::steady_clock::now() +
+                                                       std::chrono::milliseconds(shared_context.reinit_config.duration);
+                } else {
+                    internal_context.reinit_timer_active = false;
+                }
+            }
+
+            if (!internal_context.reinit_timer_active or
+                std::chrono::steady_clock::now() >= internal_context.reinit_deadline) {
+                session_log.evse(false, "Exit reinit");
+                shared_context.reinit_running = false;
+                internal_context.reinit_timer_active = false;
+                cp_state_X1();
+                shared_context.current_state = EvseState::WaitingForAuthentication;
+            }
+            break;
+
         case EvseState::PrepareCharging:
             if (initialize_state) {
                 signal_simple_event(types::evse_manager::SessionEventEnum::PrepareCharging);
@@ -710,7 +743,7 @@ void Charger::run_state_machine() {
             }
 
             // make sure we are enabling PWM
-            if (not hlc_use_5percent_current_session) {
+            if (config_context.charge_mode == ChargeMode::AC and (not hlc_use_5percent_current_session or hlc_failed)) {
                 update_pwm_now_if_changed_ampere(get_max_current_internal());
             } else {
                 update_pwm_now_if_changed(PWM_5_PERCENT);
@@ -1280,6 +1313,41 @@ void Charger::cp_state_F() {
     bsp->set_cp_state_F();
 }
 
+void Charger::cp_state_E() {
+    if (!supports_cp_state_E) {
+        EVLOG_warning << "CP state E requested but not supported by hardware. Falling back to CP state X1.";
+        cp_state_X1();
+        return;
+    }
+
+    session_log.evse(false, "Set CP state E");
+    shared_context.pwm_running = false;
+    internal_context.update_pwm_last_duty_cycle = 0.;
+    internal_context.pwm_set_last_ampere = 0.;
+    internal_context.cp_state_F_active = false;
+    bsp->set_cp_state_E();
+}
+
+void Charger::apply_configured_reinit_method() {
+    if (shared_context.reinit_config.state_transition == "CPStateE") {
+        cp_state_E();
+    } else if (shared_context.reinit_config.state_transition == "CPStateX1") {
+        cp_state_X1();
+    } else {
+        cp_state_F();
+    }
+}
+
+void Charger::set_supports_cp_state_E(bool value) {
+    supports_cp_state_E = value;
+    if (!value and config_context.switch_3ph1ph_cp_state == "E") {
+        EVLOG_warning << "Phase switch CP state E configured but BSP does not support CP state E.";
+    }
+    if (!value and config_context.reinit_method == "CPStateE") {
+        EVLOG_warning << "Reinit method CPStateE configured but BSP does not support CP state E.";
+    }
+}
+
 void Charger::run() {
     // spawn new thread and return
     main_thread_handle = std::thread(&Charger::main_thread, this);
@@ -1551,11 +1619,59 @@ bool Charger::switch_three_phases_while_charging(bool n) {
     return true;
 }
 
+bool Charger::start_reinit() {
+    Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_start_reinit);
+
+    if (shared_context.current_state == EvseState::Disabled or shared_context.current_state == EvseState::Idle) {
+        EVLOG_warning << "Rejecting reinit request: no EV plugged in or connector disabled";
+        return false;
+    }
+
+    if (config_context.reinit_method == "CPStateE" and !supports_cp_state_E) {
+        EVLOG_warning << "Reinit requested with CP state E but BSP does not support CP state E.";
+        return false;
+    }
+
+    if (shared_context.reinit_running) {
+        EVLOG_warning << "Skip reinit request. Reinit process already running";
+        return false;
+    }
+
+    shared_context.reinit_config = ReinitConfiguration{config_context.reinit_method, config_context.reinit_duration_ms};
+    shared_context.reinit_requested = true;
+    EVLOG_info << fmt::format("Reinit requested (method: {}, duration: {} ms)",
+                              shared_context.reinit_config.state_transition, shared_context.reinit_config.duration);
+    return true;
+}
+
+void Charger::process_pending_reinit_request() {
+    if (!shared_context.reinit_requested) {
+        return;
+    }
+
+    if (shared_context.current_state == EvseState::Charging) {
+        shared_context.current_state = EvseState::StoppingCharging;
+    }
+
+    if (shared_context.slac_matched) {
+        if (!shared_context.reinit_running) {
+            shared_context.reinit_running = true;
+            signal_hlc_stop_charging();
+        }
+        return;
+    }
+
+    shared_context.reinit_requested = false;
+    shared_context.reinit_running = true;
+    shared_context.current_state = EvseState::Reinit;
+}
+
 void Charger::setup(bool has_ventilation, const ChargeMode _charge_mode, bool _ac_hlc_enabled,
                     bool _ac_hlc_use_5percent, bool _ac_enforce_hlc, bool _ac_with_soc_timeout,
                     float _soft_over_current_tolerance_percent, float _soft_over_current_measurement_noise_A,
                     const int _switch_3ph1ph_delay_s, const std::string _switch_3ph1ph_cp_state,
                     const int _soft_over_current_timeout_ms, const int _state_F_after_fault_ms,
+                    const int reinit_duration_ms, const std::string& reinit_method,
                     const bool fail_on_powermeter_errors, const bool raise_mrec9,
                     const int sleep_before_enabling_pwm_hlc_mode_ms, const utils::SessionIdType session_id_type,
                     const int hlc_charge_loop_without_energy_timeout_s) {
@@ -1575,14 +1691,22 @@ void Charger::setup(bool has_ventilation, const ChargeMode _charge_mode, bool _a
     soft_over_current_measurement_noise_A = _soft_over_current_measurement_noise_A;
 
     config_context.switch_3ph1ph_delay_s = _switch_3ph1ph_delay_s;
-    config_context.switch_3ph1ph_cp_state_F = _switch_3ph1ph_cp_state == "F";
+    config_context.switch_3ph1ph_cp_state = _switch_3ph1ph_cp_state;
 
     config_context.state_F_after_fault_ms = _state_F_after_fault_ms;
+    config_context.reinit_duration_ms = reinit_duration_ms;
+    config_context.reinit_method = reinit_method;
     config_context.fail_on_powermeter_errors = fail_on_powermeter_errors;
     config_context.raise_mrec9 = raise_mrec9;
     config_context.sleep_before_enabling_pwm_hlc_mode_ms = sleep_before_enabling_pwm_hlc_mode_ms;
     config_context.session_id_type = session_id_type;
     config_context.hlc_charge_loop_without_energy_timeout_s = hlc_charge_loop_without_energy_timeout_s;
+
+    if (config_context.charge_mode == ChargeMode::DC) {
+        shared_context.hlc_charging_active = true;
+    } else if (not config_context.ac_hlc_enabled) {
+        shared_context.hlc_charging_active = false;
+    }
 
     if (config_context.charge_mode == ChargeMode::AC and config_context.ac_hlc_enabled)
         EVLOG_info << "AC HLC mode enabled.";
@@ -1904,6 +2028,9 @@ std::string Charger::evse_state_to_string(EvseState s) {
     case EvseState::T_step_X1:
         return ("T_step_X1");
         break;
+    case EvseState::Reinit:
+        return ("Reinit");
+        break;
     case EvseState::PrepareCharging:
         return ("PrepareCharging");
         break;
@@ -2024,6 +2151,12 @@ void Charger::set_matching_started(bool m) {
     shared_context.matching_started = m;
 }
 
+void Charger::set_slac_matched(bool matched) {
+    Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_set_matching_started);
+    shared_context.slac_matched = matched;
+    shared_context.matching_started = matched or shared_context.matching_started;
+}
+
 void Charger::reset_dc_enforce_target_limits_timer() {
     last_dc_enforce_target_limits = std::chrono::steady_clock::now();
 }
@@ -2075,41 +2208,43 @@ void Charger::dlink_terminate() {
 }
 
 void Charger::dlink_error() {
-    Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_dlink_error);
+    {
+        Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_dlink_error);
 
-    shared_context.hlc_allow_close_contactor = false;
-
-    // If the session is being stopped for good (e.g. the transaction was stopped on request
-    // during cable check) or is already over, the D-LINK_ERROR is a consequence of the HLC
-    // session shutting down, not a communication error to recover from. Do not restart matching
-    // in this case as the session can not continue anyway; stop PWM and power instead so the
-    // StoppingCharging state can proceed to Finished once the contactors are open.
-    const bool stopping_for_good = shared_context.current_state == EvseState::StoppingCharging and
-                                   (not shared_context.flag_transaction_active or not shared_context.flag_authorized or
-                                    shared_context.flag_disable_requested);
-    if (stopping_for_good or shared_context.current_state == EvseState::Finished) {
-        session_log.evse(false, "D-LINK_ERROR while the session is stopping or finished: not restarting matching");
-        if (shared_context.pwm_running) {
-            cp_state_X1();
+        if (shared_context.reinit_requested or shared_context.reinit_running) {
+            EVLOG_debug << "Ignoring D-LINK_ERROR.req because reinit is active";
+            return;
         }
 
-        if (config_context.charge_mode == ChargeMode::DC) {
-            signal_dc_supply_off();
+        shared_context.hlc_allow_close_contactor = false;
+        hlc_failed = true;
+
+        // If the session is being stopped for good (e.g. the transaction was stopped on request
+        // during cable check) or is already over, the D-LINK_ERROR is a consequence of the HLC
+        // session shutting down, not a communication error to recover from. Do not restart matching
+        // in this case as the session can not continue anyway; stop PWM and power instead so the
+        // StoppingCharging state can proceed to Finished once the contactors are open.
+        const bool stopping_for_good = shared_context.current_state == EvseState::StoppingCharging and
+                                       (not shared_context.flag_transaction_active or
+                                        not shared_context.flag_authorized or shared_context.flag_disable_requested);
+        if (stopping_for_good or shared_context.current_state == EvseState::Finished) {
+            session_log.evse(false, "D-LINK_ERROR while the session is stopping or finished: not restarting matching");
+            if (shared_context.pwm_running) {
+                cp_state_X1();
+            }
+
+            if (config_context.charge_mode == ChargeMode::DC) {
+                signal_dc_supply_off();
+            }
+
+            bsp->allow_power_on(false, types::evse_board_support::Reason::PowerOff);
+            return;
         }
 
-        bsp->allow_power_on(false, types::evse_board_support::Reason::PowerOff);
-        return;
-    }
+        if (config_context.charge_mode == ChargeMode::AC) {
+            shared_context.hlc_charging_active = false;
+        }
 
-    // Is PWM on at the moment?
-    if (not shared_context.pwm_running) {
-        // [V2G3-M07-04]: With receiving a D-LINK_ERROR.request from HLE in X1 state, the EVSE's
-        // communication node shall perform a state X1 to state E/F to state X1 or X2 transition.
-    } else {
-        // [V2G3-M07-05]: With receiving a D-LINK_ERROR.request in X2 state from HLE, the EVSE's
-        // communication node shall perform a state X2 to X1 to state E/F to state X1 or X2 transition.
-
-        // Are we in 5% mode or not?
         if (hlc_use_5percent_current_session) {
             // [V2G3-M07-06] Within the control pilot state X1, the communication node shall leave the
             // logical network and change the matching state to "Unmatched". [V2G3-M07-07] With reaching the
@@ -2121,26 +2256,22 @@ void Charger::dlink_error() {
             // Do t_step_X1 with a t_step_EF afterwards
             // [V2G3-M07-08] The state E/F shall be applied at least T_step_EF: This is already handled in
             // the t_step_EF state.
-            internal_context.t_step_X1_return_state = EvseState::T_step_EF;
-            internal_context.t_step_X1_return_pwm = 0.;
-            internal_context.t_step_EF_return_ampere = 0.;
-            shared_context.current_state = EvseState::T_step_X1;
-
-            // After returning from T_step_EF, go to Waiting for Auth (We are restarting the session)
-            internal_context.t_step_EF_return_state = EvseState::WaitingForAuthentication;
-            // [V2G3-M07-09] After applying state E/F, the EVSE shall switch to contol pilot state X1 or X2
-            // as soon as the EVSE is ready control for pilot incoming duty matching cycle requests: This is
-            // already handled in the Auth step.
-
-            // [V2G3-M07-05] says we need to go through X1 at the end of the sequence
-            internal_context.t_step_EF_return_pwm = 0.;
-            internal_context.t_step_EF_return_ampere = 0.;
+            cp_state_X1();
         }
-        // else {
-        // [V2G3-M07-10] Gives us two options for nominal PWM mode and HLC in case of error: We choose
-        // [V2G3-M07-12] (Don't interrupt basic AC charging just because an error in HLC happend) So we
-        // don't do anything here, SLAC will be notified anyway to reset
-        //}
+    }
+
+    // [V2G3-M07-10] Gives us two options for nominal PWM mode and HLC in case of error: We choose [V2G3-M07-12]
+    // [V2G3-M07-12] (Don't interrupt basic AC charging just because an error in HLC happend) So we
+    // don't do anything here, SLAC will be notified anyway to reset
+    // [V2G3-M07-04]: With receiving a D-LINK_ERROR.request from HLE in X1 state, the EVSE's
+    // communication node shall perform a state X1 to state E/F to state X1 or X2 transition.
+    // [V2G3-M07-05]: With receiving a D-LINK_ERROR.request in X2 state from HLC, the EVSE's
+    // communication node shall perform a state X2 to X1 to state E/F to state X1 or X2 transition.
+    // [V2G3-M07-06] Within the control pilot state X1, the communication node shall leave the
+    // logical network and change the matching state to "Unmatched". [V2G3-M07-07] With reaching the
+    // state "Unmatched", the EVSE shall switch to state E/F.
+    if (hlc_use_5percent_current_session) {
+        start_reinit();
     }
 }
 

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -67,6 +67,11 @@ public:
         DC
     };
 
+    struct ReinitConfiguration {
+        std::string state_transition;
+        int duration;
+    };
+
     enum class EvseState {
         Disabled,
         Idle,
@@ -79,6 +84,7 @@ public:
         Finished,
         T_step_EF,
         T_step_X1,
+        Reinit,
         SwitchPhases
     };
 
@@ -104,7 +110,8 @@ public:
                bool ac_enforce_hlc, bool ac_with_soc_timeout, float soft_over_current_tolerance_percent,
                float soft_over_current_measurement_noise_A, const int switch_3ph1ph_delay_s,
                const std::string switch_3ph1ph_cp_state, const int soft_over_current_timeout_ms,
-               const int _state_F_after_fault_ms, const bool fail_on_powermeter_errors, const bool raise_mrec9,
+               const int _state_F_after_fault_ms, const int reinit_duration_ms, const std::string& reinit_method,
+               const bool fail_on_powermeter_errors, const bool raise_mrec9,
                const int sleep_before_enabling_pwm_hlc_mode_ms, const utils::SessionIdType session_id_type,
                const int hlc_charge_loop_without_energy_timeout_s);
 
@@ -118,6 +125,7 @@ public:
 
     // Returns active session_uuid. Returns empty string if not session is active
     std::string get_session_id() const;
+    void set_supports_cp_state_E(bool value);
 
     // call when in state WaitingForAuthentication
     void authorize(bool a, const types::authorization::ProvidedIdToken& token,
@@ -133,6 +141,7 @@ public:
 
     // trigger replug sequence while charging to switch number of phases
     bool switch_three_phases_while_charging(bool n);
+    bool start_reinit();
 
     bool pause_charging();
     bool resume_charging();
@@ -171,6 +180,7 @@ public:
     void request_error_sequence();
 
     void set_matching_started(bool m);
+    void set_slac_matched(bool matched);
 
     void notify_currentdemand_started();
     void reset_dc_enforce_target_limits_timer();
@@ -251,7 +261,10 @@ private:
     void update_pwm_now_if_changed_ampere(float duty_cycle);
     void update_pwm_max_every_5seconds_ampere(float duty_cycle);
     void cp_state_X1();
+    void cp_state_E();
     void cp_state_F();
+    void apply_configured_reinit_method();
+    void process_pending_reinit_request();
 
     void process_cp_events_independent(CPEvent cp_event);
     void process_cp_events_state(CPEvent cp_event);
@@ -315,8 +328,8 @@ private:
         bool contactor_open{true};
         bool hlc_charging_active{false};
         HlcTerminatePause hlc_charging_terminate_pause;
-        types::iso15118::DcEvseMaximumLimits current_evse_max_limits;
-        types::iso15118::DcEvseMinimumLimits current_evse_min_limits;
+        types::iso15118::DcEvseMaximumLimits current_evse_max_limits{0, 0, 0, std::nullopt, std::nullopt};
+        types::iso15118::DcEvseMinimumLimits current_evse_min_limits{0, 0, 0, std::nullopt, std::nullopt};
         bool pwm_running{false};
         std::optional<types::authorization::ProvidedIdToken>
             stop_transaction_id_token; // only set in case transaction was stopped locally
@@ -329,6 +342,7 @@ private:
         // set to true if auth is from PnC, otherwise to false (EIM)
         bool authorized_pnc;
         bool matching_started;
+        std::atomic_bool slac_matched{false};
         float max_current;
         std::chrono::time_point<std::chrono::steady_clock> max_current_valid_until;
         std::optional<double> max_current_cable;
@@ -352,6 +366,9 @@ private:
         bool contactor_welded{false};
         bool switch_3ph1ph_threephase{false};
         bool switch_3ph1ph_threephase_ongoing{false};
+        bool reinit_requested{false};
+        bool reinit_running{false};
+        ReinitConfiguration reinit_config{"CPStateF", 3000};
 
         std::optional<types::units_signed::SignedMeterValue> stop_signed_meter_value;
         std::optional<types::units_signed::SignedMeterValue> start_signed_meter_value;
@@ -370,12 +387,16 @@ private:
         ChargeMode charge_mode{0};
         // Delay when switching from 1ph to 3ph or 3ph to 1ph
         int switch_3ph1ph_delay_s{10};
-        // Use state F if true, otherwise use X1
-        bool switch_3ph1ph_cp_state_F{false};
+        // CP state to use while switching phases
+        std::string switch_3ph1ph_cp_state{"X1"};
         // Tolerate soft over current for given time
         int soft_over_current_timeout_ms{7000};
         // Switch to F for configured ms after a fatal error
         int state_F_after_fault_ms{300};
+        // Duration in milliseconds of the reinit state before returning to normal operation
+        int reinit_duration_ms{3000};
+        // CP state to use during reinitialization
+        std::string reinit_method{"CPStateF"};
         // Fail on powermeter errors
         bool fail_on_powermeter_errors;
         // Raise MREC9 authorization timeout error
@@ -392,10 +413,13 @@ private:
     // Used by different threads, but requires no complete state machine locking
     std::atomic<float> soft_over_current_tolerance_percent{10.};
     std::atomic<float> soft_over_current_measurement_noise_A{0.5};
+    std::atomic_bool supports_cp_state_E{false};
     // HLC uses 5 percent signalling. Used both for AC and DC modes.
     std::atomic_bool hlc_use_5percent_current_session;
     // HLC enabled in current AC session. This can change during the session if e.g. HLC fails.
     std::atomic_bool ac_hlc_enabled_current_session;
+    // HLC failed for the current plug-in session. AC falls back to nominal PWM after this.
+    std::atomic_bool hlc_failed{false};
 
     // This struct is only used from main loop thread
     struct InternalContext {
@@ -438,6 +462,8 @@ private:
         std::chrono::time_point<std::chrono::steady_clock> fatal_error_became_active;
         bool fatal_error_timer_running{false};
         bool dc_statistics_printed{false};
+        bool reinit_timer_active{false};
+        std::chrono::time_point<std::chrono::steady_clock> reinit_deadline;
 
         types::evse_manager::ChargingPausedEVSEReasons last_charging_paused_evse_reasons;
     } internal_context;

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -104,7 +104,8 @@ public:
                bool ac_enforce_hlc, bool ac_with_soc_timeout, float soft_over_current_tolerance_percent,
                float soft_over_current_measurement_noise_A, const int switch_3ph1ph_delay_s,
                const std::string switch_3ph1ph_cp_state, const int soft_over_current_timeout_ms,
-               const int _state_F_after_fault_ms, const bool fail_on_powermeter_errors, const bool raise_mrec9,
+               const int _state_F_after_fault_ms, const int reinit_duration_ms, const std::string& reinit_method,
+               const bool fail_on_powermeter_errors, const bool raise_mrec9,
                const int sleep_before_enabling_pwm_hlc_mode_ms, const utils::SessionIdType session_id_type,
                const int hlc_charge_loop_without_energy_timeout_s);
 
@@ -378,6 +379,10 @@ private:
         int soft_over_current_timeout_ms{7000};
         // Switch to F for configured ms after a fatal error
         int state_F_after_fault_ms{300};
+        // Duration in milliseconds of the reinit state before returning to normal operation
+        int reinit_duration_ms{3000};
+        // CP state to use during reinitialization
+        std::string reinit_method{"CPStateF"};
         // Fail on powermeter errors
         bool fail_on_powermeter_errors;
         // Raise MREC9 authorization timeout error

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -418,6 +418,8 @@ private:
     std::atomic_bool hlc_use_5percent_current_session;
     // HLC enabled in current AC session. This can change during the session if e.g. HLC fails.
     std::atomic_bool ac_hlc_enabled_current_session;
+    // HLC failed for the current plug-in session. AC falls back to nominal PWM after this.
+    std::atomic_bool hlc_failed{false};
 
     // This struct is only used from main loop thread
     struct InternalContext {

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -118,6 +118,7 @@ public:
 
     // Returns active session_uuid. Returns empty string if not session is active
     std::string get_session_id() const;
+    void set_supports_cp_state_E(bool value);
 
     // call when in state WaitingForAuthentication
     void authorize(bool a, const types::authorization::ProvidedIdToken& token,
@@ -251,6 +252,7 @@ private:
     void update_pwm_now_if_changed_ampere(float duty_cycle);
     void update_pwm_max_every_5seconds_ampere(float duty_cycle);
     void cp_state_X1();
+    void cp_state_E();
     void cp_state_F();
 
     void process_cp_events_independent(CPEvent cp_event);
@@ -370,8 +372,8 @@ private:
         ChargeMode charge_mode{0};
         // Delay when switching from 1ph to 3ph or 3ph to 1ph
         int switch_3ph1ph_delay_s{10};
-        // Use state F if true, otherwise use X1
-        bool switch_3ph1ph_cp_state_F{false};
+        // CP state to use while switching phases
+        std::string switch_3ph1ph_cp_state{"X1"};
         // Tolerate soft over current for given time
         int soft_over_current_timeout_ms{7000};
         // Switch to F for configured ms after a fatal error
@@ -392,6 +394,7 @@ private:
     // Used by different threads, but requires no complete state machine locking
     std::atomic<float> soft_over_current_tolerance_percent{10.};
     std::atomic<float> soft_over_current_measurement_noise_A{0.5};
+    std::atomic_bool supports_cp_state_E{false};
     // HLC uses 5 percent signalling. Used both for AC and DC modes.
     std::atomic_bool hlc_use_5percent_current_session;
     // HLC enabled in current AC session. This can change during the session if e.g. HLC fails.

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -67,6 +67,11 @@ public:
         DC
     };
 
+    struct ReinitConfiguration {
+        std::string state_transition;
+        int duration;
+    };
+
     enum class EvseState {
         Disabled,
         Idle,
@@ -79,6 +84,7 @@ public:
         Finished,
         T_step_EF,
         T_step_X1,
+        Reinit,
         SwitchPhases
     };
 
@@ -135,6 +141,7 @@ public:
 
     // trigger replug sequence while charging to switch number of phases
     bool switch_three_phases_while_charging(bool n);
+    bool start_reinit();
 
     bool pause_charging();
     bool resume_charging();
@@ -173,6 +180,7 @@ public:
     void request_error_sequence();
 
     void set_matching_started(bool m);
+    void set_slac_matched(bool matched);
 
     void notify_currentdemand_started();
     void reset_dc_enforce_target_limits_timer();
@@ -255,6 +263,8 @@ private:
     void cp_state_X1();
     void cp_state_E();
     void cp_state_F();
+    void apply_configured_reinit_method();
+    void process_pending_reinit_request();
 
     void process_cp_events_independent(CPEvent cp_event);
     void process_cp_events_state(CPEvent cp_event);
@@ -318,8 +328,8 @@ private:
         bool contactor_open{true};
         bool hlc_charging_active{false};
         HlcTerminatePause hlc_charging_terminate_pause;
-        types::iso15118::DcEvseMaximumLimits current_evse_max_limits;
-        types::iso15118::DcEvseMinimumLimits current_evse_min_limits;
+        types::iso15118::DcEvseMaximumLimits current_evse_max_limits{0, 0, 0, std::nullopt, std::nullopt};
+        types::iso15118::DcEvseMinimumLimits current_evse_min_limits{0, 0, 0, std::nullopt, std::nullopt};
         bool pwm_running{false};
         std::optional<types::authorization::ProvidedIdToken>
             stop_transaction_id_token; // only set in case transaction was stopped locally
@@ -332,6 +342,7 @@ private:
         // set to true if auth is from PnC, otherwise to false (EIM)
         bool authorized_pnc;
         bool matching_started;
+        std::atomic_bool slac_matched{false};
         float max_current;
         std::chrono::time_point<std::chrono::steady_clock> max_current_valid_until;
         std::optional<double> max_current_cable;
@@ -355,6 +366,9 @@ private:
         bool contactor_welded{false};
         bool switch_3ph1ph_threephase{false};
         bool switch_3ph1ph_threephase_ongoing{false};
+        bool reinit_requested{false};
+        bool reinit_running{false};
+        ReinitConfiguration reinit_config{"CPStateF", 3000};
 
         std::optional<types::units_signed::SignedMeterValue> stop_signed_meter_value;
         std::optional<types::units_signed::SignedMeterValue> start_signed_meter_value;
@@ -446,6 +460,8 @@ private:
         std::chrono::time_point<std::chrono::steady_clock> fatal_error_became_active;
         bool fatal_error_timer_running{false};
         bool dc_statistics_printed{false};
+        bool reinit_timer_active{false};
+        std::chrono::time_point<std::chrono::steady_clock> reinit_deadline;
 
         types::evse_manager::ChargingPausedEVSEReasons last_charging_paused_evse_reasons;
     } internal_context;

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -360,7 +360,7 @@ void EvseManager::ready() {
             payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
         }
         r_hlc[0]->call_session_setup(payment_options, _contract_certificate_installation_enabled,
-                                     _central_contract_validation_allowed);
+                                     _central_contract_validation_allowed, false);
 
         r_hlc[0]->subscribe_hlc_session_failed([this](types::evse_manager::HlcSessionFailedReasonEnum reason) {
             types::evse_manager::HlcSessionFailedEvent ev;
@@ -1305,7 +1305,7 @@ void EvseManager::ready() {
             payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
         }
         r_hlc[0]->call_session_setup(payment_options, _contract_certificate_installation_enabled,
-                                     _central_contract_validation_allowed);
+                                     _central_contract_validation_allowed, false);
     });
 
     charger->signal_session_started_event.connect(
@@ -1341,7 +1341,7 @@ void EvseManager::ready() {
                 }
             }
             r_hlc[0]->call_session_setup(payment_options, _contract_certificate_installation_enabled,
-                                         _central_contract_validation_allowed);
+                                         _central_contract_validation_allowed, false);
         });
 
     invoke_ready(*p_evse);

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -198,6 +198,7 @@ void EvseManager::init() {
     pnc_enabled = config.payment_enable_contract;
     central_contract_validation_allowed = config.central_contract_validation_allowed;
     contract_certificate_installation_enabled = config.contract_certificate_installation_enabled;
+    fake_dc_enabled = config.ac_with_soc;
 
     reserved = false;
     reservation_id = -1;
@@ -361,7 +362,7 @@ void EvseManager::ready() {
             payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
         }
         r_hlc[0]->call_session_setup(payment_options, _contract_certificate_installation_enabled,
-                                     _central_contract_validation_allowed, false);
+                                     _central_contract_validation_allowed, fake_dc_enabled);
 
         r_hlc[0]->subscribe_hlc_session_failed([this](types::evse_manager::HlcSessionFailedReasonEnum reason) {
             types::evse_manager::HlcSessionFailedEvent ev;
@@ -1218,9 +1219,14 @@ void EvseManager::ready() {
             // Notify charger whether matching was started (or is done) or not
             if (s == types::slac::State::UNMATCHED) {
                 charger->set_matching_started(false);
+                charger->set_slac_matched(false);
                 slac_unmatched = true;
+            } else if (s == types::slac::State::MATCHED) {
+                charger->set_slac_matched(true);
+                slac_unmatched = false;
             } else {
                 charger->set_matching_started(true);
+                charger->set_slac_matched(false);
                 slac_unmatched = false;
             }
         });
@@ -1306,7 +1312,7 @@ void EvseManager::ready() {
             payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
         }
         r_hlc[0]->call_session_setup(payment_options, _contract_certificate_installation_enabled,
-                                     _central_contract_validation_allowed, false);
+                                     _central_contract_validation_allowed, fake_dc_enabled);
     });
 
     charger->signal_session_started_event.connect(
@@ -1342,7 +1348,7 @@ void EvseManager::ready() {
                 }
             }
             r_hlc[0]->call_session_setup(payment_options, _contract_certificate_installation_enabled,
-                                         _central_contract_validation_allowed, false);
+                                         _central_contract_validation_allowed, fake_dc_enabled);
         });
 
     invoke_ready(*p_evse);
@@ -1538,12 +1544,14 @@ void EvseManager::switch_DC_mode() {
 }
 
 void EvseManager::switch_AC_mode() {
-    setup_AC_mode();
+    setup_AC_mode(false);
+    charger->start_reinit();
 }
 
 // This sets up a fake DC mode that is just supposed to work until we get the SoC.
 // It is only used for AC<>DC<>AC<>DC mode to get AC charging with SoC.
 void EvseManager::setup_fake_DC_mode() {
+    fake_dc_enabled = true;
     charger->setup(config.has_ventilation, Charger::ChargeMode::DC, hlc_enabled, config.ac_hlc_use_5percent,
                    config.ac_enforce_hlc, false, config.soft_over_current_tolerance_percent,
                    config.soft_over_current_measurement_noise_A, config.switch_3ph1ph_delay_s,
@@ -1578,6 +1586,7 @@ void EvseManager::setup_fake_DC_mode() {
     types::iso15118::DcEvseMinimumLimits evse_min_limits;
     evse_min_limits.evse_minimum_current_limit = 0;
     evse_min_limits.evse_minimum_voltage_limit = 0;
+    evse_min_limits.evse_minimum_power_limit = 0;
     r_hlc[0]->call_update_dc_minimum_limits(evse_min_limits);
 
     constexpr auto sae_mode = types::iso15118::SaeJ2847BidiMode::None;
@@ -1587,8 +1596,9 @@ void EvseManager::setup_fake_DC_mode() {
     this->publish_and_update_supported_energy_transfers();
 }
 
-void EvseManager::setup_AC_mode() {
-    charger->setup(config.has_ventilation, Charger::ChargeMode::AC, hlc_enabled, config.ac_hlc_use_5percent,
+void EvseManager::setup_AC_mode(bool ac_hlc_enabled) {
+    fake_dc_enabled = false;
+    charger->setup(config.has_ventilation, Charger::ChargeMode::AC, ac_hlc_enabled, config.ac_hlc_use_5percent,
                    config.ac_enforce_hlc, true, config.soft_over_current_tolerance_percent,
                    config.soft_over_current_measurement_noise_A, config.switch_3ph1ph_delay_s,
                    config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms, config.state_F_after_fault_ms,
@@ -1612,10 +1622,12 @@ void EvseManager::setup_AC_mode() {
 
     constexpr auto sae_mode = types::iso15118::SaeJ2847BidiMode::None;
 
-    if (hlc_enabled) {
+    if (ac_hlc_enabled) {
         r_hlc[0]->call_setup(evseid, sae_mode, config.session_logging);
         this->update_supported_energy_transfers(transfer_modes);
         this->publish_and_update_supported_energy_transfers();
+    } else {
+        selected_protocol = "IEC61851-1";
     }
 }
 

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -373,6 +373,11 @@ void EvseManager::ready() {
 
         r_hlc[0]->subscribe_dlink_error([this] {
             session_log.evse(true, "D-LINK_ERROR.req");
+            // In case the fake DC unexpectedly disconnects due to a d-link error, we'll need to switch
+            // back to AC basic mode.
+            if (fake_dc_enabled and config.ac_with_soc) {
+                setup_AC_mode(false);
+            }
             // Inform charger
             charger->dlink_error();
             // Inform SLAC layer, it will leave the logical network

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -199,6 +199,7 @@ void EvseManager::init() {
     pnc_enabled = config.payment_enable_contract;
     central_contract_validation_allowed = config.central_contract_validation_allowed;
     contract_certificate_installation_enabled = config.contract_certificate_installation_enabled;
+    fake_dc_enabled = config.ac_with_soc;
 
     reserved = false;
     reservation_id = -1;
@@ -258,6 +259,7 @@ void EvseManager::init() {
             hw_caps_handle.wait([this]() { return ready_for_capabilities.load(); });
             *hw_caps_handle = c;
         }
+        charger->set_supports_cp_state_E(c.supports_cp_state_E);
 
         if (ac_nr_phases_active == 0) {
             ac_nr_phases_active = c.max_phase_count_import;
@@ -369,7 +371,7 @@ void EvseManager::ready() {
             payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
         }
         r_hlc[0]->call_session_setup(payment_options, _contract_certificate_installation_enabled,
-                                     _central_contract_validation_allowed);
+                                     _central_contract_validation_allowed, fake_dc_enabled);
 
         r_hlc[0]->subscribe_hlc_session_failed([this](types::evse_manager::HlcSessionFailedReasonEnum reason) {
             types::evse_manager::HlcSessionFailedEvent ev;
@@ -380,6 +382,11 @@ void EvseManager::ready() {
 
         r_hlc[0]->subscribe_dlink_error([this] {
             session_log.evse(true, "D-LINK_ERROR.req");
+            // In case the fake DC unexpectedly disconnects due to a d-link error, we'll need to switch
+            // back to AC basic mode.
+            if (fake_dc_enabled and config.ac_with_soc) {
+                setup_AC_mode(false);
+            }
             // Inform charger
             charger->dlink_error();
             // Inform SLAC layer, it will leave the logical network
@@ -1231,9 +1238,14 @@ void EvseManager::ready() {
             // Notify charger whether matching was started (or is done) or not
             if (s == types::slac::State::UNMATCHED) {
                 charger->set_matching_started(false);
+                charger->set_slac_matched(false);
                 slac_unmatched = true;
+            } else if (s == types::slac::State::MATCHED) {
+                charger->set_slac_matched(true);
+                slac_unmatched = false;
             } else {
                 charger->set_matching_started(true);
+                charger->set_slac_matched(false);
                 slac_unmatched = false;
             }
         });
@@ -1319,7 +1331,7 @@ void EvseManager::ready() {
             payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
         }
         r_hlc[0]->call_session_setup(payment_options, _contract_certificate_installation_enabled,
-                                     _central_contract_validation_allowed);
+                                     _central_contract_validation_allowed, fake_dc_enabled);
     });
 
     charger->signal_session_started_event.connect(
@@ -1355,7 +1367,7 @@ void EvseManager::ready() {
                 }
             }
             r_hlc[0]->call_session_setup(payment_options, _contract_certificate_installation_enabled,
-                                         _central_contract_validation_allowed);
+                                         _central_contract_validation_allowed, fake_dc_enabled);
         });
 
     invoke_ready(*p_evse);
@@ -1366,15 +1378,15 @@ void EvseManager::ready() {
     if (config.ac_with_soc) {
         setup_fake_DC_mode();
     } else {
-        charger->setup(config.has_ventilation,
-                       (config.charge_mode == "DC" ? Charger::ChargeMode::DC : Charger::ChargeMode::AC), hlc_enabled,
-                       config.ac_hlc_use_5percent, config.ac_enforce_hlc, false,
-                       config.soft_over_current_tolerance_percent, config.soft_over_current_measurement_noise_A,
-                       config.switch_3ph1ph_delay_s, config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms,
-                       config.state_F_after_fault_ms, config.fail_on_powermeter_errors, config.raise_mrec9,
-                       config.sleep_before_enabling_pwm_hlc_mode_ms,
-                       utils::get_session_id_type_from_string(config.session_id_type),
-                       config.hlc_charge_loop_without_energy_timeout_s);
+        charger->setup(
+            config.has_ventilation, (config.charge_mode == "DC" ? Charger::ChargeMode::DC : Charger::ChargeMode::AC),
+            hlc_enabled, config.ac_hlc_use_5percent, config.ac_enforce_hlc, false,
+            config.soft_over_current_tolerance_percent, config.soft_over_current_measurement_noise_A,
+            config.switch_3ph1ph_delay_s, config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms,
+            config.state_F_after_fault_ms, config.reinit_duration_ms, config.reinit_method,
+            config.fail_on_powermeter_errors, config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
+            utils::get_session_id_type_from_string(config.session_id_type),
+            config.hlc_charge_loop_without_energy_timeout_s);
     }
 
     telemetryThreadHandle = std::thread([this]() {
@@ -1551,17 +1563,20 @@ void EvseManager::switch_DC_mode() {
 }
 
 void EvseManager::switch_AC_mode() {
-    setup_AC_mode();
+    setup_AC_mode(false);
+    charger->start_reinit();
 }
 
 // This sets up a fake DC mode that is just supposed to work until we get the SoC.
 // It is only used for AC<>DC<>AC<>DC mode to get AC charging with SoC.
 void EvseManager::setup_fake_DC_mode() {
+    fake_dc_enabled = true;
     charger->setup(config.has_ventilation, Charger::ChargeMode::DC, hlc_enabled, config.ac_hlc_use_5percent,
                    config.ac_enforce_hlc, false, config.soft_over_current_tolerance_percent,
                    config.soft_over_current_measurement_noise_A, config.switch_3ph1ph_delay_s,
                    config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms, config.state_F_after_fault_ms,
-                   config.fail_on_powermeter_errors, config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
+                   config.reinit_duration_ms, config.reinit_method, config.fail_on_powermeter_errors,
+                   config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
                    utils::get_session_id_type_from_string(config.session_id_type),
                    config.hlc_charge_loop_without_energy_timeout_s);
 
@@ -1570,10 +1585,8 @@ void EvseManager::setup_fake_DC_mode() {
     // Set up energy transfer modes for HLC. For now we only support either DC or AC, not both at the same time.
     std::vector<types::iso15118::EnergyTransferMode> transfer_modes;
 
-    transfer_modes.push_back(types::iso15118::EnergyTransferMode::DC_core);
     transfer_modes.push_back(types::iso15118::EnergyTransferMode::DC_extended);
-    transfer_modes.push_back(types::iso15118::EnergyTransferMode::DC_combo_core);
-    transfer_modes.push_back(types::iso15118::EnergyTransferMode::DC_unique);
+    transfer_modes.push_back(types::iso15118::EnergyTransferMode::DC_core);
 
     types::iso15118::DcEvsePresentVoltageCurrent present_values;
     present_values.evse_present_voltage = 400; // FIXME: set a correct values
@@ -1590,6 +1603,7 @@ void EvseManager::setup_fake_DC_mode() {
     types::iso15118::DcEvseMinimumLimits evse_min_limits;
     evse_min_limits.evse_minimum_current_limit = 0;
     evse_min_limits.evse_minimum_voltage_limit = 0;
+    evse_min_limits.evse_minimum_power_limit = 0;
     r_hlc[0]->call_update_dc_minimum_limits(evse_min_limits);
 
     constexpr auto sae_mode = types::iso15118::SaeJ2847BidiMode::None;
@@ -1599,12 +1613,14 @@ void EvseManager::setup_fake_DC_mode() {
     this->publish_and_update_supported_energy_transfers();
 }
 
-void EvseManager::setup_AC_mode() {
-    charger->setup(config.has_ventilation, Charger::ChargeMode::AC, hlc_enabled, config.ac_hlc_use_5percent,
+void EvseManager::setup_AC_mode(bool ac_hlc_enabled) {
+    fake_dc_enabled = false;
+    charger->setup(config.has_ventilation, Charger::ChargeMode::AC, ac_hlc_enabled, config.ac_hlc_use_5percent,
                    config.ac_enforce_hlc, true, config.soft_over_current_tolerance_percent,
                    config.soft_over_current_measurement_noise_A, config.switch_3ph1ph_delay_s,
                    config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms, config.state_F_after_fault_ms,
-                   config.fail_on_powermeter_errors, config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
+                   config.reinit_duration_ms, config.reinit_method, config.fail_on_powermeter_errors,
+                   config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
                    utils::get_session_id_type_from_string(config.session_id_type),
                    config.hlc_charge_loop_without_energy_timeout_s);
 
@@ -1623,10 +1639,12 @@ void EvseManager::setup_AC_mode() {
 
     constexpr auto sae_mode = types::iso15118::SaeJ2847BidiMode::None;
 
-    if (hlc_enabled) {
+    if (ac_hlc_enabled) {
         r_hlc[0]->call_setup(evseid, sae_mode, config.session_logging);
         this->update_supported_energy_transfers(transfer_modes);
         this->publish_and_update_supported_energy_transfers();
+    } else {
+        selected_protocol = "IEC61851-1";
     }
 }
 

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -1353,15 +1353,15 @@ void EvseManager::ready() {
     if (config.ac_with_soc) {
         setup_fake_DC_mode();
     } else {
-        charger->setup(config.has_ventilation,
-                       (config.charge_mode == "DC" ? Charger::ChargeMode::DC : Charger::ChargeMode::AC), hlc_enabled,
-                       config.ac_hlc_use_5percent, config.ac_enforce_hlc, false,
-                       config.soft_over_current_tolerance_percent, config.soft_over_current_measurement_noise_A,
-                       config.switch_3ph1ph_delay_s, config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms,
-                       config.state_F_after_fault_ms, config.fail_on_powermeter_errors, config.raise_mrec9,
-                       config.sleep_before_enabling_pwm_hlc_mode_ms,
-                       utils::get_session_id_type_from_string(config.session_id_type),
-                       config.hlc_charge_loop_without_energy_timeout_s);
+        charger->setup(
+            config.has_ventilation, (config.charge_mode == "DC" ? Charger::ChargeMode::DC : Charger::ChargeMode::AC),
+            hlc_enabled, config.ac_hlc_use_5percent, config.ac_enforce_hlc, false,
+            config.soft_over_current_tolerance_percent, config.soft_over_current_measurement_noise_A,
+            config.switch_3ph1ph_delay_s, config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms,
+            config.state_F_after_fault_ms, config.reinit_duration_ms, config.reinit_method,
+            config.fail_on_powermeter_errors, config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
+            utils::get_session_id_type_from_string(config.session_id_type),
+            config.hlc_charge_loop_without_energy_timeout_s);
     }
 
     telemetryThreadHandle = std::thread([this]() {
@@ -1548,7 +1548,8 @@ void EvseManager::setup_fake_DC_mode() {
                    config.ac_enforce_hlc, false, config.soft_over_current_tolerance_percent,
                    config.soft_over_current_measurement_noise_A, config.switch_3ph1ph_delay_s,
                    config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms, config.state_F_after_fault_ms,
-                   config.fail_on_powermeter_errors, config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
+                   config.reinit_duration_ms, config.reinit_method, config.fail_on_powermeter_errors,
+                   config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
                    utils::get_session_id_type_from_string(config.session_id_type),
                    config.hlc_charge_loop_without_energy_timeout_s);
 
@@ -1591,7 +1592,8 @@ void EvseManager::setup_AC_mode() {
                    config.ac_enforce_hlc, true, config.soft_over_current_tolerance_percent,
                    config.soft_over_current_measurement_noise_A, config.switch_3ph1ph_delay_s,
                    config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms, config.state_F_after_fault_ms,
-                   config.fail_on_powermeter_errors, config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
+                   config.reinit_duration_ms, config.reinit_method, config.fail_on_powermeter_errors,
+                   config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
                    utils::get_session_id_type_from_string(config.session_id_type),
                    config.hlc_charge_loop_without_energy_timeout_s);
 

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -249,6 +249,7 @@ void EvseManager::init() {
             hw_caps_handle.wait([this]() { return ready_for_capabilities.load(); });
             *hw_caps_handle = c;
         }
+        charger->set_supports_cp_state_E(c.supports_cp_state_E);
 
         if (ac_nr_phases_active == 0) {
             ac_nr_phases_active = c.max_phase_count_import;

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -1566,10 +1566,8 @@ void EvseManager::setup_fake_DC_mode() {
     // Set up energy transfer modes for HLC. For now we only support either DC or AC, not both at the same time.
     std::vector<types::iso15118::EnergyTransferMode> transfer_modes;
 
-    transfer_modes.push_back(types::iso15118::EnergyTransferMode::DC_core);
     transfer_modes.push_back(types::iso15118::EnergyTransferMode::DC_extended);
-    transfer_modes.push_back(types::iso15118::EnergyTransferMode::DC_combo_core);
-    transfer_modes.push_back(types::iso15118::EnergyTransferMode::DC_unique);
+    transfer_modes.push_back(types::iso15118::EnergyTransferMode::DC_core);
 
     types::iso15118::DcEvsePresentVoltageCurrent present_values;
     present_values.evse_present_voltage = 400; // FIXME: set a correct values

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -75,6 +75,8 @@ struct Conf {
     bool ac_hlc_use_5percent;
     bool ac_enforce_hlc;
     bool ac_with_soc;
+    int reinit_duration_ms;
+    std::string reinit_method;
     int internal_over_voltage_duration_ms;
     bool dbg_hlc_auth_after_tstep;
     int dc_isolation_voltage_V;
@@ -240,6 +242,7 @@ public:
     void process_dc_ev_target_voltage_current(const types::iso15118::DcEvseMaximumLimits& hlc_limits);
 
     std::string selected_protocol = "Unknown";
+    bool fake_dc_enabled{false};
 
     std::atomic_bool sae_bidi_active{false};
 
@@ -370,7 +373,7 @@ private:
     // Voltage plausibility monitor
     std::unique_ptr<VoltagePlausibilityMonitor> voltage_plausibility_monitor;
 
-    void setup_AC_mode();
+    void setup_AC_mode(bool ac_hlc_enabled = true);
     void setup_fake_DC_mode();
 
     // special funtion to switch mode while session is active

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -240,6 +240,7 @@ public:
     void process_dc_ev_target_voltage_current(const types::iso15118::DcEvseMaximumLimits& hlc_limits);
 
     std::string selected_protocol = "Unknown";
+    bool fake_dc_enabled{false};
 
     std::atomic_bool sae_bidi_active{false};
 
@@ -376,7 +377,7 @@ private:
     // Voltage plausibility monitor
     std::unique_ptr<VoltagePlausibilityMonitor> voltage_plausibility_monitor;
 
-    void setup_AC_mode();
+    void setup_AC_mode(bool ac_hlc_enabled = true);
     void setup_fake_DC_mode();
 
     // special funtion to switch mode while session is active

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -75,6 +75,8 @@ struct Conf {
     bool ac_hlc_use_5percent;
     bool ac_enforce_hlc;
     bool ac_with_soc;
+    int reinit_duration_ms;
+    std::string reinit_method;
     int internal_over_voltage_duration_ms;
     bool dbg_hlc_auth_after_tstep;
     int dc_isolation_voltage_V;

--- a/modules/EVSE/EvseManager/IECStateMachine.cpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.cpp
@@ -285,20 +285,29 @@ std::queue<CPEvent> IECStateMachine::state_machine(std::optional<RawCPState> con
             }
             break;
 
-        case RawCPState::E:
-            connector_unlock();
+        case RawCPState::E: {
+            const bool state_e_triggered_by_evse = state_e_triggered_through_handle.exchange(false);
+
+            if (!state_e_triggered_by_evse) {
+                connector_unlock();
+            }
             if (last_cp_state != RawCPState::E) {
                 timer_state_C1 = TimerControl::stop;
                 call_allow_power_on_bsp(false);
                 pwm_running = false;
-                r_bsp->call_cp_state_X1();
+                if (!state_e_triggered_by_evse) {
+                    r_bsp->call_cp_state_X1();
+                }
                 if (last_cp_state == RawCPState::B || last_cp_state == RawCPState::C ||
                     last_cp_state == RawCPState::D) {
                     events.push(CPEvent::BCDtoEF);
-                    events.push(CPEvent::BCDtoE);
+                    if (!state_e_triggered_by_evse) {
+                        events.push(CPEvent::BCDtoE);
+                    }
                 }
             }
             break;
+        }
 
         case RawCPState::F:
             timer_state_C1 = TimerControl::stop;
@@ -394,6 +403,18 @@ void IECStateMachine::set_cp_state_F() {
         pwm_running = false;
     }
     r_bsp->call_cp_state_F();
+    // Don't run the state machine in the callers context
+    feed_state_machine(std::nullopt);
+}
+
+// High level state machine sets state E
+void IECStateMachine::set_cp_state_E() {
+    {
+        Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::IEC_set_cp_state_E);
+        pwm_running = false;
+        state_e_triggered_through_handle = true;
+    }
+    r_bsp->call_cp_state_E();
     // Don't run the state machine in the callers context
     feed_state_machine(std::nullopt);
 }

--- a/modules/EVSE/EvseManager/IECStateMachine.cpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.cpp
@@ -191,7 +191,7 @@ std::queue<CPEvent> IECStateMachine::state_machine(std::optional<RawCPState> con
                 connector_unlock();
             }
 
-            if (last_cp_state != RawCPState::A && last_cp_state != RawCPState::B) {
+            if (last_cp_state == RawCPState::C || last_cp_state == RawCPState::D) {
 
                 events.push(CPEvent::CarRequestedStopPower);
                 // Need to switch off according to Table A.6 Sequence 8.1

--- a/modules/EVSE/EvseManager/IECStateMachine.cpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.cpp
@@ -195,7 +195,7 @@ std::queue<CPEvent> IECStateMachine::state_machine(std::optional<RawCPState> con
                 connector_unlock();
             }
 
-            if (last_cp_state != RawCPState::A && last_cp_state != RawCPState::B) {
+            if (last_cp_state == RawCPState::C || last_cp_state == RawCPState::D) {
 
                 events.push(CPEvent::CarRequestedStopPower);
                 // Need to switch off according to Table A.6 Sequence 8.1
@@ -289,22 +289,29 @@ std::queue<CPEvent> IECStateMachine::state_machine(std::optional<RawCPState> con
             }
             break;
 
-        case RawCPState::E:
-            connector_unlock();
+        case RawCPState::E: {
+            const bool state_e_triggered_by_evse = state_e_triggered_through_handle.exchange(false);
+
+            if (!state_e_triggered_by_evse) {
+                connector_unlock();
+            }
             if (last_cp_state != RawCPState::E) {
                 timer_state_C1 = TimerControl::stop;
                 call_allow_power_on_bsp(false);
                 pwm_running = false;
-                if (not cp_state_f_requested) {
+                if (not state_e_triggered_by_evse and not cp_state_f_requested) {
                     r_bsp->call_cp_state_X1();
                 }
                 if (last_cp_state == RawCPState::B || last_cp_state == RawCPState::C ||
                     last_cp_state == RawCPState::D) {
                     events.push(CPEvent::BCDtoEF);
-                    events.push(CPEvent::BCDtoE);
+                    if (!state_e_triggered_by_evse) {
+                        events.push(CPEvent::BCDtoE);
+                    }
                 }
             }
             break;
+        }
 
         case RawCPState::F:
             timer_state_C1 = TimerControl::stop;
@@ -403,6 +410,18 @@ void IECStateMachine::set_cp_state_F() {
         cp_state_f_requested = true;
     }
     r_bsp->call_cp_state_F();
+    // Don't run the state machine in the callers context
+    feed_state_machine(std::nullopt);
+}
+
+// High level state machine sets state E
+void IECStateMachine::set_cp_state_E() {
+    {
+        Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::IEC_set_cp_state_E);
+        pwm_running = false;
+        state_e_triggered_through_handle = true;
+    }
+    r_bsp->call_cp_state_E();
     // Don't run the state machine in the callers context
     feed_state_machine(std::nullopt);
 }

--- a/modules/EVSE/EvseManager/IECStateMachine.hpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.hpp
@@ -90,6 +90,7 @@ public:
 
     void set_pwm(double value);
     void set_cp_state_X1();
+    void set_cp_state_E();
     void set_cp_state_F();
 
     void set_max_phases(AcPhases phases) {
@@ -155,6 +156,7 @@ private:
 
     std::atomic_bool enabled{false};
     std::atomic_bool relais_on{false};
+    std::atomic_bool state_e_triggered_through_handle{false};
 
     static constexpr std::chrono::seconds power_off_under_load_in_c1_timeout{6};
     static constexpr std::chrono::seconds unlock_in_state_f_timeout{5};

--- a/modules/EVSE/EvseManager/IECStateMachine.hpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.hpp
@@ -90,6 +90,7 @@ public:
 
     void set_pwm(double value);
     void set_cp_state_X1();
+    void set_cp_state_E();
     void set_cp_state_F();
 
     void set_max_phases(AcPhases phases) {
@@ -158,6 +159,7 @@ private:
 
     std::atomic_bool enabled{false};
     std::atomic_bool relais_on{false};
+    std::atomic_bool state_e_triggered_through_handle{false};
 
     static constexpr std::chrono::seconds power_off_under_load_in_c1_timeout{6};
     static constexpr std::chrono::seconds unlock_in_state_f_timeout{5};

--- a/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
+++ b/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
@@ -172,6 +172,9 @@ types::energy::EvseState to_energy_evse_state(const Charger::EvseState charger_s
     case Charger::EvseState::T_step_X1:
         return types::energy::EvseState::PrepareCharging;
         break;
+    case Charger::EvseState::Reinit:
+        return types::energy::EvseState::PrepareCharging;
+        break;
     case Charger::EvseState::SwitchPhases:
         return types::energy::EvseState::Charging;
         break;

--- a/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
+++ b/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
@@ -179,6 +179,9 @@ types::energy::EvseState to_energy_evse_state(const Charger::EvseState charger_s
     case Charger::EvseState::T_step_X1:
         return types::energy::EvseState::PrepareCharging;
         break;
+    case Charger::EvseState::Reinit:
+        return types::energy::EvseState::PrepareCharging;
+        break;
     case Charger::EvseState::SwitchPhases:
         return types::energy::EvseState::Charging;
         break;

--- a/modules/EVSE/EvseManager/manifest.yaml
+++ b/modules/EVSE/EvseManager/manifest.yaml
@@ -90,6 +90,24 @@ config:
       Special mode that switches between AC and DC charging to get SoC percentage with AC charging
     type: boolean
     default: false
+  reinit_duration_ms:
+    description: Duration in milliseconds of the reinit state before going back to normal operation
+    type: integer
+    default: 3000
+  reinit_method:
+    description: >-
+      Configures the control pilot behaviour during reinitialization of the connection to the EV. Reinitialization
+      may be used to recover from an unsuccessful PLC link setup, wake up the EV, or switch between HLC and basic AC
+      charging in AC with SoC mode.
+        CPStateE: set CP to state E (0 V) to simulate an unplug. This requires BSP support for CP state E.
+        CPStateF: set CP to state F (-12 V) to signal a temporary unavailability.
+        CPStateX1: keep CP powered with 100% duty cycle to signal that no energy is available.
+    type: string
+    enum:
+      - CPStateE
+      - CPStateF
+      - CPStateX1
+    default: CPStateF
   internal_over_voltage_duration_ms:
     description: >-
       Time in milliseconds the internal software over voltage monitor waits before raising MREC5 once the measured
@@ -293,6 +311,7 @@ config:
     type: string
     enum:
       - X1
+      - E
       - F
     default: X1
   soft_over_current_timeout_ms:

--- a/modules/EVSE/EvseManager/manifest.yaml
+++ b/modules/EVSE/EvseManager/manifest.yaml
@@ -293,6 +293,7 @@ config:
     type: string
     enum:
       - X1
+      - E
       - F
     default: X1
   soft_over_current_timeout_ms:

--- a/modules/EVSE/EvseManager/manifest.yaml
+++ b/modules/EVSE/EvseManager/manifest.yaml
@@ -90,6 +90,24 @@ config:
       Special mode that switches between AC and DC charging to get SoC percentage with AC charging
     type: boolean
     default: false
+  reinit_duration_ms:
+    description: Duration in milliseconds of the reinit state before going back to normal operation
+    type: integer
+    default: 3000
+  reinit_method:
+    description: >-
+      Configures the control pilot behaviour during reinitialization of the connection to the EV. Reinitialization
+      may be used to recover from an unsuccessful PLC link setup, wake up the EV, or switch between HLC and basic AC
+      charging in AC with SoC mode.
+        CPStateE: set CP to state E (0 V) to simulate an unplug. This requires BSP support for CP state E.
+        CPStateF: set CP to state F (-12 V) to signal a temporary unavailability.
+        CPStateX1: keep CP powered with 100% duty cycle to signal that no energy is available.
+    type: string
+    enum:
+      - CPStateE
+      - CPStateF
+      - CPStateX1
+    default: CPStateF
   internal_over_voltage_duration_ms:
     description: >-
       Time in milliseconds the internal software over voltage monitor waits before raising MREC5 once the measured

--- a/modules/EVSE/EvseManager/scoped_lock_timeout.hpp
+++ b/modules/EVSE/EvseManager/scoped_lock_timeout.hpp
@@ -52,12 +52,14 @@ enum class MutexDescription {
     Charger_errors_prevent_charging,
     Charger_set_max_current,
     Charger_switch_three_phases_while_charging,
+    Charger_start_reinit,
     Charger_get_last_stop_transaction,
     Charger_set_hlc_d20_active,
     IEC_process_bsp_event,
     IEC_state_machine,
     IEC_set_pwm,
     IEC_set_cp_state_X1,
+    IEC_set_cp_state_E,
     IEC_set_cp_state_F,
     IEC_allow_power_on,
     IEC_force_unlock,
@@ -163,6 +165,8 @@ static std::string to_string(MutexDescription d) {
         return "Charger.cpp: set max current";
     case MutexDescription::Charger_switch_three_phases_while_charging:
         return "Charger.cpp switch_three_phases_while_charging";
+    case MutexDescription::Charger_start_reinit:
+        return "Charger.cpp: start_reinit";
     case MutexDescription::Charger_get_last_stop_transaction:
         return "Charger.cpp get_last_stop_transaction";
     case MutexDescription::Charger_set_hlc_d20_active:
@@ -175,6 +179,8 @@ static std::string to_string(MutexDescription d) {
         return "IECStateMachine::set_pwm";
     case MutexDescription::IEC_set_cp_state_X1:
         return "IECStateMachine::set_cp_state_X1";
+    case MutexDescription::IEC_set_cp_state_E:
+        return "IECStateMachine::set_cp_state_E";
     case MutexDescription::IEC_set_cp_state_F:
         return "IECStateMachine::set_cp_state_F";
     case MutexDescription::IEC_allow_power_on:

--- a/modules/EVSE/EvseManager/scoped_lock_timeout.hpp
+++ b/modules/EVSE/EvseManager/scoped_lock_timeout.hpp
@@ -52,6 +52,7 @@ enum class MutexDescription {
     Charger_errors_prevent_charging,
     Charger_set_max_current,
     Charger_switch_three_phases_while_charging,
+    Charger_start_reinit,
     Charger_get_last_stop_transaction,
     Charger_set_hlc_d20_active,
     IEC_process_bsp_event,
@@ -164,6 +165,8 @@ static std::string to_string(MutexDescription d) {
         return "Charger.cpp: set max current";
     case MutexDescription::Charger_switch_three_phases_while_charging:
         return "Charger.cpp switch_three_phases_while_charging";
+    case MutexDescription::Charger_start_reinit:
+        return "Charger.cpp: start_reinit";
     case MutexDescription::Charger_get_last_stop_transaction:
         return "Charger.cpp get_last_stop_transaction";
     case MutexDescription::Charger_set_hlc_d20_active:

--- a/modules/EVSE/EvseManager/scoped_lock_timeout.hpp
+++ b/modules/EVSE/EvseManager/scoped_lock_timeout.hpp
@@ -58,6 +58,7 @@ enum class MutexDescription {
     IEC_state_machine,
     IEC_set_pwm,
     IEC_set_cp_state_X1,
+    IEC_set_cp_state_E,
     IEC_set_cp_state_F,
     IEC_allow_power_on,
     IEC_force_unlock,
@@ -175,6 +176,8 @@ static std::string to_string(MutexDescription d) {
         return "IECStateMachine::set_pwm";
     case MutexDescription::IEC_set_cp_state_X1:
         return "IECStateMachine::set_cp_state_X1";
+    case MutexDescription::IEC_set_cp_state_E:
+        return "IECStateMachine::set_cp_state_E";
     case MutexDescription::IEC_set_cp_state_F:
         return "IECStateMachine::set_cp_state_F";
     case MutexDescription::IEC_allow_power_on:

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -806,6 +806,10 @@ void IECStateMachine::set_pwm(double value) {
 }
 void IECStateMachine::set_cp_state_X1() {
 }
+
+void IECStateMachine::set_cp_state_E() {
+}
+
 void IECStateMachine::set_cp_state_F() {
 }
 

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -8,6 +8,10 @@
 #include <memory>
 #include <optional>
 
+namespace module {
+std::vector<std::string> observed_cp_state_commands;
+}
+
 namespace {
 using namespace module;
 using namespace types::evse_manager;
@@ -72,6 +76,7 @@ struct ChargerTest : public testing::Test {
 
     void SetUp() override {
         reset_last_event();
+        observed_cp_state_commands.clear();
         charger = std::make_unique<ChargerDerived>(
             charger_bsp, charger_error_handling, charger_powermeter_billing, charger_store,
             types::evse_board_support::Connector_type::IEC62196Type2Socket, "EVSETEST");
@@ -764,11 +769,14 @@ TEST_F(ChargerTest, DisableDuringIdle) {
 
 // ----------------------------------------------------------------------------
 // tests for dlink_error()
-// A D-LINK_ERROR normally restarts SLAC matching via T_step_X1/T_step_EF
-// ([V2G3-M07-05] error recovery). When the session is being stopped for good or
-// is already finished, the D-LINK_ERROR is just the consequence of the HLC
-// session shutting down and matching must NOT be restarted, so the session can
-// end in StoppingCharging -> Finished.
+// A D-LINK_ERROR normally restarts SLAC matching according to the ISO 15118-3
+// error recovery sequence ([V2G3-M07-05]). For an HLC session, CP is first
+// switched to X1 before the state machine starts the configured reinitialization
+// (defaulting to T_step_EF).
+// When the session is being stopped for good or is already finished, the
+// D-LINK_ERROR is just the consequence of the HLC session shutting down and
+// matching must NOT be restarted, so the session can end in
+// StoppingCharging -> Finished.
 
 struct ChargerDlinkErrorTest : public ChargerTest {
     // never dereferenced: the IECStateMachine used here is the no-op stub below
@@ -844,13 +852,20 @@ TEST_F(ChargerDlinkErrorTest, NoMatchingRestartWhenFinished) {
 
 TEST_F(ChargerDlinkErrorTest, MatchingRestartDuringActiveSession) {
     // A D-LINK_ERROR during an active session (e.g. HLC communication error during
-    // cable check with the transaction still running) must keep the ISO 15118-3
-    // error recovery: restart matching via T_step_X1 -> T_step_EF
+    // cable check with the transaction still running) switches CP to X1 before
+    // the configured reinitialization starts.
     setup_hlc_session_in(Charger::EvseState::PrepareCharging);
 
     charger->dlink_error();
 
-    EXPECT_EQ(charger->current_state(), Charger::EvseState::T_step_X1);
+    EXPECT_EQ(observed_cp_state_commands, std::vector<std::string>{"X1"});
+    EXPECT_FALSE(charger->get_shared_context().pwm_running);
+    EXPECT_TRUE(charger->get_shared_context().reinit_requested);
+    EXPECT_EQ(charger->current_state(), Charger::EvseState::PrepareCharging);
+
+    charger->run_state_machine();
+
+    EXPECT_EQ(charger->current_state(), Charger::EvseState::Reinit);
 }
 
 TEST_F(ChargerDlinkErrorTest, MatchingRestartWhenStoppingToPause) {
@@ -862,7 +877,16 @@ TEST_F(ChargerDlinkErrorTest, MatchingRestartWhenStoppingToPause) {
 
     charger->dlink_error();
 
-    EXPECT_EQ(charger->current_state(), Charger::EvseState::T_step_X1);
+    // A pause continues the session, so it follows the same X1-before-reinit
+    // recovery sequence as an active session.
+    EXPECT_EQ(observed_cp_state_commands, std::vector<std::string>{"X1"});
+    EXPECT_FALSE(ctx.pwm_running);
+    EXPECT_TRUE(ctx.reinit_requested);
+    EXPECT_EQ(charger->current_state(), Charger::EvseState::StoppingCharging);
+
+    charger->run_state_machine();
+
+    EXPECT_EQ(charger->current_state(), Charger::EvseState::Reinit);
 }
 
 TEST_F(ChargerDlinkErrorTest, NoMatchingRestartWithNominalPwm) {
@@ -920,8 +944,15 @@ void IECStateMachine::set_overcurrent_limit(double amps) {
 void IECStateMachine::set_pwm(double value) {
 }
 void IECStateMachine::set_cp_state_X1() {
+    observed_cp_state_commands.emplace_back("X1");
 }
+
+void IECStateMachine::set_cp_state_E() {
+    observed_cp_state_commands.emplace_back("E");
+}
+
 void IECStateMachine::set_cp_state_F() {
+    observed_cp_state_commands.emplace_back("F");
 }
 
 void IECStateMachine::enable(bool en) {

--- a/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -193,7 +193,7 @@ void ISO15118_chargerImpl::handle_set_charging_parameters(types::iso15118::Setup
 
 void ISO15118_chargerImpl::handle_session_setup(std::vector<types::iso15118::PaymentOption>& payment_options,
                                                 bool& supported_certificate_service,
-                                                bool& central_contract_validation_allowed) {
+                                                bool& central_contract_validation_allowed, bool& fake_dc_enabled) {
     if (not v2g_ctx->hlc_pause_active) {
         v2g_ctx->evse_v2g_data.payment_option_list.clear();
         if (not payment_options.empty()) {
@@ -257,6 +257,7 @@ void ISO15118_chargerImpl::handle_session_setup(std::vector<types::iso15118::Pay
     v2g_ctx->evse_v2g_data.evse_processing[PHASE_AUTH] = (uint8_t)iso2_EVSEProcessingType_Ongoing;
 
     v2g_ctx->evse_v2g_data.central_contract_validation_allowed = central_contract_validation_allowed;
+    v2g_ctx->is_fake_dc = fake_dc_enabled;
 }
 
 void ISO15118_chargerImpl::handle_bpt_setup(types::iso15118::BptSetup& bpt_config) {
@@ -503,7 +504,7 @@ void ISO15118_chargerImpl::handle_update_energy_transfer_modes(
         }
     }
 
-    if (mod->config.supported_DIN70121 and not v2g_ctx->is_dc_charger) {
+    if (mod->config.supported_DIN70121 and not v2g_ctx->is_dc_charger and not v2g_ctx->is_fake_dc) {
         v2g_ctx->supported_protocols &= ~(1 << V2G_PROTO_DIN70121);
         dlog(DLOG_LEVEL_WARNING, "Removed DIN70121 from the list of supported protocols as AC is enabled");
     }

--- a/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.hpp
+++ b/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.hpp
@@ -38,8 +38,8 @@ protected:
                               bool& debug_mode) override;
     virtual void handle_set_charging_parameters(types::iso15118::SetupPhysicalValues& physical_values) override;
     virtual void handle_session_setup(std::vector<types::iso15118::PaymentOption>& payment_options,
-                                      bool& supported_certificate_service,
-                                      bool& central_contract_validation_allowed) override;
+                                      bool& supported_certificate_service, bool& central_contract_validation_allowed,
+                                      bool& fake_dc_enabled) override;
     virtual void handle_bpt_setup(types::iso15118::BptSetup& bpt_config) override;
     virtual void handle_set_powersupply_capabilities(types::power_supply_DC::Capabilities& capabilities) override;
     virtual void handle_authorization_response(types::authorization::AuthorizationStatus& authorization_status,

--- a/modules/EVSE/EvseV2G/din_server.cpp
+++ b/modules/EVSE/EvseV2G/din_server.cpp
@@ -649,6 +649,7 @@ static enum v2g_event handle_din_charge_parameter(struct v2g_connection* conn) {
             transport.set(&telemetry_types::V2gTransport::charge_parameter_discovery_requested, true);
         });
     }
+    const bool first_req = conn->ctx->last_v2g_msg != V2G_CHARGE_PARAMETER_DISCOVERY_MSG;
 
     /* At first, publish the received EV request message to the customer MQTT interface */
     publish_din_charge_parameter_discovery_req(conn->ctx, req);
@@ -657,14 +658,14 @@ static enum v2g_event handle_din_charge_parameter(struct v2g_connection* conn) {
     res->ResponseCode = din_responseCodeType_OK; // [V2G-DC-388]
     res->AC_EVSEChargeParameter_isUsed = 0u;
 
-    if (((req->EVRequestedEnergyTransferType != din_EVRequestedEnergyTransferType_DC_core) &&
-         (req->EVRequestedEnergyTransferType != din_EVRequestedEnergyTransferType_DC_extended)) ||
-        conn->ctx->evse_v2g_data.charge_service.SupportedEnergyTransferMode.EnergyTransferMode.array[0] !=
+    if (((req->EVRequestedEnergyTransferType == din_EVRequestedEnergyTransferType_DC_core) ||
+         (req->EVRequestedEnergyTransferType == din_EVRequestedEnergyTransferType_DC_extended)) &&
+        conn->ctx->evse_v2g_data.charge_service.SupportedEnergyTransferMode.EnergyTransferMode.array[0] ==
             (iso2_EnergyTransferModeType)req->EVRequestedEnergyTransferType) {
+        log_selected_energy_transfer_type((int)req->EVRequestedEnergyTransferType);
+    } else if (conn->ctx->is_fake_dc == false) {
         res->ResponseCode = din_responseCodeType_FAILED_WrongEnergyTransferType; // [V2G-DC-397] Failed reponse code is
                                                                                  // logged at the end of the function
-    } else {
-        log_selected_energy_transfer_type((int)req->EVRequestedEnergyTransferType);
     }
 
     res->ResponseCode = (req->AC_EVChargeParameter_isUsed == (unsigned int)1)
@@ -782,12 +783,30 @@ static enum v2g_event handle_din_charge_parameter(struct v2g_connection* conn) {
         res->DC_EVSEChargeParameter.DC_EVSEStatus.NotificationMaxDelay = 0;
     }
 
+    /* If fake HLC DC is active, try to stop the charging session over EVSENotification and EVSEStatusCode first.
+     * If the EV is ignoring the shutdown request, stop the charging session in the next response message with a failed
+     * response code.
+     */
+    if (conn->ctx->is_fake_dc) {
+        res->DC_EVSEChargeParameter.DC_EVSEStatus.EVSENotification = din_EVSENotificationType_StopCharging;
+        res->DC_EVSEChargeParameter.DC_EVSEStatus.NotificationMaxDelay = 0;
+        res->DC_EVSEChargeParameter.DC_EVSEStatus.EVSEStatusCode = din_DC_EVSEStatusCodeType_EVSE_Shutdown;
+
+        if (first_req == true) {
+            dlog(DLOG_LEVEL_INFO, "Initiate stop of the fake HLC DIN DC session");
+            res->EVSEProcessing = din_EVSEProcessingType_Ongoing;
+        } else {
+            res->ResponseCode = din_responseCodeType_FAILED;
+        }
+    }
+
     /* Check the current response code and check if no external error has occurred */
     nextEvent = utils::din_validate_response_code(&res->ResponseCode, conn);
 
     /* Set next expected req msg */
     if (res->EVSEProcessing == din_EVSEProcessingType_Finished) {
-        if (res->DC_EVSEChargeParameter.DC_EVSEStatus.EVSEStatusCode != din_DC_EVSEStatusCodeType_EVSE_Ready) {
+        if ((res->DC_EVSEChargeParameter.DC_EVSEStatus.EVSEStatusCode != din_DC_EVSEStatusCodeType_EVSE_Ready) &&
+            (conn->ctx->is_fake_dc == false)) {
             dlog(DLOG_LEVEL_WARNING,
                  "EVSE wants to finish charge parameter phase, but status code is not set to 'ready' (1)");
         }

--- a/modules/EVSE/EvseV2G/iso_server.cpp
+++ b/modules/EVSE/EvseV2G/iso_server.cpp
@@ -1435,6 +1435,7 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
             transport.set(&telemetry_types::V2gTransport::charge_parameter_discovery_requested, true);
         });
     }
+    const bool first_req = conn->ctx->last_v2g_msg != V2G_CHARGE_PARAMETER_DISCOVERY_MSG;
 
     /* At first, publish the received ev request message to the MQTT interface */
     publish_iso_charge_parameter_discovery_req(conn->ctx, req);
@@ -1577,11 +1578,8 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
     } else {
 
         if (conn->ctx->evse_v2g_data.sae_bidi_data.enabled_sae_v2h == true) {
-            static bool first_req = true;
-
             if (first_req == true) {
                 res->EVSEProcessing = iso2_EVSEProcessingType_Ongoing;
-                first_req = false;
             } else {
                 // Check if second req message contains neg values
                 // Check if bulk soc is set
@@ -1595,8 +1593,6 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
                     res->ResponseCode = iso2_responseCodeType::iso2_responseCodeType_FAILED_WrongEnergyTransferMode;
                 }
                 res->EVSEProcessing = iso2_EVSEProcessingType_Finished;
-                // reset first_req
-                first_req = true;
             }
         }
 
@@ -1665,6 +1661,24 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
                 conn->ctx->evse_v2g_data.no_energy_pause == NoEnergyPauseStatus::BeforeCableCheck
                     ? 0
                     : PAUSE_NOTIFICATION_DELAY;
+        }
+    }
+
+    /* If fake HLC DC is active, try to stop the charging session over EVSENotification and EVSEStatusCode first.
+     * If the EV is ignoring the shutdown request, stop the charging session in the next response message with a failed
+     * response code.
+     */
+    if (conn->ctx->is_fake_dc) {
+        res->DC_EVSEChargeParameter.DC_EVSEStatus.EVSENotification = iso2_EVSENotificationType_StopCharging;
+        res->DC_EVSEChargeParameter.DC_EVSEStatus.NotificationMaxDelay = 0;
+        res->DC_EVSEChargeParameter.DC_EVSEStatus.EVSEStatusCode = iso2_DC_EVSEStatusCodeType_EVSE_Shutdown;
+
+        if (first_req == true) {
+            dlog(DLOG_LEVEL_INFO, "Initiate stop of the fake HLC ISO DC session");
+            res->EVSEProcessing = iso2_EVSEProcessingType_Ongoing;
+        } else {
+            res->ResponseCode = iso2_responseCodeType_FAILED;
+            res->EVSEProcessing = iso2_EVSEProcessingType_Finished;
         }
     }
 

--- a/modules/EVSE/EvseV2G/tests/ISO15118_chargerImplStub.hpp
+++ b/modules/EVSE/EvseV2G/tests/ISO15118_chargerImplStub.hpp
@@ -35,7 +35,8 @@ struct ISO15118_chargerImplStub : public ISO15118_chargerImplBase {
         std::cout << "ISO15118_chargerImplBase::handle_set_charging_parameters called" << std::endl;
     }
     virtual void handle_session_setup(std::vector<types::iso15118::PaymentOption>& payment_options,
-                                      bool& supported_certificate_service, bool& central_contract_validation_allowed) {
+                                      bool& supported_certificate_service, bool& central_contract_validation_allowed,
+                                      bool& fake_dc_enabled) {
         std::cout << "ISO15118_chargerImplBase::handle_session_setup called" << std::endl;
     }
     virtual void handle_authorization_response(types::authorization::AuthorizationStatus& authorization_status,

--- a/modules/EVSE/EvseV2G/v2g.hpp
+++ b/modules/EVSE/EvseV2G/v2g.hpp
@@ -249,6 +249,7 @@ struct v2g_context {
     int state;                         /* holds the current state id */
     bool is_dc_charger; /* Is set to true if it is a DC charger. Value is configured after configuration of the
                            supported energy type */
+    bool is_fake_dc;    /* Is set to true if fake DC (AC with SoC) is active */
     bool debugMode;     /* To activate/deactivate the debug mode */
     std::atomic<int8_t>
         supported_protocols; /* Is an bit mask and holds the supported app protocols. See v2g_protocol enum */

--- a/modules/EVSE/EvseV2G/v2g_ctx.cpp
+++ b/modules/EVSE/EvseV2G/v2g_ctx.cpp
@@ -288,6 +288,7 @@ struct v2g_context* v2g_ctx_create(ISO15118_chargerImplBase* p_chargerImplBase,
     ctx->local_tls_addr = NULL;
 
     ctx->is_dc_charger = true;
+    ctx->is_fake_dc = false;
 
     v2g_ctx_init_charging_session(ctx, true);
 

--- a/modules/EVSE/IsoMux/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/IsoMux/charger/ISO15118_chargerImpl.cpp
@@ -554,11 +554,11 @@ void ISO15118_chargerImpl::handle_set_charging_parameters(types::iso15118::Setup
 
 void ISO15118_chargerImpl::handle_session_setup(std::vector<types::iso15118::PaymentOption>& payment_options,
                                                 bool& supported_certificate_service,
-                                                bool& central_contract_validation_allowed) {
+                                                bool& central_contract_validation_allowed, bool& fake_dc_enabled) {
     mod->r_iso20->call_session_setup(payment_options, supported_certificate_service,
-                                     central_contract_validation_allowed);
-    mod->r_iso2->call_session_setup(payment_options, supported_certificate_service,
-                                    central_contract_validation_allowed);
+                                     central_contract_validation_allowed, fake_dc_enabled);
+    mod->r_iso2->call_session_setup(payment_options, supported_certificate_service, central_contract_validation_allowed,
+                                    fake_dc_enabled);
 }
 
 void ISO15118_chargerImpl::handle_bpt_setup(types::iso15118::BptSetup& bpt_config) {

--- a/modules/EVSE/IsoMux/charger/ISO15118_chargerImpl.hpp
+++ b/modules/EVSE/IsoMux/charger/ISO15118_chargerImpl.hpp
@@ -42,8 +42,8 @@ protected:
                               bool& debug_mode) override;
     virtual void handle_set_charging_parameters(types::iso15118::SetupPhysicalValues& physical_values) override;
     virtual void handle_session_setup(std::vector<types::iso15118::PaymentOption>& payment_options,
-                                      bool& supported_certificate_service,
-                                      bool& central_contract_validation_allowed) override;
+                                      bool& supported_certificate_service, bool& central_contract_validation_allowed,
+                                      bool& fake_dc_enabled) override;
     virtual void handle_bpt_setup(types::iso15118::BptSetup& bpt_config) override;
     virtual void handle_set_powersupply_capabilities(types::power_supply_DC::Capabilities& capabilities) override;
     virtual void handle_authorization_response(types::authorization::AuthorizationStatus& authorization_status,

--- a/modules/Testing/DummyV2G/main/ISO15118_chargerImpl.cpp
+++ b/modules/Testing/DummyV2G/main/ISO15118_chargerImpl.cpp
@@ -23,7 +23,8 @@ void ISO15118_chargerImpl::handle_set_charging_parameters(types::iso15118::Setup
 
 void ISO15118_chargerImpl::handle_session_setup(std::vector<types::iso15118::PaymentOption>& payment_options,
                                                 bool& supported_certificate_service,
-                                                bool& central_contract_validation_allowed) {
+                                                bool& central_contract_validation_allowed,
+                                                [[maybe_unused]] bool& fake_dc_enabled) {
     // your code for cmd session_setup goes here
 }
 

--- a/modules/Testing/DummyV2G/main/ISO15118_chargerImpl.hpp
+++ b/modules/Testing/DummyV2G/main/ISO15118_chargerImpl.hpp
@@ -37,8 +37,8 @@ protected:
                               bool& debug_mode) override;
     virtual void handle_set_charging_parameters(types::iso15118::SetupPhysicalValues& physical_values) override;
     virtual void handle_session_setup(std::vector<types::iso15118::PaymentOption>& payment_options,
-                                      bool& supported_certificate_service,
-                                      bool& central_contract_validation_allowed) override;
+                                      bool& supported_certificate_service, bool& central_contract_validation_allowed,
+                                      bool& fake_dc_enabled) override;
     virtual void handle_bpt_setup(types::iso15118::BptSetup& bpt_config) override;
     virtual void handle_set_powersupply_capabilities(types::power_supply_DC::Capabilities& capabilities) override;
     virtual void handle_authorization_response(types::authorization::AuthorizationStatus& authorization_status,


### PR DESCRIPTION
## Describe your changes

Under the term “feature/dynamic_ac_config,” we at chargebyte want to integrate the feature for dynamic configuration of an AC session into everest in stages.

This PR improves AC charging with SoC support by allowing the EVSE to temporarily use a fake DC ISO15118 session to retrieve the EV SoC and then switch back to AC basic charging.

It also adds configurable reinitialization behavior for AC/HLC fallback flows, D-LINK error recovery, and phase switching.

## Changes

- Add SIL AC-with-SoC configuration.
- Extend `ISO15118_charger.session_setup` with a `fake_dc_enabled` flag.
- Configure EvseV2G DIN/ISO15118-2 fake-DC sessions to stop after SoC/charge-parameter exchange.
- Add configurable reinitialization method and duration:
  - `CPStateF`
  - `CPStateE`
  - `CPStateX1`
- Rework phase switching CP handling to use the configured CP state method and allow `CPStateE` when supported by the BSP.
- Add CP state E support in the IEC state machine where supported by BSP capabilities.
- Fall back from failed AC HLC to nominal PWM/basic AC charging.
- Ignore D-LINK errors while reinitialization is already active.
- Avoid shared static `first_req` state in DIN/ISO charge-parameter handlers.

Tests: Successfully tested with sil-dc, sil-ac, the new sil-ac-soc, and with Charge Control C.


## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
