### PR TITLE
feat(tls/iso15118): TLS 1.3 multi-chain + rotation

### DIFF
--- a/lib/everest/iso15118/include/iso15118/config.hpp
+++ b/lib/everest/iso15118/include/iso15118/config.hpp
@@ -31,6 +31,10 @@ struct ChainConfig {
     std::string path_certificate_key;                  //!< PEM file: private key for the leaf
     std::optional<std::string> private_key_password{}; //!< optional password for the private key
     std::vector<std::string> ocsp_response_files{};    //!< OCSP DER files in chain order
+    //!< inline PEM of the chain's self-signed root; drives TLS 1.3 chain selection
+    //!< (certificate_authorities) and TLS 1.2 trusted_ca_keys. Empty disables this chain
+    //!< from selection (it can still be the default chain when first in the list).
+    std::optional<std::string> trust_anchor_pem{};
 };
 
 /**

--- a/lib/everest/iso15118/include/iso15118/config.hpp
+++ b/lib/everest/iso15118/include/iso15118/config.hpp
@@ -30,11 +30,20 @@ struct ChainConfig {
     std::string path_certificate_chain;                //!< PEM file: leaf followed by intermediate CAs
     std::string path_certificate_key;                  //!< PEM file: private key for the leaf
     std::optional<std::string> private_key_password{}; //!< optional password for the private key
-    std::vector<std::string> ocsp_response_files{};    //!< OCSP DER files in chain order
-    //!< inline PEM of the chain's self-signed root; drives TLS 1.3 chain selection
-    //!< (certificate_authorities) and TLS 1.2 trusted_ca_keys. Empty disables this chain
-    //!< from selection (it can still be the default chain when first in the list).
+    /// OCSP DER files: one entry per chain certificate in chain order; std::nullopt
+    /// means no OCSP staple for that position
+    std::vector<std::optional<std::string>> ocsp_response_files{};
+    /// inline PEM of the chain's self-signed root; drives TLS 1.3 chain selection
+    /// (certificate_authorities) and TLS 1.2 trusted_ca_keys. Empty disables this chain
+    /// from selection (it can still be the default chain when first in the list).
     std::optional<std::string> trust_anchor_pem{};
+
+    bool operator==(const ChainConfig& other) const {
+        return path_certificate_chain == other.path_certificate_chain &&
+               path_certificate_key == other.path_certificate_key &&
+               private_key_password == other.private_key_password && ocsp_response_files == other.ocsp_response_files &&
+               trust_anchor_pem == other.trust_anchor_pem;
+    }
 };
 
 /**
@@ -57,6 +66,15 @@ struct SSLConfig {
     bool enable_tls_key_logging{false};           //!< write SSLKEYLOGFILE entries
     bool enforce_tls_1_3{false};                  //!< require TLS 1.3 minimum
     std::filesystem::path tls_key_logging_path{}; //!< destination directory for keylog
+
+    bool operator==(const SSLConfig& other) const {
+        return backend == other.backend && config_string == other.config_string && chains == other.chains &&
+               path_certificate_v2g_root == other.path_certificate_v2g_root &&
+               path_certificate_mo_root == other.path_certificate_mo_root &&
+               enable_ssl_logging == other.enable_ssl_logging &&
+               enable_tls_key_logging == other.enable_tls_key_logging && enforce_tls_1_3 == other.enforce_tls_1_3 &&
+               tls_key_logging_path == other.tls_key_logging_path;
+    }
 };
 
 } // namespace iso15118::config

--- a/lib/everest/iso15118/include/iso15118/detail/io/ssl_config_builder.hpp
+++ b/lib/everest/iso15118/include/iso15118/detail/io/ssl_config_builder.hpp
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#pragma once
+
+#include <vector>
+
+#include <everest/tls/tls.hpp>
+
+#include <iso15118/config.hpp>
+
+namespace iso15118::io {
+
+/// \brief Map iso15118 SSLConfig chains to tls::Server certificate chain configs.
+/// Each ChainConfig.trust_anchor_pem (the chain's self-signed root PEM) is forwarded
+/// to certificate_config_t.trust_anchor_pem so tls::Server can admit the chain into its
+/// TLS 1.3 / trusted_ca_keys selection pool. Exposed (rather than file-local) for unit testing.
+std::vector<tls::Server::certificate_config_t> build_chain_configs(const config::SSLConfig& cfg);
+
+} // namespace iso15118::io

--- a/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
+++ b/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
@@ -67,6 +67,12 @@ public:
     void update_supported_der_functions(iec::DERControlName der_control, const iec::DERControlFunction& function);
     void update_unsupported_der_functions(iec::DERControlName der_control);
 
+    /// Replaces the current SSL config snapshot with a new one.
+    void set_ssl_config(config::SSLConfig new_config);
+
+    /// Returns a copy of the current SSL config snapshot.
+    [[nodiscard]] config::SSLConfig ssl_config_snapshot() const;
+
 private:
     io::PollManager poll_manager;
     std::unique_ptr<io::SdpServer> sdp_server;
@@ -95,6 +101,8 @@ private:
     std::optional<Timeout> communication_setup_timeout;
 
     ConnectionFactory connection_factory;
+
+    mutable everest::lib::util::monitor<config::SSLConfig> m_ssl_config;
 };
 
 } // namespace iso15118

--- a/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
+++ b/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
@@ -27,8 +27,7 @@ namespace iso15118 {
 
 struct TbdConfig {
     /// `ssl` here is the INITIAL value only; the live config is owned by `m_ssl_config` after construction —
-    /// read it via `ssl_config_snapshot()`, never `config.ssl`. A future refactor moves `ssl` out of
-    /// `TbdConfig` entirely — see plans/2026-06-10-tls-multichain-structural-followup.md.
+    /// read it via `ssl_config_snapshot()`, never `config.ssl`.
     config::SSLConfig ssl{};
     std::string interface_name;
     config::TlsNegotiationStrategy tls_negotiation_strategy{config::TlsNegotiationStrategy::ACCEPT_CLIENT_OFFER};

--- a/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
+++ b/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
@@ -26,6 +26,9 @@
 namespace iso15118 {
 
 struct TbdConfig {
+    /// `ssl` here is the INITIAL value only; the live config is owned by `m_ssl_config` after construction —
+    /// read it via `ssl_config_snapshot()`, never `config.ssl`. A future refactor moves `ssl` out of
+    /// `TbdConfig` entirely — see plans/2026-06-10-tls-multichain-structural-followup.md.
     config::SSLConfig ssl{};
     std::string interface_name;
     config::TlsNegotiationStrategy tls_negotiation_strategy{config::TlsNegotiationStrategy::ACCEPT_CLIENT_OFFER};
@@ -67,11 +70,16 @@ public:
     void update_supported_der_functions(iec::DERControlName der_control, const iec::DERControlFunction& function);
     void update_unsupported_der_functions(iec::DERControlName der_control);
 
-    /// Replaces the current SSL config snapshot with a new one.
+    /// Replaces the stored SSL config (thread-safe). Takes effect for the next incoming secure connection;
+    /// established connections are unaffected.
     void set_ssl_config(config::SSLConfig new_config);
 
-    /// Returns a copy of the current SSL config snapshot.
+    /// Returns a copy of the stored SSL config (thread-safe).
     [[nodiscard]] config::SSLConfig ssl_config_snapshot() const;
+
+    /// The single seam every new secure connection reads its SSL config from, so a rotation via
+    /// `set_ssl_config()` is picked up by the next connection.
+    [[nodiscard]] config::SSLConfig connection_ssl_config() const;
 
 private:
     io::PollManager poll_manager;

--- a/lib/everest/iso15118/src/iso15118/CMakeLists.txt
+++ b/lib/everest/iso15118/src/iso15118/CMakeLists.txt
@@ -96,6 +96,7 @@ target_link_libraries(iso15118
 target_sources(iso15118
     PRIVATE
     io/connection_ssl.cpp
+    io/ssl_config_builder.cpp
 )
 
 # FIXME (aw): do we want to have this public here?

--- a/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
@@ -19,6 +19,7 @@
 
 #include <iso15118/detail/helper.hpp>
 #include <iso15118/detail/io/socket_helper.hpp>
+#include <iso15118/detail/io/ssl_config_builder.hpp>
 
 namespace iso15118::io {
 
@@ -48,30 +49,6 @@ std::string_view result_name(tls::Connection::result_t r) {
         return "want_write";
     }
     return "unknown";
-}
-
-std::vector<tls::Server::certificate_config_t> build_chain_configs(const config::SSLConfig& cfg) {
-    std::vector<tls::Server::certificate_config_t> chains;
-    chains.reserve(cfg.chains.size());
-
-    for (const auto& src : cfg.chains) {
-        std::vector<tls::ConfigItem> ocsp_items;
-        ocsp_items.reserve(src.ocsp_response_files.size());
-        for (const auto& f : src.ocsp_response_files) {
-            ocsp_items.emplace_back(f);
-        }
-
-        tls::Server::certificate_config_t chain_cfg{};
-        chain_cfg.certificate_chain_file = src.path_certificate_chain;
-        chain_cfg.private_key_file = src.path_certificate_key;
-        if (src.private_key_password.has_value()) {
-            chain_cfg.private_key_password = src.private_key_password.value();
-        }
-        chain_cfg.ocsp_response_files = std::move(ocsp_items);
-        chains.push_back(std::move(chain_cfg));
-    }
-
-    return chains;
 }
 
 tls::Server::config_t make_tls_server_config(const config::SSLConfig& cfg, const std::string& interface_name,

--- a/lib/everest/iso15118/src/iso15118/io/ssl_config_builder.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/ssl_config_builder.cpp
@@ -19,7 +19,7 @@ std::vector<tls::Server::certificate_config_t> build_chain_configs(const config:
         std::vector<tls::ConfigItem> ocsp_items;
         ocsp_items.reserve(src.ocsp_response_files.size());
         for (const auto& f : src.ocsp_response_files) {
-            ocsp_items.emplace_back(f);
+            ocsp_items.emplace_back(f.has_value() ? tls::ConfigItem(f.value()) : tls::ConfigItem(nullptr));
         }
 
         tls::Server::certificate_config_t chain_cfg{};

--- a/lib/everest/iso15118/src/iso15118/io/ssl_config_builder.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/ssl_config_builder.cpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include <iso15118/detail/io/ssl_config_builder.hpp>
+
+#include <utility>
+#include <vector>
+
+#include <everest/tls/tls.hpp>
+
+#include <iso15118/config.hpp>
+
+namespace iso15118::io {
+
+std::vector<tls::Server::certificate_config_t> build_chain_configs(const config::SSLConfig& cfg) {
+    std::vector<tls::Server::certificate_config_t> chains;
+    chains.reserve(cfg.chains.size());
+
+    for (const auto& src : cfg.chains) {
+        std::vector<tls::ConfigItem> ocsp_items;
+        ocsp_items.reserve(src.ocsp_response_files.size());
+        for (const auto& f : src.ocsp_response_files) {
+            ocsp_items.emplace_back(f);
+        }
+
+        tls::Server::certificate_config_t chain_cfg{};
+        chain_cfg.certificate_chain_file = src.path_certificate_chain;
+        chain_cfg.private_key_file = src.path_certificate_key;
+        if (src.private_key_password.has_value()) {
+            chain_cfg.private_key_password = src.private_key_password.value();
+        }
+        if (src.trust_anchor_pem.has_value()) {
+            chain_cfg.trust_anchor_pem = src.trust_anchor_pem.value();
+        }
+        chain_cfg.ocsp_response_files = std::move(ocsp_items);
+        chains.push_back(std::move(chain_cfg));
+    }
+
+    return chains;
+}
+
+} // namespace iso15118::io

--- a/lib/everest/iso15118/src/iso15118/tbd_controller.cpp
+++ b/lib/everest/iso15118/src/iso15118/tbd_controller.cpp
@@ -29,7 +29,8 @@ TbdController::TbdController(TbdConfig config_, session::feedback::Callbacks cal
     callbacks(std::move(callbacks_)),
     evse_setup(std::move(setup_)),
     interface_name(config.interface_name),
-    connection_factory(std::move(connection_factory_)) {
+    connection_factory(std::move(connection_factory_)),
+    m_ssl_config(config.ssl) {
 
     const auto result_interface_check = io::check_and_update_interface(interface_name);
     if (result_interface_check) {
@@ -196,6 +197,16 @@ void TbdController::update_ac_limits(const d20::AcTransferLimits& limits) {
     }
 }
 
+void TbdController::set_ssl_config(config::SSLConfig new_config) {
+    auto handle = m_ssl_config.handle();
+    *handle = std::move(new_config);
+}
+
+config::SSLConfig TbdController::ssl_config_snapshot() const {
+    auto handle = m_ssl_config.handle();
+    return *handle;
+}
+
 void TbdController::set_dlink_ready(bool ready) {
     if (sdp_server) {
         sdp_server->set_dlink_ready(ready);
@@ -267,7 +278,7 @@ void TbdController::handle_sdp_server_input() {
     auto connection = [this](bool secure_connection) -> std::unique_ptr<io::IConnection> {
         try {
             if (secure_connection) {
-                return std::make_unique<io::ConnectionSSL>(poll_manager, interface_name, config.ssl);
+                return std::make_unique<io::ConnectionSSL>(poll_manager, interface_name, ssl_config_snapshot());
             }
             return std::make_unique<io::ConnectionPlain>(poll_manager, interface_name);
         } catch (const std::runtime_error& e) {

--- a/lib/everest/iso15118/src/iso15118/tbd_controller.cpp
+++ b/lib/everest/iso15118/src/iso15118/tbd_controller.cpp
@@ -207,6 +207,10 @@ config::SSLConfig TbdController::ssl_config_snapshot() const {
     return *handle;
 }
 
+config::SSLConfig TbdController::connection_ssl_config() const {
+    return ssl_config_snapshot();
+}
+
 void TbdController::set_dlink_ready(bool ready) {
     if (sdp_server) {
         sdp_server->set_dlink_ready(ready);
@@ -278,7 +282,7 @@ void TbdController::handle_sdp_server_input() {
     auto connection = [this](bool secure_connection) -> std::unique_ptr<io::IConnection> {
         try {
             if (secure_connection) {
-                return std::make_unique<io::ConnectionSSL>(poll_manager, interface_name, ssl_config_snapshot());
+                return std::make_unique<io::ConnectionSSL>(poll_manager, interface_name, connection_ssl_config());
             }
             return std::make_unique<io::ConnectionPlain>(poll_manager, interface_name);
         } catch (const std::runtime_error& e) {

--- a/lib/everest/iso15118/test/iso15118/CMakeLists.txt
+++ b/lib/everest/iso15118/test/iso15118/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(fsm)
 add_subdirectory(io)
 add_subdirectory(session)
 add_subdirectory(states)
+add_subdirectory(tbd)
 
 # add_executable(secc)
 #

--- a/lib/everest/iso15118/test/iso15118/io/CMakeLists.txt
+++ b/lib/everest/iso15118/test/iso15118/io/CMakeLists.txt
@@ -24,6 +24,15 @@ catch_discover_tests(test_connection_plain
     PROPERTIES RESOURCE_LOCK iso15118_tls_port_50000
 )
 
+add_executable(ssl_config_builder_test ssl_config_builder_test.cpp)
+target_link_libraries(ssl_config_builder_test
+    PRIVATE
+        iso15118::iso15118
+        everest::tls
+        Catch2::Catch2WithMain
+)
+catch_discover_tests(ssl_config_builder_test)
+
 add_executable(connection_openssl_test)
 add_custom_command(
     TARGET connection_openssl_test POST_BUILD

--- a/lib/everest/iso15118/test/iso15118/io/ssl_config_builder_test.cpp
+++ b/lib/everest/iso15118/test/iso15118/io/ssl_config_builder_test.cpp
@@ -2,6 +2,7 @@
 // Copyright Pionix GmbH and Contributors to EVerest
 #include <catch2/catch_test_macros.hpp>
 
+#include <optional>
 #include <string>
 
 #include <iso15118/config.hpp>
@@ -28,6 +29,27 @@ TEST_CASE("build_chain_configs forwards trust_anchor_pem and chain fields") {
     CHECK(std::string(static_cast<const char*>(out[0].private_key_file)) == "/p/a/key.pem");
     CHECK(std::string(static_cast<const char*>(out[0].trust_anchor_pem)) == "----A ROOT PEM----");
     CHECK(std::string(static_cast<const char*>(out[1].trust_anchor_pem)) == "----B ROOT PEM----");
+}
+
+TEST_CASE("build_chain_configs preserves OCSP staple order and forwards key password") {
+    iso15118::config::SSLConfig cfg{};
+
+    iso15118::config::ChainConfig a{};
+    a.path_certificate_chain = "/p/a/chain.pem";
+    a.path_certificate_key = "/p/a/key.pem";
+    a.private_key_password = "key-secret";
+    a.ocsp_response_files = {"ocsp0.der", std::nullopt, "ocsp2.der"};
+    cfg.chains = {a};
+
+    const auto out = iso15118::io::build_chain_configs(cfg);
+    REQUIRE(out.size() == 1);
+
+    REQUIRE(out[0].ocsp_response_files.size() == 3);
+    CHECK(std::string(static_cast<const char*>(out[0].ocsp_response_files[0])) == "ocsp0.der");
+    CHECK(static_cast<const char*>(out[0].ocsp_response_files[1]) == nullptr);
+    CHECK(std::string(static_cast<const char*>(out[0].ocsp_response_files[2])) == "ocsp2.der");
+
+    CHECK(std::string(static_cast<const char*>(out[0].private_key_password)) == "key-secret");
 }
 
 TEST_CASE("build_chain_configs leaves trust_anchor unset when root absent") {

--- a/lib/everest/iso15118/test/iso15118/io/ssl_config_builder_test.cpp
+++ b/lib/everest/iso15118/test/iso15118/io/ssl_config_builder_test.cpp
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+
+#include <iso15118/config.hpp>
+#include <iso15118/detail/io/ssl_config_builder.hpp>
+
+TEST_CASE("build_chain_configs forwards trust_anchor_pem and chain fields") {
+    iso15118::config::SSLConfig cfg{};
+
+    iso15118::config::ChainConfig a{};
+    a.path_certificate_chain = "/p/a/chain.pem";
+    a.path_certificate_key = "/p/a/key.pem";
+    a.trust_anchor_pem = "----A ROOT PEM----";
+
+    iso15118::config::ChainConfig b{};
+    b.path_certificate_chain = "/p/b/chain.pem";
+    b.path_certificate_key = "/p/b/key.pem";
+    b.trust_anchor_pem = "----B ROOT PEM----";
+
+    cfg.chains = {a, b};
+
+    const auto out = iso15118::io::build_chain_configs(cfg);
+    REQUIRE(out.size() == 2);
+    CHECK(std::string(static_cast<const char*>(out[0].certificate_chain_file)) == "/p/a/chain.pem");
+    CHECK(std::string(static_cast<const char*>(out[0].private_key_file)) == "/p/a/key.pem");
+    CHECK(std::string(static_cast<const char*>(out[0].trust_anchor_pem)) == "----A ROOT PEM----");
+    CHECK(std::string(static_cast<const char*>(out[1].trust_anchor_pem)) == "----B ROOT PEM----");
+}
+
+TEST_CASE("build_chain_configs leaves trust_anchor unset when root absent") {
+    iso15118::config::SSLConfig cfg{};
+    iso15118::config::ChainConfig a{};
+    a.path_certificate_chain = "/p/a/chain.pem";
+    a.path_certificate_key = "/p/a/key.pem";
+    // trust_anchor_pem left nullopt
+    cfg.chains = {a};
+
+    const auto out = iso15118::io::build_chain_configs(cfg);
+    REQUIRE(out.size() == 1);
+    CHECK(static_cast<const char*>(out[0].trust_anchor_pem) == nullptr);
+}

--- a/lib/everest/iso15118/test/iso15118/tbd/CMakeLists.txt
+++ b/lib/everest/iso15118/test/iso15118/tbd/CMakeLists.txt
@@ -1,0 +1,11 @@
+include(Catch)
+
+add_executable(test_tbd_controller_monitor tbd_controller_monitor_test.cpp)
+
+target_link_libraries(test_tbd_controller_monitor
+    PRIVATE
+        iso15118
+        Catch2::Catch2WithMain
+)
+
+catch_discover_tests(test_tbd_controller_monitor)

--- a/lib/everest/iso15118/test/iso15118/tbd/tbd_controller_monitor_test.cpp
+++ b/lib/everest/iso15118/test/iso15118/tbd/tbd_controller_monitor_test.cpp
@@ -22,13 +22,11 @@ namespace {
 SSLConfig make_cfg_a() {
     SSLConfig cfg{};
     cfg.backend = CertificateBackend::EVEREST_LAYOUT;
-    cfg.chains.push_back(iso15118::config::ChainConfig{
-        "/tmp/iso15118-test/a/chain.pem",
-        "/tmp/iso15118-test/a/key.pem",
-        std::nullopt,
-        {},
-        "/tmp/iso15118-test/a/v2g_root.pem", // trust_anchor_pem
-    });
+    iso15118::config::ChainConfig chain{};
+    chain.path_certificate_chain = "/tmp/iso15118-test/a/chain.pem";
+    chain.path_certificate_key = "/tmp/iso15118-test/a/key.pem";
+    chain.trust_anchor_pem = "/tmp/iso15118-test/a/v2g_root.pem";
+    cfg.chains.push_back(std::move(chain));
     cfg.path_certificate_v2g_root = "/tmp/iso15118-test/a/v2g_root.pem";
     cfg.path_certificate_mo_root = "/tmp/iso15118-test/a/mo_root.pem";
     cfg.enforce_tls_1_3 = false;
@@ -38,41 +36,15 @@ SSLConfig make_cfg_a() {
 SSLConfig make_cfg_b() {
     SSLConfig cfg{};
     cfg.backend = CertificateBackend::EVEREST_LAYOUT;
-    cfg.chains.push_back(iso15118::config::ChainConfig{
-        "/tmp/iso15118-test/b/chain.pem",
-        "/tmp/iso15118-test/b/key.pem",
-        std::nullopt,
-        {},
-        "/tmp/iso15118-test/b/v2g_root.pem", // trust_anchor_pem
-    });
+    iso15118::config::ChainConfig chain{};
+    chain.path_certificate_chain = "/tmp/iso15118-test/b/chain.pem";
+    chain.path_certificate_key = "/tmp/iso15118-test/b/key.pem";
+    chain.trust_anchor_pem = "/tmp/iso15118-test/b/v2g_root.pem";
+    cfg.chains.push_back(std::move(chain));
     cfg.path_certificate_v2g_root = "/tmp/iso15118-test/b/v2g_root.pem";
     cfg.path_certificate_mo_root = "/tmp/iso15118-test/b/mo_root.pem";
     cfg.enforce_tls_1_3 = true;
     return cfg;
-}
-
-bool chain_config_equal(const iso15118::config::ChainConfig& lhs, const iso15118::config::ChainConfig& rhs) {
-    return lhs.path_certificate_chain == rhs.path_certificate_chain &&
-           lhs.path_certificate_key == rhs.path_certificate_key &&
-           lhs.private_key_password == rhs.private_key_password && lhs.ocsp_response_files == rhs.ocsp_response_files &&
-           lhs.trust_anchor_pem == rhs.trust_anchor_pem;
-}
-
-bool ssl_config_equal(const SSLConfig& lhs, const SSLConfig& rhs) {
-    if (lhs.chains.size() != rhs.chains.size()) {
-        return false;
-    }
-    for (std::size_t i = 0; i < lhs.chains.size(); ++i) {
-        if (!chain_config_equal(lhs.chains[i], rhs.chains[i])) {
-            return false;
-        }
-    }
-    return lhs.backend == rhs.backend && lhs.config_string == rhs.config_string &&
-           lhs.path_certificate_v2g_root == rhs.path_certificate_v2g_root &&
-           lhs.path_certificate_mo_root == rhs.path_certificate_mo_root &&
-           lhs.enable_ssl_logging == rhs.enable_ssl_logging &&
-           lhs.enable_tls_key_logging == rhs.enable_tls_key_logging && lhs.enforce_tls_1_3 == rhs.enforce_tls_1_3 &&
-           lhs.tls_key_logging_path == rhs.tls_key_logging_path;
 }
 
 TbdController make_controller(SSLConfig initial) {
@@ -97,7 +69,7 @@ SCENARIO("TbdController SSL config monitor: set then snapshot returns the new va
             const SSLConfig snap = controller.ssl_config_snapshot();
 
             THEN("the snapshot exposes cfg_a") {
-                REQUIRE(ssl_config_equal(snap, cfg_a));
+                REQUIRE(snap == cfg_a);
             }
         }
     }
@@ -117,14 +89,14 @@ SCENARIO("TbdController SSL config monitor: second write does not mutate earlier
             const SSLConfig snap_b = controller.ssl_config_snapshot();
 
             THEN("snap_a still observes cfg_a and snap_b observes cfg_b") {
-                REQUIRE(ssl_config_equal(snap_a, cfg_a));
-                REQUIRE(ssl_config_equal(snap_b, cfg_b));
+                REQUIRE(snap_a == cfg_a);
+                REQUIRE(snap_b == cfg_b);
             }
         }
     }
 }
 
-SCENARIO("TbdController SSL config monitor: concurrent reader and writer never tear") {
+SCENARIO("TbdController SSL config monitor: concurrent snapshots always observe a complete config") {
     GIVEN("a controller, a writer alternating cfg_a/cfg_b, and a reader taking snapshots") {
         auto controller = make_controller(SSLConfig{});
         const auto cfg_a = make_cfg_a();
@@ -145,7 +117,7 @@ SCENARIO("TbdController SSL config monitor: concurrent reader and writer never t
             std::thread reader([&]() {
                 for (int i = 0; i < iterations; ++i) {
                     const SSLConfig snap = controller.ssl_config_snapshot();
-                    if (!ssl_config_equal(snap, cfg_a) && !ssl_config_equal(snap, cfg_b)) {
+                    if (!(snap == cfg_a) && !(snap == cfg_b)) {
                         torn.store(true);
                         return;
                     }

--- a/lib/everest/iso15118/test/iso15118/tbd/tbd_controller_monitor_test.cpp
+++ b/lib/everest/iso15118/test/iso15118/tbd/tbd_controller_monitor_test.cpp
@@ -96,6 +96,27 @@ SCENARIO("TbdController SSL config monitor: second write does not mutate earlier
     }
 }
 
+// Value-level pin of the rotation seam: connection_ssl_config() must expose the
+// rotated config, not the construction-time TbdConfig::ssl. The factory lambda's
+// choice of accessor is not observable here (connection construction needs a live
+// SDP/TLS stack); the named seam and its doc comment guard that wiring.
+SCENARIO("TbdController SSL config monitor: the rotation seam exposes the rotated config") {
+    GIVEN("a controller constructed with cfg_a") {
+        const auto cfg_a = make_cfg_a();
+        auto controller = make_controller(cfg_a);
+
+        WHEN("set_ssl_config(cfg_b) rotates the config") {
+            const auto cfg_b = make_cfg_b();
+            controller.set_ssl_config(cfg_b);
+
+            THEN("connection_ssl_config() returns cfg_b, not the construction-time cfg_a") {
+                REQUIRE(controller.connection_ssl_config() == cfg_b);
+                REQUIRE_FALSE(controller.connection_ssl_config() == cfg_a);
+            }
+        }
+    }
+}
+
 SCENARIO("TbdController SSL config monitor: concurrent snapshots always observe a complete config") {
     GIVEN("a controller, a writer alternating cfg_a/cfg_b, and a reader taking snapshots") {
         auto controller = make_controller(SSLConfig{});

--- a/lib/everest/iso15118/test/iso15118/tbd/tbd_controller_monitor_test.cpp
+++ b/lib/everest/iso15118/test/iso15118/tbd/tbd_controller_monitor_test.cpp
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <atomic>
+#include <memory>
+#include <thread>
+
+#include <iso15118/config.hpp>
+#include <iso15118/d20/config.hpp>
+#include <iso15118/session/feedback.hpp>
+#include <iso15118/tbd_controller.hpp>
+
+using iso15118::TbdConfig;
+using iso15118::TbdController;
+using iso15118::config::CertificateBackend;
+using iso15118::config::SSLConfig;
+
+namespace {
+
+SSLConfig make_cfg_a() {
+    SSLConfig cfg{};
+    cfg.backend = CertificateBackend::EVEREST_LAYOUT;
+    cfg.chains.push_back(iso15118::config::ChainConfig{
+        "/tmp/iso15118-test/a/chain.pem",
+        "/tmp/iso15118-test/a/key.pem",
+        std::nullopt,
+        {},
+        "/tmp/iso15118-test/a/v2g_root.pem", // trust_anchor_pem
+    });
+    cfg.path_certificate_v2g_root = "/tmp/iso15118-test/a/v2g_root.pem";
+    cfg.path_certificate_mo_root = "/tmp/iso15118-test/a/mo_root.pem";
+    cfg.enforce_tls_1_3 = false;
+    return cfg;
+}
+
+SSLConfig make_cfg_b() {
+    SSLConfig cfg{};
+    cfg.backend = CertificateBackend::EVEREST_LAYOUT;
+    cfg.chains.push_back(iso15118::config::ChainConfig{
+        "/tmp/iso15118-test/b/chain.pem",
+        "/tmp/iso15118-test/b/key.pem",
+        std::nullopt,
+        {},
+        "/tmp/iso15118-test/b/v2g_root.pem", // trust_anchor_pem
+    });
+    cfg.path_certificate_v2g_root = "/tmp/iso15118-test/b/v2g_root.pem";
+    cfg.path_certificate_mo_root = "/tmp/iso15118-test/b/mo_root.pem";
+    cfg.enforce_tls_1_3 = true;
+    return cfg;
+}
+
+bool chain_config_equal(const iso15118::config::ChainConfig& lhs, const iso15118::config::ChainConfig& rhs) {
+    return lhs.path_certificate_chain == rhs.path_certificate_chain &&
+           lhs.path_certificate_key == rhs.path_certificate_key &&
+           lhs.private_key_password == rhs.private_key_password && lhs.ocsp_response_files == rhs.ocsp_response_files &&
+           lhs.trust_anchor_pem == rhs.trust_anchor_pem;
+}
+
+bool ssl_config_equal(const SSLConfig& lhs, const SSLConfig& rhs) {
+    if (lhs.chains.size() != rhs.chains.size()) {
+        return false;
+    }
+    for (std::size_t i = 0; i < lhs.chains.size(); ++i) {
+        if (!chain_config_equal(lhs.chains[i], rhs.chains[i])) {
+            return false;
+        }
+    }
+    return lhs.backend == rhs.backend && lhs.config_string == rhs.config_string &&
+           lhs.path_certificate_v2g_root == rhs.path_certificate_v2g_root &&
+           lhs.path_certificate_mo_root == rhs.path_certificate_mo_root &&
+           lhs.enable_ssl_logging == rhs.enable_ssl_logging &&
+           lhs.enable_tls_key_logging == rhs.enable_tls_key_logging && lhs.enforce_tls_1_3 == rhs.enforce_tls_1_3 &&
+           lhs.tls_key_logging_path == rhs.tls_key_logging_path;
+}
+
+TbdController make_controller(SSLConfig initial) {
+    TbdConfig tbd_cfg{};
+    tbd_cfg.ssl = std::move(initial);
+    tbd_cfg.interface_name = "lo";
+    tbd_cfg.enable_sdp_server = false;
+    return TbdController{std::move(tbd_cfg), iso15118::session::feedback::Callbacks{},
+                         iso15118::d20::EvseSetupConfig{}};
+}
+
+} // namespace
+
+SCENARIO("TbdController SSL config monitor: set then snapshot returns the new value") {
+    GIVEN("a controller initialized with a baseline SSL config") {
+        auto controller = make_controller(SSLConfig{});
+
+        WHEN("set_ssl_config(cfg_a) is called and a snapshot is taken") {
+            const auto cfg_a = make_cfg_a();
+            controller.set_ssl_config(cfg_a);
+
+            const SSLConfig snap = controller.ssl_config_snapshot();
+
+            THEN("the snapshot exposes cfg_a") {
+                REQUIRE(ssl_config_equal(snap, cfg_a));
+            }
+        }
+    }
+}
+
+SCENARIO("TbdController SSL config monitor: second write does not mutate earlier snapshot") {
+    GIVEN("a controller and two distinct SSL configs") {
+        auto controller = make_controller(SSLConfig{});
+        const auto cfg_a = make_cfg_a();
+        const auto cfg_b = make_cfg_b();
+
+        WHEN("cfg_a is written, snapshot taken, then cfg_b is written and snapshot taken") {
+            controller.set_ssl_config(cfg_a);
+            const SSLConfig snap_a = controller.ssl_config_snapshot();
+
+            controller.set_ssl_config(cfg_b);
+            const SSLConfig snap_b = controller.ssl_config_snapshot();
+
+            THEN("snap_a still observes cfg_a and snap_b observes cfg_b") {
+                REQUIRE(ssl_config_equal(snap_a, cfg_a));
+                REQUIRE(ssl_config_equal(snap_b, cfg_b));
+            }
+        }
+    }
+}
+
+SCENARIO("TbdController SSL config monitor: concurrent reader and writer never tear") {
+    GIVEN("a controller, a writer alternating cfg_a/cfg_b, and a reader taking snapshots") {
+        auto controller = make_controller(SSLConfig{});
+        const auto cfg_a = make_cfg_a();
+        const auto cfg_b = make_cfg_b();
+        controller.set_ssl_config(cfg_a);
+
+        constexpr int iterations = 100;
+
+        WHEN("100 writes and 100 reads run concurrently") {
+            std::atomic<bool> torn{false};
+
+            std::thread writer([&]() {
+                for (int i = 0; i < iterations; ++i) {
+                    controller.set_ssl_config((i % 2 == 0) ? cfg_a : cfg_b);
+                }
+            });
+
+            std::thread reader([&]() {
+                for (int i = 0; i < iterations; ++i) {
+                    const SSLConfig snap = controller.ssl_config_snapshot();
+                    if (!ssl_config_equal(snap, cfg_a) && !ssl_config_equal(snap, cfg_b)) {
+                        torn.store(true);
+                        return;
+                    }
+                }
+            });
+
+            writer.join();
+            reader.join();
+
+            THEN("every observed snapshot equals either cfg_a or cfg_b") {
+                REQUIRE_FALSE(torn.load());
+            }
+        }
+    }
+}

--- a/lib/everest/tls/extensions/trusted_ca_keys.cpp
+++ b/lib/everest/tls/extensions/trusted_ca_keys.cpp
@@ -466,9 +466,17 @@ int ServerTrustedCaKeys::apply_selection_locked(SSL* ssl, const std::lock_guard<
                     ": selected chain failed to apply and is the only/default chain");
         return 0;
     }
+    if (fallback == nullptr) {
+        // use_certificate_and_key() already called SSL_certs_clear(), so the connection
+        // has no certificate. With no default chain to fall back to, continuing would
+        // reach an opaque OpenSSL error mid-handshake; abort explicitly instead.
+        log_warning(std::string("terminating TLS handshake: ") + context_label +
+                    ": selected chain failed to apply and no default chain is available");
+        return 0;
+    }
     log_warning(std::string(context_label) + ": selected chain (" + leaf_subject_name(*selected) +
                 ") failed to apply; serving default chain");
-    if (fallback != nullptr && not use_certificate_and_key(ssl, *fallback)) {
+    if (not use_certificate_and_key(ssl, *fallback)) {
         log_warning(std::string("terminating TLS handshake: ") + context_label);
         return 0;
     }

--- a/lib/everest/tls/extensions/trusted_ca_keys.cpp
+++ b/lib/everest/tls/extensions/trusted_ca_keys.cpp
@@ -312,38 +312,61 @@ const chain_t* select(const trusted_ca_keys_t& extension, const chain_list& chai
     return result;
 }
 
+namespace {
+
+/**
+ * \brief check a chain's trust anchors against a list of distinguished names
+ * \param[in] chain contains the list of trust anchors
+ * \param[in] names is the list of distinguished names advertised by the peer
+ * \param[in] name_count is the number of entries in names
+ * \param[inout] warned_malformed caps the malformed-DN warning at one line per
+ *               selection; the peer controls names, so per-comparison logging
+ *               could emit name_count x trust-anchor lines per handshake
+ * \return true on the first (trust anchor subject, name) match
+ */
+bool chain_matches_dn_list(const chain_t& chain, const STACK_OF(X509_NAME) * names, int name_count,
+                           bool& warned_malformed) {
+    for (const auto& ta : chain.chain.trust_anchors) {
+        auto* subject = X509_get_subject_name(ta.get());
+        if (subject == nullptr) {
+            continue;
+        }
+        for (int i = 0; i < name_count; ++i) {
+            const auto* candidate = sk_X509_NAME_value(names, i);
+            if (candidate == nullptr) {
+                continue;
+            }
+            const int cmp = X509_NAME_cmp(subject, candidate);
+            if (cmp == 0) {
+                return true;
+            }
+            if ((cmp == -2) && not warned_malformed) {
+                log_warning("select_by_dn_list: malformed DN skipped in comparison");
+                warned_malformed = true;
+            }
+        }
+    }
+    return false;
+}
+
+} // namespace
+
 const chain_t* select_by_dn_list(const STACK_OF(X509_NAME) * names, const chain_list& chains) {
-    const chain_t* result{nullptr};
     if (names == nullptr) {
-        return result;
+        return nullptr;
     }
     const int name_count = sk_X509_NAME_num(names);
     if (name_count <= 0) {
-        return result;
+        return nullptr;
     }
 
+    bool warned_malformed{false};
     for (const auto& chain : chains) {
-        for (const auto& ta : chain.chain.trust_anchors) {
-            auto* subject = X509_get_subject_name(ta.get());
-            if (subject == nullptr) {
-                continue;
-            }
-            for (int i = 0; i < name_count; ++i) {
-                const auto* candidate = sk_X509_NAME_value(names, i);
-                if (candidate != nullptr && X509_NAME_cmp(subject, candidate) == 0) {
-                    result = &chain;
-                    break;
-                }
-            }
-            if (result != nullptr) {
-                break;
-            }
-        }
-        if (result != nullptr) {
-            break;
+        if (chain_matches_dn_list(chain, names, name_count, warned_malformed)) {
+            return &chain;
         }
     }
-    return result;
+    return nullptr;
 }
 
 int ServerTrustedCaKeys::s_index{-1};

--- a/lib/everest/tls/extensions/trusted_ca_keys.cpp
+++ b/lib/everest/tls/extensions/trusted_ca_keys.cpp
@@ -6,6 +6,7 @@
 #include <boost/smart_ptr/shared_ptr.hpp>
 #include <everest/tls/openssl_util.hpp>
 
+#include <array>
 #include <cassert>
 #include <limits>
 
@@ -424,8 +425,32 @@ int ServerTrustedCaKeys::trusted_ca_keys_cb(SSL* ctx, unsigned int ext_type, uns
     return 1;
 }
 
-int ServerTrustedCaKeys::apply_selection_locked(SSL* ssl, const chain_t* selected, const char* context_label) {
-    // m_mux is held by the caller.
+namespace {
+
+/**
+ * \brief name a chain by its leaf certificate subject for log messages
+ * \param[in] chain the chain to name
+ * \return the leaf subject as a one-line string, or a placeholder when the
+ *         chain has no leaf or the subject cannot be rendered
+ */
+std::string leaf_subject_name(const chain_t& chain) {
+    const auto* leaf = chain.chain.leaf.get();
+    if (leaf == nullptr) {
+        return "<no leaf>";
+    }
+    std::array<char, 256> buf{};
+    // X509_NAME_oneline renders a null/empty subject as an empty string, not an error
+    if ((X509_NAME_oneline(X509_get_subject_name(leaf), buf.data(), static_cast<int>(buf.size())) == nullptr) ||
+        (buf[0] == '\0')) {
+        return "<unknown subject>";
+    }
+    return std::string(buf.data());
+}
+
+} // namespace
+
+int ServerTrustedCaKeys::apply_selection_locked(SSL* ssl, const std::lock_guard<std::mutex>& /* m_mux witness */,
+                                                const chain_t* selected, const char* context_label) {
     if (selected == nullptr) {
         // No specific chain matched; keep the default certificate already
         // configured on the SSL_CTX.
@@ -436,6 +461,13 @@ int ServerTrustedCaKeys::apply_selection_locked(SSL* ssl, const chain_t* selecte
     }
     // The selected chain failed to apply; fall back to the default chain.
     const auto* fallback = select_default();
+    if (fallback == selected) {
+        log_warning(std::string("terminating TLS handshake: ") + context_label +
+                    ": selected chain failed to apply and is the only/default chain");
+        return 0;
+    }
+    log_warning(std::string(context_label) + ": selected chain (" + leaf_subject_name(*selected) +
+                ") failed to apply; serving default chain");
     if (fallback != nullptr && not use_certificate_and_key(ssl, *fallback)) {
         log_warning(std::string("terminating TLS handshake: ") + context_label);
         return 0;
@@ -473,7 +505,13 @@ int ServerTrustedCaKeys::handle_certificate_cb(SSL* ssl, void* arg) {
         if (names != nullptr && sk_X509_NAME_num(names) > 0) {
             std::lock_guard lock(tck_p->m_mux);
             const auto* selected = select_by_dn_list(names, tck_p->m_chains);
-            result = tck_p->apply_selection_locked(ssl, selected, "certificate_authorities");
+            if (selected == nullptr) {
+                log_warning("certificate_authorities: no configured chain matched the peer's advertised CA names; "
+                            "serving default chain");
+            }
+            result = tck_p->apply_selection_locked(ssl, lock, selected, "certificate_authorities");
+        } else {
+            log_debug("certificate_authorities: peer sent no certificate_authorities; serving default chain");
         }
         return result;
     }
@@ -483,7 +521,11 @@ int ServerTrustedCaKeys::handle_certificate_cb(SSL* ssl, void* arg) {
     if ((keys_p != nullptr) && (keys_p->flags.has_trusted_ca_keys())) {
         std::lock_guard lock(tck_p->m_mux);
         const auto* selected = tck_p->select(keys_p->tck);
-        result = tck_p->apply_selection_locked(ssl, selected, "trusted_ca_keys");
+        if (selected == nullptr) {
+            log_warning("trusted_ca_keys: no configured chain matched the peer's trusted_ca_keys; "
+                        "serving default chain");
+        }
+        result = tck_p->apply_selection_locked(ssl, lock, selected, "trusted_ca_keys");
     }
     return result;
 }

--- a/lib/everest/tls/extensions/trusted_ca_keys.cpp
+++ b/lib/everest/tls/extensions/trusted_ca_keys.cpp
@@ -312,6 +312,40 @@ const chain_t* select(const trusted_ca_keys_t& extension, const chain_list& chai
     return result;
 }
 
+const chain_t* select_by_dn_list(const STACK_OF(X509_NAME) * names, const chain_list& chains) {
+    const chain_t* result{nullptr};
+    if (names == nullptr) {
+        return result;
+    }
+    const int name_count = sk_X509_NAME_num(names);
+    if (name_count <= 0) {
+        return result;
+    }
+
+    for (const auto& chain : chains) {
+        for (const auto& ta : chain.chain.trust_anchors) {
+            auto* subject = X509_get_subject_name(ta.get());
+            if (subject == nullptr) {
+                continue;
+            }
+            for (int i = 0; i < name_count; ++i) {
+                const auto* candidate = sk_X509_NAME_value(names, i);
+                if (candidate != nullptr && X509_NAME_cmp(subject, candidate) == 0) {
+                    result = &chain;
+                    break;
+                }
+            }
+            if (result != nullptr) {
+                break;
+            }
+        }
+        if (result != nullptr) {
+            break;
+        }
+    }
+    return result;
+}
+
 int ServerTrustedCaKeys::s_index{-1};
 
 ServerTrustedCaKeys::ServerTrustedCaKeys() {
@@ -322,7 +356,9 @@ ServerTrustedCaKeys::ServerTrustedCaKeys() {
 
 bool ServerTrustedCaKeys::init_ssl(SslContext* ctx) {
     bool bRes{true};
-    // TLS 1.2 and below only - use certificate_authorities in TLS 1.3
+    // Legacy custom trusted_ca_keys extension is TLS 1.2 and below only.
+    // TLS 1.3 multi-chain selection uses SSL_get0_peer_CA_list (driven by
+    // the peer's certificate_authorities extension) in handle_certificate_cb.
     constexpr int context_tck =
         SSL_EXT_TLS_ONLY | SSL_EXT_TLS1_2_AND_BELOW_ONLY | SSL_EXT_IGNORE_ON_RESUMPTION | SSL_EXT_CLIENT_HELLO;
     if (SSL_CTX_add_custom_ext(ctx, TLSEXT_TYPE_trusted_ca_keys, context_tck, nullptr, nullptr, nullptr,
@@ -365,6 +401,25 @@ int ServerTrustedCaKeys::trusted_ca_keys_cb(SSL* ctx, unsigned int ext_type, uns
     return 1;
 }
 
+int ServerTrustedCaKeys::apply_selection_locked(SSL* ssl, const chain_t* selected, const char* context_label) {
+    // m_mux is held by the caller.
+    if (selected == nullptr) {
+        // No specific chain matched; keep the default certificate already
+        // configured on the SSL_CTX.
+        return 1;
+    }
+    if (use_certificate_and_key(ssl, *selected)) {
+        return 1;
+    }
+    // The selected chain failed to apply; fall back to the default chain.
+    const auto* fallback = select_default();
+    if (fallback != nullptr && not use_certificate_and_key(ssl, *fallback)) {
+        log_warning(std::string("terminating TLS handshake: ") + context_label);
+        return 0;
+    }
+    return 1;
+}
+
 int ServerTrustedCaKeys::handle_certificate_cb(SSL* ssl, void* arg) {
     /*
      * return values:
@@ -375,7 +430,6 @@ int ServerTrustedCaKeys::handle_certificate_cb(SSL* ssl, void* arg) {
     int result{1};
 
     auto* tck_p = reinterpret_cast<ServerTrustedCaKeys*>(arg);
-    auto* keys_p = get_data(ssl);
 
     /*
      * From OpenSSL man page
@@ -385,25 +439,28 @@ int ServerTrustedCaKeys::handle_certificate_cb(SSL* ssl, void* arg) {
      * It might also call SSL_certs_clear().
      */
 
-    if ((tck_p != nullptr) && (keys_p != nullptr) && (keys_p->flags.has_trusted_ca_keys())) {
-        // prevent update() from changing pointers
-        std::lock_guard lock(tck_p->m_mux);
+    if (tck_p == nullptr) {
+        return result;
+    }
 
-        const auto* selected = tck_p->select(keys_p->tck);
-        if (selected != nullptr) {
-            if (!use_certificate_and_key(ssl, *selected)) {
-                // setting failed - try and use the default
-                selected = tck_p->select_default();
-                if (selected != nullptr) {
-                    if (!use_certificate_and_key(ssl, *selected)) {
-                        // there has been a problem setting the server
-                        // certificate, key and chain
-                        result = 0;
-                        log_warning("terminating TLS handshake: trusted_ca_keys");
-                    }
-                }
-            }
+    if (SSL_version(ssl) == TLS1_3_VERSION) {
+        // TLS 1.3: select chain based on the peer's certificate_authorities
+        // extension exposed via SSL_get0_peer_CA_list.
+        const STACK_OF(X509_NAME)* names = SSL_get0_peer_CA_list(ssl);
+        if (names != nullptr && sk_X509_NAME_num(names) > 0) {
+            std::lock_guard lock(tck_p->m_mux);
+            const auto* selected = select_by_dn_list(names, tck_p->m_chains);
+            result = tck_p->apply_selection_locked(ssl, selected, "certificate_authorities");
         }
+        return result;
+    }
+
+    // TLS 1.2 and below: legacy custom trusted_ca_keys extension path.
+    auto* keys_p = get_data(ssl);
+    if ((keys_p != nullptr) && (keys_p->flags.has_trusted_ca_keys())) {
+        std::lock_guard lock(tck_p->m_mux);
+        const auto* selected = tck_p->select(keys_p->tck);
+        result = tck_p->apply_selection_locked(ssl, selected, "trusted_ca_keys");
     }
     return result;
 }

--- a/lib/everest/tls/extensions/trusted_ca_keys.hpp
+++ b/lib/everest/tls/extensions/trusted_ca_keys.hpp
@@ -234,13 +234,16 @@ public:
                                   void* object);
 
     /**
-     * \brief the OpenSSL callback for the trusted_ca_keys extension
-     * \param[in] ctx the connection context
+     * \brief OpenSSL certificate callback driving chain selection for both the
+     *        TLS 1.2 trusted_ca_keys and TLS 1.3 certificate_authorities features
+     * \param[in] ssl the connection context
      * \param[in] arg A ServerTrustedCaKeys object
      * \return success = 1, error = zero or negative
      *
-     * Calls select() and select_default() after acquiring the mutex to ensure
-     * that calls to update() don't invalidate the pointers.
+     * Branches on SSL_version(): select() for TLS 1.2 and below,
+     * select_by_dn_list() for TLS 1.3. The chosen chain is applied via
+     * apply_selection_locked() (which may fall back to select_default()), all
+     * under the mutex so calls to update() don't invalidate the pointers.
      */
     static int handle_certificate_cb(Ssl* ssl, void* arg);
 

--- a/lib/everest/tls/extensions/trusted_ca_keys.hpp
+++ b/lib/everest/tls/extensions/trusted_ca_keys.hpp
@@ -147,7 +147,7 @@ struct server_trusted_ca_keys_t {
  *
  * Despite the name, this handler drives chain selection for BOTH legs:
  *  - TLS 1.2 and below: the legacy custom trusted_ca_keys extension
- *    (cert/key SHA-1 hashes), via select()/select_by_*().
+ *    (cert/key SHA-1 hashes and x509 DNs), via select().
  *  - TLS 1.3: the standard certificate_authorities extension exposed by
  *    OpenSSL as the peer CA list, via select_by_dn_list().
  * handle_certificate_cb() branches on SSL_version() and both legs converge
@@ -163,13 +163,15 @@ private:
     /**
      * \brief apply a selected chain, falling back to the default chain
      * \param[in] ssl the connection context
+     * \param[in] lock witness that the caller holds m_mux
      * \param[in] selected chain chosen by the per-version selector, or nullptr
      * \param[in] context_label feature name used in the abort log line
      * \return 1 to continue the handshake, 0 to abort it
      * \note m_mux MUST be held by the caller: select + apply must be atomic
      *       with respect to update() swapping m_chains.
      */
-    int apply_selection_locked(SSL* ssl, const chain_t* selected, const char* context_label);
+    int apply_selection_locked(SSL* ssl, const std::lock_guard<std::mutex>& lock, const chain_t* selected,
+                               const char* context_label);
 
 public:
     ServerTrustedCaKeys();

--- a/lib/everest/tls/extensions/trusted_ca_keys.hpp
+++ b/lib/everest/tls/extensions/trusted_ca_keys.hpp
@@ -7,6 +7,9 @@
 #include <everest/tls/openssl_util.hpp>
 #include <everest/tls/tls_types.hpp>
 
+#include <openssl/safestack.h>
+#include <openssl/x509.h>
+
 #include <mutex>
 
 namespace tls::trusted_ca_keys {
@@ -119,18 +122,54 @@ bool match(const trusted_ca_keys_t& extension, const chain_t& chain);
  */
 const chain_t* select(const trusted_ca_keys_t& extension, const chain_list& chains);
 
+/**
+ * \brief select the certificate chain to use based on a DN list
+ * \param[in] names the list of distinguished names from the peer
+ * \param[in] chains the list of certificate chains to check against
+ * \return a pointer to the chain (in chains) or nullptr when none match
+ *
+ * Used to drive TLS 1.3 chain selection from the peer's
+ * certificate_authorities extension via SSL_get0_peer_CA_list. A chain
+ * matches when any of its trust anchors' subject DN equals an entry in
+ * names. Returns nullptr for an empty or null DN list.
+ */
+const chain_t* select_by_dn_list(const STACK_OF(X509_NAME) * names, const chain_list& chains);
+
 /// \brief per connection data
 struct server_trusted_ca_keys_t {
     trusted_ca_keys_t& tck;  //!< parsed values
     tls::StatusFlags& flags; //!< flags to indicate which extensions were present
 };
 
-/// \brief trusted_ca_keys extension handler for a TLS server
+/**
+ * \brief server-side certificate-chain selection for the trusted_ca_keys /
+ *        certificate_authorities feature
+ *
+ * Despite the name, this handler drives chain selection for BOTH legs:
+ *  - TLS 1.2 and below: the legacy custom trusted_ca_keys extension
+ *    (cert/key SHA-1 hashes), via select()/select_by_*().
+ *  - TLS 1.3: the standard certificate_authorities extension exposed by
+ *    OpenSSL as the peer CA list, via select_by_dn_list().
+ * handle_certificate_cb() branches on SSL_version() and both legs converge
+ * on apply_selection_locked() for the apply / fall-back-to-default / abort
+ * sequence.
+ */
 class ServerTrustedCaKeys {
 private:
     static int s_index;  //!< index used for storing per connection data
     chain_list m_chains; //!< known certificate chains
     std::mutex m_mux;    //!< protects m_chains
+
+    /**
+     * \brief apply a selected chain, falling back to the default chain
+     * \param[in] ssl the connection context
+     * \param[in] selected chain chosen by the per-version selector, or nullptr
+     * \param[in] context_label feature name used in the abort log line
+     * \return 1 to continue the handshake, 0 to abort it
+     * \note m_mux MUST be held by the caller: select + apply must be atomic
+     *       with respect to update() swapping m_chains.
+     */
+    int apply_selection_locked(SSL* ssl, const chain_t* selected, const char* context_label);
 
 public:
     ServerTrustedCaKeys();

--- a/lib/everest/tls/include/everest/tls/tls.hpp
+++ b/lib/everest/tls/include/everest/tls/tls.hpp
@@ -480,6 +480,10 @@ private:
     ConfigItem m_tls_key_interface{nullptr};
     bool m_verify_client_on_tls13{false};
     std::filesystem::path tls_key_log_file_path{};
+    //! index into config_t::chains of the first chain that passed verification in
+    //! init_certificates(); installed by init_ssl() as the SSL_CTX default so the
+    //! no-match fallback and select_default() agree. 0 when no chain verified.
+    std::size_t m_default_chain_index{0};
 
     /**
      * \brief initialise the server socket

--- a/lib/everest/tls/src/tls.cpp
+++ b/lib/everest/tls/src/tls.cpp
@@ -1153,6 +1153,17 @@ bool Server::init_certificates(const std::vector<certificate_config_t>& chain_fi
 
                 if (openssl::verify_chain(chain)) {
                     chains.emplace_back(std::move(chain));
+                } else {
+                    const auto subject = openssl::certificate_subject(chain.chain.leaf.get());
+                    std::string msg("chain verification failed, excluding chain (leaf:");
+                    for (const auto& item : subject) {
+                        msg += ' ';
+                        msg += item.first;
+                        msg += ':';
+                        msg += item.second;
+                    }
+                    msg += ')';
+                    log_warning(msg);
                 }
             } else {
                 const auto subject = openssl::certificate_subject(certs[0].get());
@@ -1165,6 +1176,11 @@ bool Server::init_certificates(const std::vector<certificate_config_t>& chain_fi
                 }
                 log_warning(msg);
             }
+        } else {
+            const auto* file = static_cast<const char*>(i.certificate_chain_file);
+            std::string msg("certificate chain file yielded no certificates: ");
+            msg += (file != nullptr) ? file : "<not set>";
+            log_warning(msg);
         }
     }
 

--- a/lib/everest/tls/src/tls.cpp
+++ b/lib/everest/tls/src/tls.cpp
@@ -1049,9 +1049,13 @@ bool Server::init_ssl(const config_t& cfg) {
     SSL_CTX* ctx = nullptr;
 
     if (result) {
-        // use the first server chain
+        // Use the first VERIFIED server chain (recorded by init_certificates) as the
+        // SSL_CTX default so the no-match / no-extension fallback serves a chain
+        // clients can build a path for; select_default() agrees since m_chains only
+        // holds verified chains. Falls back to chains[0] when no chain verified.
+        const auto default_index = (m_default_chain_index < cfg.chains.size()) ? m_default_chain_index : 0;
         const ssl_ctx_params params{true, cfg.ciphersuites, cfg.cipher_list, true, cfg.enforce_tls_1_3};
-        result = configure_ssl_ctx(ctx, cfg.chains[0], params);
+        result = configure_ssl_ctx(ctx, cfg.chains[default_index], params);
         if (result) {
 
             if (cfg.tls_key_logging) {
@@ -1106,7 +1110,9 @@ void Server::deinit_ssl() {
 bool Server::init_certificates(const std::vector<certificate_config_t>& chain_files) {
     std::vector<OcspCache::ocsp_entry_t> entries;
     openssl::chain_list chains;
+    m_default_chain_index = 0;
 
+    std::size_t config_index{0};
     for (const auto& i : chain_files) {
         auto certs = openssl::load_certificates(i.certificate_chain_file);
         auto tas = openssl::load_certificates(i.trust_anchor_file);
@@ -1152,6 +1158,9 @@ bool Server::init_certificates(const std::vector<certificate_config_t>& chain_fi
                 chain.private_key = std::move(pkey);
 
                 if (openssl::verify_chain(chain)) {
+                    if (chains.empty()) {
+                        m_default_chain_index = config_index;
+                    }
                     chains.emplace_back(std::move(chain));
                 } else {
                     const auto subject = openssl::certificate_subject(chain.chain.leaf.get());
@@ -1182,6 +1191,7 @@ bool Server::init_certificates(const std::vector<certificate_config_t>& chain_fi
             msg += (file != nullptr) ? file : "<not set>";
             log_warning(msg);
         }
+        config_index++;
     }
 
     bool result{true};
@@ -1189,6 +1199,17 @@ bool Server::init_certificates(const std::vector<certificate_config_t>& chain_fi
     if (chains.empty()) {
         // continue without trusted_ca_keys support
         log_warning("trusted_ca_keys support disabled");
+        if (!chain_files.empty()) {
+            log_warning("no configured chain passed verification; the SSL_CTX default certificate remains "
+                        "chains[0] and clients may not be able to build a path for it");
+        }
+    } else if (m_default_chain_index != 0) {
+        std::string msg("first ");
+        msg += std::to_string(m_default_chain_index);
+        msg += " configured chain(s) unusable (see warnings above); serving chains[";
+        msg += std::to_string(m_default_chain_index);
+        msg += "] as the default certificate";
+        log_warning(msg);
     }
     m_server_trusted_ca_keys.update(std::move(chains));
 

--- a/lib/everest/tls/tests/tls_connection_test.cpp
+++ b/lib/everest/tls/tests/tls_connection_test.cpp
@@ -913,4 +913,61 @@ TEST_F(TlsTest, SuspendToRunning) {
     EXPECT_EQ(server.state(), state_t::running);
 }
 
+TEST_F(TlsTest, Tls13MultiChainCertificateAuthorities) {
+    // End-to-end test that the TLS 1.3 chain-selection path picks the chain
+    // whose trust anchor's subject DN appears in the client's
+    // certificate_authorities extension. Two chains are configured by the
+    // fixture: chains[0] (root CN 00000000) and chains[1] (alt root CN
+    // 11111111). The client publishes only the alt root's DN and the server
+    // must reply with the alt leaf certificate.
+    server_config.ciphersuites = "TLS_AES_256_GCM_SHA384";
+    server_config.enforce_tls_1_3 = true;
+    server_config.verify_client = true;
+    server_config.verify_locations_file = "client_root_cert.pem";
+
+    client_config.cipher_list = nullptr;
+    client_config.ciphersuites = "TLS_AES_256_GCM_SHA384";
+    client_config.min_proto_version = TLS1_3_VERSION;
+    client_config.certificate_chain_file = "client_chain.pem";
+    client_config.private_key_file = "client_priv.pem";
+    // Verify against the alt root because that is the chain we expect the
+    // server to send back.
+    client_config.verify_locations_file = "alt_server_root_cert.pem";
+
+    std::map<std::string, std::string> subject;
+    auto client_handler_fn = [this, &subject](tls::Client::ConnectionPtr& connection) {
+        if (!connection) {
+            return;
+        }
+        // Inject the alt root DN into the certificate_authorities extension on
+        // the client SSL handle before the handshake runs. This is the signal
+        // the server's TLS 1.3 chain dispatcher reads via
+        // SSL_get0_peer_CA_list to pick chains[1].
+        //
+        // Connection::ssl_context() is marked [[deprecated]] for callers
+        // outside the library (it is only kept for IsoMux); the surrounding
+        // pragmas suppress the deprecation warning here because the test
+        // legitimately needs the raw SSL* to drive SSL_add1_to_CA_list.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        SSL* ssl = connection->ssl_context();
+#pragma GCC diagnostic pop
+        ASSERT_NE(ssl, nullptr);
+        auto alt_roots = openssl::load_certificates("alt_server_root_cert.pem");
+        ASSERT_FALSE(alt_roots.empty());
+        ASSERT_EQ(SSL_add1_to_CA_list(ssl, alt_roots.front().get()), 1);
+
+        if (connection->connect() == result_t::success) {
+            this->set(ClientTest::flags_t::connected);
+            subject = openssl::certificate_subject(connection->peer_certificate());
+            (void)connection->shutdown();
+        }
+    };
+
+    start();
+    connect(client_handler_fn);
+    EXPECT_TRUE(is_set(flags_t::connected));
+    EXPECT_EQ(subject["CN"], alt_server_root_CN);
+}
+
 } // namespace

--- a/lib/everest/tls/tests/tls_connection_test.cpp
+++ b/lib/everest/tls/tests/tls_connection_test.cpp
@@ -1021,6 +1021,60 @@ TEST_F(TlsTest, Tls13NoMatchServesDefault) {
     EXPECT_EQ(subject["CN"], server_root_CN);
 }
 
+TEST_F(TlsTest, Tls13NoMatchSkipsUnverifiedDefault) {
+    // chains[0] is deliberately broken: its chain file holds only the leaf, so
+    // verify_chain() cannot build a path to the trust anchor (missing
+    // intermediate) and the chain is excluded at config time. The default
+    // served to no-match clients must be the first chain that PASSED
+    // verification - chains[1], alt leaf CN 11111111 - not the broken
+    // chains[0]; otherwise every no-match client is served a chain it cannot
+    // build a path for.
+    server_config.chains[0].certificate_chain_file = "server_cert.pem";
+    server_config.chains[0].ocsp_response_files = {"ocsp_response.der"};
+    server_config.ciphersuites = "TLS_AES_256_GCM_SHA384";
+    server_config.enforce_tls_1_3 = true;
+    server_config.verify_client = true;
+    server_config.verify_locations_file = "client_root_cert.pem";
+
+    client_config.cipher_list = nullptr;
+    client_config.ciphersuites = "TLS_AES_256_GCM_SHA384";
+    client_config.min_proto_version = TLS1_3_VERSION;
+    client_config.certificate_chain_file = "client_chain.pem";
+    client_config.private_key_file = "client_priv.pem";
+    // Verify against chains[1]'s root because the first verified chain is
+    // expected to be served.
+    client_config.verify_locations_file = "alt_server_root_cert.pem";
+
+    std::map<std::string, std::string> subject;
+    auto client_handler_fn = [this, &subject](tls::Client::ConnectionPtr& connection) {
+        if (!connection) {
+            return;
+        }
+        // Inject a DN matching neither server chain's trust anchor. See
+        // Tls13MultiChainCertificateAuthorities for the ssl_context() pragma
+        // rationale.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        SSL* ssl = connection->ssl_context();
+#pragma GCC diagnostic pop
+        ASSERT_NE(ssl, nullptr);
+        auto foreign_roots = openssl::load_certificates("client_root_cert.pem");
+        ASSERT_FALSE(foreign_roots.empty());
+        ASSERT_EQ(SSL_add1_to_CA_list(ssl, foreign_roots.front().get()), 1);
+
+        if (connection->connect() == result_t::success) {
+            this->set(ClientTest::flags_t::connected);
+            subject = openssl::certificate_subject(connection->peer_certificate());
+            (void)connection->shutdown();
+        }
+    };
+
+    start();
+    connect(client_handler_fn);
+    EXPECT_TRUE(is_set(flags_t::connected));
+    EXPECT_EQ(subject["CN"], alt_server_root_CN);
+}
+
 TEST_F(TlsTest, MixedVersionServerSelectsAltChain) {
     // One server offering both TLS 1.2 (cipher_list) and TLS 1.3
     // (ciphersuites). The SSL_version dispatch in the certificate callback

--- a/lib/everest/tls/tests/tls_connection_test.cpp
+++ b/lib/everest/tls/tests/tls_connection_test.cpp
@@ -917,9 +917,10 @@ TEST_F(TlsTest, Tls13MultiChainCertificateAuthorities) {
     // End-to-end test that the TLS 1.3 chain-selection path picks the chain
     // whose trust anchor's subject DN appears in the client's
     // certificate_authorities extension. Two chains are configured by the
-    // fixture: chains[0] (root CN 00000000) and chains[1] (alt root CN
-    // 11111111). The client publishes only the alt root's DN and the server
-    // must reply with the alt leaf certificate.
+    // fixture: chains[0] (leaf CN 00000000, root 'Root Trust Anchor') and
+    // chains[1] (alt leaf CN 11111111, root 'Alternate Root Trust Anchor').
+    // The client publishes only the alt root's DN; the server must reply with
+    // the alt leaf (CN 11111111).
     server_config.ciphersuites = "TLS_AES_256_GCM_SHA384";
     server_config.enforce_tls_1_3 = true;
     server_config.verify_client = true;
@@ -967,6 +968,130 @@ TEST_F(TlsTest, Tls13MultiChainCertificateAuthorities) {
     start();
     connect(client_handler_fn);
     EXPECT_TRUE(is_set(flags_t::connected));
+    EXPECT_EQ(subject["CN"], alt_server_root_CN);
+}
+
+TEST_F(TlsTest, Tls13NoMatchServesDefault) {
+    // End-to-end test of the TLS 1.3 no-match path: the client advertises a
+    // certificate_authorities DN the server holds no chain for (the client
+    // root, C=DE/L=Frankfurt/CN=Root Trust Anchor). select_by_dn_list returns
+    // no chain and the server must keep the default chain already configured
+    // on the SSL_CTX - chains[0], leaf CN 00000000 - instead of aborting the
+    // handshake.
+    server_config.ciphersuites = "TLS_AES_256_GCM_SHA384";
+    server_config.enforce_tls_1_3 = true;
+    server_config.verify_client = true;
+    server_config.verify_locations_file = "client_root_cert.pem";
+
+    client_config.cipher_list = nullptr;
+    client_config.ciphersuites = "TLS_AES_256_GCM_SHA384";
+    client_config.min_proto_version = TLS1_3_VERSION;
+    client_config.certificate_chain_file = "client_chain.pem";
+    client_config.private_key_file = "client_priv.pem";
+    // Verify against chains[0]'s root because the default chain is expected.
+    client_config.verify_locations_file = "server_root_cert.pem";
+
+    std::map<std::string, std::string> subject;
+    auto client_handler_fn = [this, &subject](tls::Client::ConnectionPtr& connection) {
+        if (!connection) {
+            return;
+        }
+        // Inject a DN matching neither server chain's trust anchor. See
+        // Tls13MultiChainCertificateAuthorities for the ssl_context() pragma
+        // rationale.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        SSL* ssl = connection->ssl_context();
+#pragma GCC diagnostic pop
+        ASSERT_NE(ssl, nullptr);
+        auto foreign_roots = openssl::load_certificates("client_root_cert.pem");
+        ASSERT_FALSE(foreign_roots.empty());
+        ASSERT_EQ(SSL_add1_to_CA_list(ssl, foreign_roots.front().get()), 1);
+
+        if (connection->connect() == result_t::success) {
+            this->set(ClientTest::flags_t::connected);
+            subject = openssl::certificate_subject(connection->peer_certificate());
+            (void)connection->shutdown();
+        }
+    };
+
+    start();
+    connect(client_handler_fn);
+    EXPECT_TRUE(is_set(flags_t::connected));
+    EXPECT_EQ(subject["CN"], server_root_CN);
+}
+
+TEST_F(TlsTest, MixedVersionServerSelectsAltChain) {
+    // One server offering both TLS 1.2 (cipher_list) and TLS 1.3
+    // (ciphersuites). The SSL_version dispatch in the certificate callback
+    // must route a TLS 1.2 trusted_ca_keys client and a TLS 1.3
+    // certificate_authorities client to the same alt chain (leaf CN 11111111).
+    server_config.ciphersuites = "TLS_AES_256_GCM_SHA384";
+
+    std::map<std::string, std::string> subject;
+    int negotiated_version{0};
+
+    // TLS 1.2 leg: trusted_ca_keys advertising the alt root; an empty
+    // ciphersuites string caps the client at TLS 1.2.
+    client_config.ciphersuites = "";
+    client_config.trusted_ca_keys = true;
+    client_config.verify_locations_file = "alt_server_root_cert.pem";
+    add_ta_cert_hash("alt_server_root_cert.pem");
+
+    auto tls12_handler_fn = [this, &subject, &negotiated_version](tls::Client::ConnectionPtr& connection) {
+        if (!connection) {
+            return;
+        }
+        if (connection->connect() == result_t::success) {
+            this->set(ClientTest::flags_t::connected);
+            subject = openssl::certificate_subject(connection->peer_certificate());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+            negotiated_version = SSL_version(connection->ssl_context());
+#pragma GCC diagnostic pop
+            (void)connection->shutdown();
+        }
+    };
+
+    start();
+    connect(tls12_handler_fn);
+    EXPECT_TRUE(is_set(flags_t::connected));
+    EXPECT_EQ(negotiated_version, TLS1_2_VERSION);
+    EXPECT_EQ(subject["CN"], alt_server_root_CN);
+
+    // TLS 1.3 leg against the same running server: certificate_authorities
+    // advertising the alt root's DN.
+    subject.clear();
+    negotiated_version = 0;
+    client_config.trusted_ca_keys = false;
+    client_config.cipher_list = nullptr;
+    client_config.ciphersuites = "TLS_AES_256_GCM_SHA384";
+    client_config.min_proto_version = TLS1_3_VERSION;
+
+    auto tls13_handler_fn = [this, &subject, &negotiated_version](tls::Client::ConnectionPtr& connection) {
+        if (!connection) {
+            return;
+        }
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        SSL* ssl = connection->ssl_context();
+#pragma GCC diagnostic pop
+        ASSERT_NE(ssl, nullptr);
+        auto alt_roots = openssl::load_certificates("alt_server_root_cert.pem");
+        ASSERT_FALSE(alt_roots.empty());
+        ASSERT_EQ(SSL_add1_to_CA_list(ssl, alt_roots.front().get()), 1);
+
+        if (connection->connect() == result_t::success) {
+            this->set(ClientTest::flags_t::connected);
+            subject = openssl::certificate_subject(connection->peer_certificate());
+            negotiated_version = SSL_version(ssl);
+            (void)connection->shutdown();
+        }
+    };
+
+    connect(tls13_handler_fn);
+    EXPECT_TRUE(is_set(flags_t::connected));
+    EXPECT_EQ(negotiated_version, TLS1_3_VERSION);
     EXPECT_EQ(subject["CN"], alt_server_root_CN);
 }
 

--- a/lib/everest/tls/tests/tls_test.cpp
+++ b/lib/everest/tls/tests/tls_test.cpp
@@ -471,9 +471,26 @@ TEST(TrustedCaKeys, selectByDnListEmpty) {
     auto root = load_certificates("server_root_cert.pem");
     chains[0].chain.trust_anchors.emplace_back(std::move(root[0]));
 
+    chains.emplace_back();
+    auto alt_root = load_certificates("alt_server_root_cert.pem");
+    chains[1].chain.trust_anchors.emplace_back(std::move(alt_root[0]));
+
     auto* stack = sk_X509_NAME_new_null();
     EXPECT_EQ(select_by_dn_list(stack, chains), nullptr);
     sk_X509_NAME_pop_free(stack, X509_NAME_free);
+}
+
+TEST(TrustedCaKeys, selectByDnListNullNames) {
+    chain_list chains;
+    chains.emplace_back();
+    auto root = load_certificates("server_root_cert.pem");
+    chains[0].chain.trust_anchors.emplace_back(std::move(root[0]));
+
+    chains.emplace_back();
+    auto alt_root = load_certificates("alt_server_root_cert.pem");
+    chains[1].chain.trust_anchors.emplace_back(std::move(alt_root[0]));
+
+    EXPECT_EQ(select_by_dn_list(nullptr, chains), nullptr);
 }
 
 TEST(TrustedCaKeys, selectByDnListMatch) {
@@ -507,6 +524,58 @@ TEST(TrustedCaKeys, selectByDnListNoMatch) {
     auto unrelated = load_certificates("client_root_cert.pem");
     auto* stack = make_dn_stack({unrelated[0].get()});
     EXPECT_EQ(select_by_dn_list(stack, chains), nullptr);
+    sk_X509_NAME_pop_free(stack, X509_NAME_free);
+}
+
+TEST(TrustedCaKeys, selectByDnListMatchFirstChain) {
+    chain_list chains;
+    chains.emplace_back();
+    auto server_root = load_certificates("server_root_cert.pem");
+    chains[0].chain.trust_anchors.emplace_back(std::move(server_root[0]));
+
+    chains.emplace_back();
+    auto alt_root = load_certificates("alt_server_root_cert.pem");
+    chains[1].chain.trust_anchors.emplace_back(std::move(alt_root[0]));
+
+    // The DN list contains the server root's subject; selection should return chains[0].
+    auto* stack = make_dn_stack({chains[0].chain.trust_anchors[0].get()});
+    EXPECT_EQ(select_by_dn_list(stack, chains), &chains[0]);
+    sk_X509_NAME_pop_free(stack, X509_NAME_free);
+}
+
+TEST(TrustedCaKeys, selectByDnListFirstChainWins) {
+    chain_list chains;
+    chains.emplace_back();
+    auto server_root = load_certificates("server_root_cert.pem");
+    chains[0].chain.trust_anchors.emplace_back(std::move(server_root[0]));
+
+    chains.emplace_back();
+    auto alt_root = load_certificates("alt_server_root_cert.pem");
+    chains[1].chain.trust_anchors.emplace_back(std::move(alt_root[0]));
+
+    // Both chains' DNs are advertised (alt root first in the stack); chain
+    // iteration order wins, not DN stack order.
+    auto* stack = make_dn_stack({chains[1].chain.trust_anchors[0].get(), chains[0].chain.trust_anchors[0].get()});
+    EXPECT_EQ(select_by_dn_list(stack, chains), &chains[0]);
+    sk_X509_NAME_pop_free(stack, X509_NAME_free);
+}
+
+TEST(TrustedCaKeys, selectByDnListSecondAnchorMatch) {
+    chain_list chains;
+    chains.emplace_back();
+    auto server_root = load_certificates("server_root_cert.pem");
+    chains[0].chain.trust_anchors.emplace_back(std::move(server_root[0]));
+
+    // A chain with two trust anchors where only the second matches the
+    // advertised DN.
+    chains.emplace_back();
+    auto client_root = load_certificates("client_root_cert.pem");
+    auto alt_root = load_certificates("alt_server_root_cert.pem");
+    chains[1].chain.trust_anchors.emplace_back(std::move(client_root[0]));
+    chains[1].chain.trust_anchors.emplace_back(std::move(alt_root[0]));
+
+    auto* stack = make_dn_stack({chains[1].chain.trust_anchors[1].get()});
+    EXPECT_EQ(select_by_dn_list(stack, chains), &chains[1]);
     sk_X509_NAME_pop_free(stack, X509_NAME_free);
 }
 

--- a/lib/everest/tls/tests/tls_test.cpp
+++ b/lib/everest/tls/tests/tls_test.cpp
@@ -6,10 +6,13 @@
 #include <everest/tls/tls.hpp>
 #include <gtest/gtest.h>
 #include <iterator>
+#include <openssl/ssl.h>
 #include <openssl/x509.h>
 
 #include <cstring>
+#include <memory>
 #include <utility>
+#include <vector>
 
 std::string to_string(const std::uint8_t* const ptr, const std::size_t len) {
     std::stringstream string_stream;
@@ -577,6 +580,173 @@ TEST(TrustedCaKeys, selectByDnListSecondAnchorMatch) {
     auto* stack = make_dn_stack({chains[1].chain.trust_anchors[1].get()});
     EXPECT_EQ(select_by_dn_list(stack, chains), &chains[1]);
     sk_X509_NAME_pop_free(stack, X509_NAME_free);
+}
+
+// ----------------------------------------------------------------------------
+// ServerTrustedCaKeys apply path via handle_certificate_cb (TLS 1.2 leg)
+
+std::vector<std::pair<openssl::log_level_t, std::string>> captured_logs;
+
+void capture_log(openssl::log_level_t level, const std::string& str) {
+    captured_logs.emplace_back(level, str);
+}
+
+// Captures library log output for the lifetime of the object; restores the
+// previous handler on destruction.
+class LogCapture {
+public:
+    LogCapture() : previous(openssl::set_log_handler(&capture_log)) {
+        captured_logs.clear();
+    }
+    ~LogCapture() {
+        openssl::set_log_handler(previous);
+    }
+    LogCapture(const LogCapture&) = delete;
+    LogCapture& operator=(const LogCapture&) = delete;
+
+    static bool contains(openssl::log_level_t level, const std::string& needle) {
+        for (const auto& [entry_level, entry_str] : captured_logs) {
+            if ((entry_level == level) && (entry_str.find(needle) != std::string::npos)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+private:
+    openssl::log_handler_t previous;
+};
+
+chain_t make_test_chain(const char* leaf, const char* ca, const char* root, const char* key) {
+    chain_t result;
+    result.chain = load_certificates(leaf, ca, root);
+    result.private_key = load_private_key(key, nullptr);
+    return result;
+}
+
+trusted_ca_keys_t make_cert_hash_keys(const char* root_file) {
+    trusted_ca_keys_t keys;
+    auto root = load_certificates(root_file);
+    sha_1_digest_t digest{};
+    if (!root.empty() && certificate_sha_1(digest, root[0].get())) {
+        keys.cert_sha1_hash.push_back(digest);
+    }
+    return keys;
+}
+
+// Drives ServerTrustedCaKeys::handle_certificate_cb on a raw server SSL*
+// pinned below TLS 1.3 so the legacy trusted_ca_keys leg is taken.
+class ServerTrustedCaKeysApply : public testing::Test {
+protected:
+    void SetUp() override {
+        // TLSv1_2_server_method (rather than TLS_server_method + a version
+        // clamp) so that SSL_version() on the unconnected SSL reports
+        // TLS1_2_VERSION and handle_certificate_cb takes the legacy leg.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        ctx = SSL_CTX_new(TLSv1_2_server_method());
+#pragma GCC diagnostic pop
+        ASSERT_NE(ctx, nullptr);
+        ssl = SSL_new(ctx);
+        ASSERT_NE(ssl, nullptr);
+        ASSERT_EQ(SSL_version(ssl), TLS1_2_VERSION);
+        flags.trusted_ca_keys_received();
+    }
+
+    void TearDown() override {
+        SSL_free(ssl);
+        SSL_CTX_free(ctx);
+    }
+
+    void set_peer_keys(trusted_ca_keys_t&& peer_keys) {
+        keys = std::move(peer_keys);
+        data = std::make_unique<server_trusted_ca_keys_t>(server_trusted_ca_keys_t{keys, flags});
+        ServerTrustedCaKeys::set_data(ssl, data.get());
+    }
+
+    static void expect_installed_leaf(SSL* ssl_ptr, const char* leaf_file) {
+        auto expected = load_certificates(leaf_file);
+        ASSERT_EQ(expected.size(), 1);
+        auto* installed = SSL_get_certificate(ssl_ptr);
+        ASSERT_NE(installed, nullptr);
+        EXPECT_EQ(X509_cmp(installed, expected[0].get()), 0);
+    }
+
+    SSL_CTX* ctx{nullptr};
+    SSL* ssl{nullptr};
+    ServerTrustedCaKeys tck;
+    trusted_ca_keys_t keys;
+    tls::StatusFlags flags;
+    std::unique_ptr<server_trusted_ca_keys_t> data;
+};
+
+TEST_F(ServerTrustedCaKeysApply, selectedChainApplies) {
+    chain_list chains;
+    chains.push_back(
+        make_test_chain("server_cert.pem", "server_ca_cert.pem", "server_root_cert.pem", "server_priv.pem"));
+    chains.push_back(make_test_chain("alt_server_cert.pem", "alt_server_ca_cert.pem", "alt_server_root_cert.pem",
+                                     "alt_server_priv.pem"));
+    tck.update(std::move(chains));
+
+    set_peer_keys(make_cert_hash_keys("alt_server_root_cert.pem"));
+    ASSERT_FALSE(keys.cert_sha1_hash.empty());
+
+    LogCapture capture;
+    EXPECT_EQ(ServerTrustedCaKeys::handle_certificate_cb(ssl, &tck), 1);
+    expect_installed_leaf(ssl, "alt_server_cert.pem");
+}
+
+TEST_F(ServerTrustedCaKeysApply, selectedChainFailsFallsBackToDefault) {
+    chain_list chains;
+    chains.push_back(
+        make_test_chain("server_cert.pem", "server_ca_cert.pem", "server_root_cert.pem", "server_priv.pem"));
+    // The selected chain's private key does not match its leaf, so the apply
+    // fails and the (different) default chain is served instead.
+    chains.push_back(make_test_chain("alt_server_cert.pem", "alt_server_ca_cert.pem", "alt_server_root_cert.pem",
+                                     "server_priv.pem"));
+    tck.update(std::move(chains));
+
+    set_peer_keys(make_cert_hash_keys("alt_server_root_cert.pem"));
+    ASSERT_FALSE(keys.cert_sha1_hash.empty());
+
+    LogCapture capture;
+    EXPECT_EQ(ServerTrustedCaKeys::handle_certificate_cb(ssl, &tck), 1);
+    expect_installed_leaf(ssl, "server_cert.pem");
+    EXPECT_TRUE(LogCapture::contains(openssl::log_level_t::warning, "failed to apply; serving default chain"));
+}
+
+TEST_F(ServerTrustedCaKeysApply, onlyChainFailsAborts) {
+    chain_list chains;
+    // Single chain: selected AND default, with a mismatched private key so the
+    // apply fails. There is no other chain to fall back to: abort.
+    chains.push_back(make_test_chain("alt_server_cert.pem", "alt_server_ca_cert.pem", "alt_server_root_cert.pem",
+                                     "server_priv.pem"));
+    tck.update(std::move(chains));
+
+    set_peer_keys(make_cert_hash_keys("alt_server_root_cert.pem"));
+    ASSERT_FALSE(keys.cert_sha1_hash.empty());
+
+    LogCapture capture;
+    EXPECT_EQ(ServerTrustedCaKeys::handle_certificate_cb(ssl, &tck), 0);
+    EXPECT_TRUE(LogCapture::contains(openssl::log_level_t::warning, "only/default chain"));
+}
+
+TEST_F(ServerTrustedCaKeysApply, noMatchKeepsDefaultAndWarns) {
+    chain_list chains;
+    chains.push_back(
+        make_test_chain("server_cert.pem", "server_ca_cert.pem", "server_root_cert.pem", "server_priv.pem"));
+    tck.update(std::move(chains));
+
+    // The peer's trusted_ca_keys match no configured chain.
+    set_peer_keys(make_cert_hash_keys("client_root_cert.pem"));
+    ASSERT_FALSE(keys.cert_sha1_hash.empty());
+
+    LogCapture capture;
+    EXPECT_EQ(ServerTrustedCaKeys::handle_certificate_cb(ssl, &tck), 1);
+    // No chain is installed on the SSL: the default certificate configured on
+    // the SSL_CTX is kept.
+    EXPECT_EQ(SSL_get_certificate(ssl), nullptr);
+    EXPECT_TRUE(LogCapture::contains(openssl::log_level_t::warning, "no configured chain matched"));
 }
 
 } // namespace

--- a/lib/everest/tls/tests/tls_test.cpp
+++ b/lib/everest/tls/tests/tls_test.cpp
@@ -6,6 +6,7 @@
 #include <everest/tls/tls.hpp>
 #include <gtest/gtest.h>
 #include <iterator>
+#include <openssl/x509.h>
 
 #include <cstring>
 #include <utility>
@@ -447,6 +448,66 @@ TEST(TrustedCaKeys, select) {
     auto result = select(keys, chains);
     EXPECT_NE(result, nullptr);
     EXPECT_EQ(result, &chains[2]);
+}
+
+namespace {
+
+// Build a STACK_OF(X509_NAME) from the subject names of the given certs.
+// Caller owns the returned stack and must release it with sk_X509_NAME_pop_free.
+STACK_OF(X509_NAME) * make_dn_stack(const std::vector<X509*>& certs) {
+    auto* stack = sk_X509_NAME_new_null();
+    for (auto* cert : certs) {
+        auto* name = X509_get_subject_name(cert);
+        sk_X509_NAME_push(stack, X509_NAME_dup(name));
+    }
+    return stack;
+}
+
+} // namespace
+
+TEST(TrustedCaKeys, selectByDnListEmpty) {
+    chain_list chains;
+    chains.emplace_back();
+    auto root = load_certificates("server_root_cert.pem");
+    chains[0].chain.trust_anchors.emplace_back(std::move(root[0]));
+
+    auto* stack = sk_X509_NAME_new_null();
+    EXPECT_EQ(select_by_dn_list(stack, chains), nullptr);
+    sk_X509_NAME_pop_free(stack, X509_NAME_free);
+}
+
+TEST(TrustedCaKeys, selectByDnListMatch) {
+    chain_list chains;
+    chains.emplace_back();
+    auto server_root = load_certificates("server_root_cert.pem");
+    chains[0].chain.trust_anchors.emplace_back(std::move(server_root[0]));
+
+    chains.emplace_back();
+    auto alt_root = load_certificates("alt_server_root_cert.pem");
+    chains[1].chain.trust_anchors.emplace_back(std::move(alt_root[0]));
+
+    // The DN list contains the alt root's subject; selection should return chains[1].
+    auto* stack = make_dn_stack({chains[1].chain.trust_anchors[0].get()});
+    auto* result = select_by_dn_list(stack, chains);
+    EXPECT_EQ(result, &chains[1]);
+    sk_X509_NAME_pop_free(stack, X509_NAME_free);
+}
+
+TEST(TrustedCaKeys, selectByDnListNoMatch) {
+    chain_list chains;
+    chains.emplace_back();
+    auto server_root = load_certificates("server_root_cert.pem");
+    chains[0].chain.trust_anchors.emplace_back(std::move(server_root[0]));
+
+    chains.emplace_back();
+    auto alt_root = load_certificates("alt_server_root_cert.pem");
+    chains[1].chain.trust_anchors.emplace_back(std::move(alt_root[0]));
+
+    // The DN list contains a name that matches no chain's trust anchor.
+    auto unrelated = load_certificates("client_root_cert.pem");
+    auto* stack = make_dn_stack({unrelated[0].get()});
+    EXPECT_EQ(select_by_dn_list(stack, chains), nullptr);
+    sk_X509_NAME_pop_free(stack, X509_NAME_free);
 }
 
 } // namespace

--- a/modules/EVSE/Evse15118D20/CMakeLists.txt
+++ b/modules/EVSE/Evse15118D20/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(${MODULE_NAME}
     PRIVATE
         charger/der_relay.cpp
         charger/der_setup.cpp
+        charger/evse_security_chain_mapper.cpp
         charger/grid_event.cpp
         charger/utils.cpp
 )

--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -248,12 +248,15 @@ void ISO15118_chargerImpl::ready() {
 
     auto ssl_for_controller = build_current_ssl_config();
     if (ssl_for_controller.chains.empty()) {
-        if (negotiation_strategy == iso15118::config::TlsNegotiationStrategy::ENFORCE_TLS) {
+        switch (decide_startup_empty_chains(negotiation_strategy)) {
+        case StartupChainPolicy::Throw:
             EVLOG_AND_THROW(Everest::EverestConfigError(
                 "No usable V2G certificate chains available and tls_negotiation_strategy is ENFORCE_TLS"));
+        case StartupChainPolicy::WarnAndContinue:
+            EVLOG_warning << "No usable V2G certificate chains available; continuing with empty chain list. "
+                             "TLS connection attempts will fail until certificates are provisioned.";
+            break;
         }
-        EVLOG_warning << "No usable V2G certificate chains available; continuing with empty chain list. "
-                         "TLS connection attempts will fail until certificates are provisioned.";
     }
 
     iso15118::TbdConfig tbd_config = {
@@ -283,11 +286,8 @@ void ISO15118_chargerImpl::ready() {
 
     controller = std::make_unique<iso15118::TbdController>(std::move(tbd_config), std::move(callbacks), setup_config);
 
-    auto* active_controller = controller.get();
     mod->r_security->subscribe_certificate_store_update(
-        [this, active_controller](const types::evse_security::CertificateStoreUpdate& event) {
-            this->on_certificate_store_update(active_controller, event);
-        });
+        [this](const types::evse_security::CertificateStoreUpdate& event) { on_certificate_store_update(event); });
 
     // if the vas providers report their supported vas services before the controller exists,
     // we need to update the controller with the supported vas services after instantiation
@@ -325,23 +325,14 @@ iso15118::config::SSLConfig ISO15118_chargerImpl::build_current_ssl_config() {
     return cfg;
 }
 
-void ISO15118_chargerImpl::on_certificate_store_update(iso15118::TbdController* active_controller,
-                                                       const types::evse_security::CertificateStoreUpdate& event) {
-    if (not is_relevant_certificate_store_update(event)) {
+void ISO15118_chargerImpl::on_certificate_store_update(const types::evse_security::CertificateStoreUpdate& event) {
+    if (controller == nullptr) {
+        EVLOG_warning << "certificate_store_update received before controller ready; ignoring";
         return;
     }
-
-    auto refreshed = build_current_ssl_config();
-    switch (decide_certificate_store_update(refreshed)) {
-    case CertUpdateAction::PreserveLastGood:
-        EVLOG_error << "certificate_store_update produced no usable V2G certificate chains; "
-                       "preserving last-good SSL config";
-        return;
-    case CertUpdateAction::Apply:
-        EVLOG_info << "certificate_store_update: refreshing SSL config with " << refreshed.chains.size() << " chain(s)";
-        active_controller->set_ssl_config(std::move(refreshed));
-        return;
-    }
+    module::charger::handle_certificate_store_update(
+        event, [this] { return build_current_ssl_config(); },
+        [this](iso15118::config::SSLConfig cfg) { controller->set_ssl_config(std::move(cfg)); });
 }
 
 void ISO15118_chargerImpl::update_supported_vas_services() {

--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -289,6 +289,13 @@ void ISO15118_chargerImpl::ready() {
     mod->r_security->subscribe_certificate_store_update(
         [this](const types::evse_security::CertificateStoreUpdate& event) { on_certificate_store_update(event); });
 
+    // Close the startup window: a V2G certificate install completing between the initial config
+    // build above and the subscription registration would otherwise be served only at the next
+    // store update. Rebuild+apply once through the same idempotent path.
+    module::charger::resync_ssl_config(
+        [this] { return build_current_ssl_config(); },
+        [this](iso15118::config::SSLConfig cfg) { controller->set_ssl_config(std::move(cfg)); });
+
     // if the vas providers report their supported vas services before the controller exists,
     // we need to update the controller with the supported vas services after instantiation
     {

--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -5,12 +5,14 @@
 #include <fmt/ranges.h>
 
 #include "der_setup.hpp"
+#include "evse_security_chain_mapper.hpp"
 #include "grid_event.hpp"
 #include "utils.hpp"
 
 #include <utils/date.hpp>
 
 #include <iso15118/config.hpp>
+
 #include <iso15118/io/logging.hpp>
 
 namespace module {
@@ -239,51 +241,25 @@ void ISO15118_chargerImpl::ready() {
                          "Instead use the PacketSniffer module, tpcdump or Wireshark to log the v2gtp messages";
     }
 
-    // Obtain certificate location from the security module
-    const auto certificate_response = mod->r_security->call_get_leaf_certificate_info(
-        types::evse_security::LeafCertificateType::V2G, types::evse_security::EncodingFormat::PEM, false);
-
-    if (certificate_response.status != types::evse_security::GetCertificateInfoStatus::Accepted or
-        !certificate_response.info.has_value()) {
-        EVLOG_AND_THROW(Everest::EverestConfigError("V2G certificate not found"));
-    }
-
-    const auto& certificate_info = certificate_response.info.value();
-    std::string path_chain;
-
-    if (certificate_info.certificate.has_value()) {
-        path_chain = certificate_info.certificate.value();
-    } else if (certificate_info.certificate_single.has_value()) {
-        path_chain = certificate_info.certificate_single.value();
-    } else {
-        EVLOG_AND_THROW(Everest::EverestConfigError("V2G certificate not found"));
-    }
-
-    const auto v2g_root_cert_path = mod->r_security->call_get_verify_file(types::evse_security::CaCertificateType::V2G);
-    const auto mo_root_cert_path = mod->r_security->call_get_verify_file(types::evse_security::CaCertificateType::MO);
-
     // TODO(mlitre): Should be updated once libiso supports service renegotiation
     this->mod->p_extensions->publish_service_renegotiation_supported(false);
 
-    iso15118::config::SSLConfig ssl_for_controller{};
-    ssl_for_controller.backend = iso15118::config::CertificateBackend::EVEREST_LAYOUT;
-    ssl_for_controller.path_certificate_v2g_root = v2g_root_cert_path;
-    ssl_for_controller.path_certificate_mo_root = mo_root_cert_path;
-    ssl_for_controller.enable_ssl_logging = mod->config.enable_ssl_logging;
-    ssl_for_controller.enable_tls_key_logging = mod->config.enable_tls_key_logging;
-    ssl_for_controller.enforce_tls_1_3 = mod->config.enforce_tls_1_3;
-    ssl_for_controller.tls_key_logging_path = mod->config.tls_key_logging_path;
-    ssl_for_controller.chains.push_back(iso15118::config::ChainConfig{
-        path_chain,
-        certificate_info.key,
-        certificate_info.password,
-        {}, // ocsp_response_files — none for the single-chain leaf path
-    });
+    const auto negotiation_strategy = convert_tls_negotiation_strategy(mod->config.tls_negotiation_strategy);
+
+    auto ssl_for_controller = build_current_ssl_config();
+    if (ssl_for_controller.chains.empty()) {
+        if (negotiation_strategy == iso15118::config::TlsNegotiationStrategy::ENFORCE_TLS) {
+            EVLOG_AND_THROW(Everest::EverestConfigError(
+                "No usable V2G certificate chains available and tls_negotiation_strategy is ENFORCE_TLS"));
+        }
+        EVLOG_warning << "No usable V2G certificate chains available; continuing with empty chain list. "
+                         "TLS connection attempts will fail until certificates are provisioned.";
+    }
 
     iso15118::TbdConfig tbd_config = {
         std::move(ssl_for_controller),
         mod->config.device,
-        convert_tls_negotiation_strategy(mod->config.tls_negotiation_strategy),
+        negotiation_strategy,
         mod->config.enable_sdp_server,
     };
     auto callbacks = create_callbacks();
@@ -307,6 +283,12 @@ void ISO15118_chargerImpl::ready() {
 
     controller = std::make_unique<iso15118::TbdController>(std::move(tbd_config), std::move(callbacks), setup_config);
 
+    auto* active_controller = controller.get();
+    mod->r_security->subscribe_certificate_store_update(
+        [this, active_controller](const types::evse_security::CertificateStoreUpdate& event) {
+            this->on_certificate_store_update(active_controller, event);
+        });
+
     // if the vas providers report their supported vas services before the controller exists,
     // we need to update the controller with the supported vas services after instantiation
     {
@@ -320,6 +302,45 @@ void ISO15118_chargerImpl::ready() {
         controller->loop();
     } catch (const std::exception& e) {
         EVLOG_error << e.what();
+    }
+}
+
+iso15118::config::SSLConfig ISO15118_chargerImpl::build_base_ssl_config() {
+    iso15118::config::SSLConfig cfg{};
+    cfg.backend = iso15118::config::CertificateBackend::EVEREST_LAYOUT;
+    cfg.path_certificate_v2g_root = mod->r_security->call_get_verify_file(types::evse_security::CaCertificateType::V2G);
+    cfg.path_certificate_mo_root = mod->r_security->call_get_verify_file(types::evse_security::CaCertificateType::MO);
+    cfg.enable_ssl_logging = mod->config.enable_ssl_logging;
+    cfg.enable_tls_key_logging = mod->config.enable_tls_key_logging;
+    cfg.enforce_tls_1_3 = mod->config.enforce_tls_1_3;
+    cfg.tls_key_logging_path = mod->config.tls_key_logging_path;
+    return cfg;
+}
+
+iso15118::config::SSLConfig ISO15118_chargerImpl::build_current_ssl_config() {
+    auto cfg = build_base_ssl_config();
+    const auto certs_result = mod->r_security->call_get_all_valid_certificates_info(
+        types::evse_security::LeafCertificateType::V2G, types::evse_security::EncodingFormat::PEM, true);
+    cfg.chains = map_valid_chains(certs_result);
+    return cfg;
+}
+
+void ISO15118_chargerImpl::on_certificate_store_update(iso15118::TbdController* active_controller,
+                                                       const types::evse_security::CertificateStoreUpdate& event) {
+    if (not is_relevant_certificate_store_update(event)) {
+        return;
+    }
+
+    auto refreshed = build_current_ssl_config();
+    switch (decide_certificate_store_update(refreshed)) {
+    case CertUpdateAction::PreserveLastGood:
+        EVLOG_error << "certificate_store_update produced no usable V2G certificate chains; "
+                       "preserving last-good SSL config";
+        return;
+    case CertUpdateAction::Apply:
+        EVLOG_info << "certificate_store_update: refreshing SSL config with " << refreshed.chains.size() << " chain(s)";
+        active_controller->set_ssl_config(std::move(refreshed));
+        return;
     }
 }
 

--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.hpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.hpp
@@ -122,8 +122,8 @@ private:
     void apply_active_der_directives();
 
     /// Builds the base SSLConfig: backend, V2G/MO trust-anchor paths, and the module-level
-    /// TLS flags. Carries no certificate chains. Always available - independent of the
-    /// evse_security leaf-certificate state.
+    /// TLS flags. Carries no certificate chains. Does not depend on leaf-certificate
+    /// availability (still queries evse_security for the V2G/MO verify files).
     iso15118::config::SSLConfig build_base_ssl_config();
 
     /// Builds the current SSLConfig: the base config plus the valid V2G certificate chains
@@ -131,11 +131,12 @@ private:
     /// empty when no usable chains are available.
     iso15118::config::SSLConfig build_current_ssl_config();
 
-    /// Subscriber for evse_security::certificate_store_update. Receives the controller captured
-    /// at subscription time. Filters via is_relevant_certificate_store_update(), rebuilds the
-    /// SSLConfig, and either applies it or preserves the last-good config when the rebuild is empty.
-    void on_certificate_store_update(iso15118::TbdController* active_controller,
-                                     const types::evse_security::CertificateStoreUpdate& event);
+    /// Subscriber for evse_security::certificate_store_update. Reads this->controller under a
+    /// null guard; the controller is created once in ready() and never reset. Delegates to
+    /// charger::handle_certificate_store_update(), which gates on relevance, rebuilds the
+    /// SSLConfig, and applies it or preserves the last-good config; rebuild exceptions are
+    /// caught there so the subscriber thread survives RPC failures.
+    void on_certificate_store_update(const types::evse_security::CertificateStoreUpdate& event);
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 

--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.hpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.hpp
@@ -20,6 +20,9 @@
 #include "grid_event.hpp"
 #include "utils.hpp"
 
+#include <generated/types/evse_security.hpp>
+
+#include <iso15118/config.hpp>
 #include <iso15118/d20/config.hpp>
 #include <iso15118/session/feedback.hpp>
 #include <iso15118/tbd_controller.hpp>
@@ -117,6 +120,22 @@ private:
     // concurrent applies and leave a mixed DER-function map. Outermost lock; acquired before GEL.
     std::mutex der_apply_mutex;
     void apply_active_der_directives();
+
+    /// Builds the base SSLConfig: backend, V2G/MO trust-anchor paths, and the module-level
+    /// TLS flags. Carries no certificate chains. Always available - independent of the
+    /// evse_security leaf-certificate state.
+    iso15118::config::SSLConfig build_base_ssl_config();
+
+    /// Builds the current SSLConfig: the base config plus the valid V2G certificate chains
+    /// queried from evse_security and mapped via map_valid_chains(). The chains vector is
+    /// empty when no usable chains are available.
+    iso15118::config::SSLConfig build_current_ssl_config();
+
+    /// Subscriber for evse_security::certificate_store_update. Receives the controller captured
+    /// at subscription time. Filters via is_relevant_certificate_store_update(), rebuilds the
+    /// SSLConfig, and either applies it or preserves the last-good config when the rebuild is empty.
+    void on_certificate_store_update(iso15118::TbdController* active_controller,
+                                     const types::evse_security::CertificateStoreUpdate& event);
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 

--- a/modules/EVSE/Evse15118D20/charger/evse_security_chain_mapper.cpp
+++ b/modules/EVSE/Evse15118D20/charger/evse_security_chain_mapper.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include <everest/logging.hpp>
+#include <utils/exceptions.hpp>
 
 namespace module::charger {
 
@@ -82,6 +83,41 @@ bool is_relevant_certificate_store_update(const types::evse_security::Certificat
 
 CertUpdateAction decide_certificate_store_update(const iso15118::config::SSLConfig& refreshed) {
     return refreshed.chains.empty() ? CertUpdateAction::PreserveLastGood : CertUpdateAction::Apply;
+}
+
+void handle_certificate_store_update(const types::evse_security::CertificateStoreUpdate& event,
+                                     const std::function<iso15118::config::SSLConfig()>& rebuild,
+                                     const std::function<void(iso15118::config::SSLConfig)>& apply) {
+    if (not is_relevant_certificate_store_update(event)) {
+        return;
+    }
+
+    try {
+        auto refreshed = rebuild();
+        switch (decide_certificate_store_update(refreshed)) {
+        case CertUpdateAction::PreserveLastGood:
+            EVLOG_error << "certificate_store_update produced no usable V2G certificate chains; "
+                           "preserving last-good SSL config";
+            return;
+        case CertUpdateAction::Apply:
+            EVLOG_info << "certificate_store_update: applying SSL config with " << refreshed.chains.size()
+                       << " chain(s)";
+            apply(std::move(refreshed));
+            return;
+        }
+    } catch (const Everest::CmdTimeout& e) {
+        EVLOG_error << "certificate_store_update: evse_security RPC timed out; keeping last-good SSL config. "
+                       "New V2G certificates will NOT be served until the next store update: "
+                    << e.what();
+    } catch (const std::exception& e) {
+        EVLOG_error << "certificate_store_update: SSL config refresh failed; keeping last-good SSL config: "
+                    << e.what();
+    }
+}
+
+StartupChainPolicy decide_startup_empty_chains(iso15118::config::TlsNegotiationStrategy strategy) {
+    return strategy == iso15118::config::TlsNegotiationStrategy::ENFORCE_TLS ? StartupChainPolicy::Throw
+                                                                             : StartupChainPolicy::WarnAndContinue;
 }
 
 } // namespace module::charger

--- a/modules/EVSE/Evse15118D20/charger/evse_security_chain_mapper.cpp
+++ b/modules/EVSE/Evse15118D20/charger/evse_security_chain_mapper.cpp
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include "evse_security_chain_mapper.hpp"
+
+#include <utility>
+
+#include <everest/logging.hpp>
+
+namespace module::charger {
+
+std::vector<iso15118::config::ChainConfig>
+map_valid_chains(const types::evse_security::GetCertificateFullInfoResult& result) {
+    using types::evse_security::GetCertificateInfoStatus;
+
+    if (result.status != GetCertificateInfoStatus::Accepted) {
+        EVLOG_warning << "get_all_valid_certificates_info returned non-Accepted status: "
+                      << types::evse_security::get_certificate_info_status_to_string(result.status);
+        return {};
+    }
+
+    if (result.info.empty()) {
+        EVLOG_warning << "get_all_valid_certificates_info returned no certificate info";
+        return {};
+    }
+
+    std::vector<iso15118::config::ChainConfig> chains;
+    chains.reserve(result.info.size());
+
+    for (const auto& chain : result.info) {
+        std::string path_chain;
+        if (chain.certificate.has_value()) {
+            path_chain = chain.certificate.value();
+        } else if (chain.certificate_single.has_value()) {
+            path_chain = chain.certificate_single.value();
+        } else {
+            EVLOG_warning << "Skipping certificate info entry with neither certificate nor certificate_single set";
+            continue;
+        }
+
+        std::vector<std::string> ocsp_response_files;
+        if (chain.ocsp.has_value()) {
+            ocsp_response_files.reserve(chain.ocsp->size());
+            for (const auto& entry : *chain.ocsp) {
+                if (entry.ocsp_path.has_value()) {
+                    ocsp_response_files.push_back(*entry.ocsp_path);
+                }
+            }
+        }
+
+        chains.push_back(iso15118::config::ChainConfig{
+            std::move(path_chain), chain.key, chain.password, std::move(ocsp_response_files),
+            chain.certificate_root, // trust_anchor_pem (inline PEM of the chain's V2G root)
+        });
+    }
+
+    if (chains.empty()) {
+        EVLOG_warning << "get_all_valid_certificates_info produced no usable chain entries";
+        return {};
+    }
+
+    return chains;
+}
+
+bool is_relevant_certificate_store_update(const types::evse_security::CertificateStoreUpdate& event) {
+    const bool relevant_leaf = event.leaf_certificate_type.has_value() &&
+                               event.leaf_certificate_type.value() == types::evse_security::LeafCertificateType::V2G;
+    const bool relevant_ca = event.ca_certificate_type.has_value() &&
+                             (event.ca_certificate_type.value() == types::evse_security::CaCertificateType::V2G ||
+                              event.ca_certificate_type.value() == types::evse_security::CaCertificateType::MO);
+    return relevant_leaf || relevant_ca;
+}
+
+CertUpdateAction decide_certificate_store_update(const iso15118::config::SSLConfig& refreshed) {
+    return refreshed.chains.empty() ? CertUpdateAction::PreserveLastGood : CertUpdateAction::Apply;
+}
+
+} // namespace module::charger

--- a/modules/EVSE/Evse15118D20/charger/evse_security_chain_mapper.cpp
+++ b/modules/EVSE/Evse15118D20/charger/evse_security_chain_mapper.cpp
@@ -37,20 +37,30 @@ map_valid_chains(const types::evse_security::GetCertificateFullInfoResult& resul
             continue;
         }
 
-        std::vector<std::string> ocsp_response_files;
+        std::vector<std::optional<std::string>> ocsp_response_files;
         if (chain.ocsp.has_value()) {
             ocsp_response_files.reserve(chain.ocsp->size());
             for (const auto& entry : *chain.ocsp) {
-                if (entry.ocsp_path.has_value()) {
-                    ocsp_response_files.push_back(*entry.ocsp_path);
-                }
+                // one entry per chain certificate, in chain order; nullopt means
+                // "no OCSP staple for this position" and must be preserved so the
+                // TLS layer can pair staples with certificates positionally
+                ocsp_response_files.push_back(entry.ocsp_path);
             }
         }
 
-        chains.push_back(iso15118::config::ChainConfig{
-            std::move(path_chain), chain.key, chain.password, std::move(ocsp_response_files),
-            chain.certificate_root, // trust_anchor_pem (inline PEM of the chain's V2G root)
-        });
+        if (not chain.certificate_root.has_value()) {
+            EVLOG_warning << "Certificate chain (key: " << chain.key
+                          << ") has no certificate_root; it will be excluded from TLS 1.3 certificate_authorities / "
+                             "trusted_ca_keys selection";
+        }
+
+        iso15118::config::ChainConfig chain_config{};
+        chain_config.path_certificate_chain = std::move(path_chain);
+        chain_config.path_certificate_key = chain.key;
+        chain_config.private_key_password = chain.password;
+        chain_config.ocsp_response_files = std::move(ocsp_response_files);
+        chain_config.trust_anchor_pem = chain.certificate_root; // inline PEM of the chain's V2G root
+        chains.push_back(std::move(chain_config));
     }
 
     if (chains.empty()) {

--- a/modules/EVSE/Evse15118D20/charger/evse_security_chain_mapper.cpp
+++ b/modules/EVSE/Evse15118D20/charger/evse_security_chain_mapper.cpp
@@ -85,34 +85,36 @@ CertUpdateAction decide_certificate_store_update(const iso15118::config::SSLConf
     return refreshed.chains.empty() ? CertUpdateAction::PreserveLastGood : CertUpdateAction::Apply;
 }
 
+void resync_ssl_config(const std::function<iso15118::config::SSLConfig()>& rebuild,
+                       const std::function<void(iso15118::config::SSLConfig)>& apply) {
+    try {
+        auto refreshed = rebuild();
+        switch (decide_certificate_store_update(refreshed)) {
+        case CertUpdateAction::PreserveLastGood:
+            EVLOG_error << "SSL config refresh produced no usable V2G certificate chains; "
+                           "preserving last-good SSL config";
+            return;
+        case CertUpdateAction::Apply:
+            EVLOG_info << "SSL config refresh: applying SSL config with " << refreshed.chains.size() << " chain(s)";
+            apply(std::move(refreshed));
+            return;
+        }
+    } catch (const Everest::CmdTimeout& e) {
+        EVLOG_error << "SSL config refresh: evse_security RPC timed out; keeping last-good SSL config. "
+                       "New V2G certificates will NOT be served until the next refresh: "
+                    << e.what();
+    } catch (const std::exception& e) {
+        EVLOG_error << "SSL config refresh failed; keeping last-good SSL config: " << e.what();
+    }
+}
+
 void handle_certificate_store_update(const types::evse_security::CertificateStoreUpdate& event,
                                      const std::function<iso15118::config::SSLConfig()>& rebuild,
                                      const std::function<void(iso15118::config::SSLConfig)>& apply) {
     if (not is_relevant_certificate_store_update(event)) {
         return;
     }
-
-    try {
-        auto refreshed = rebuild();
-        switch (decide_certificate_store_update(refreshed)) {
-        case CertUpdateAction::PreserveLastGood:
-            EVLOG_error << "certificate_store_update produced no usable V2G certificate chains; "
-                           "preserving last-good SSL config";
-            return;
-        case CertUpdateAction::Apply:
-            EVLOG_info << "certificate_store_update: applying SSL config with " << refreshed.chains.size()
-                       << " chain(s)";
-            apply(std::move(refreshed));
-            return;
-        }
-    } catch (const Everest::CmdTimeout& e) {
-        EVLOG_error << "certificate_store_update: evse_security RPC timed out; keeping last-good SSL config. "
-                       "New V2G certificates will NOT be served until the next store update: "
-                    << e.what();
-    } catch (const std::exception& e) {
-        EVLOG_error << "certificate_store_update: SSL config refresh failed; keeping last-good SSL config: "
-                    << e.what();
-    }
+    resync_ssl_config(rebuild, apply);
 }
 
 StartupChainPolicy decide_startup_empty_chains(iso15118::config::TlsNegotiationStrategy strategy) {

--- a/modules/EVSE/Evse15118D20/charger/evse_security_chain_mapper.hpp
+++ b/modules/EVSE/Evse15118D20/charger/evse_security_chain_mapper.hpp
@@ -17,7 +17,8 @@ namespace module::charger {
 ///  - path_certificate_chain: chain.certificate when set, else chain.certificate_single
 ///  - path_certificate_key: chain.key
 ///  - private_key_password: chain.password
-///  - ocsp_response_files: collected from chain.ocsp[].ocsp_path (entries without ocsp_path are skipped)
+///  - ocsp_response_files: one entry per chain.ocsp[] entry in chain order, forwarding ocsp_path
+///    verbatim (std::nullopt is preserved, marking "no OCSP staple for this position")
 ///  - trust_anchor_pem: chain.certificate_root (the self-signed V2G root PEM that issued this leaf;
 ///    drives TLS 1.3 / trusted_ca_keys chain selection)
 ///

--- a/modules/EVSE/Evse15118D20/charger/evse_security_chain_mapper.hpp
+++ b/modules/EVSE/Evse15118D20/charger/evse_security_chain_mapper.hpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include <generated/types/evse_security.hpp>
+#include <iso15118/config.hpp>
+
+namespace module::charger {
+
+/// \brief Maps the multi-chain result of evse_security::get_all_valid_certificates_info into a
+/// vector of iso15118::config::ChainConfig — one ChainConfig per accepted CertificateInfo.
+///
+/// Each accepted CertificateInfo is mapped to one ChainConfig:
+///  - path_certificate_chain: chain.certificate when set, else chain.certificate_single
+///  - path_certificate_key: chain.key
+///  - private_key_password: chain.password
+///  - ocsp_response_files: collected from chain.ocsp[].ocsp_path (entries without ocsp_path are skipped)
+///  - trust_anchor_pem: chain.certificate_root (the self-signed V2G root PEM that issued this leaf;
+///    drives TLS 1.3 / trusted_ca_keys chain selection)
+///
+/// Returns an empty vector when:
+///  - the result status is not Accepted, or
+///  - the info vector is empty, or
+///  - no usable chain entries remain after filtering (entries lacking both `certificate`
+///    and `certificate_single` are skipped).
+///
+/// Trust-anchor paths and module-level TLS flags are not this function's concern; the caller
+/// assembles those separately before forwarding to the controller.
+std::vector<iso15118::config::ChainConfig>
+map_valid_chains(const types::evse_security::GetCertificateFullInfoResult& result);
+
+/// \brief True when a certificate_store_update event affects the V2G SSL config:
+/// a V2G leaf event, or a V2G/MO CA event. False otherwise (incl. an event carrying
+/// neither leaf nor CA type). Cheap gate evaluated before any evse_security RPC.
+bool is_relevant_certificate_store_update(const types::evse_security::CertificateStoreUpdate& event);
+
+/// \brief What to do with a freshly rebuilt SSL config after a relevant store update.
+enum class CertUpdateAction {
+    PreserveLastGood, //!< rebuild produced no usable chains; keep the controller's current config
+    Apply,            //!< rebuild has at least one chain; push it to the controller
+};
+
+/// \brief Decide whether to apply a rebuilt SSL config or preserve the last-good one.
+CertUpdateAction decide_certificate_store_update(const iso15118::config::SSLConfig& refreshed);
+
+} // namespace module::charger

--- a/modules/EVSE/Evse15118D20/charger/evse_security_chain_mapper.hpp
+++ b/modules/EVSE/Evse15118D20/charger/evse_security_chain_mapper.hpp
@@ -2,6 +2,7 @@
 // Copyright Pionix GmbH and Contributors to EVerest
 #pragma once
 
+#include <functional>
 #include <optional>
 #include <string>
 
@@ -46,5 +47,25 @@ enum class CertUpdateAction {
 
 /// \brief Decide whether to apply a rebuilt SSL config or preserve the last-good one.
 CertUpdateAction decide_certificate_store_update(const iso15118::config::SSLConfig& refreshed);
+
+/// \brief Handles a certificate_store_update event: gates on
+/// is_relevant_certificate_store_update(), rebuilds the SSLConfig via \p rebuild, then either
+/// forwards it via \p apply or preserves the last-good config when the rebuild yields no chains.
+/// All exceptions thrown by \p rebuild (incl. Everest::CmdTimeout from the evse_security RPC)
+/// are caught and logged; nothing escapes, so the framework subscriber thread survives RPC
+/// failures.
+void handle_certificate_store_update(const types::evse_security::CertificateStoreUpdate& event,
+                                     const std::function<iso15118::config::SSLConfig()>& rebuild,
+                                     const std::function<void(iso15118::config::SSLConfig)>& apply);
+
+/// \brief What ready() must do when the initial SSL config carries no usable chains.
+enum class StartupChainPolicy {
+    Throw,           //!< refuse to start: TLS is mandatory but cannot be served
+    WarnAndContinue, //!< start anyway; TLS connection attempts fail until certificates arrive
+};
+
+/// \brief Startup policy for an empty chain list: ENFORCE_TLS demands a usable chain (Throw);
+/// every other negotiation strategy can operate without TLS (WarnAndContinue).
+StartupChainPolicy decide_startup_empty_chains(iso15118::config::TlsNegotiationStrategy strategy);
 
 } // namespace module::charger

--- a/modules/EVSE/Evse15118D20/charger/evse_security_chain_mapper.hpp
+++ b/modules/EVSE/Evse15118D20/charger/evse_security_chain_mapper.hpp
@@ -48,12 +48,17 @@ enum class CertUpdateAction {
 /// \brief Decide whether to apply a rebuilt SSL config or preserve the last-good one.
 CertUpdateAction decide_certificate_store_update(const iso15118::config::SSLConfig& refreshed);
 
+/// \brief Rebuild the SSLConfig via \p rebuild and either forward it via \p apply or preserve
+/// the last-good config when the rebuild yields no chains. All exceptions thrown by \p rebuild
+/// (incl. Everest::CmdTimeout from the evse_security RPC) are caught and logged; nothing escapes,
+/// so the caller's thread survives RPC failures. Applying a config identical to the current one is
+/// harmless (apply is a single atomic write), so this is safe to invoke as a one-shot re-sync to
+/// close the startup window between the initial config build and store-update subscription.
+void resync_ssl_config(const std::function<iso15118::config::SSLConfig()>& rebuild,
+                       const std::function<void(iso15118::config::SSLConfig)>& apply);
+
 /// \brief Handles a certificate_store_update event: gates on
-/// is_relevant_certificate_store_update(), rebuilds the SSLConfig via \p rebuild, then either
-/// forwards it via \p apply or preserves the last-good config when the rebuild yields no chains.
-/// All exceptions thrown by \p rebuild (incl. Everest::CmdTimeout from the evse_security RPC)
-/// are caught and logged; nothing escapes, so the framework subscriber thread survives RPC
-/// failures.
+/// is_relevant_certificate_store_update(), then delegates to resync_ssl_config().
 void handle_certificate_store_update(const types::evse_security::CertificateStoreUpdate& event,
                                      const std::function<iso15118::config::SSLConfig()>& rebuild,
                                      const std::function<void(iso15118::config::SSLConfig)>& apply);

--- a/modules/EVSE/Evse15118D20/manifest.yaml
+++ b/modules/EVSE/Evse15118D20/manifest.yaml
@@ -22,7 +22,11 @@ config:
       - ENFORCE_NO_TLS
     default: ACCEPT_CLIENT_OFFER  
   enforce_tls_1_3:
-    description: Enforcing tls version 1.3. Only applies if tls_negotiation_strategy is ENFORCE_TLS.
+    description: >-
+      Enforcing tls version 1.3. Only applies if tls_negotiation_strategy is ENFORCE_TLS.
+      Multi-chain selection works on both TLS 1.2 (driven by the trusted_ca_keys extension)
+      and TLS 1.3 (driven by the native certificate_authorities extension), so multiple V2G
+      leaf chains can be installed concurrently regardless of this flag.
     type: boolean
     default: false
   enable_ssl_logging:

--- a/modules/EVSE/Evse15118D20/tests/CMakeLists.txt
+++ b/modules/EVSE/Evse15118D20/tests/CMakeLists.txt
@@ -33,3 +33,27 @@ target_link_libraries(${TEST_TARGET_NAME} PRIVATE
 
 add_test(${TEST_TARGET_NAME} ${TEST_TARGET_NAME})
 ev_register_test_target(${TEST_TARGET_NAME})
+
+set(TEST_TARGET_NAME ${PROJECT_NAME}_evse15118d20_evse_security_chain_mapper_test)
+
+set(MODULE_DIR
+    "${PROJECT_SOURCE_DIR}/modules/EVSE/Evse15118D20")
+
+add_executable(${TEST_TARGET_NAME}
+    evse_security_chain_mapper_test.cpp
+    ${MODULE_DIR}/charger/evse_security_chain_mapper.cpp
+)
+
+target_include_directories(${TEST_TARGET_NAME} PRIVATE
+    ${MODULE_DIR}
+    ${GENERATED_INCLUDE_DIR}
+)
+
+target_link_libraries(${TEST_TARGET_NAME} PRIVATE
+    GTest::gtest_main
+    iso15118::iso15118
+    everest::framework
+)
+
+add_test(${TEST_TARGET_NAME} ${TEST_TARGET_NAME})
+ev_register_test_target(${TEST_TARGET_NAME})

--- a/modules/EVSE/Evse15118D20/tests/evse_security_chain_mapper_test.cpp
+++ b/modules/EVSE/Evse15118D20/tests/evse_security_chain_mapper_test.cpp
@@ -280,6 +280,42 @@ TEST(HandleCertStoreUpdate, CmdTimeoutFromRebuildIsSwallowedAndApplyNotCalled) {
     EXPECT_FALSE(apply_called);
 }
 
+TEST(ResyncSslConfig, PicksUpChainInstalledAfterInitialBuild) {
+    // Startup window: ready() built the initial config, then a V2G certificate
+    // install completed before the store-update subscription was registered. The
+    // one-shot re-sync must rebuild and serve the newly installed chain.
+    auto newly_installed = make_single_chain_config();
+    newly_installed.chains[0].path_certificate_chain = "/tmp/iso/installed-during-boot/chain.pem";
+
+    int apply_count = 0;
+    iso15118::config::SSLConfig applied{};
+
+    module::charger::resync_ssl_config([&]() { return newly_installed; },
+                                       [&](iso15118::config::SSLConfig cfg) {
+                                           ++apply_count;
+                                           applied = std::move(cfg);
+                                       });
+
+    ASSERT_EQ(apply_count, 1);
+    ASSERT_EQ(applied.chains.size(), 1u);
+    EXPECT_EQ(applied.chains[0].path_certificate_chain, "/tmp/iso/installed-during-boot/chain.pem");
+}
+
+TEST(ResyncSslConfig, EmptyRebuildPreservesLastGood) {
+    bool apply_called = false;
+    module::charger::resync_ssl_config([&]() -> iso15118::config::SSLConfig { return {}; },
+                                       [&](iso15118::config::SSLConfig) { apply_called = true; });
+    EXPECT_FALSE(apply_called);
+}
+
+TEST(ResyncSslConfig, CmdTimeoutFromRebuildIsSwallowedAndApplyNotCalled) {
+    bool apply_called = false;
+    EXPECT_NO_THROW(module::charger::resync_ssl_config(
+        [&]() -> iso15118::config::SSLConfig { throw Everest::CmdTimeout("evse_security RPC timed out"); },
+        [&](iso15118::config::SSLConfig) { apply_called = true; }));
+    EXPECT_FALSE(apply_called);
+}
+
 TEST(StartupEmptyChains, EnforceTlsThrows) {
     EXPECT_EQ(module::charger::decide_startup_empty_chains(iso15118::config::TlsNegotiationStrategy::ENFORCE_TLS),
               module::charger::StartupChainPolicy::Throw);

--- a/modules/EVSE/Evse15118D20/tests/evse_security_chain_mapper_test.cpp
+++ b/modules/EVSE/Evse15118D20/tests/evse_security_chain_mapper_test.cpp
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+// Unit tests for the pure helpers in evse_security_chain_mapper (module::charger):
+//
+//  - map_valid_chains: maps the multi-chain result of
+//    evse_security::get_all_valid_certificates_info into a
+//    std::vector<iso15118::config::ChainConfig> (one ChainConfig per accepted
+//    CertificateInfo), including propagation of certificate_root into the
+//    trust_anchor_pem field.
+//  - is_relevant_certificate_store_update: the cheap relevance predicate that
+//    gates whether a certificate_store_update event affects the V2G SSL config.
+//  - decide_certificate_store_update: the apply/preserve decision applied to a
+//    freshly rebuilt SSL config.
+//
+// Trust-anchor roots and module-level TLS flags are assembled elsewhere; these
+// helpers are concerned only with the per-chain mapping and the store-update
+// gating/decision. The end-to-end TLS handshake assertions (peer-CA-driven chain
+// selection, OCSP staple delivery) are covered at the libeverest-tls layer in
+// lib/everest/tls/tests; here we only verify the helper shapes.
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <generated/types/evse_security.hpp>
+
+#include <iso15118/config.hpp>
+
+#include "../charger/evse_security_chain_mapper.hpp"
+
+namespace {
+
+using types::evse_security::CertificateInfo;
+using types::evse_security::GetCertificateFullInfoResult;
+using types::evse_security::GetCertificateInfoStatus;
+
+CertificateInfo make_cert_info(const std::string& chain_path, const std::string& key_path,
+                               std::optional<std::string> password = std::nullopt) {
+    CertificateInfo info{};
+    info.key = key_path;
+    info.certificate_count = 2;
+    info.certificate = chain_path;
+    info.password = std::move(password);
+    return info;
+}
+
+} // namespace
+
+TEST(MapValidChains, MultiChainMappingProducesOneChainPerCertificateInfo) {
+    GetCertificateFullInfoResult certs{};
+    certs.status = GetCertificateInfoStatus::Accepted;
+    certs.info.push_back(make_cert_info("/tmp/iso/a/chain.pem", "/tmp/iso/a/key.pem"));
+    certs.info.push_back(make_cert_info("/tmp/iso/b/chain.pem", "/tmp/iso/b/key.pem", std::string{"secret-b"}));
+
+    auto chains = module::charger::map_valid_chains(certs);
+
+    ASSERT_EQ(chains.size(), 2u);
+
+    EXPECT_EQ(chains[0].path_certificate_chain, "/tmp/iso/a/chain.pem");
+    EXPECT_EQ(chains[0].path_certificate_key, "/tmp/iso/a/key.pem");
+    EXPECT_FALSE(chains[0].private_key_password.has_value());
+
+    EXPECT_EQ(chains[1].path_certificate_chain, "/tmp/iso/b/chain.pem");
+    EXPECT_EQ(chains[1].path_certificate_key, "/tmp/iso/b/key.pem");
+    ASSERT_TRUE(chains[1].private_key_password.has_value());
+    EXPECT_EQ(*chains[1].private_key_password, "secret-b");
+}
+
+TEST(MapValidChains, EmptyInfoReturnsEmptyVector) {
+    GetCertificateFullInfoResult certs{};
+    certs.status = GetCertificateInfoStatus::Accepted;
+    // info is intentionally empty
+
+    EXPECT_TRUE(module::charger::map_valid_chains(certs).empty());
+}
+
+TEST(MapValidChains, NonAcceptedStatusReturnsEmptyVector) {
+    GetCertificateFullInfoResult certs{};
+    certs.status = GetCertificateInfoStatus::NotFoundValid;
+    certs.info.push_back(make_cert_info("/tmp/iso/a/chain.pem", "/tmp/iso/a/key.pem"));
+
+    EXPECT_TRUE(module::charger::map_valid_chains(certs).empty());
+}
+
+TEST(MapValidChains, CertificateSingleIsUsedWhenCertificateAbsent) {
+    GetCertificateFullInfoResult certs{};
+    certs.status = GetCertificateInfoStatus::Accepted;
+
+    CertificateInfo info{};
+    info.key = "/tmp/iso/single/key.pem";
+    info.certificate_count = 1;
+    info.certificate_single = "/tmp/iso/single/leaf.pem";
+    certs.info.push_back(std::move(info));
+
+    auto chains = module::charger::map_valid_chains(certs);
+
+    ASSERT_EQ(chains.size(), 1u);
+    EXPECT_EQ(chains[0].path_certificate_chain, "/tmp/iso/single/leaf.pem");
+    EXPECT_EQ(chains[0].path_certificate_key, "/tmp/iso/single/key.pem");
+}
+
+TEST(MapValidChains, CertificateInfoWithoutAnyCertPathIsSkipped) {
+    GetCertificateFullInfoResult certs{};
+    certs.status = GetCertificateInfoStatus::Accepted;
+
+    CertificateInfo bad{};
+    bad.key = "/tmp/iso/bad/key.pem";
+    bad.certificate_count = 0;
+    // neither certificate nor certificate_single set
+    certs.info.push_back(std::move(bad));
+
+    certs.info.push_back(make_cert_info("/tmp/iso/good/chain.pem", "/tmp/iso/good/key.pem"));
+
+    auto chains = module::charger::map_valid_chains(certs);
+
+    ASSERT_EQ(chains.size(), 1u);
+    EXPECT_EQ(chains[0].path_certificate_chain, "/tmp/iso/good/chain.pem");
+}
+
+TEST(MapValidChains, PropagatesCertificateRootToTrustAnchorPem) {
+    types::evse_security::GetCertificateFullInfoResult certs{};
+    certs.status = types::evse_security::GetCertificateInfoStatus::Accepted;
+    types::evse_security::CertificateInfo info{};
+    info.certificate = "/tmp/iso/a/chain.pem";
+    info.key = "/tmp/iso/a/key.pem";
+    info.certificate_count = 2;
+    info.certificate_root = "----ROOT A PEM----";
+    certs.info.push_back(info);
+
+    const auto chains = module::charger::map_valid_chains(certs);
+    ASSERT_EQ(chains.size(), 1u);
+    ASSERT_TRUE(chains[0].trust_anchor_pem.has_value());
+    EXPECT_EQ(chains[0].trust_anchor_pem.value(), "----ROOT A PEM----");
+}
+
+TEST(CertStoreUpdateFilter, RelevantForV2gLeaf) {
+    types::evse_security::CertificateStoreUpdate ev{};
+    ev.leaf_certificate_type = types::evse_security::LeafCertificateType::V2G;
+    EXPECT_TRUE(module::charger::is_relevant_certificate_store_update(ev));
+}
+TEST(CertStoreUpdateFilter, RelevantForV2gAndMoCa) {
+    types::evse_security::CertificateStoreUpdate v2g{};
+    v2g.ca_certificate_type = types::evse_security::CaCertificateType::V2G;
+    EXPECT_TRUE(module::charger::is_relevant_certificate_store_update(v2g));
+    types::evse_security::CertificateStoreUpdate mo{};
+    mo.ca_certificate_type = types::evse_security::CaCertificateType::MO;
+    EXPECT_TRUE(module::charger::is_relevant_certificate_store_update(mo));
+}
+TEST(CertStoreUpdateFilter, IrrelevantForNonV2gAndEmpty) {
+    types::evse_security::CertificateStoreUpdate non_v2g_leaf{};
+    non_v2g_leaf.leaf_certificate_type = types::evse_security::LeafCertificateType::CSMS;
+    EXPECT_FALSE(module::charger::is_relevant_certificate_store_update(non_v2g_leaf));
+    types::evse_security::CertificateStoreUpdate other_ca{};
+    other_ca.ca_certificate_type = types::evse_security::CaCertificateType::CSMS;
+    EXPECT_FALSE(module::charger::is_relevant_certificate_store_update(other_ca));
+    types::evse_security::CertificateStoreUpdate empty{};
+    EXPECT_FALSE(module::charger::is_relevant_certificate_store_update(empty));
+}
+
+TEST(CertUpdateDecision, ApplyWhenChainsPresent) {
+    iso15118::config::SSLConfig cfg{};
+    cfg.chains.push_back(iso15118::config::ChainConfig{});
+    EXPECT_EQ(module::charger::decide_certificate_store_update(cfg), module::charger::CertUpdateAction::Apply);
+}
+TEST(CertUpdateDecision, PreserveWhenChainsEmpty) {
+    iso15118::config::SSLConfig cfg{};
+    EXPECT_EQ(module::charger::decide_certificate_store_update(cfg),
+              module::charger::CertUpdateAction::PreserveLastGood);
+}

--- a/modules/EVSE/Evse15118D20/tests/evse_security_chain_mapper_test.cpp
+++ b/modules/EVSE/Evse15118D20/tests/evse_security_chain_mapper_test.cpp
@@ -1,31 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
 
-// Unit tests for the pure helpers in evse_security_chain_mapper (module::charger):
-//
-//  - map_valid_chains: maps the multi-chain result of
-//    evse_security::get_all_valid_certificates_info into a
-//    std::vector<iso15118::config::ChainConfig> (one ChainConfig per accepted
-//    CertificateInfo), including propagation of certificate_root into the
-//    trust_anchor_pem field.
-//  - is_relevant_certificate_store_update: the cheap relevance predicate that
-//    gates whether a certificate_store_update event affects the V2G SSL config.
-//  - decide_certificate_store_update: the apply/preserve decision applied to a
-//    freshly rebuilt SSL config.
-//
-// Trust-anchor roots and module-level TLS flags are assembled elsewhere; these
-// helpers are concerned only with the per-chain mapping and the store-update
-// gating/decision. The end-to-end TLS handshake assertions (peer-CA-driven chain
-// selection, OCSP staple delivery) are covered at the libeverest-tls layer in
+// The end-to-end TLS handshake assertions (peer-CA-driven chain selection,
+// OCSP staple delivery) are covered at the libeverest-tls layer in
 // lib/everest/tls/tests; here we only verify the helper shapes.
 
 #include <gtest/gtest.h>
 
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <generated/types/evse_security.hpp>
+#include <utils/exceptions.hpp>
 
 #include <iso15118/config.hpp>
 
@@ -217,4 +205,90 @@ TEST(CertUpdateDecision, PreserveWhenChainsEmpty) {
     iso15118::config::SSLConfig cfg{};
     EXPECT_EQ(module::charger::decide_certificate_store_update(cfg),
               module::charger::CertUpdateAction::PreserveLastGood);
+}
+
+namespace {
+
+types::evse_security::CertificateStoreUpdate make_relevant_event() {
+    types::evse_security::CertificateStoreUpdate event{};
+    event.leaf_certificate_type = types::evse_security::LeafCertificateType::V2G;
+    return event;
+}
+
+iso15118::config::SSLConfig make_single_chain_config() {
+    iso15118::config::SSLConfig cfg{};
+    iso15118::config::ChainConfig chain{};
+    chain.path_certificate_chain = "/tmp/iso/a/chain.pem";
+    chain.path_certificate_key = "/tmp/iso/a/key.pem";
+    cfg.chains.push_back(std::move(chain));
+    return cfg;
+}
+
+} // namespace
+
+TEST(HandleCertStoreUpdate, IrrelevantEventCallsNeitherRebuildNorApply) {
+    const types::evse_security::CertificateStoreUpdate irrelevant{};
+    bool rebuild_called = false;
+    bool apply_called = false;
+
+    module::charger::handle_certificate_store_update(
+        irrelevant,
+        [&]() -> iso15118::config::SSLConfig {
+            rebuild_called = true;
+            return {};
+        },
+        [&](iso15118::config::SSLConfig) { apply_called = true; });
+
+    EXPECT_FALSE(rebuild_called);
+    EXPECT_FALSE(apply_called);
+}
+
+TEST(HandleCertStoreUpdate, RelevantEventWithChainsAppliesRebuiltConfigOnce) {
+    const auto rebuilt = make_single_chain_config();
+    int apply_count = 0;
+    iso15118::config::SSLConfig applied{};
+
+    module::charger::handle_certificate_store_update(
+        make_relevant_event(), [&]() { return rebuilt; },
+        [&](iso15118::config::SSLConfig cfg) {
+            ++apply_count;
+            applied = std::move(cfg);
+        });
+
+    EXPECT_EQ(apply_count, 1);
+    EXPECT_EQ(applied, rebuilt);
+}
+
+TEST(HandleCertStoreUpdate, RelevantEventWithEmptyRebuildPreservesLastGood) {
+    bool apply_called = false;
+
+    module::charger::handle_certificate_store_update(
+        make_relevant_event(), [&]() -> iso15118::config::SSLConfig { return {}; },
+        [&](iso15118::config::SSLConfig) { apply_called = true; });
+
+    EXPECT_FALSE(apply_called);
+}
+
+TEST(HandleCertStoreUpdate, CmdTimeoutFromRebuildIsSwallowedAndApplyNotCalled) {
+    bool apply_called = false;
+
+    EXPECT_NO_THROW(module::charger::handle_certificate_store_update(
+        make_relevant_event(),
+        [&]() -> iso15118::config::SSLConfig { throw Everest::CmdTimeout("evse_security RPC timed out"); },
+        [&](iso15118::config::SSLConfig) { apply_called = true; }));
+
+    EXPECT_FALSE(apply_called);
+}
+
+TEST(StartupEmptyChains, EnforceTlsThrows) {
+    EXPECT_EQ(module::charger::decide_startup_empty_chains(iso15118::config::TlsNegotiationStrategy::ENFORCE_TLS),
+              module::charger::StartupChainPolicy::Throw);
+}
+
+TEST(StartupEmptyChains, NonEnforcingStrategiesWarnAndContinue) {
+    EXPECT_EQ(
+        module::charger::decide_startup_empty_chains(iso15118::config::TlsNegotiationStrategy::ACCEPT_CLIENT_OFFER),
+        module::charger::StartupChainPolicy::WarnAndContinue);
+    EXPECT_EQ(module::charger::decide_startup_empty_chains(iso15118::config::TlsNegotiationStrategy::ENFORCE_NO_TLS),
+              module::charger::StartupChainPolicy::WarnAndContinue);
 }

--- a/modules/EVSE/Evse15118D20/tests/evse_security_chain_mapper_test.cpp
+++ b/modules/EVSE/Evse15118D20/tests/evse_security_chain_mapper_test.cpp
@@ -136,6 +136,54 @@ TEST(MapValidChains, PropagatesCertificateRootToTrustAnchorPem) {
     EXPECT_EQ(chains[0].trust_anchor_pem.value(), "----ROOT A PEM----");
 }
 
+TEST(MapValidChains, OcspEntriesPreserveChainOrderIncludingNullopt) {
+    using types::evse_security::CertificateOCSP;
+    using types::evse_security::HashAlgorithm;
+
+    GetCertificateFullInfoResult certs{};
+    certs.status = GetCertificateInfoStatus::Accepted;
+
+    auto info = make_cert_info("/tmp/iso/a/chain.pem", "/tmp/iso/a/key.pem");
+
+    types::evse_security::CertificateHashData hash{};
+    hash.hash_algorithm = HashAlgorithm::SHA256;
+
+    CertificateOCSP ocsp0{};
+    ocsp0.hash = hash;
+    ocsp0.ocsp_path = "/p0";
+    CertificateOCSP ocsp1{};
+    ocsp1.hash = hash;
+    ocsp1.ocsp_path = std::nullopt;
+    CertificateOCSP ocsp2{};
+    ocsp2.hash = hash;
+    ocsp2.ocsp_path = "/p2";
+    info.ocsp = std::vector<CertificateOCSP>{ocsp0, ocsp1, ocsp2};
+
+    certs.info.push_back(std::move(info));
+
+    const auto chains = module::charger::map_valid_chains(certs);
+
+    ASSERT_EQ(chains.size(), 1u);
+    const std::vector<std::optional<std::string>> expected{"/p0", std::nullopt, "/p2"};
+    EXPECT_EQ(chains[0].ocsp_response_files, expected);
+}
+
+TEST(MapValidChains, RootlessChainIsStillMapped) {
+    GetCertificateFullInfoResult certs{};
+    certs.status = GetCertificateInfoStatus::Accepted;
+    auto info = make_cert_info("/tmp/iso/a/chain.pem", "/tmp/iso/a/key.pem");
+    // certificate_root intentionally left nullopt: the chain cannot participate in
+    // TLS 1.3 certificate_authorities / trusted_ca_keys selection but is still
+    // usable as the default chain, so it must remain mapped (a warning is logged).
+    certs.info.push_back(std::move(info));
+
+    const auto chains = module::charger::map_valid_chains(certs);
+
+    ASSERT_EQ(chains.size(), 1u);
+    EXPECT_EQ(chains[0].path_certificate_chain, "/tmp/iso/a/chain.pem");
+    EXPECT_FALSE(chains[0].trust_anchor_pem.has_value());
+}
+
 TEST(CertStoreUpdateFilter, RelevantForV2gLeaf) {
     types::evse_security::CertificateStoreUpdate ev{};
     ev.leaf_certificate_type = types::evse_security::LeafCertificateType::V2G;


### PR DESCRIPTION
## Describe your changes

> **Stacked PR** — the stack is `refactor/tls-iso15118-adapter` (#2225) → `fix/iso15118-disconnect-teardown` (#2393) → this PR. #2225 lands the `ConnectionSSL` adapter + `Connection::last_error()` refactor this builds on; #2393 lands the iso15118 disconnect-teardown fixes. Review/merge them first. The GitHub base branch is still `refactor/tls-iso15118-adapter`, so the diff shown here includes #2393's commits until that PR merges; this PR's own changes are the TLS multi-chain + rotation work described below.

Enables **TLS 1.3 multi-chain certificate selection** and **live V2G certificate rotation** for the ISO 15118 SECC. A charger serving more than one V2G trust chain (e.g. `V2G_ROOT_CA` plus a grid-operator root) now presents the chain the connecting vehicle actually trusts, and picks up renewed/rotated leaf certificates without a process restart.

**Why:** the SECC previously always served `chains[0]` — the per-chain trust anchor never reached `tls::Server`, so its TLS 1.3 selection pool was permanently empty and multi-root deployments could fail the handshake against a vehicle that advertises a `certificate_authorities` list. Leaf rotation also required a module restart.

### libtls — TLS 1.3 chain selection

- `lib/everest/tls/extensions/trusted_ca_keys.{hpp,cpp}`: TLS 1.3 selection is driven by the peer's `certificate_authorities` extension via `select_by_dn_list()` (`SSL_get0_peer_CA_list`); the legacy custom `trusted_ca_keys` extension is scoped to TLS 1.2 and below.
- `handle_certificate_cb` branches on `SSL_version()` and both legs converge on a single `apply_selection_locked()` helper for the apply → fall-back-to-default → abort sequence. The lock requirement is structural: the helper takes a `std::lock_guard` witness, so it cannot be called without `m_mux` held.
- Failure semantics are explicit: when no configured chain matches the peer's advertised CAs the default chain is served and a warning names the decision; when the selected chain fails to apply, the server falls back to the default (logged with the failed chain's leaf subject) — unless the failed chain *is* the default, or no default chain is available at all, in which case the handshake aborts. The no-default abort matters because `use_certificate_and_key()` has already cleared the connection's certificates by that point — continuing would only reach an opaque OpenSSL error mid-handshake. Malformed peer DNs in the comparison are logged (capped at one line per selection, since the peer controls the list size).
- `lib/everest/tls/src/tls.cpp`: the SSL_CTX default certificate is now the **first chain that passed verification** in `init_certificates` (tracked as `m_default_chain_index`), not blindly `chains[0]` — so the no-match / no-extension fallback serves a chain clients can build a path for, and it agrees with the selection pool's `select_default()`. Skipping unusable leading chains is logged, as is the degenerate case where no chain verified at all.
- `init_certificates`: chains dropped at startup/rotation are now observable — a chain failing `verify_chain` logs its leaf subject, and a chain file yielding no certificates logs the file name.
- The libtls selection pool (in the refactor base this stacks on) admits a chain only when it carries a trust anchor — so populating the per-chain `trust_anchor_pem` from the iso15118 side is what activates TLS 1.3 selection.

### iso15118 library — per-chain trust anchor + thread-safe config

- `lib/everest/iso15118/include/iso15118/config.hpp`: `config::ChainConfig` gains `trust_anchor_pem` (the chain's self-signed root PEM). `ocsp_response_files` is now `std::vector<std::optional<std::string>>` — one entry per chain certificate in chain order, `std::nullopt` meaning "no OCSP staple at this position". This keeps the OCSP vector positionally aligned with the certificate chain (the evse_security producer emits placeholder entries; `tls::Server` requires equal sizes and pairs them by index), so a single certificate without OCSP data no longer silently disables stapling for the whole chain. Both `ChainConfig` and `SSLConfig` gain member-wise `operator==`.
- `lib/everest/iso15118/src/iso15118/io/ssl_config_builder.cpp` (declared in the install-excluded `include/iso15118/detail/io/ssl_config_builder.hpp`): `io::build_chain_configs` forwards `trust_anchor_pem` and each OCSP entry (`std::nullopt` → `tls::ConfigItem(nullptr)`) into `tls::Server::certificate_config_t`, so each chain enters the TLS 1.3 / `trusted_ca_keys` selection pool with its staples intact. Extracted from `connection_ssl.cpp` (which still calls it) into its own translation unit so it can be unit-tested.
- `lib/everest/iso15118/src/iso15118/tbd_controller.cpp`: `TbdController` holds the `SSLConfig` behind a monitor and exposes `set_ssl_config` + `ssl_config_snapshot` for thread-safe live updates. `connection_ssl_config()` is the single named seam every new secure connection reads its config from — rotation takes effect for the next incoming connection; established connections are unaffected. `TbdConfig::ssl` is documented as the initial value only.

### Evse15118D20 module — live rotation

- `modules/EVSE/Evse15118D20/charger/evse_security_chain_mapper.{hpp,cpp}`: `map_valid_chains` maps the multi-chain `GetCertificateFullInfoResult` into a fresh `SSLConfig`, forwarding each `CertificateInfo.certificate_root` into `trust_anchor_pem` (a chain without a root is still mapped — it can serve as the default — but logs that it is excluded from TLS 1.3 selection) and preserving OCSP entries verbatim in chain order. The rebuild-and-apply orchestration lives in a testable free function `resync_ssl_config(rebuild, apply)`: an empty rebuild preserves the last-good config, and **all** rebuild failures (`Everest::CmdTimeout` from the evse_security RPC, or any other exception) are caught and logged instead of escaping into the caller's thread — the SECC keeps serving its last-good certificates and retries on the next store update. `handle_certificate_store_update(event, rebuild, apply)` filters irrelevant events cheaply, then delegates to the same function.
- `modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.{hpp,cpp}`: subscribes to `evse_security.certificate_store_update`; on a relevant event it rebuilds the config and pushes it into `TbdController` without a module restart. Right after registering the subscription, `ready()` runs a one-shot `resync_ssl_config` to close the startup window — a V2G certificate install completing between the initial config build and the subscription registration would otherwise not be served until the next store update (re-applying an identical config is harmless: apply is a single atomic write). The handler reads `this->controller` under a null guard (the controller is created once in `ready()` and never reset). The startup decision for an empty chain list is a pure helper: `ENFORCE_TLS` throws, other negotiation strategies warn and continue.

### Verification

All unit suites pass on this branch (rebuilt clean; suites re-run after the last commit):

- `tls_test` — 134 cases pass. Selection/apply coverage: `TrustedCaKeys.selectByDnList*` ×7 (first-match-wins, null/empty DN list, multi-anchor chains), `ServerTrustedCaKeysApply` ×4 (clean apply, fallback-to-default on key/leaf mismatch, abort when the only chain fails, no-match keeps default — driven through `handle_certificate_cb` on a raw `SSL*`). E2E: `Tls13MultiChainCertificateAuthorities` (peer CA list picks the alt chain), `Tls13NoMatchServesDefault` (no matching chain still completes the handshake on the default chain), `Tls13NoMatchSkipsUnverifiedDefault` (an unverifiable `chains[0]` is skipped and the first verified chain is served as the default), `MixedVersionServerSelectsAltChain` (one server, TLS 1.2 `trusted_ca_keys` leg + TLS 1.3 `certificate_authorities` leg, negotiated version asserted on each).
- iso15118 unit suite — `build_chain_configs` ×3 (`ssl_config_builder_test`, incl. OCSP staple order + key-password forwarding) and `TbdController SSL config monitor` ×4 (rotation seam, snapshot isolation, concurrent reader/writer) all pass.
- `evse_security_chain_mapper_test` — 22/22 pass (`MapValidChains` ×8 incl. OCSP order/nullopt preservation and rootless chains, `CertStoreUpdateFilter` ×3, `CertUpdateDecision` ×2, `HandleCertStoreUpdate` ×4 incl. RPC-timeout survival, `ResyncSslConfig` ×3 incl. the startup-window re-sync, `StartupEmptyChains` ×2).
- Over-the-wire multi-chain selection is exercised by the libtls TLS 1.3 E2E tests; full SIL validation additionally needs an EVCC that advertises the `certificate_authorities` extension.

## Issue ticket number and link

_None tracked — TLS / ISO 15118 SECC feature work. Add a link here if there is an associated issue._

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
