### PR TITLE
Enable basic Pionix ChargeBridge telemetry

### DIFF
--- a/applications/pionix_chargebridge/CMakeLists.txt
+++ b/applications/pionix_chargebridge/CMakeLists.txt
@@ -24,10 +24,12 @@ add_executable(pionix_chargebridge
   src/utilities/logging.cpp
   src/utilities/parse_config.cpp
   src/utilities/print_config.cpp
+  src/utilities/print_status.cpp
   src/utilities/string.cpp
   src/utilities/symlink.cpp
   src/utilities/sync_udp_client.cpp
   src/utilities/type_converters.cpp
+  src/status_ui.cpp
 
   src/can_bridge.cpp
   src/charge_bridge.cpp

--- a/applications/pionix_chargebridge/config/config-CB-EVAL-EV.yaml
+++ b/applications/pionix_chargebridge/config/config-CB-EVAL-EV.yaml
@@ -11,7 +11,7 @@ heartbeat:
   connection_to_s: 10
 
 telemetry:
-  enable: false
+  enable: true
   mqtt_remote: "localhost"
   mqtt_port: 1883
   telemetry_topic: "pionix/chargebridge/telemetry"

--- a/applications/pionix_chargebridge/config/config-CB-EVAL-EV.yaml
+++ b/applications/pionix_chargebridge/config/config-CB-EVAL-EV.yaml
@@ -10,6 +10,12 @@ heartbeat:
   interval_s: 1
   connection_to_s: 10
 
+telemetry:
+  enable: false
+  mqtt_remote: "localhost"
+  mqtt_port: 1883
+  telemetry_topic: "pionix/chargebridge/telemetry"
+
 safety:
   pp_mode: "disabled"
   cp_avg_ms: 10

--- a/applications/pionix_chargebridge/config/config-CB-EVAL-SIM.yaml
+++ b/applications/pionix_chargebridge/config/config-CB-EVAL-SIM.yaml
@@ -10,6 +10,12 @@ heartbeat:
   interval_s: 1
   connection_to_s: 10
 
+telemetry:
+  enable: true
+  mqtt_remote: "localhost"
+  mqtt_port: 1883
+  telemetry_topic: "pionix/chargebridge/telemetry"
+
 safety:
   pp_mode: "disabled"
   cp_avg_ms: 10

--- a/applications/pionix_chargebridge/config/config-CB-EVAL.yaml
+++ b/applications/pionix_chargebridge/config/config-CB-EVAL.yaml
@@ -11,6 +11,12 @@ heartbeat:
   interval_s: 1
   connection_to_s: 10
 
+telemetry:
+  enable: false
+  mqtt_remote: "localhost"
+  mqtt_port: 1883
+  telemetry_topic: "pionix/chargebridge/telemetry"
+
 safety:
   pp_mode: "disabled"
   cp_avg_ms: 10

--- a/applications/pionix_chargebridge/config/config-CB-EVAL.yaml
+++ b/applications/pionix_chargebridge/config/config-CB-EVAL.yaml
@@ -12,7 +12,7 @@ heartbeat:
   connection_to_s: 10
 
 telemetry:
-  enable: false
+  enable: true
   mqtt_remote: "localhost"
   mqtt_port: 1883
   telemetry_topic: "pionix/chargebridge/telemetry"

--- a/applications/pionix_chargebridge/config/config-CB-SAT-AC.yaml
+++ b/applications/pionix_chargebridge/config/config-CB-SAT-AC.yaml
@@ -10,7 +10,7 @@ heartbeat:
   connection_to_s: 10
 
 telemetry:
-  enable: false
+  enable: true
   mqtt_remote: "localhost"
   mqtt_port: 1883
   telemetry_topic: "pionix/chargebridge/telemetry"

--- a/applications/pionix_chargebridge/config/config-CB-SAT-AC.yaml
+++ b/applications/pionix_chargebridge/config/config-CB-SAT-AC.yaml
@@ -9,6 +9,12 @@ heartbeat:
   interval_s: 1
   connection_to_s: 10
 
+telemetry:
+  enable: false
+  mqtt_remote: "localhost"
+  mqtt_port: 1883
+  telemetry_topic: "pionix/chargebridge/telemetry"
+
 safety:
   pp_mode: "disabled"
   cp_avg_ms: 10

--- a/applications/pionix_chargebridge/config/config-multi-bridge.yaml
+++ b/applications/pionix_chargebridge/config/config-multi-bridge.yaml
@@ -11,6 +11,12 @@ heartbeat:
   interval_s: 1
   connection_to_s: 10
 
+telemetry:
+  enable: false
+  mqtt_remote: "localhost"
+  mqtt_port: 1883
+  telemetry_topic: "pionix/chargebridge/telemetry"
+
 safety:
   pp_mode: "disabled"
   cp_avg_ms: 10

--- a/applications/pionix_chargebridge/config/config-multi-bridge.yaml
+++ b/applications/pionix_chargebridge/config/config-multi-bridge.yaml
@@ -12,7 +12,7 @@ heartbeat:
   connection_to_s: 10
 
 telemetry:
-  enable: false
+  enable: true
   mqtt_remote: "localhost"
   mqtt_port: 1883
   telemetry_topic: "pionix/chargebridge/telemetry"

--- a/applications/pionix_chargebridge/include/charge_bridge/bsp_bridge.hpp
+++ b/applications/pionix_chargebridge/include/charge_bridge/bsp_bridge.hpp
@@ -5,7 +5,9 @@
 #include <charge_bridge/everest_api/api_connector.hpp>
 #include <everest/io/event/fd_event_register_interface.hpp>
 #include <everest/io/udp/udp_client.hpp>
+#include <everest/util/misc/observable.hpp>
 #include <everest_api_types/evse_board_support/API.hpp>
+#include <memory>
 
 namespace charge_bridge {
 
@@ -19,19 +21,31 @@ struct bsp_bridge_config {
 
 class bsp_bridge : public everest::lib::io::event::fd_event_register_interface {
 public:
-    bsp_bridge(bsp_bridge_config const& config);
+    bsp_bridge(bsp_bridge_config const& config, everest::lib::io::event::event_fd& ready_notify);
     ~bsp_bridge() = default;
 
     bool register_events(everest::lib::io::event::fd_event_handler& handler) override;
     bool unregister_events(everest::lib::io::event::fd_event_handler& handler) override;
+    void disconnect_cb_endpoint();
+    void connect_cb_endpoint(std::string const& remote);
+    bool available() const;
 
 private:
     void handle_timer_event();
+    void handle_status();
+    void create_udp_client(std::string const& remote, uint16_t remote_port, std::string const& identifier);
+    bool m_api_good{false};
 
     evse_bsp::api_connector m_api;
-    everest::lib::io::udp::udp_client m_udp;
+    std::unique_ptr<everest::lib::io::udp::udp_client> m_udp;
+    std::string m_identifier;
+    bool m_udp_ready{false};
+    std::uint16_t m_udp_port{0};
+    std::string m_udp_remote;
     everest::lib::io::event::timer_fd m_timer;
     bool m_udp_on_error{false};
+    everest::lib::util::observable<bool> m_ready{false};
+    everest::lib::io::event::event_fd& m_ready_notify;
 };
 
 } // namespace charge_bridge

--- a/applications/pionix_chargebridge/include/charge_bridge/can_bridge.hpp
+++ b/applications/pionix_chargebridge/include/charge_bridge/can_bridge.hpp
@@ -2,12 +2,14 @@
 // Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
 #pragma once
 
+#include "everest/io/event/event_fd.hpp"
 #include <chrono>
 #include <everest/io/can/can_payload.hpp>
 #include <everest/io/can/socket_can.hpp>
 #include <everest/io/event/fd_event_register_interface.hpp>
 #include <everest/io/event/timer_fd.hpp>
 #include <everest/io/udp/udp_client.hpp>
+#include <everest/util/misc/observable.hpp>
 #include <memory>
 
 extern "C" struct cb_can_message;
@@ -24,22 +26,34 @@ struct can_bridge_config {
 
 class can_bridge : public everest::lib::io::event::fd_event_register_interface {
 public:
-    can_bridge(can_bridge_config const& config);
+    can_bridge(can_bridge_config const& config, everest::lib::io::event::event_fd& ready_notify);
     ~can_bridge();
 
     bool register_events(everest::lib::io::event::fd_event_handler& handler) override;
     bool unregister_events(everest::lib::io::event::fd_event_handler& handler) override;
+    void disconnect_cb_endpoint();
+    void connect_cb_endpoint(std::string const& remote);
+    bool available() const;
+    void set_cb_connection_status(bool connected);
 
 private:
-    void handle_error_timer();
     void handle_heartbeat_timer();
+    void handle_ready();
+    void create_udp_client(std::string const& remote, uint16_t remote_port);
     void send_can_to_udp(cb_can_message const& pl);
     std::unique_ptr<everest::lib::io::can::socket_can> m_can;
-    everest::lib::io::udp::udp_client m_udp;
+    std::unique_ptr<everest::lib::io::udp::udp_client> m_udp;
+    uint16_t m_cb_port{0};
+    std::string m_cb_remote;
     std::string m_can_device;
     std::string m_identifier;
     everest::lib::io::event::timer_fd m_heartbeat_timer;
     std::chrono::steady_clock::time_point m_last_msg_to_cb;
+    bool m_udp_ready{false};
+    bool m_can_ready{false};
+    everest::lib::util::observable<bool> m_ready{false};
+    everest::lib::io::event::event_fd& m_ready_notify;
+    everest::lib::util::observable<bool> m_cb_is_connected{false};
 };
 
 } // namespace charge_bridge

--- a/applications/pionix_chargebridge/include/charge_bridge/charge_bridge.hpp
+++ b/applications/pionix_chargebridge/include/charge_bridge/charge_bridge.hpp
@@ -2,6 +2,7 @@
 // Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 #pragma once
 
+#include "everest/io/event/timer_fd.hpp"
 #include <atomic>
 #include <charge_bridge/bsp_bridge.hpp>
 #include <charge_bridge/can_bridge.hpp>
@@ -11,14 +12,20 @@
 #include <charge_bridge/heartbeat_service.hpp>
 #include <charge_bridge/plc_bridge.hpp>
 #include <charge_bridge/serial_bridge.hpp>
+#include <charge_bridge/utilities/print_status.hpp>
 #include <charge_bridge/utilities/symlink.hpp>
 #include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/mqtt/mosquitto_cpp.hpp>
 #include <everest/io/serial/event_pty.hpp>
 #include <everest/io/tun_tap/tap_client.hpp>
 #include <everest/util/async/monitor.hpp>
 
+#include <functional>
+#include <future>
 #include <memory>
 #include <optional>
+#include <set>
+#include <thread>
 
 namespace charge_bridge {
 
@@ -27,10 +34,21 @@ struct charge_bridge_status {
     bool discovery_pending{false};
 };
 
+struct telemetry_config {
+    std::string cb;
+    std::string item;
+    std::string mqtt_remote;
+    std::string mqtt_bind;
+    std::uint32_t mqtt_ping_interval_ms;
+    std::uint16_t mqtt_port;
+    std::string telemetry_topic;
+};
+
 struct charge_bridge_config {
     std::string cb_name;
     std::uint16_t cb_port;
     std::string cb_remote;
+    std::optional<telemetry_config> telemetry;
     std::optional<can_bridge_config> can0;
     std::optional<serial_bridge_config> serial1;
     std::optional<serial_bridge_config> serial2;
@@ -42,11 +60,24 @@ struct charge_bridge_config {
     firmware_update::fw_update_config firmware;
 };
 
+enum class endpoint_intent {
+    fixed_ip,
+    any_evse_mdns,
+    any_ev_mdns,
+};
+
+struct endpoint_intent_info {
+    endpoint_intent value{endpoint_intent::fixed_ip};
+    std::set<std::string> interfaces;
+    bool excluding_interfaces{false};
+};
+
 void print_charge_bridge_config(charge_bridge_config const& config);
 
 class charge_bridge : public everest::lib::io::event::fd_event_register_interface {
 public:
-    charge_bridge(charge_bridge_config const& config);
+    charge_bridge(charge_bridge_config const& config,
+                  std::function<void(utilities::chargebridge_status)> status_sink = {});
     ~charge_bridge();
 
     bool update_firmware(bool force);
@@ -63,9 +94,29 @@ public:
     void manage(everest::lib::io::event::fd_event_handler& handler, std::atomic_bool const& exit, bool force_update);
 
 private:
-    void init();
+    std::future<bool> start_internal_runtime();
+    void create_internal_runtime();
+    void cleanup_internal_runtime();
+    void disconnect_internal_runtime_endpoints();
+    bool unregister_internal_runtime_events(everest::lib::io::event::fd_event_handler& handler);
+    std::future<bool> stop_internal_runtime();
     void init_discovery(discovery_device_type type, std::set<std::string> const& interfaces, bool excluding);
+    bool is_mdns_endpoint() const;
+    discovery_device_type mdns_device_type() const;
+    std::set<std::string> select_discovery_interfaces() const;
+    void start_discovery_attempt(std::set<std::string> const& interfaces);
+    void stop_discovery();
+    void set_discovery_pending(bool pending);
+    void set_discovery_pending(charge_bridge_status& status, bool pending);
     void handle_discovery(std::string const& ip);
+    void handle_ready();
+    void handle_tick();
+    bool register_internal_events(everest::lib::io::event::fd_event_handler& handler);
+    bool unregister_internal_events(everest::lib::io::event::fd_event_handler& handler);
+    bool register_manage_events(everest::lib::io::event::fd_event_handler& handler);
+    bool unregister_manage_events(everest::lib::io::event::fd_event_handler& handler);
+    void publish_status(utilities::chargebridge_status const& status);
+    utilities::chargebridge_status get_status();
 
 private:
     std::unique_ptr<can_bridge> m_can_0_client;
@@ -79,12 +130,19 @@ private:
     std::unique_ptr<discovery> m_discovery;
 
     everest::lib::io::event::fd_event_handler* m_event_handler{nullptr};
+    everest::lib::io::event::event_fd m_ready_notify;
+    everest::lib::io::event::timer_fd m_1s_tick;
     bool m_force_firmware_update{false};
     everest::lib::util::monitor<charge_bridge_status> m_cb_status;
     bool m_was_connected{false};
     bool m_discovery_active{false};
+    bool m_internal_runtime_started{false};
+    std::thread m_manager;
+    endpoint_intent_info m_endpoint_intent;
+    std::function<void(utilities::chargebridge_status)> m_status_sink;
 
     charge_bridge_config m_config;
+    std::unique_ptr<everest::lib::io::mqtt::mqtt_client> m_mqtt;
 };
 
 } // namespace charge_bridge

--- a/applications/pionix_chargebridge/include/charge_bridge/everest_api/api_connector.hpp
+++ b/applications/pionix_chargebridge/include/charge_bridge/everest_api/api_connector.hpp
@@ -10,6 +10,7 @@
 #include <everest/io/event/fd_event_register_interface.hpp>
 #include <everest/io/event/timer_fd.hpp>
 #include <everest/io/mqtt/mqtt_client.hpp>
+#include <everest/util/misc/observable.hpp>
 #include <everest_api_types/evse_board_support/API.hpp>
 #include <everest_api_types/evse_manager/API.hpp>
 #include <everest_api_types/utilities/Topics.hpp>
@@ -36,11 +37,13 @@ struct everest_api_config {
 class api_connector : public everest::lib::io::event::fd_event_register_interface {
     using tx_ftor = std::function<void(evse_bsp_host_to_cb const&)>;
     using rx_ftor = std::function<void(evse_bsp_cb_to_host const&)>;
+    using error_ftor = std::function<void(bool /*status [true=noerror, false=error]*/)>;
 
 public:
     api_connector(everest_api_config const& config, std::string const& cb_identifier);
     void set_cb_tx(tx_ftor const& handler);
     void set_cb_message(evse_bsp_cb_to_host const& msg);
+    void set_error_handler(error_ftor const& handler);
 
     bool register_events(everest::lib::io::event::fd_event_handler& handler) override;
     bool unregister_events(everest::lib::io::event::fd_event_handler& handler) override;
@@ -72,5 +75,6 @@ private:
     evse_bsp_api m_evse_bsp;
     ovm_api m_ovm;
     ev_bsp_api m_ev_bsp;
+    everest::lib::util::observable<bool> m_ready{false};
 };
 } // namespace charge_bridge::evse_bsp

--- a/applications/pionix_chargebridge/include/charge_bridge/gpio_bridge.hpp
+++ b/applications/pionix_chargebridge/include/charge_bridge/gpio_bridge.hpp
@@ -9,6 +9,7 @@
 #include <everest/io/event/timer_fd.hpp>
 #include <everest/io/mqtt/mqtt_client.hpp>
 #include <everest/io/udp/udp_client.hpp>
+#include <everest/util/misc/observable.hpp>
 #include <protocol/cb_management.h>
 
 namespace charge_bridge {
@@ -27,30 +28,43 @@ struct gpio_config {
 
 class gpio_bridge : public everest::lib::io::event::fd_event_register_interface {
 public:
-    gpio_bridge(gpio_config const& config);
+    gpio_bridge(gpio_config const& config, everest::lib::io::event::event_fd& ready_notify);
     ~gpio_bridge();
 
     bool register_events(everest::lib::io::event::fd_event_handler& handler) override;
     bool unregister_events(everest::lib::io::event::fd_event_handler& handler) override;
+    void disconnect_cb_endpoint();
+    void connect_cb_endpoint(std::string const& remote);
+    bool available() const;
+    void set_cb_connection_status(bool connected);
 
 private:
     void handle_error_timer();
     void handle_heartbeat_timer();
+    void handle_ready();
+    void create_udp_client(std::string const& remote, uint16_t remote_port);
     void handle_udp_rx(everest::lib::io::udp::udp_payload const& payload);
     void dispatch(everest::lib::io::mqtt::mqtt_client::message const& data);
     void send_mqtt(std::string const& topic, std::string const& message);
     void send_udp();
 
-    everest::lib::io::udp::udp_client m_udp;
+    std::unique_ptr<everest::lib::io::udp::udp_client> m_udp;
+    std::uint16_t m_udp_port{0};
+    std::string m_udp_remote;
     bool m_udp_on_error{false};
+    bool m_udp_ready{false};
     everest::lib::io::event::timer_fd m_heartbeat_timer;
     std::chrono::steady_clock::time_point last_heartbeat;
     CbManagementPacket<CbGpioPacket> m_message;
     std::string m_identifier;
     bool m_mqtt_on_error{false};
+    bool m_mqtt_ready{false};
     everest::lib::io::mqtt::mqtt_client m_mqtt;
     std::string m_receive_topic;
     std::string m_send_topic;
+    everest::lib::util::observable<bool> m_ready{false};
+    everest::lib::util::observable<bool> m_cb_is_connected{false};
+    everest::lib::io::event::event_fd& m_ready_notify;
 };
 
 } // namespace charge_bridge

--- a/applications/pionix_chargebridge/include/charge_bridge/heartbeat_service.hpp
+++ b/applications/pionix_chargebridge/include/charge_bridge/heartbeat_service.hpp
@@ -8,6 +8,7 @@
 #include <everest/io/event/fd_event_register_interface.hpp>
 #include <everest/io/event/timer_fd.hpp>
 #include <everest/io/udp/udp_client.hpp>
+#include <everest/util/misc/observable.hpp>
 #include <memory>
 #include <protocol/cb_config.h>
 
@@ -25,19 +26,29 @@ struct heartbeat_config {
 
 class heartbeat_service : public everest::lib::io::event::fd_event_register_interface {
 public:
-    heartbeat_service(heartbeat_config const& config, std::function<void(bool)> const& publish_connection_status);
+    heartbeat_service(heartbeat_config const& config, std::function<void(bool)> const& publish_connection_status,
+                      everest::lib::io::event::event_fd& ready_notify);
     ~heartbeat_service();
 
     bool register_events(everest::lib::io::event::fd_event_handler& handler) override;
     bool unregister_events(everest::lib::io::event::fd_event_handler& handler) override;
+    void disconnect_cb_endpoint();
+    void connect_cb_endpoint(std::string const& remote);
+    bool available() const;
+    int mcu_reset_count() const;
 
 private:
     void handle_error_timer();
     void handle_heartbeat_timer();
     void handle_udp_rx(everest::lib::io::udp::udp_payload const& payload);
+    void create_udp_client(std::string const& remote, uint16_t remote_port);
+    void handle_ready();
 
-    everest::lib::io::udp::udp_client m_udp;
+    std::unique_ptr<everest::lib::io::udp::udp_client> m_udp;
+    std::uint16_t m_udp_port{0};
+    std::string m_udp_remote;
     bool m_udp_on_error{false};
+    bool m_udp_ready{false};
     everest::lib::io::event::timer_fd m_heartbeat_timer;
     std::string m_identifier;
     CbManagementPacket<CbConfig> m_config_message;
@@ -49,6 +60,8 @@ private:
     std::function<void(bool)> m_publish_connection_status;
     std::uint32_t m_mcu_timestamp{0};
     int m_mcu_reset_count{0};
+    everest::lib::util::observable<bool> m_ready{false};
+    everest::lib::io::event::event_fd& m_ready_notify;
 };
 
 } // namespace charge_bridge

--- a/applications/pionix_chargebridge/include/charge_bridge/plc_bridge.hpp
+++ b/applications/pionix_chargebridge/include/charge_bridge/plc_bridge.hpp
@@ -6,6 +6,8 @@
 #include <everest/io/event/timer_fd.hpp>
 #include <everest/io/tun_tap/tap_client.hpp>
 #include <everest/io/udp/udp_client.hpp>
+#include <everest/util/misc/observable.hpp>
+#include <memory>
 
 namespace charge_bridge {
 
@@ -22,20 +24,33 @@ struct plc_bridge_config {
 
 class plc_bridge : public everest::lib::io::event::fd_event_register_interface {
 public:
-    plc_bridge(plc_bridge_config const& config);
+    plc_bridge(plc_bridge_config const& config, everest::lib::io::event::event_fd& ready_notify);
     ~plc_bridge() = default;
 
     bool register_events(everest::lib::io::event::fd_event_handler& handler) override;
     bool unregister_events(everest::lib::io::event::fd_event_handler& handler) override;
+    void disconnect_cb_endpoint();
+    void connect_cb_endpoint(std::string const& remote);
+    bool available() const;
+    void set_cb_connection_status(bool connected);
 
 private:
     void handle_timer_event();
-
+    void handle_ready();
+    void create_udp_client(std::string const& remote, uint16_t remote_port, std::string const& identifier);
     everest::lib::io::tun_tap::tap_client m_tap;
-    everest::lib::io::udp::udp_client m_udp;
+    std::unique_ptr<everest::lib::io::udp::udp_client> m_udp;
     everest::lib::io::event::timer_fd m_timer;
+    uint16_t m_udp_port{0};
+    std::string m_udp_remote;
+    std::string m_identifier;
     bool m_udp_on_error{false};
     bool m_tap_on_error{false};
+    bool m_udp_ready{false};
+    bool m_tap_ready{false};
+    everest::lib::util::observable<bool> m_cb_is_connected{false};
+    everest::lib::util::observable<bool> m_ready{false};
+    everest::lib::io::event::event_fd& m_ready_notify;
 };
 
 } // namespace charge_bridge

--- a/applications/pionix_chargebridge/include/charge_bridge/serial_bridge.hpp
+++ b/applications/pionix_chargebridge/include/charge_bridge/serial_bridge.hpp
@@ -7,6 +7,8 @@
 #include <everest/io/event/timer_fd.hpp>
 #include <everest/io/serial/event_pty.hpp>
 #include <everest/io/tcp/tcp_client.hpp>
+#include <everest/util/misc/observable.hpp>
+#include <memory>
 
 namespace charge_bridge {
 
@@ -20,20 +22,31 @@ struct serial_bridge_config {
 
 class serial_bridge : public everest::lib::io::event::fd_event_register_interface {
 public:
-    serial_bridge(serial_bridge_config const& config);
+    serial_bridge(serial_bridge_config const& config, everest::lib::io::event::event_fd& ready_notify);
     ~serial_bridge() = default;
 
     bool register_events(everest::lib::io::event::fd_event_handler& handler) override;
     bool unregister_events(everest::lib::io::event::fd_event_handler& handler) override;
+    void disconnect_cb_endpoint();
+    void connect_cb_endpoint(std::string const& remote);
     std::string get_slave_path();
+    bool available() const;
 
 private:
-    void reset_tcp();
+    void create_tcp_client(std::string const& remote, uint16_t remote_port);
+    void handle_ready();
 
     everest::lib::io::serial::event_pty m_pty;
-    everest::lib::io::tcp::tcp_client m_tcp;
+    std::unique_ptr<everest::lib::io::tcp::tcp_client> m_tcp;
     utilities::symlink m_symlink;
+    std::string m_identifier;
     int m_tcp_last_error_id = -1;
+    std::uint16_t m_tcp_port{0};
+    std::string m_tcp_remote;
+    bool m_tcp_ready{false};
+    bool m_pty_ready{false};
+    everest::lib::util::observable<bool> m_ready{false};
+    everest::lib::io::event::event_fd& m_ready_notify;
 };
 
 } // namespace charge_bridge

--- a/applications/pionix_chargebridge/include/charge_bridge/status_ui.hpp
+++ b/applications/pionix_chargebridge/include/charge_bridge/status_ui.hpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <deque>
+#include <optional>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+#include <charge_bridge/utilities/print_status.hpp>
+#include <everest/util/async/monitor.hpp>
+#include <everest/util/queue/thread_safe_queue.hpp>
+
+namespace charge_bridge {
+
+struct status_ui_options {
+    utilities::status_output_mode status_output{utilities::status_output_mode::auto_mode};
+    std::chrono::milliseconds status_refresh_ms{std::chrono::milliseconds(100)};
+    std::size_t status_message_lines{10};
+    bool no_color{false};
+};
+
+class status_ui {
+public:
+    explicit status_ui(status_ui_options options, std::vector<std::string> cb_names);
+    ~status_ui();
+
+    void publish(utilities::chargebridge_status status);
+    void publish_message(std::string message);
+    void run();
+    void stop();
+
+private:
+    void run_internal();
+
+    struct status_row {
+        std::string cb_name;
+        std::optional<bool> discovered;
+        std::optional<bool> connected;
+        std::optional<bool> can0;
+        std::optional<bool> serial1;
+        std::optional<bool> serial2;
+        std::optional<bool> serial3;
+        std::optional<bool> plc;
+        std::optional<bool> bsp;
+        std::optional<bool> heartbeat;
+        std::optional<bool> gpio;
+        std::optional<int> mcu_resets;
+    };
+
+    struct status_update_event {
+        utilities::chargebridge_status status;
+    };
+
+    struct log_message_event {
+        std::string message;
+    };
+
+    using status_ui_event = std::variant<status_update_event, log_message_event>;
+
+    void apply_status_row(utilities::chargebridge_status const& status);
+    void apply_log_message(std::string message);
+    void process_event(status_ui_event const& event);
+    bool has_message_event(status_ui_event const& event);
+    void render_terminal_status();
+
+    void render_field(std::string const& value, const char* color, std::size_t width);
+    const char* maybe_no_color(const char* color) const;
+    void render_message_row(std::string const& text, std::size_t width);
+    std::string center(std::string text, std::size_t width);
+    void render_border(std::size_t field_count, std::size_t width);
+
+    status_ui_options m_options;
+    everest::lib::util::thread_safe_queue<status_ui_event> m_status_queue;
+    std::vector<status_row> m_status_rows;
+    std::unordered_map<std::string, std::size_t> m_cb_name_to_row;
+    std::deque<std::string> m_log_messages;
+    std::atomic_bool m_running{false};
+    std::thread m_thread;
+    std::atomic_bool m_terminal_cursor_hidden{false};
+
+    bool m_terminal_active() const;
+    void notify_terminal_ready();
+    void wait_for_terminal_ready();
+
+    everest::lib::util::monitor<bool> m_initial_terminal_render_done{false};
+};
+
+} // namespace charge_bridge

--- a/applications/pionix_chargebridge/include/charge_bridge/utilities/logging.hpp
+++ b/applications/pionix_chargebridge/include/charge_bridge/utilities/logging.hpp
@@ -1,10 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
 #pragma once
+#include <functional>
 #include <iostream>
+#include <string>
 
 namespace charge_bridge::utilities {
 
-std::ostream& print_error(std::string const& device, std::string const& unit, int status);
+using print_error_sink = std::function<void(std::string)>;
 
-}
+std::ostream& print_error(std::string const& device, std::string const& unit, int status);
+void set_print_error_sink(print_error_sink sink);
+void clear_print_error_sink();
+
+} // namespace charge_bridge::utilities

--- a/applications/pionix_chargebridge/include/charge_bridge/utilities/print_status.hpp
+++ b/applications/pionix_chargebridge/include/charge_bridge/utilities/print_status.hpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace charge_bridge::utilities {
+
+enum class status_output_mode {
+    auto_mode,
+    log,
+    terminal,
+    off,
+};
+
+struct chargebridge_status {
+    std::string cb_name;
+    bool connected{false};
+    std::optional<bool> discovered;
+    std::optional<bool> can0;
+    std::optional<bool> serial1;
+    std::optional<bool> serial2;
+    std::optional<bool> serial3;
+    std::optional<bool> plc;
+    std::optional<bool> bsp;
+    std::optional<bool> heartbeat;
+    std::optional<bool> gpio;
+    std::optional<int> mcu_resets;
+};
+
+void print_status(const chargebridge_status& status, status_output_mode output_mode = status_output_mode::terminal);
+
+} // namespace charge_bridge::utilities

--- a/applications/pionix_chargebridge/main.cpp
+++ b/applications/pionix_chargebridge/main.cpp
@@ -1,18 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 #include "charge_bridge/charge_bridge.hpp"
+#include "charge_bridge/status_ui.hpp"
 #include "charge_bridge/utilities/string.hpp"
 #include <algorithm>
 #include <atomic>
 #include <charge_bridge/utilities/parse_config.hpp>
 #include <chrono>
 #include <csignal>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <everest/io/event/fd_event_handler.hpp>
 #include <everest/io/event/timer_fd.hpp>
 #include <iostream>
+#include <limits>
 #include <numeric>
+#include <unistd.h>
 
 using namespace everest::lib::io::event;
 using namespace everest::lib::API::V1_0::types;
@@ -25,20 +29,39 @@ enum class mode {
     update_only,
 };
 
-mode parse_args(int argc, char* argv[], std::vector<std::string>& config_files) {
+mode parse_args(int argc, char* argv[], std::vector<std::string>& config_files,
+                utilities::status_output_mode& status_output_mode, status_ui_options& status_ui_opts) {
     // clang-format off
     auto print_msg = []() {
         std::cout << "\nUSAGE: \n";
-        std::cout << "pionix_chargebridge [--update][--update_only] {config_file [config_file_2 ....]} \n";
+        std::cout << "pionix_chargebridge [--update][--update_only][--status-output=auto|log|terminal|off] "
+                     "[--status-refresh-ms=100] [--status-message-lines=10] [--status-no-color] {config_file [config_file_2 ....]} \n";
         std::cout << "\n";
         std::cout << "--update            use this flag to execute an update at start and continue operation after\n";
         std::cout << "--update_only       use this flag to execute an update and stop the application after\n";
+        std::cout << "--status-output=auto|log|terminal|off\n"
+                     "                    output mode for charge_bridge status output.\n"
+                     "                    auto: table in TTY, key=value log otherwise\n"
+                     "                    log: one-line key=value output\n"
+                     "                    terminal: always table output (requires stdout TTY)\n"
+                     "                    off: suppress status output\n";
+        std::cout << "--status-refresh-ms=100\n"
+                     "                    terminal refresh rate in milliseconds, minimum is 0 (immediate)\n"
+                     "                    ignored in log/off modes\n";
+        std::cout << "--status-message-lines=10\n"
+                     "                    terminal message buffer size, minimum is 0 (disabled), maximum is 1000\n"
+                     "                    shows latest N non-success messages below dashboard\n"
+                     "                    ignored in log/off modes\n";
+        std::cout << "--status-no-color  disable ANSI colors in the terminal dashboard output\n"
+                     "                    message area and non-color controls remain unchanged\n";
         std::cout << "config_file         use this configuration file\n";
         std::cout << "config_file_x       add more configuration files for each additional ChargeBridge group\n";
         std::cout << "\n";
     };
     // clang-format on
 
+    status_output_mode = utilities::status_output_mode::auto_mode;
+    status_ui_opts.status_refresh_ms = std::chrono::milliseconds(100);
     auto mode = mode::connector;
     for (int i = 1; i < argc; ++i) {
         std::string current_arg = argv[i];
@@ -46,6 +69,72 @@ mode parse_args(int argc, char* argv[], std::vector<std::string>& config_files) 
             mode = mode::update_only;
         } else if (current_arg == "--update") {
             mode = mode::update;
+        } else if (utilities::string_starts_with(current_arg, "--status-output=")) {
+            auto output = current_arg.substr(std::string("--status-output=").size());
+            if (output == "auto") {
+                status_output_mode = utilities::status_output_mode::auto_mode;
+            } else if (output == "log") {
+                status_output_mode = utilities::status_output_mode::log;
+            } else if (output == "terminal") {
+                status_output_mode = utilities::status_output_mode::terminal;
+            } else if (output == "off") {
+                status_output_mode = utilities::status_output_mode::off;
+            } else {
+                mode = mode::error;
+                break;
+            }
+        } else if (utilities::string_starts_with(current_arg, "--status-refresh-ms=")) {
+            auto value = current_arg.substr(std::string("--status-refresh-ms=").size());
+            if (value.empty()) {
+                mode = mode::error;
+                break;
+            }
+            try {
+                if (value.find_first_not_of("0123456789") != std::string::npos) {
+                    mode = mode::error;
+                    break;
+                }
+                auto refresh_ms = std::stoull(value);
+                using status_refresh_rep = std::chrono::milliseconds::rep;
+                constexpr auto max_refresh_ms =
+                    std::min<std::uint64_t>(static_cast<std::uint64_t>(std::numeric_limits<status_refresh_rep>::max()),
+                                            static_cast<std::uint64_t>(std::numeric_limits<int>::max()));
+                if (refresh_ms > max_refresh_ms) {
+                    mode = mode::error;
+                    break;
+                }
+                status_ui_opts.status_refresh_ms =
+                    std::chrono::milliseconds(static_cast<status_refresh_rep>(refresh_ms));
+            } catch (...) {
+                mode = mode::error;
+                break;
+            }
+        } else if (utilities::string_starts_with(current_arg, "--status-message-lines=")) {
+            auto value = current_arg.substr(std::string("--status-message-lines=").size());
+            if (value.empty()) {
+                mode = mode::error;
+                break;
+            }
+
+            if (value.find_first_not_of("0123456789") != std::string::npos) {
+                mode = mode::error;
+                break;
+            }
+
+            try {
+                auto lines = std::stoull(value);
+                constexpr std::size_t max_status_message_lines = 1000;
+                if (lines > max_status_message_lines) {
+                    mode = mode::error;
+                    break;
+                }
+                status_ui_opts.status_message_lines = static_cast<std::size_t>(lines);
+            } catch (...) {
+                mode = mode::error;
+                break;
+            }
+        } else if (current_arg == "--status-no-color") {
+            status_ui_opts.no_color = true;
         } else if (utilities::string_starts_with(current_arg, "--")) {
             mode = mode::error;
             break;
@@ -78,43 +167,74 @@ int main(int argc, char* argv[]) {
     std::signal(SIGTERM, signal_handler);
 
     std::vector<std::string> config_files;
+    utilities::status_output_mode status_output_mode;
+    status_ui_options ui_options;
+    fd_event_handler ev_handler;
     std::vector<charge_bridge_config> cb_configs;
-    std::vector<std::unique_ptr<::charge_bridge::charge_bridge>> cb_handler;
+    std::vector<std::string> cb_names;
+    std::set<std::string> cb_ids_in_use;
 
-    auto mode_of_operation = parse_args(argc, argv, config_files);
+    auto mode_of_operation = parse_args(argc, argv, config_files, status_output_mode, ui_options);
     if (mode_of_operation == mode::error) {
         return EXIT_FAILURE;
     }
-    fd_event_handler ev_handler;
+    bool stdout_is_tty = isatty(STDOUT_FILENO);
+    if (status_output_mode == utilities::status_output_mode::terminal && not stdout_is_tty) {
+        std::cerr << "--status-output=terminal requires stdout to be a TTY" << std::endl;
+        return EXIT_FAILURE;
+    }
 
-    std::set<std::string> cb_ids_in_use;
-
+    auto effective_status_output_mode = status_output_mode;
+    if (status_output_mode == utilities::status_output_mode::auto_mode) {
+        effective_status_output_mode =
+            stdout_is_tty ? utilities::status_output_mode::terminal : utilities::status_output_mode::log;
+    }
+    status_ui_options effective_ui_options;
+    effective_ui_options.status_output = effective_status_output_mode;
+    effective_ui_options.status_refresh_ms = ui_options.status_refresh_ms;
+    effective_ui_options.status_message_lines = ui_options.status_message_lines;
+    effective_ui_options.no_color = ui_options.no_color;
     for (auto const& elem : config_files) {
         auto config_list = utilities::parse_config_multi(elem);
         if (config_list.empty()) {
-            g_run_application.store(false);
-            break;
+            return EXIT_FAILURE;
         }
+
         for (auto const& config : config_list) {
-            print_charge_bridge_config(config);
             if (cb_ids_in_use.count(config.cb_name) > 0) {
                 std::cerr << "Duplicate charge_bridge::name '" << config.cb_name << "'" << std::endl;
                 return EXIT_FAILURE;
             }
 
             cb_ids_in_use.insert(config.cb_name);
-            cb_handler.push_back(std::make_unique<::charge_bridge::charge_bridge>(config));
-            auto& cb = *cb_handler.rbegin();
-
-            if (mode_of_operation == mode::update_only) {
-                cb->update_firmware(true);
-            }
-
-            auto force_update = mode_of_operation == mode::update;
-            cb->manage(ev_handler, g_run_application, force_update);
+            cb_names.push_back(config.cb_name);
+            cb_configs.push_back(config);
         }
     }
 
+    status_ui ui(effective_ui_options, cb_names);
+    auto status_sink = [&ui](utilities::chargebridge_status status) { ui.publish(std::move(status)); };
+    std::vector<std::unique_ptr<::charge_bridge::charge_bridge>> cb_handler;
+
+    for (auto const& config : cb_configs) {
+        print_charge_bridge_config(config);
+        cb_handler.push_back(std::make_unique<::charge_bridge::charge_bridge>(config, status_sink));
+        auto& cb = *cb_handler.rbegin();
+
+        if (mode_of_operation == mode::update_only) {
+            cb->update_firmware(true);
+        }
+    }
+
+    ui.run();
+
+    for (auto& cb : cb_handler) {
+        auto force_update = mode_of_operation == mode::update;
+        cb->manage(ev_handler, g_run_application, force_update);
+    }
+
     ev_handler.run(g_run_application);
+    cb_handler.clear();
+    ui.stop();
     return EXIT_SUCCESS;
 }

--- a/applications/pionix_chargebridge/src/bsp_bridge.cpp
+++ b/applications/pionix_chargebridge/src/bsp_bridge.cpp
@@ -14,40 +14,92 @@ const int default_udp_timeout_ms = 1000;
 
 namespace charge_bridge {
 
-bsp_bridge::bsp_bridge(bsp_bridge_config const& config) :
-    m_api(config.api, config.cb + "/" + config.item), m_udp(config.cb_remote, config.cb_port, default_udp_timeout_ms) {
+bsp_bridge::bsp_bridge(bsp_bridge_config const& config, everest::lib::io::event::event_fd& ready_notify) :
+    m_api(config.api, config.cb + "/" + config.item),
+    m_udp_port(config.cb_port),
+    m_udp_remote(config.cb_remote),
+    m_identifier(config.cb + "/" + config.item),
+    m_ready_notify(ready_notify) {
     using namespace std::chrono_literals;
     m_timer.set_timeout(5s);
+    auto identifier = config.cb + "/" + config.item;
+    m_identifier = identifier;
+    create_udp_client(config.cb_remote, config.cb_port, identifier);
 
     m_api.set_cb_tx([this](auto& data) {
-        everest::lib::io::udp::udp_payload pl;
-        pl.set_message(&data, sizeof(data));
-        m_udp.tx(pl);
+        if (m_udp) {
+            everest::lib::io::udp::udp_payload pl;
+            pl.set_message(&data, sizeof(data));
+            m_udp->tx(pl);
+        }
     });
 
-    m_udp.set_rx_handler([this](auto const& data, auto&) {
+    m_api.set_error_handler([this](bool good) {
+        m_api_good = good;
+        handle_status();
+    });
+
+    m_ready.setCallback([this](auto&, auto&) { m_ready_notify.notify(); });
+}
+
+void bsp_bridge::create_udp_client(std::string const& remote, uint16_t remote_port, std::string const& identifier) {
+    m_udp = std::make_unique<everest::lib::io::udp::udp_client>(remote, remote_port, default_udp_timeout_ms);
+    m_udp_ready = false;
+    m_udp_on_error = false;
+    m_udp->set_rx_handler([this](auto const& data, auto&) {
         evse_bsp_cb_to_host msg;
         std::memcpy(&msg, data.buffer.data(), data.size());
         m_api.set_cb_message(msg);
     });
-
-    auto identifier = config.cb + "/" + config.item;
-    m_udp.set_error_handler([this, identifier](auto id, auto const& msg) {
+    m_udp->set_error_handler([this, identifier](auto id, auto const& msg) {
         utilities::print_error(identifier, "BSP/UDP", id) << msg << std::endl;
+        m_udp_ready = id == 0;
         m_udp_on_error = id not_eq 0;
+        if (not m_udp_ready and m_udp) {
+            m_udp->reset();
+        }
+        handle_status();
     });
+}
+
+void bsp_bridge::disconnect_cb_endpoint() {
+    m_udp_ready = false;
+    m_udp_on_error = true;
+    if (m_udp) {
+        m_udp->reset();
+    }
+    m_udp.reset();
+    handle_status();
+}
+
+void bsp_bridge::connect_cb_endpoint(std::string const& remote) {
+    m_udp_remote = remote;
+    disconnect_cb_endpoint();
+    create_udp_client(m_udp_remote, m_udp_port, m_identifier);
+    handle_status();
 }
 
 void bsp_bridge::handle_timer_event() {
     if (m_udp_on_error) {
-        m_udp.reset();
+        if (m_udp) {
+            m_udp->reset();
+        }
     }
+}
+
+void bsp_bridge::handle_status() {
+    auto status = m_api_good && m_udp_ready && not m_udp_on_error;
+    m_ready.set(status);
+}
+
+bool bsp_bridge::available() const {
+    return m_ready;
 }
 
 bool bsp_bridge::register_events(everest::lib::io::event::fd_event_handler& handler) {
     auto result = true;
     result = handler.register_event_handler(&m_api) && result;
-    result = handler.register_event_handler(&m_udp) && result;
+    result = handler.register_event_handler(m_udp.get()) && result;
     result = handler.register_event_handler(&m_timer, [this](auto&) { handle_timer_event(); }) && result;
     return result;
 }
@@ -55,7 +107,7 @@ bool bsp_bridge::register_events(everest::lib::io::event::fd_event_handler& hand
 bool bsp_bridge::unregister_events(everest::lib::io::event::fd_event_handler& handler) {
     auto result = true;
     result = handler.unregister_event_handler(&m_api) && result;
-    result = handler.unregister_event_handler(&m_udp) && result;
+    result = handler.unregister_event_handler(m_udp.get()) && result;
     result = handler.unregister_event_handler(&m_timer) && result;
     return result;
 }

--- a/applications/pionix_chargebridge/src/can_bridge.cpp
+++ b/applications/pionix_chargebridge/src/can_bridge.cpp
@@ -49,10 +49,12 @@ bool is_data_msg([[maybe_unused]] cb_can_message const& msg) {
 
 } // namespace
 
-can_bridge::can_bridge(can_bridge_config const& config) :
-    m_udp(config.cb_remote, config.cb_port, default_udp_timeout_ms),
+can_bridge::can_bridge(can_bridge_config const& config, everest::lib::io::event::event_fd& ready_notify) :
+    m_cb_port(config.cb_port),
+    m_cb_remote(config.cb_remote),
     m_can_device(config.can_device),
-    m_last_msg_to_cb(std::chrono::steady_clock::time_point()) {
+    m_last_msg_to_cb(std::chrono::steady_clock::time_point()),
+    m_ready_notify(ready_notify) {
 
     auto& manager = everest::lib::io::netlink::vcan_netlink_manager::Instance();
     auto success = manager.create(config.can_device) && manager.bring_up(config.can_device);
@@ -76,7 +78,34 @@ can_bridge::can_bridge(can_bridge_config const& config) :
         send_can_to_udp(msg);
     });
 
-    m_udp.set_rx_handler([this](auto const& data, auto&) {
+    create_udp_client(config.cb_remote, config.cb_port);
+
+    auto identifier = config.cb + "/" + config.item;
+    m_identifier = identifier;
+    m_can->set_error_handler([this](auto id, auto const& msg) {
+        utilities::print_error(m_identifier, "CAN/HW", id) << msg << std::endl;
+        m_can_ready = id == 0;
+        if (not m_can_ready) {
+            // This is a smart pointer!! Using .reset() would delete the obj!
+            m_can->reset();
+        }
+        handle_ready();
+    });
+    m_heartbeat_timer.set_timeout(10s);
+    m_ready.setCallback([this](auto&, auto&) { m_ready_notify.notify(); });
+    m_cb_is_connected.setCallback([this](bool last, bool current) {
+        if (not last and current) {
+            if (m_udp) {
+                m_udp->reset();
+            }
+        }
+        handle_ready();
+    });
+}
+
+void can_bridge::create_udp_client(std::string const& remote, uint16_t remote_port) {
+    m_udp = std::make_unique<everest::lib::io::udp::udp_client>(remote, remote_port, default_udp_timeout_ms);
+    m_udp->set_rx_handler([this](auto const& data, auto&) {
         everest::lib::io::can::socket_can::ClientPayloadT pl;
         cb_can_message msg;
         std::memcpy(&msg, data.buffer.data(), sizeof(cb_can_message));
@@ -86,24 +115,33 @@ can_bridge::can_bridge(can_bridge_config const& config) :
             m_can->tx(pl);
         }
     });
-
-    m_identifier = config.cb + "/" + config.item;
-    m_can->set_error_handler([this](auto id, auto const& msg) {
-        utilities::print_error(m_identifier, "CAN/HW", id) << msg << std::endl;
-        if (id not_eq 0) {
-            // This is a smart pointer!! Using .reset() would delete the obj!
-            m_can->reset();
-        }
-    });
-
-    m_udp.set_error_handler([this](auto id, auto const& msg) {
+    m_udp->set_error_handler([this](auto id, auto const& msg) {
         utilities::print_error(m_identifier, "CAN/UDP", id) << msg << std::endl;
-        if (id not_eq 0) {
-            m_udp.reset();
+        m_udp_ready = id == 0;
+        if (not m_udp_ready) {
+            if (m_udp) {
+                m_udp->reset();
+            }
         }
+        handle_ready();
     });
+}
 
-    m_heartbeat_timer.set_timeout(10s);
+void can_bridge::disconnect_cb_endpoint() {
+    m_udp_ready = false;
+    m_last_msg_to_cb = std::chrono::steady_clock::time_point{};
+    if (m_udp) {
+        m_udp->reset();
+    }
+    m_udp.reset();
+    handle_ready();
+}
+
+void can_bridge::connect_cb_endpoint(std::string const& remote) {
+    m_cb_remote = remote;
+    disconnect_cb_endpoint();
+    create_udp_client(m_cb_remote, m_cb_port);
+    handle_ready();
 }
 
 can_bridge::~can_bridge() {
@@ -116,7 +154,7 @@ can_bridge::~can_bridge() {
 
 bool can_bridge::register_events(everest::lib::io::event::fd_event_handler& handler) {
     auto result = handler.register_event_handler(m_can.get());
-    result = handler.register_event_handler(&m_udp) && result;
+    result = handler.register_event_handler(m_udp.get()) && result;
     result = handler.register_event_handler(&m_heartbeat_timer, [this](auto&) { handle_heartbeat_timer(); }) && result;
 
     if (result) {
@@ -128,21 +166,24 @@ bool can_bridge::register_events(everest::lib::io::event::fd_event_handler& hand
 
 bool can_bridge::unregister_events(everest::lib::io::event::fd_event_handler& handler) {
     auto result = handler.unregister_event_handler(m_can.get());
-    result = handler.unregister_event_handler(&m_udp) && result;
+    result = handler.unregister_event_handler(m_udp.get()) && result;
     result = handler.unregister_event_handler(&m_heartbeat_timer) && result;
     return result;
 }
 
 void can_bridge::send_can_to_udp(cb_can_message const& msg) {
+    if (not m_udp) {
+        return;
+    }
     everest::lib::io::udp::udp_client::ClientPayloadT udp_pl;
     udp_pl.buffer.resize(sizeof(cb_can_message));
     std::memcpy(udp_pl.buffer.data(), &msg, sizeof(cb_can_message));
-    m_udp.tx(udp_pl);
+    m_udp->tx(udp_pl);
     m_last_msg_to_cb = std::chrono::steady_clock::now();
 }
 
 void can_bridge::handle_heartbeat_timer() {
-    if (m_udp.on_error()) {
+    if (not m_udp or m_udp->on_error()) {
         // If the connection is not available, retry soon and invalidate last hearbeat
         m_heartbeat_timer.set_timeout(250ms);
         m_last_msg_to_cb = std::chrono::steady_clock::time_point();
@@ -157,6 +198,18 @@ void can_bridge::handle_heartbeat_timer() {
         msg.packet_type = CanPacketType_Keep_Alive;
         send_can_to_udp(msg);
     }
+}
+
+void can_bridge::handle_ready() {
+    m_ready.set(m_udp_ready and m_can_ready and m_cb_is_connected);
+}
+
+bool can_bridge::available() const {
+    return m_ready;
+}
+
+void can_bridge::set_cb_connection_status(bool connected) {
+    m_cb_is_connected.set(connected);
 }
 
 } // namespace charge_bridge

--- a/applications/pionix_chargebridge/src/charge_bridge.cpp
+++ b/applications/pionix_chargebridge/src/charge_bridge.cpp
@@ -469,8 +469,11 @@ void charge_bridge::manage(everest::lib::io::event::fd_event_handler& handler, s
 
             m_mqtt->set_callback_connect(
                 [this](auto&, auto, auto, auto const&) { m_1s_tick.set_timeout(std::chrono::seconds(1)); });
-            register_manage_events(*m_event_handler);
         }
+        // Register the manage events (readiness notifier + tick) regardless of telemetry, so the
+        // status report is produced even when telemetry/MQTT is disabled. The MQTT fd itself is only
+        // registered when the telemetry client exists (see register_manage_events).
+        register_manage_events(*m_event_handler);
     });
 
     if (is_mdns_endpoint()) {
@@ -850,7 +853,7 @@ void charge_bridge::publish_status(utilities::chargebridge_status const& status)
     if (status.heartbeat.has_value()) {
         auto available = status.heartbeat.value();
         result = result && available;
-        publish_status("heatbeat", available);
+        publish_status("heartbeat", available);
     }
     if (status.gpio.has_value()) {
         auto available = status.gpio.value();
@@ -880,11 +883,15 @@ bool charge_bridge::register_manage_events(everest::lib::io::event::fd_event_han
         handler.register_event_handler(&m_1s_tick, everest::lib::util::bind_obj(&charge_bridge::handle_tick, this)) &&
         result;
 
+    // The readiness notifier drives the status report (status UI line + the telemetry status publish),
+    // so it must be registered regardless of telemetry. publish_status() itself no-ops when telemetry
+    // is disabled, and the MQTT fd below is only registered when the client exists.
+    result = handler.register_event_handler(&m_ready_notify,
+                                            everest::lib::util::bind_obj(&charge_bridge::handle_ready, this)) &&
+             result;
+
     if (m_mqtt) {
         result = handler.register_event_handler(m_mqtt.get()) && result;
-        result = handler.register_event_handler(&m_ready_notify,
-                                                everest::lib::util::bind_obj(&charge_bridge::handle_ready, this)) &&
-                 result;
     }
 
     return result;
@@ -892,9 +899,9 @@ bool charge_bridge::register_manage_events(everest::lib::io::event::fd_event_han
 bool charge_bridge::unregister_manage_events(everest::lib::io::event::fd_event_handler& handler) {
     auto result = true;
     result = handler.unregister_event_handler(&m_1s_tick) && result;
+    result = handler.unregister_event_handler(&m_ready_notify) && result;
     if (m_mqtt) {
         result = handler.unregister_event_handler(m_mqtt.get()) && result;
-        result = handler.unregister_event_handler(&m_ready_notify) && result;
     }
 
     return result;

--- a/applications/pionix_chargebridge/src/charge_bridge.cpp
+++ b/applications/pionix_chargebridge/src/charge_bridge.cpp
@@ -12,15 +12,21 @@
 #include <charge_bridge/utilities/sync_udp_client.hpp>
 #include <everest/io/event/fd_event_sync_interface.hpp>
 #include <everest/io/netlink/vcan_netlink_manager.hpp>
+#include <everest/io/socket/socket.hpp>
 #include <everest/util/misc/bind.hpp>
 
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <thread>
 
 namespace charge_bridge {
 
 namespace {
+constexpr auto discovery_attempt_timeout = std::chrono::seconds(10);
+constexpr auto discovery_retry_delay = std::chrono::seconds(1);
+constexpr auto manager_base_cycle = std::chrono::seconds(10);
+
 std::pair<bool, std::set<std::string>> make_interface_list(std::string const& str, std::string const& pattern) {
     if (str == pattern) {
         return {false, {}};
@@ -37,18 +43,35 @@ std::pair<bool, std::set<std::string>> make_interface_list(std::string const& st
     std::cout << std::endl;
     return {exclude, items};
 }
+
+const int mqtt_reconnect_timeout_ms = 1000;
+
+endpoint_intent_info parse_endpoint_intent(std::string const& cb_remote) {
+    endpoint_intent_info result;
+
+    if (utilities::string_starts_with(cb_remote, "ANY_EVSE")) {
+        auto params = make_interface_list(cb_remote, "ANY_EVSE");
+        result.value = endpoint_intent::any_evse_mdns;
+        result.excluding_interfaces = params.first;
+        result.interfaces = params.second;
+    } else if (utilities::string_starts_with(cb_remote, "ANY_EV")) {
+        auto params = make_interface_list(cb_remote, "ANY_EV");
+        result.value = endpoint_intent::any_ev_mdns;
+        result.excluding_interfaces = params.first;
+        result.interfaces = params.second;
+    }
+
+    return result;
+}
+
 } // namespace
 
-charge_bridge::charge_bridge(charge_bridge_config const& config) : m_config(config) {
-    if (utilities::string_starts_with(config.cb_remote, "ANY_EVSE")) {
-        auto params = make_interface_list(config.cb_remote, "ANY_EVSE");
-        init_discovery(discovery_device_type::CB_EVSE, params.second, params.first);
-    } else if (utilities::string_starts_with(config.cb_remote, "ANY_EV")) {
-        auto params = make_interface_list(config.cb_remote, "ANY_EV");
-        init_discovery(discovery_device_type::CB_EV, params.second, params.first);
-    } else {
-        init();
-    }
+charge_bridge::charge_bridge(charge_bridge_config const& config,
+                             std::function<void(utilities::chargebridge_status)> status_sink) :
+    m_status_sink(std::move(status_sink)), m_config(config) {
+    std::cout << "CB CONSTRUCT" << std::endl;
+
+    m_endpoint_intent = parse_endpoint_intent(config.cb_remote);
 }
 
 void charge_bridge::init_discovery(discovery_device_type type, std::set<std::string> const& interfaces,
@@ -58,11 +81,98 @@ void charge_bridge::init_discovery(discovery_device_type type, std::set<std::str
 
     m_discovery = std::make_unique<discovery>(type, interfaces, excluding);
     m_discovery->set_discovery_callback(bind_obj(&charge_bridge::handle_discovery, this));
-    {
-        auto handle = m_cb_status.handle();
-        handle->discovery_pending = true;
+    set_discovery_pending(true);
+}
+
+bool charge_bridge::is_mdns_endpoint() const {
+    return m_endpoint_intent.value != endpoint_intent::fixed_ip;
+}
+
+discovery_device_type charge_bridge::mdns_device_type() const {
+    if (m_endpoint_intent.value == endpoint_intent::any_evse_mdns) {
+        return discovery_device_type::CB_EVSE;
     }
-    m_cb_status.notify_one();
+    return discovery_device_type::CB_EV;
+}
+
+std::set<std::string> charge_bridge::select_discovery_interfaces() const {
+    std::set<std::string> available_interfaces;
+    try {
+        for (auto const& item : everest::lib::io::socket::get_all_interaces()) {
+            available_interfaces.insert(item.name);
+        }
+    } catch (std::exception const&) {
+        return {};
+    }
+
+    if (m_endpoint_intent.interfaces.empty()) {
+        return available_interfaces;
+    }
+
+    std::set<std::string> selected_interfaces;
+    if (m_endpoint_intent.excluding_interfaces) {
+        for (auto const& item : available_interfaces) {
+            if (m_endpoint_intent.interfaces.count(item) == 0) {
+                selected_interfaces.insert(item);
+            }
+        }
+        return selected_interfaces;
+    }
+
+    for (auto const& item : m_endpoint_intent.interfaces) {
+        if (available_interfaces.count(item) > 0) {
+            selected_interfaces.insert(item);
+        }
+    }
+    return selected_interfaces;
+}
+
+void charge_bridge::start_discovery_attempt(std::set<std::string> const& interfaces) {
+    if (not m_event_handler) {
+        return;
+    }
+    auto type = mdns_device_type();
+    m_event_handler->add_action([this, type, interfaces]() {
+        try {
+            if (m_discovery) {
+                m_event_handler->unregister_event_handler(m_discovery.get());
+            }
+            m_discovery.reset();
+            init_discovery(type, interfaces, false);
+            auto registered = m_event_handler->register_event_handler(m_discovery.get());
+            if (not registered) {
+                m_event_handler->unregister_event_handler(m_discovery.get());
+                utilities::print_error(m_config.cb_name, "DISCOVERY", -1)
+                    << "Failed to register mDNS discovery handler" << std::endl;
+                std::unique_ptr<discovery> tmp;
+                std::swap(m_discovery, tmp);
+                set_discovery_pending(true);
+            }
+        } catch (std::exception const& e) {
+            utilities::print_error(m_config.cb_name, "DISCOVERY", -1)
+                << "Failed to start mDNS discovery: " << e.what() << std::endl;
+            if (m_discovery) {
+                m_event_handler->unregister_event_handler(m_discovery.get());
+            }
+            std::unique_ptr<discovery> tmp;
+            std::swap(m_discovery, tmp);
+            set_discovery_pending(true);
+        }
+        m_cb_status.notify_one();
+    });
+}
+
+void charge_bridge::stop_discovery() {
+    if (not m_event_handler) {
+        return;
+    }
+    m_event_handler->add_action([this]() {
+        std::unique_ptr<discovery> tmp;
+        if (m_discovery) {
+            m_event_handler->unregister_event_handler(m_discovery.get());
+        }
+        std::swap(m_discovery, tmp);
+    });
 }
 
 void charge_bridge::handle_discovery(std::string const& ip) {
@@ -97,91 +207,435 @@ void charge_bridge::handle_discovery(std::string const& ip) {
 
     m_event_handler->add_action([this]() {
         std::unique_ptr<discovery> tmp;
+        if (m_discovery) {
+            m_event_handler->unregister_event_handler(m_discovery.get());
+        }
         std::swap(m_discovery, tmp);
 
-        init();
-        {
-            auto handle = m_cb_status.handle();
-            handle->discovery_pending = false;
-        }
-        m_cb_status.notify_one();
+        set_discovery_pending(false);
     });
 }
 
-void charge_bridge::init() {
+void charge_bridge::set_discovery_pending(bool pending) {
+    auto handle = m_cb_status.handle();
+    set_discovery_pending(*handle, pending);
+}
+
+void charge_bridge::set_discovery_pending(charge_bridge_status& status, bool pending) {
+    auto changed = status.discovery_pending != pending;
+    status.discovery_pending = pending;
+    m_cb_status.notify_one();
+    if (changed) {
+        m_ready_notify.notify();
+    }
+}
+
+std::future<bool> charge_bridge::start_internal_runtime() {
+    auto promise = std::make_shared<std::promise<bool>>();
+    auto result = promise->get_future();
+    auto preserve_runtime_objects =
+        m_can_0_client || m_pty_1 || m_pty_2 || m_pty_3 || m_bsp || m_plc || m_gpio || m_heartbeat;
+
+    if (not m_event_handler) {
+        promise->set_value(false);
+        return result;
+    }
+
+    m_event_handler->add_action([this, promise = std::move(promise), preserve_runtime_objects]() mutable {
+        try {
+            create_internal_runtime();
+            auto runtime_registered = register_internal_events(*m_event_handler);
+            if (not runtime_registered) {
+                unregister_internal_runtime_events(*m_event_handler);
+                if (preserve_runtime_objects) {
+                    disconnect_internal_runtime_endpoints();
+                } else {
+                    cleanup_internal_runtime();
+                }
+                promise->set_value(false);
+                m_cb_status.notify_one();
+                return;
+            }
+
+            promise->set_value(true);
+            m_cb_status.notify_one();
+        } catch (...) {
+            unregister_internal_runtime_events(*m_event_handler);
+            if (preserve_runtime_objects) {
+                disconnect_internal_runtime_endpoints();
+            } else {
+                cleanup_internal_runtime();
+            }
+            promise->set_exception(std::current_exception());
+            m_cb_status.notify_one();
+        }
+    });
+
+    return result;
+}
+
+void charge_bridge::create_internal_runtime() {
     if (m_config.can0.has_value()) {
-        m_can_0_client = std::make_unique<can_bridge>(m_config.can0.value());
+        if (not m_can_0_client) {
+            m_can_0_client = std::make_unique<can_bridge>(m_config.can0.value(), m_ready_notify);
+        } else {
+            m_can_0_client->connect_cb_endpoint(m_config.can0->cb_remote);
+        }
     }
     if (m_config.serial1.has_value()) {
-        m_pty_1 = std::make_unique<serial_bridge>(m_config.serial1.value());
+        if (not m_pty_1) {
+            m_pty_1 = std::make_unique<serial_bridge>(m_config.serial1.value(), m_ready_notify);
+        } else {
+            m_pty_1->connect_cb_endpoint(m_config.serial1->cb_remote);
+        }
     }
     if (m_config.serial2.has_value()) {
-        m_pty_2 = std::make_unique<serial_bridge>(m_config.serial2.value());
+        if (not m_pty_2) {
+            m_pty_2 = std::make_unique<serial_bridge>(m_config.serial2.value(), m_ready_notify);
+        } else {
+            m_pty_2->connect_cb_endpoint(m_config.serial2->cb_remote);
+        }
     }
     if (m_config.serial3.has_value()) {
-        m_pty_3 = std::make_unique<serial_bridge>(m_config.serial3.value());
+        if (not m_pty_3) {
+            m_pty_3 = std::make_unique<serial_bridge>(m_config.serial3.value(), m_ready_notify);
+        } else {
+            m_pty_3->connect_cb_endpoint(m_config.serial3->cb_remote);
+        }
     }
     if (m_config.plc.has_value()) {
-        m_plc = std::make_unique<plc_bridge>(m_config.plc.value());
+        if (not m_plc) {
+            m_plc = std::make_unique<plc_bridge>(m_config.plc.value(), m_ready_notify);
+        } else {
+            m_plc->connect_cb_endpoint(m_config.plc->cb_remote);
+        }
     }
     if (m_config.bsp.has_value()) {
-        m_bsp = std::make_unique<bsp_bridge>(m_config.bsp.value());
+        if (not m_bsp) {
+            m_bsp = std::make_unique<bsp_bridge>(m_config.bsp.value(), m_ready_notify);
+        } else {
+            m_bsp->connect_cb_endpoint(m_config.bsp->cb_remote);
+        }
+    }
+    if (m_config.gpio.has_value()) {
+        if (not m_gpio) {
+            m_gpio = std::make_unique<gpio_bridge>(m_config.gpio.value(), m_ready_notify);
+        } else {
+            m_gpio->connect_cb_endpoint(m_config.gpio->cb_remote);
+        }
     }
     if (m_config.heartbeat.has_value()) {
-        m_heartbeat = std::make_unique<heartbeat_service>(m_config.heartbeat.value(), [this](bool connected) {
+        auto heartbeat_cb = [this](bool connected) {
             {
                 auto handle = m_cb_status.handle();
                 handle->is_connected = connected;
             }
+            if (m_plc) {
+                m_plc->set_cb_connection_status(connected);
+            }
+            if (m_gpio) {
+                m_gpio->set_cb_connection_status(connected);
+            }
+            if (m_can_0_client) {
+                m_can_0_client->set_cb_connection_status(connected);
+            }
             m_cb_status.notify_one();
-        });
+        };
+
+        if (not m_heartbeat) {
+            m_heartbeat = std::make_unique<heartbeat_service>(m_config.heartbeat.value(), heartbeat_cb, m_ready_notify);
+        } else {
+            m_heartbeat->connect_cb_endpoint(m_config.heartbeat->cb_remote);
+        }
     }
-    if (m_config.gpio.has_value()) {
-        m_gpio = std::make_unique<gpio_bridge>(m_config.gpio.value());
+}
+
+void charge_bridge::cleanup_internal_runtime() {
+    disconnect_internal_runtime_endpoints();
+    m_can_0_client.reset();
+    m_pty_1.reset();
+    m_pty_2.reset();
+    m_pty_3.reset();
+    m_bsp.reset();
+    m_plc.reset();
+    m_gpio.reset();
+    m_heartbeat.reset();
+}
+
+void charge_bridge::disconnect_internal_runtime_endpoints() {
+    if (m_can_0_client) {
+        m_can_0_client->disconnect_cb_endpoint();
     }
+    if (m_pty_1) {
+        m_pty_1->disconnect_cb_endpoint();
+    }
+    if (m_pty_2) {
+        m_pty_2->disconnect_cb_endpoint();
+    }
+    if (m_pty_3) {
+        m_pty_3->disconnect_cb_endpoint();
+    }
+    if (m_bsp) {
+        m_bsp->disconnect_cb_endpoint();
+    }
+    if (m_plc) {
+        m_plc->disconnect_cb_endpoint();
+    }
+    if (m_gpio) {
+        m_gpio->disconnect_cb_endpoint();
+    }
+    if (m_heartbeat) {
+        m_heartbeat->disconnect_cb_endpoint();
+    }
+}
+
+bool charge_bridge::unregister_internal_runtime_events(everest::lib::io::event::fd_event_handler& handler) {
+    auto result = true;
+    if (m_can_0_client) {
+        result = handler.unregister_event_handler(m_can_0_client.get()) && result;
+    }
+    if (m_pty_1) {
+        result = handler.unregister_event_handler(m_pty_1.get()) && result;
+    }
+    if (m_pty_2) {
+        result = handler.unregister_event_handler(m_pty_2.get()) && result;
+    }
+    if (m_pty_3) {
+        result = handler.unregister_event_handler(m_pty_3.get()) && result;
+    }
+    if (m_bsp) {
+        result = handler.unregister_event_handler(m_bsp.get()) && result;
+    }
+    if (m_plc) {
+        result = handler.unregister_event_handler(m_plc.get()) && result;
+    }
+    if (m_heartbeat) {
+        result = handler.unregister_event_handler(m_heartbeat.get()) && result;
+    }
+    if (m_gpio) {
+        result = handler.unregister_event_handler(m_gpio.get()) && result;
+    }
+    return result;
+}
+
+std::future<bool> charge_bridge::stop_internal_runtime() {
+    auto promise = std::make_shared<std::promise<bool>>();
+    auto result = promise->get_future();
+
+    if (not m_event_handler) {
+        cleanup_internal_runtime();
+        promise->set_value(true);
+        return result;
+    }
+    m_event_handler->add_action([this, promise = std::move(promise)]() mutable {
+        try {
+            unregister_internal_runtime_events(*m_event_handler);
+            disconnect_internal_runtime_endpoints();
+            promise->set_value(true);
+        } catch (...) {
+            disconnect_internal_runtime_endpoints();
+            promise->set_exception(std::current_exception());
+        }
+        m_cb_status.notify_one();
+    });
+
+    return result;
 }
 
 charge_bridge::~charge_bridge() {
     m_cb_status.notify_one();
+    if (m_manager.joinable()) {
+        m_manager.join();
+    }
 }
 
 void charge_bridge::manage(everest::lib::io::event::fd_event_handler& handler, std::atomic_bool const& run,
                            bool force_update) {
+    if (m_manager.joinable()) {
+        std::cerr << "WARN: charge_bridge::manage called while manager thread is already running" << std::endl;
+        return;
+    }
+
     using namespace std::chrono_literals;
     m_event_handler = &handler;
     m_force_firmware_update = force_update;
 
-    auto action = [this](bool is_connected, bool discovery_pending, int& error_count) {
-        if (discovery_pending) {
-            if (m_discovery_active) {
+    m_event_handler->add_action([this]() {
+        if (m_config.telemetry.has_value()) {
+            m_1s_tick.disarm();
+            m_mqtt = std::make_unique<everest::lib::io::mqtt::mqtt_client>(mqtt_reconnect_timeout_ms);
+            m_mqtt->connect(m_config.telemetry->mqtt_bind, m_config.telemetry->mqtt_remote,
+                            m_config.telemetry->mqtt_port, m_config.telemetry->mqtt_ping_interval_ms);
+
+            m_mqtt->set_callback_connect(
+                [this](auto&, auto, auto, auto const&) { m_1s_tick.set_timeout(std::chrono::seconds(1)); });
+            register_manage_events(*m_event_handler);
+        }
+    });
+
+    if (is_mdns_endpoint()) {
+        set_discovery_pending(true);
+    }
+
+    using clock = std::chrono::steady_clock;
+    auto action = [this](charge_bridge_status& current_status, int& error_count,
+                         std::optional<clock::time_point>& next_connect_retry_time, std::future<bool>& startup_runtime,
+                         bool& startup_runtime_in_progress,
+                         std::optional<clock::time_point>& discovery_attempt_deadline,
+                         std::optional<clock::time_point>& discovery_retry_time, std::future<bool>& stop_runtime,
+                         bool& runtime_stop_in_progress) {
+        auto now = clock::now();
+        if (runtime_stop_in_progress) {
+            if (stop_runtime.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
                 return;
             }
-            m_discovery_active = true;
-            m_event_handler->add_action([this]() { register_events(*m_event_handler); });
-            return;
-        }
-        if (m_was_connected and not is_connected) {
-            if (error_count > 1) {
-                m_event_handler->add_action([this]() { unregister_events(*m_event_handler); });
-                m_was_connected = false;
-            } else {
-                error_count++;
+            try {
+                stop_runtime.get();
+            } catch (...) {
+            }
+            runtime_stop_in_progress = false;
+            m_internal_runtime_started = false;
+            m_was_connected = false;
+            error_count = 0;
+
+            if (is_mdns_endpoint()) {
+                set_discovery_pending(current_status, true);
+                m_discovery_active = false;
+                next_connect_retry_time.reset();
+                discovery_attempt_deadline.reset();
+                discovery_retry_time.reset();
+                return;
             }
         }
+        if (next_connect_retry_time.has_value() && now < next_connect_retry_time.value()) {
+            return;
+        } else if (next_connect_retry_time.has_value()) {
+            next_connect_retry_time.reset();
+        }
+        if (current_status.discovery_pending) {
+            if (m_discovery_active) {
+                if (discovery_attempt_deadline.has_value() && now >= discovery_attempt_deadline.value()) {
+                    stop_discovery();
+                    m_discovery_active = false;
+                    discovery_attempt_deadline.reset();
+                    discovery_retry_time = now + discovery_retry_delay;
+                }
+                return;
+            }
+
+            if (discovery_retry_time.has_value() && now < discovery_retry_time.value()) {
+                return;
+            }
+
+            auto discovery_interfaces = select_discovery_interfaces();
+            if (discovery_interfaces.empty()) {
+                discovery_retry_time = now + discovery_retry_delay;
+                return;
+            }
+
+            start_discovery_attempt(discovery_interfaces);
+            m_discovery_active = true;
+            discovery_attempt_deadline = now + discovery_attempt_timeout;
+            discovery_retry_time.reset();
+            return;
+        }
+
+        if (m_discovery_active) {
+            m_discovery_active = false;
+            discovery_attempt_deadline.reset();
+            discovery_retry_time.reset();
+        }
+
+        if (m_was_connected and not current_status.is_connected) {
+            stop_runtime = stop_internal_runtime();
+            runtime_stop_in_progress = true;
+        }
         if (not m_was_connected) {
+            if (startup_runtime_in_progress) {
+                if (startup_runtime.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+                    bool runtime_started = false;
+                    try {
+                        runtime_started = startup_runtime.get();
+                    } catch (...) {
+                        runtime_started = false;
+                    }
+                    startup_runtime_in_progress = false;
+                    if (runtime_started) {
+                        m_internal_runtime_started = true;
+                        m_was_connected = true;
+                        error_count = 0;
+                    }
+                }
+                return;
+            }
+
             if (update_firmware(m_force_firmware_update)) {
-                m_event_handler->add_action([this]() { register_events(*m_event_handler); });
-                m_was_connected = true;
-                error_count = 0;
+                if (not m_internal_runtime_started) {
+                    startup_runtime = start_internal_runtime();
+                    startup_runtime_in_progress = true;
+                } else {
+                    m_event_handler->add_action([this]() { register_internal_events(*m_event_handler); });
+                    m_was_connected = true;
+                    error_count = 0;
+                }
+            } else if (is_mdns_endpoint() && not m_internal_runtime_started) {
+                set_discovery_pending(current_status, true);
+                next_connect_retry_time = clock::now() + manager_base_cycle;
             }
         }
     };
+    m_manager = std::thread([&run, action, this]() {
+        using clock = std::chrono::steady_clock;
+        std::future<bool> startup_runtime;
+        bool startup_runtime_in_progress = false;
+        std::future<bool> stop_runtime;
+        bool runtime_stop_in_progress = false;
+        std::optional<clock::time_point> discovery_attempt_deadline;
+        std::optional<clock::time_point> discovery_retry_time;
+        std::optional<clock::time_point> next_connect_retry_time;
 
-    std::thread manager([&run, action, this]() {
+        auto is_startup_runtime_ready = [&startup_runtime, &startup_runtime_in_progress]() {
+            return startup_runtime_in_progress &&
+                   startup_runtime.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
+        };
+        auto is_stop_runtime_ready = [&stop_runtime, &runtime_stop_in_progress]() {
+            return runtime_stop_in_progress &&
+                   stop_runtime.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
+        };
+
         auto handle = m_cb_status.handle();
         bool last_is_connected = handle->is_connected;
         bool last_discovery_pending = handle->discovery_pending;
         int error_count = 0;
+        auto compute_wait_timeout = [&](std::chrono::milliseconds wait_timeout) {
+            if (handle->discovery_pending && is_mdns_endpoint()) {
+                if (next_connect_retry_time.has_value()) {
+                    auto now = clock::now();
+                    auto retry_remaining =
+                        std::chrono::duration_cast<std::chrono::milliseconds>(next_connect_retry_time.value() - now);
+                    if (retry_remaining < wait_timeout) {
+                        return retry_remaining;
+                    }
+                }
+                if (m_discovery_active && discovery_attempt_deadline.has_value()) {
+                    auto now = clock::now();
+                    auto attempt_remaining =
+                        std::chrono::duration_cast<std::chrono::milliseconds>(discovery_attempt_deadline.value() - now);
+                    if (attempt_remaining < wait_timeout) {
+                        return attempt_remaining;
+                    }
+                } else if (discovery_retry_time.has_value()) {
+                    auto now = clock::now();
+                    auto retry_remaining =
+                        std::chrono::duration_cast<std::chrono::milliseconds>(discovery_retry_time.value() - now);
+                    if (retry_remaining < wait_timeout) {
+                        return retry_remaining;
+                    }
+                }
+            }
+            return wait_timeout;
+        };
+
         auto condition = [&] {
             if (handle->is_connected not_eq last_is_connected) {
                 return true;
@@ -189,19 +643,53 @@ void charge_bridge::manage(everest::lib::io::event::fd_event_handler& handler, s
             if (handle->discovery_pending not_eq last_discovery_pending) {
                 return true;
             }
+            if (is_startup_runtime_ready()) {
+                return true;
+            }
+            if (is_stop_runtime_ready()) {
+                return true;
+            }
+            if (handle->discovery_pending && m_discovery_active && discovery_attempt_deadline.has_value()) {
+                if (clock::now() >= discovery_attempt_deadline.value()) {
+                    return true;
+                }
+            }
+            if (handle->discovery_pending && (not m_discovery_active) && discovery_retry_time.has_value()) {
+                if (clock::now() >= discovery_retry_time.value()) {
+                    return true;
+                }
+            }
+            if (handle->discovery_pending && next_connect_retry_time.has_value()) {
+                if (clock::now() >= next_connect_retry_time.value()) {
+                    return true;
+                }
+            }
             if (not run.load()) {
                 return true;
             }
             return false;
         };
         while (run.load()) {
-            action(handle->is_connected, handle->discovery_pending, error_count);
-            handle.wait_for(condition, 10s);
+            action(*handle, error_count, next_connect_retry_time, startup_runtime, startup_runtime_in_progress,
+                   discovery_attempt_deadline, discovery_retry_time, stop_runtime, runtime_stop_in_progress);
+            if (handle->discovery_pending && is_mdns_endpoint()) {
+                auto wait_timeout =
+                    compute_wait_timeout(std::chrono::duration_cast<std::chrono::milliseconds>(manager_base_cycle));
+                if (wait_timeout < 0ms) {
+                    wait_timeout = 0ms;
+                }
+                handle.wait_for(condition, wait_timeout);
+                last_is_connected = handle->is_connected;
+                last_discovery_pending = handle->discovery_pending;
+                continue;
+            }
+
+            auto wait_timeout = std::chrono::duration_cast<std::chrono::milliseconds>(manager_base_cycle);
+            handle.wait_for(condition, wait_timeout);
             last_is_connected = handle->is_connected;
             last_discovery_pending = handle->discovery_pending;
         }
     });
-    manager.detach();
 }
 
 bool charge_bridge::update_firmware(bool force) {
@@ -245,7 +733,174 @@ std::string charge_bridge::get_pty_3_slave_path() {
     return "";
 }
 
+utilities::chargebridge_status charge_bridge::get_status() {
+    utilities::chargebridge_status status;
+
+    status.cb_name = m_config.cb_name;
+    {
+        auto handle = m_cb_status.handle();
+        status.connected = handle->is_connected;
+        if (m_endpoint_intent.value != endpoint_intent::fixed_ip) {
+            status.discovered = not handle->discovery_pending;
+        }
+    }
+
+    if (m_can_0_client) {
+        auto available = m_can_0_client->available();
+        status.can0.emplace(available);
+    }
+    if (m_pty_1) {
+        auto available = m_pty_1->available();
+        status.serial1.emplace(available);
+    }
+    if (m_pty_2) {
+        auto available = m_pty_2->available();
+        status.serial2.emplace(available);
+    }
+    if (m_pty_3) {
+        auto available = m_pty_3->available();
+        status.serial3.emplace(available);
+    }
+    if (m_bsp) {
+        auto available = m_bsp->available();
+        status.bsp.emplace(available);
+    }
+    if (m_plc) {
+        auto available = m_plc->available();
+        status.plc.emplace(available);
+    }
+    if (m_heartbeat) {
+        auto available = m_heartbeat->available();
+        status.heartbeat.emplace(available);
+        status.mcu_resets.emplace(m_heartbeat->mcu_reset_count());
+    }
+    if (m_gpio) {
+        auto available = m_gpio->available();
+        status.gpio.emplace(available);
+    }
+
+    return status;
+}
+
+void charge_bridge::handle_ready() {
+    auto status = get_status();
+    publish_status(status);
+    if (m_status_sink) {
+        m_status_sink(status);
+    }
+}
+
+void charge_bridge::handle_tick() {
+    auto status = get_status();
+    publish_status(status);
+}
+
+void charge_bridge::publish_status(utilities::chargebridge_status const& status) {
+    if (not m_config.telemetry.has_value()) {
+        return;
+    }
+
+    bool result = true;
+    auto publish = [this](std::string_view component, std::string_view item, bool status) {
+        std::stringstream topic;
+        topic << m_config.telemetry->telemetry_topic << "/" << m_config.cb_name << "/" << component << "/" << item;
+        std::string_view payload = status ? "true" : "false";
+        m_mqtt->publish(topic.str(), payload);
+    };
+
+    publish("chargebridge", "connected", status.connected);
+    if (status.discovered.has_value()) {
+        auto discovered = status.discovered.value();
+        publish("chargebridge", "discovered", discovered);
+        result = result && discovered;
+    }
+
+    auto publish_status = [publish](std::string_view component, bool status) { publish(component, "status", status); };
+
+    if (status.can0.has_value()) {
+        auto available = status.can0.value();
+        result = result && available;
+        publish_status("can_0", available);
+    }
+    if (status.serial1.has_value()) {
+        auto available = status.serial1.value();
+        result = result && available;
+        publish_status("serial_1", available);
+    }
+    if (status.serial2.has_value()) {
+        auto available = status.serial2.value();
+        result = result && available;
+        publish_status("serial_2", available);
+    }
+    if (status.serial3.has_value()) {
+        auto available = status.serial3.value();
+        result = result && available;
+        publish_status("serial_3", available);
+    }
+    if (status.bsp.has_value()) {
+        auto available = status.bsp.value();
+        result = result && available;
+        publish_status("bsp", available);
+    }
+    if (status.plc.has_value()) {
+        auto available = status.plc.value();
+        result = result && available;
+        publish_status("plc", available);
+    }
+    if (status.heartbeat.has_value()) {
+        auto available = status.heartbeat.value();
+        result = result && available;
+        publish_status("heatbeat", available);
+    }
+    if (status.gpio.has_value()) {
+        auto available = status.gpio.value();
+        result = result && available;
+        publish_status("gpio", available);
+    }
+    publish_status("chargebridge", result);
+}
+
 bool charge_bridge::register_events(everest::lib::io::event::fd_event_handler& handler) {
+    auto result = true;
+    result = register_internal_events(handler) && result;
+    result = register_manage_events(handler) && result;
+
+    return result;
+}
+bool charge_bridge::unregister_events(everest::lib::io::event::fd_event_handler& handler) {
+    auto result = true;
+    result = unregister_internal_events(handler) && result;
+    result = unregister_manage_events(handler) && result;
+
+    return result;
+}
+bool charge_bridge::register_manage_events(everest::lib::io::event::fd_event_handler& handler) {
+    auto result = true;
+    result =
+        handler.register_event_handler(&m_1s_tick, everest::lib::util::bind_obj(&charge_bridge::handle_tick, this)) &&
+        result;
+
+    if (m_mqtt) {
+        result = handler.register_event_handler(m_mqtt.get()) && result;
+        result = handler.register_event_handler(&m_ready_notify,
+                                                everest::lib::util::bind_obj(&charge_bridge::handle_ready, this)) &&
+                 result;
+    }
+
+    return result;
+}
+bool charge_bridge::unregister_manage_events(everest::lib::io::event::fd_event_handler& handler) {
+    auto result = true;
+    result = handler.unregister_event_handler(&m_1s_tick) && result;
+    if (m_mqtt) {
+        result = handler.unregister_event_handler(m_mqtt.get()) && result;
+        result = handler.unregister_event_handler(&m_ready_notify) && result;
+    }
+
+    return result;
+}
+
+bool charge_bridge::register_internal_events(everest::lib::io::event::fd_event_handler& handler) {
     auto result = true;
     if (m_can_0_client) {
         result = handler.register_event_handler(m_can_0_client.get()) && result;
@@ -277,8 +932,9 @@ bool charge_bridge::register_events(everest::lib::io::event::fd_event_handler& h
 
     return result;
 }
-bool charge_bridge::unregister_events(everest::lib::io::event::fd_event_handler& handler) {
+bool charge_bridge::unregister_internal_events(everest::lib::io::event::fd_event_handler& handler) {
     auto result = true;
+
     if (m_can_0_client) {
         result = handler.unregister_event_handler(m_can_0_client.get()) && result;
     }
@@ -306,6 +962,7 @@ bool charge_bridge::unregister_events(everest::lib::io::event::fd_event_handler&
     if (m_discovery) {
         result = handler.unregister_event_handler(m_discovery.get()) && result;
     }
+
     return result;
 }
 

--- a/applications/pionix_chargebridge/src/everest_api/api_connector.cpp
+++ b/applications/pionix_chargebridge/src/everest_api/api_connector.cpp
@@ -134,6 +134,10 @@ void api_connector::set_cb_message(evse_bsp_cb_to_host const& msg) {
     }
 }
 
+void api_connector::set_error_handler(error_ftor const& handler) {
+    m_ready.setCallback([handler](bool, bool new_value) { handler(new_value); });
+}
+
 bool api_connector::check_cb_heartbeat() {
     if (m_last_cb_heartbeat == std::chrono::steady_clock::time_point::max()) {
         return false;
@@ -209,6 +213,7 @@ void api_connector::handle_cb_connection_state() {
         handle_status(not m_cb_connected);
     }
     m_cb_connected = current;
+    m_ready.set(m_cb_connected);
 }
 
 } // namespace charge_bridge::evse_bsp

--- a/applications/pionix_chargebridge/src/gpio_bridge.cpp
+++ b/applications/pionix_chargebridge/src/gpio_bridge.cpp
@@ -26,21 +26,18 @@ const int default_udp_timeout_ms = 1000;
 const int mqtt_reconnect_timeout_ms = 1000;
 } // namespace
 
-gpio_bridge::gpio_bridge(gpio_config const& config) :
-    m_udp(config.cb_remote, config.cb_port, default_udp_timeout_ms),
-    m_mqtt(mqtt_reconnect_timeout_ms)
+gpio_bridge::gpio_bridge(gpio_config const& config, everest::lib::io::event::event_fd& ready_notify) :
+    m_mqtt(mqtt_reconnect_timeout_ms),
+    m_udp_port(config.cb_port),
+    m_udp_remote(config.cb_remote),
+    m_ready_notify(ready_notify)
 
 {
     m_identifier = config.cb + "/" + config.item;
 
     m_heartbeat_timer.set_timeout(std::chrono::seconds(config.interval_s));
 
-    m_udp.set_rx_handler([this](auto const& data, auto&) { handle_udp_rx(data); });
-
-    m_udp.set_error_handler([this](auto id, auto const& msg) {
-        utilities::print_error(m_identifier, "GPIO/UDP", id) << msg << std::endl;
-        m_udp_on_error = id not_eq 0;
-    });
+    create_udp_client(m_udp_remote, m_udp_port);
 
     m_receive_topic = "pionix/chargebridge/" + config.cb + "/gpio/output/";
     m_send_topic = "pionix/chargebridge/" + config.cb + "/gpio/input/";
@@ -48,6 +45,8 @@ gpio_bridge::gpio_bridge(gpio_config const& config) :
     m_mqtt.set_error_handler([this, config](int id, std::string const& msg) {
         utilities::print_error(m_identifier, "GPIO/MQTT", id) << msg << std::endl;
         m_mqtt_on_error = id not_eq 0;
+        m_mqtt_ready = id == 0;
+        handle_ready();
     });
 
     m_mqtt.set_callback_connect([this](auto&, auto, auto, auto const&) {
@@ -61,20 +60,60 @@ gpio_bridge::gpio_bridge(gpio_config const& config) :
     m_message.type = CbStructType::CST_HostToCb_Gpio;
     m_message.data.number_of_gpios = CB_NUMBER_OF_GPIOS;
     std::memset(m_message.data.gpio_values, 0, sizeof(m_message.data.gpio_values));
+
+    m_ready.setCallback([this](auto&, auto&) { m_ready_notify.notify(); });
+    m_cb_is_connected.setCallback([this](bool last, bool current) {
+        if (not last and current) {
+            if (m_udp) {
+                m_udp->reset();
+            }
+        }
+        handle_ready();
+    });
+}
+
+void gpio_bridge::create_udp_client(std::string const& remote, uint16_t remote_port) {
+    m_udp = std::make_unique<everest::lib::io::udp::udp_client>(remote, remote_port, default_udp_timeout_ms);
+    m_udp_ready = false;
+    m_udp_on_error = false;
+    m_udp->set_rx_handler([this](auto const& data, auto&) { handle_udp_rx(data); });
+    m_udp->set_error_handler([this](auto id, auto const& msg) {
+        utilities::print_error(m_identifier, "GPIO/UDP", id) << msg << std::endl;
+        m_udp_on_error = id not_eq 0;
+        m_udp_ready = id == 0;
+        handle_ready();
+    });
+}
+
+void gpio_bridge::disconnect_cb_endpoint() {
+    m_udp_ready = false;
+    m_udp_on_error = true;
+    if (m_udp) {
+        m_udp->reset();
+    }
+    m_udp.reset();
+    handle_ready();
+}
+
+void gpio_bridge::connect_cb_endpoint(std::string const& remote) {
+    m_udp_remote = remote;
+    disconnect_cb_endpoint();
+    create_udp_client(m_udp_remote, m_udp_port);
+    handle_ready();
 }
 
 gpio_bridge::~gpio_bridge() {
 }
 
 bool gpio_bridge::register_events(everest::lib::io::event::fd_event_handler& handler) {
-    auto result = handler.register_event_handler(&m_udp);
+    auto result = handler.register_event_handler(m_udp.get());
     result = handler.register_event_handler(&m_mqtt) && result;
     result = handler.register_event_handler(&m_heartbeat_timer, [this](auto&) { handle_heartbeat_timer(); }) && result;
     return result;
 }
 
 bool gpio_bridge::unregister_events(everest::lib::io::event::fd_event_handler& handler) {
-    auto result = handler.unregister_event_handler(&m_udp);
+    auto result = handler.unregister_event_handler(m_udp.get());
     result = handler.unregister_event_handler(&m_mqtt) && result;
     result = handler.unregister_event_handler(&m_heartbeat_timer) && result;
     return result;
@@ -124,16 +163,18 @@ void gpio_bridge::send_mqtt(std::string const& topic, std::string const& message
 }
 
 void gpio_bridge::send_udp() {
-    if (not m_udp_on_error) {
+    if (not m_udp_on_error && m_udp) {
         everest::lib::io::udp::udp_payload payload;
         utilities::struct_to_vector(m_message, payload.buffer);
-        m_udp.tx(payload);
+        m_udp->tx(payload);
     }
 }
 
 void gpio_bridge::handle_error_timer() {
     if (m_udp_on_error) {
-        m_udp.reset();
+        if (m_udp) {
+            m_udp->reset();
+        }
     }
 }
 
@@ -151,6 +192,18 @@ void gpio_bridge::handle_udp_rx(everest::lib::io::udp::udp_payload const& payloa
     } else {
         std::cout << "INVALID DATA SIZE in UDP RX of GPIO: " << payload.size() << " vs " << sizeof(data) << std::endl;
     }
+}
+
+void gpio_bridge::handle_ready() {
+    m_ready.set(m_udp_ready and m_mqtt_ready and m_cb_is_connected);
+}
+
+bool gpio_bridge::available() const {
+    return m_ready;
+}
+
+void gpio_bridge::set_cb_connection_status(bool connected) {
+    m_cb_is_connected.set(connected);
 }
 
 } // namespace charge_bridge

--- a/applications/pionix_chargebridge/src/heartbeat_service.cpp
+++ b/applications/pionix_chargebridge/src/heartbeat_service.cpp
@@ -20,9 +20,13 @@ namespace charge_bridge {
 using namespace std::chrono_literals;
 
 heartbeat_service::heartbeat_service(heartbeat_config const& config,
-                                     std::function<void(bool)> const& publish_connection_status) :
-    m_udp(config.cb_remote, config.cb_port, default_udp_timeout_ms),
-    m_publish_connection_status(publish_connection_status) {
+                                     std::function<void(bool)> const& publish_connection_status,
+                                     everest::lib::io::event::event_fd& ready_notify) :
+    m_udp_port(config.cb_port),
+    m_udp_remote(config.cb_remote),
+    m_publish_connection_status(publish_connection_status),
+    m_ready_notify(ready_notify) {
+
     m_identifier = config.cb + "/" + config.item;
     std::memcpy(&m_config_message.data, &config.cb_config, sizeof(CbConfig));
     m_config_message.type = CbStructType::CST_HostToCb_Heartbeat;
@@ -31,16 +35,45 @@ heartbeat_service::heartbeat_service(heartbeat_config const& config,
     m_heartbeat_timer.set_timeout(m_heartbeat_interval);
     m_last_heartbeat_reply = std::chrono::steady_clock::time_point();
 
-    m_udp.set_rx_handler([this](auto const& data, auto&) { handle_udp_rx(data); });
+    create_udp_client(m_udp_remote, m_udp_port);
 
-    m_udp.set_error_handler([this](auto id, auto const& msg) {
+    m_ready.setCallback([this](auto&, auto&) { m_ready_notify.notify(); });
+}
+
+void heartbeat_service::create_udp_client(std::string const& remote, uint16_t remote_port) {
+    m_udp = std::make_unique<everest::lib::io::udp::udp_client>(remote, remote_port, default_udp_timeout_ms);
+    m_udp_on_error = false;
+    m_udp_ready = false;
+    m_udp->set_rx_handler([this](auto const& data, auto&) { handle_udp_rx(data); });
+    m_udp->set_error_handler([this](auto id, auto const& msg) {
         if (m_inital_cb_commcheck and id == 0) {
             utilities::print_error(m_identifier, "HEARTBEAT/UDP", 1) << "Waiting for ChargeBridge" << std::endl;
         } else {
             utilities::print_error(m_identifier, "HEARTBEAT/UDP", id) << msg << std::endl;
         }
         m_udp_on_error = id not_eq 0;
+        m_udp_ready = id == 0;
+        handle_ready();
     });
+}
+
+void heartbeat_service::disconnect_cb_endpoint() {
+    m_udp_ready = false;
+    m_udp_on_error = true;
+    m_cb_connected = false;
+    m_last_heartbeat_reply = std::chrono::steady_clock::time_point();
+    if (m_udp) {
+        m_udp->reset();
+    }
+    m_udp.reset();
+    handle_ready();
+}
+
+void heartbeat_service::connect_cb_endpoint(std::string const& remote) {
+    m_udp_remote = remote;
+    disconnect_cb_endpoint();
+    create_udp_client(m_udp_remote, m_udp_port);
+    handle_ready();
 }
 
 heartbeat_service::~heartbeat_service() {
@@ -49,7 +82,7 @@ heartbeat_service::~heartbeat_service() {
 bool heartbeat_service::register_events(everest::lib::io::event::fd_event_handler& handler) {
     // clang-format off
     return
-        handler.register_event_handler(&m_udp) &&
+        handler.register_event_handler(m_udp.get()) &&
         handler.register_event_handler(&m_heartbeat_timer, [this](auto&) { handle_heartbeat_timer(); });
     // clang-format on
 }
@@ -57,36 +90,52 @@ bool heartbeat_service::register_events(everest::lib::io::event::fd_event_handle
 bool heartbeat_service::unregister_events(everest::lib::io::event::fd_event_handler& handler) {
     // clang-format off
     return
-        handler.unregister_event_handler(&m_udp) &&
+        handler.unregister_event_handler(m_udp.get()) &&
         handler.unregister_event_handler(&m_heartbeat_timer);
     // clang-format on
 }
 
 void heartbeat_service::handle_error_timer() {
     if (m_udp_on_error) {
-        m_udp.reset();
+        if (m_udp) {
+            m_udp->reset();
+        }
     }
 }
 
 void heartbeat_service::handle_heartbeat_timer() {
-    if (not m_udp_on_error) {
+    if (not m_udp_on_error && m_udp) {
         everest::lib::io::udp::udp_payload payload;
         utilities::struct_to_vector(m_config_message, payload.buffer);
-        m_udp.tx(payload);
+        m_udp->tx(payload);
     }
     auto timeout = std::chrono::steady_clock::now() - m_last_heartbeat_reply > m_connection_to;
     if (timeout and m_cb_connected) {
         utilities::print_error(m_identifier, "HEARTBEAT/UDP", 1) << "ChargeBridge connection lost" << std::endl;
         m_cb_connected = false;
+        handle_ready();
     }
 
     else if (not timeout and not m_cb_connected) {
         utilities::print_error(m_identifier, "HEARTBEAT/UDP", 0) << "ChargeBridge connected" << std::endl;
         m_cb_connected = true;
+        handle_ready();
     }
     if (m_publish_connection_status) {
         m_publish_connection_status(m_cb_connected);
     }
+}
+
+void heartbeat_service::handle_ready() {
+    m_ready.set(m_cb_connected and m_udp_ready);
+}
+
+bool heartbeat_service::available() const {
+    return m_ready;
+}
+
+int heartbeat_service::mcu_reset_count() const {
+    return m_mcu_reset_count;
 }
 
 void heartbeat_service::handle_udp_rx(everest::lib::io::udp::udp_payload const& payload) {
@@ -99,6 +148,7 @@ void heartbeat_service::handle_udp_rx(everest::lib::io::udp::udp_payload const& 
             m_mcu_reset_count++;
             utilities::print_error(m_identifier, "HEARTBEAT/UDP", -1)
                 << "ChargeBridge reset count " << m_mcu_reset_count << std::endl;
+            m_ready_notify.notify();
         }
         m_mcu_timestamp = mcu_current;
 

--- a/applications/pionix_chargebridge/src/plc_bridge.cpp
+++ b/applications/pionix_chargebridge/src/plc_bridge.cpp
@@ -12,45 +12,98 @@ const int default_udp_timeout_ms = 1000;
 
 namespace charge_bridge {
 
-plc_bridge::plc_bridge(plc_bridge_config const& config) :
+plc_bridge::plc_bridge(plc_bridge_config const& config, everest::lib::io::event::event_fd& ready_notify) :
     m_tap(config.plc_tap, config.plc_ip, config.plc_netmaks, config.plc_mtu),
-    m_udp(config.cb_remote, config.cb_port, default_udp_timeout_ms) {
+    m_udp_port(config.cb_port),
+    m_udp_remote(config.cb_remote),
+    m_ready_notify(ready_notify) {
+
     using namespace std::chrono_literals;
     m_timer.set_timeout(5s);
 
+    auto identifier = config.cb + "/" + config.item;
+    m_identifier = identifier;
     m_tap.set_rx_handler([this](auto const& data, auto&) {
         everest::lib::io::udp::udp_payload pl;
         pl.buffer = data;
-        m_udp.tx(pl);
+        if (m_udp) {
+            m_udp->tx(pl);
+        }
     });
 
-    m_udp.set_rx_handler([this](auto const& data, auto&) { m_tap.tx(data.buffer); });
+    create_udp_client(config.cb_remote, config.cb_port, identifier);
 
-    auto identifier = config.cb + "/" + config.item;
     m_tap.set_error_handler([this, identifier](auto id, auto const& msg) {
         utilities::print_error(identifier, "PLC/TAP", id) << msg << std::endl;
         m_tap_on_error = id not_eq 0;
+        m_tap_ready = id == 0;
+        handle_ready();
     });
+    m_ready.setCallback([this](auto&, auto&) { m_ready_notify.notify(); });
+    m_cb_is_connected.setCallback([this](bool last, bool current) {
+        if (not last and current) {
+            if (m_udp) {
+                m_udp->reset();
+            }
+        }
+        handle_ready();
+    });
+}
 
-    m_udp.set_error_handler([this, identifier](auto id, auto const& msg) {
+void plc_bridge::create_udp_client(std::string const& remote, uint16_t remote_port, std::string const& identifier) {
+    m_udp = std::make_unique<everest::lib::io::udp::udp_client>(remote, remote_port, default_udp_timeout_ms);
+    m_udp_ready = false;
+    m_udp_on_error = false;
+    m_udp->set_rx_handler([this](auto const& data, auto&) { m_tap.tx(data.buffer); });
+    m_udp->set_error_handler([this, identifier](auto id, auto const& msg) {
         utilities::print_error(identifier, "PLC/UDP", id) << msg << std::endl;
         m_udp_on_error = id not_eq 0;
+        m_udp_ready = id == 0;
+        handle_ready();
     });
+}
+
+void plc_bridge::disconnect_cb_endpoint() {
+    m_udp_ready = false;
+    m_udp_on_error = false;
+    m_udp.reset();
+    handle_ready();
+}
+
+void plc_bridge::connect_cb_endpoint(std::string const& remote) {
+    m_udp_remote = remote;
+    disconnect_cb_endpoint();
+    create_udp_client(m_udp_remote, m_udp_port, m_identifier);
+    handle_ready();
 }
 
 void plc_bridge::handle_timer_event() {
     if (m_udp_on_error) {
-        m_udp.reset();
+        if (m_udp) {
+            m_udp->reset();
+        }
     }
     if (m_tap_on_error) {
         m_tap.reset();
     }
 }
 
+void plc_bridge::handle_ready() {
+    m_ready.set(m_udp_ready and m_tap_ready and m_cb_is_connected);
+}
+
+bool plc_bridge::available() const {
+    return m_ready;
+}
+
+void plc_bridge::set_cb_connection_status(bool connected) {
+    m_cb_is_connected.set(connected);
+}
+
 bool plc_bridge::register_events(everest::lib::io::event::fd_event_handler& handler) {
     auto result = true;
     result = handler.register_event_handler(&m_tap) && result;
-    result = handler.register_event_handler(&m_udp) && result;
+    result = handler.register_event_handler(m_udp.get()) && result;
     result = handler.register_event_handler(&m_timer, [this](auto) { handle_timer_event(); }) && result;
     return result;
 }
@@ -58,7 +111,7 @@ bool plc_bridge::register_events(everest::lib::io::event::fd_event_handler& hand
 bool plc_bridge::unregister_events(everest::lib::io::event::fd_event_handler& handler) {
     auto result = true;
     result = handler.unregister_event_handler(&m_tap) && result;
-    result = handler.unregister_event_handler(&m_udp) && result;
+    result = handler.unregister_event_handler(m_udp.get()) && result;
     result = handler.unregister_event_handler(&m_timer) && result;
     return result;
 }

--- a/applications/pionix_chargebridge/src/serial_bridge.cpp
+++ b/applications/pionix_chargebridge/src/serial_bridge.cpp
@@ -14,8 +14,8 @@ const std::uint32_t tcp_user_timeout_ms = 4000;
 
 namespace charge_bridge {
 
-serial_bridge::serial_bridge(serial_bridge_config const& config) :
-    m_pty(), m_tcp(config.cb_remote, config.cb_port, default_udp_timeout_ms) {
+serial_bridge::serial_bridge(serial_bridge_config const& config, everest::lib::io::event::event_fd& ready_notify) :
+    m_pty(), m_tcp_port(config.cb_port), m_tcp_remote(config.cb_remote), m_ready_notify(ready_notify) {
     using namespace std::chrono_literals;
 
     auto link_ok = m_symlink.set_link(m_pty.get_slave_path(), config.serial_device);
@@ -23,36 +23,64 @@ serial_bridge::serial_bridge(serial_bridge_config const& config) :
         throw std::runtime_error("Failed to setup symbolic links for serial ports");
     }
 
-    m_tcp.set_on_ready_action([this]() {
-        m_tcp.get_raw_handler()->set_keep_alive(3, 1, 1);
-        m_tcp.get_raw_handler()->set_user_timeout(tcp_user_timeout_ms);
-    });
+    m_identifier = config.cb + "/" + config.item;
 
-    m_pty.set_data_handler([this](auto const& data, auto&) { m_tcp.tx(data); });
+    create_tcp_client(m_tcp_remote, m_tcp_port);
+    m_ready.setCallback([this](auto&, auto&) { m_ready_notify.notify(); });
 
-    m_tcp.set_rx_handler([this](auto const& data, auto&) { m_pty.tx(data); });
-
-    auto identifier = config.cb + "/" + config.item;
-    m_pty.set_error_handler([this, identifier](auto id, auto const& msg) {
-        utilities::print_error(identifier, "SERIAL/PTY", id) << msg << std::endl;
-        if (id not_eq 0) {
+    m_pty.set_error_handler([this](auto id, auto const& msg) {
+        utilities::print_error(m_identifier, "SERIAL/PTY", id) << msg << std::endl;
+        m_pty_ready = id == 0;
+        if (not m_pty_ready) {
             m_pty.reset();
         }
-    });
-
-    m_tcp.set_error_handler([this, identifier](auto id, auto const& msg) {
-        if (m_tcp_last_error_id not_eq id) {
-            utilities::print_error(identifier, "SERIAL/TCP", id) << msg << std::endl;
-            m_tcp_last_error_id = id;
-        }
-        if (id not_eq 0) {
-            m_tcp.reset();
-        }
+        handle_ready();
     });
 }
 
-void serial_bridge::reset_tcp() {
+void serial_bridge::create_tcp_client(std::string const& remote, uint16_t remote_port) {
+    m_tcp = std::make_unique<everest::lib::io::tcp::tcp_client>(remote, remote_port, default_udp_timeout_ms);
+    m_tcp->set_on_ready_action([this]() {
+        m_tcp->get_raw_handler()->set_keep_alive(3, 1, 1);
+        m_tcp->get_raw_handler()->set_user_timeout(tcp_user_timeout_ms);
+    });
+
+    m_pty.set_data_handler([this](auto const& data, auto&) {
+        if (m_tcp) {
+            m_tcp->tx(data);
+        }
+    });
+    m_tcp->set_rx_handler([this](auto const& data, auto&) { m_pty.tx(data); });
+    m_tcp->set_error_handler([this](auto id, auto const& msg) {
+        if (m_tcp_last_error_id not_eq id) {
+            utilities::print_error(m_identifier, "SERIAL/TCP", id) << msg << std::endl;
+            m_tcp_last_error_id = id;
+        }
+        m_tcp_ready = id == 0;
+        if (not m_tcp_ready) {
+            if (m_tcp) {
+                m_tcp->reset();
+            }
+        }
+        handle_ready();
+    });
+}
+
+void serial_bridge::disconnect_cb_endpoint() {
+    m_tcp_ready = false;
+    m_tcp_last_error_id = -1;
+    if (m_tcp) {
+        m_tcp->reset();
+    }
     m_tcp.reset();
+    handle_ready();
+}
+
+void serial_bridge::connect_cb_endpoint(std::string const& remote) {
+    m_tcp_remote = remote;
+    disconnect_cb_endpoint();
+    create_tcp_client(m_tcp_remote, m_tcp_port);
+    handle_ready();
 }
 
 std::string serial_bridge::get_slave_path() {
@@ -62,15 +90,23 @@ std::string serial_bridge::get_slave_path() {
 bool serial_bridge::register_events(everest::lib::io::event::fd_event_handler& handler) {
     auto result = true;
     result = handler.register_event_handler(&m_pty) && result;
-    result = handler.register_event_handler(&m_tcp) && result;
+    result = handler.register_event_handler(m_tcp.get()) && result;
     return result;
 }
 
 bool serial_bridge::unregister_events(everest::lib::io::event::fd_event_handler& handler) {
     auto result = true;
     result = handler.unregister_event_handler(&m_pty) && result;
-    result = handler.unregister_event_handler(&m_tcp) && result;
+    result = handler.unregister_event_handler(m_tcp.get()) && result;
     return result;
+}
+
+void serial_bridge::handle_ready() {
+    m_ready.set(m_tcp_ready and m_pty_ready);
+}
+
+bool serial_bridge::available() const {
+    return m_ready;
 }
 
 } // namespace charge_bridge

--- a/applications/pionix_chargebridge/src/status_ui.cpp
+++ b/applications/pionix_chargebridge/src/status_ui.cpp
@@ -1,0 +1,394 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#include <charge_bridge/status_ui.hpp>
+#include <charge_bridge/utilities/logging.hpp>
+
+#include <array>
+#include <chrono>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace {
+
+constexpr char ANSI_RESET[] = "\033[0m";
+constexpr char ANSI_GREEN[] = "\033[32m";
+constexpr char ANSI_BOLD_BRIGHT_RED[] = "\033[1;91m";
+constexpr char ANSI_BOLD_WHITE[] = "\033[1;97m";
+constexpr char ANSI_BRIGHT_WHITE[] = "\033[97m";
+constexpr char ANSI_GRAY[] = "\033[90m";
+constexpr char ANSI_CURSOR_HOME[] = "\033[H";
+constexpr char ANSI_RETURN_TO_START[] = "\r";
+constexpr char ANSI_HIDE_CURSOR[] = "\033[?25l";
+constexpr char ANSI_SHOW_CURSOR[] = "\033[?25h";
+constexpr char ANSI_CLEAR_TO_END[] = "\033[0J";
+
+constexpr std::size_t STATUS_FIELD_COUNT = 12;
+constexpr std::size_t STATUS_FIELD_WIDTH = 12;
+constexpr std::size_t STATUS_LINE_WIDTH = 1 + STATUS_FIELD_COUNT * (STATUS_FIELD_WIDTH + 1);
+constexpr std::size_t STATUS_MESSAGE_WIDTH = STATUS_LINE_WIDTH - 2;
+constexpr std::size_t STATUS_MESSAGE_MAX_LENGTH = 1024;
+
+} // namespace
+
+namespace charge_bridge {
+
+status_ui::status_ui(status_ui_options options, std::vector<std::string> cb_names) : m_options(std::move(options)) {
+    m_status_rows.reserve(cb_names.size());
+    for (auto const& cb_name : cb_names) {
+        status_row row;
+        row.cb_name = cb_name;
+        auto insertion = m_cb_name_to_row.try_emplace(cb_name, m_status_rows.size());
+        if (insertion.second) {
+            m_status_rows.push_back(std::move(row));
+        }
+    }
+
+    if (m_terminal_active()) {
+        utilities::set_print_error_sink([this](std::string message) { publish_message(std::move(message)); });
+    }
+}
+
+status_ui::~status_ui() {
+    stop();
+}
+
+void status_ui::publish(utilities::chargebridge_status status) {
+    if (m_options.status_output == utilities::status_output_mode::off) {
+        return;
+    }
+
+    m_status_queue.push(status_update_event{std::move(status)});
+}
+
+void status_ui::publish_message(std::string message) {
+    if (m_options.status_output != utilities::status_output_mode::terminal || m_options.status_message_lines == 0) {
+        return;
+    }
+
+    if (message.size() > STATUS_MESSAGE_MAX_LENGTH) {
+        message.resize(STATUS_MESSAGE_MAX_LENGTH);
+    }
+
+    m_status_queue.push(log_message_event{std::move(message)});
+}
+
+void status_ui::run() {
+    if (m_options.status_output == utilities::status_output_mode::off) {
+        return;
+    }
+
+    bool expected = false;
+    if (not m_running.compare_exchange_strong(expected, true)) {
+        return;
+    }
+
+    m_thread = std::thread(&status_ui::run_internal, this);
+
+    if (m_terminal_active()) {
+        wait_for_terminal_ready();
+    }
+}
+
+void status_ui::notify_terminal_ready() {
+    if (not m_terminal_active()) {
+        return;
+    }
+
+    {
+        auto handle = m_initial_terminal_render_done.handle();
+        *handle = true;
+    }
+    m_initial_terminal_render_done.notify_one();
+}
+
+void status_ui::wait_for_terminal_ready() {
+    auto handle = m_initial_terminal_render_done.handle();
+    handle.wait([&handle] { return *handle; });
+}
+
+void status_ui::stop() {
+    m_status_queue.stop();
+    auto const was_running = m_running.exchange(false);
+
+    if (was_running && m_thread.joinable()) {
+        m_thread.join();
+    }
+
+    if (m_terminal_cursor_hidden.exchange(false)) {
+        std::cout << ANSI_SHOW_CURSOR << std::flush;
+    }
+
+    if (m_terminal_active()) {
+        utilities::clear_print_error_sink();
+    }
+}
+
+bool status_ui::m_terminal_active() const {
+    return m_options.status_output == utilities::status_output_mode::terminal;
+}
+
+void status_ui::apply_status_row(utilities::chargebridge_status const& status) {
+    auto row_it = m_cb_name_to_row.find(status.cb_name);
+    if (row_it == m_cb_name_to_row.end()) {
+        return;
+    }
+
+    auto& row = m_status_rows[row_it->second];
+    row.discovered = status.discovered;
+    row.connected = status.connected;
+    row.can0 = status.can0;
+    row.serial1 = status.serial1;
+    row.serial2 = status.serial2;
+    row.serial3 = status.serial3;
+    row.plc = status.plc;
+    row.bsp = status.bsp;
+    row.heartbeat = status.heartbeat;
+    row.gpio = status.gpio;
+    row.mcu_resets = status.mcu_resets;
+}
+
+void status_ui::apply_log_message(std::string message) {
+    m_log_messages.push_back(std::move(message));
+    if (m_log_messages.size() > m_options.status_message_lines) {
+        m_log_messages.pop_front();
+    }
+}
+
+void status_ui::process_event(status_ui_event const& event) {
+    if (auto* status_update = std::get_if<status_update_event>(&event)) {
+        apply_status_row(status_update->status);
+        return;
+    }
+
+    if (auto* log_message = std::get_if<log_message_event>(&event)) {
+        apply_log_message(log_message->message);
+    }
+}
+
+bool status_ui::has_message_event(status_ui_event const& event) {
+    return std::holds_alternative<log_message_event>(event);
+}
+
+std::string status_ui::center(std::string text, std::size_t width) {
+    if (text.size() >= width) {
+        return text.substr(0, width);
+    }
+
+    const std::size_t left = (width - text.size()) / 2;
+    const std::size_t right = width - text.size() - left;
+    return std::string(left, ' ') + text + std::string(right, ' ');
+}
+
+void status_ui::render_border(std::size_t field_count, std::size_t width) {
+    std::cout << '+';
+    for (std::size_t i = 0; i < field_count; ++i) {
+        std::cout << std::string(width, '-') << '+';
+    }
+    std::cout << '\n';
+}
+
+const char* status_ui::maybe_no_color(const char* color) const {
+    return m_options.no_color ? "" : color;
+}
+
+void status_ui::render_field(std::string const& value, const char* color, std::size_t width) {
+    std::cout << maybe_no_color(color) << center(value, width) << maybe_no_color(ANSI_RESET) << '|';
+}
+
+void status_ui::render_message_row(std::string const& text, std::size_t width) {
+    std::cout << '|';
+    if (text.size() >= width) {
+        std::cout << text.substr(0, width);
+    } else {
+        std::cout << text << std::string(width - text.size(), ' ');
+    }
+    std::cout << "|\n";
+}
+
+void status_ui::render_terminal_status() {
+    std::cout << ANSI_RETURN_TO_START << ANSI_CURSOR_HOME << ANSI_CLEAR_TO_END;
+
+    static const std::array<char const*, STATUS_FIELD_COUNT> k_headers = {
+        "cb_name", "discovered", "connected", "can0",      "serial1", "serial2",
+        "serial3", "plc",        "bsp",       "heartbeat", "gpio",    "mcu_resets",
+    };
+
+    render_border(STATUS_FIELD_COUNT, STATUS_FIELD_WIDTH);
+
+    auto render_bool_cell = [this](std::optional<bool> value) {
+        if (!value.has_value()) {
+            render_field("N/A", ANSI_GRAY, STATUS_FIELD_WIDTH);
+            return;
+        }
+
+        if (*value) {
+            render_field("OK", ANSI_GREEN, STATUS_FIELD_WIDTH);
+        } else {
+            render_field("ERROR", ANSI_BOLD_BRIGHT_RED, STATUS_FIELD_WIDTH);
+        }
+    };
+
+    std::cout << '|';
+    for (std::size_t col = 0; col < STATUS_FIELD_COUNT; ++col) {
+        std::cout << maybe_no_color(ANSI_BOLD_WHITE) << center(k_headers[col], STATUS_FIELD_WIDTH)
+                  << maybe_no_color(ANSI_RESET) << '|';
+    }
+    std::cout << '\n';
+
+    for (auto const& row : m_status_rows) {
+        std::cout << '|';
+        std::cout << maybe_no_color(ANSI_BOLD_WHITE) << center(row.cb_name, STATUS_FIELD_WIDTH)
+                  << maybe_no_color(ANSI_RESET) << '|';
+
+        render_bool_cell(row.discovered);
+        render_bool_cell(row.connected);
+        render_bool_cell(row.can0);
+        render_bool_cell(row.serial1);
+        render_bool_cell(row.serial2);
+        render_bool_cell(row.serial3);
+        render_bool_cell(row.plc);
+        render_bool_cell(row.bsp);
+        render_bool_cell(row.heartbeat);
+        render_bool_cell(row.gpio);
+
+        if (row.mcu_resets.has_value()) {
+            render_field(std::to_string(*row.mcu_resets), ANSI_BRIGHT_WHITE, STATUS_FIELD_WIDTH);
+        } else {
+            render_field("N/A", ANSI_GRAY, STATUS_FIELD_WIDTH);
+        }
+
+        std::cout << '\n';
+    }
+
+    render_border(STATUS_FIELD_COUNT, STATUS_FIELD_WIDTH);
+
+    if (m_options.status_message_lines > 0) {
+        const std::size_t blank_rows = m_options.status_message_lines > m_log_messages.size()
+                                           ? m_options.status_message_lines - m_log_messages.size()
+                                           : 0;
+
+        std::cout << '+' << std::string(STATUS_MESSAGE_WIDTH, '-') << "+\n";
+        std::ostringstream header;
+        header << " Messages (showing last " << m_options.status_message_lines << ")";
+        auto const header_text = header.str();
+        if (header_text.size() >= STATUS_MESSAGE_WIDTH) {
+            render_message_row(header_text.substr(0, STATUS_MESSAGE_WIDTH), STATUS_MESSAGE_WIDTH);
+        } else {
+            render_message_row(header_text, STATUS_MESSAGE_WIDTH);
+        }
+
+        for (std::size_t i = 0; i < blank_rows; ++i) {
+            render_message_row("", STATUS_MESSAGE_WIDTH);
+        }
+
+        for (auto const& message : m_log_messages) {
+            render_message_row(message, STATUS_MESSAGE_WIDTH);
+        }
+    }
+
+    std::cout << std::flush;
+}
+
+void status_ui::run_internal() {
+    const bool is_terminal = m_terminal_active();
+    const bool terminal_with_refresh = is_terminal && (m_options.status_refresh_ms.count() > 0);
+
+    if (is_terminal) {
+        m_terminal_cursor_hidden.store(true);
+        std::cout << ANSI_HIDE_CURSOR;
+        render_terminal_status();
+        notify_terminal_ready();
+    }
+
+    if (not is_terminal) {
+        while (true) {
+            auto event = m_status_queue.wait_and_pop();
+            if (!event.has_value()) {
+                return;
+            }
+
+            if (auto* status_event = std::get_if<status_update_event>(&*event)) {
+                utilities::print_status(status_event->status, m_options.status_output);
+            }
+
+            if (!m_running.load(std::memory_order_acquire)) {
+                auto next_event = m_status_queue.try_pop(std::chrono::milliseconds{0});
+                while (next_event.has_value()) {
+                    if (auto* status_event = std::get_if<status_update_event>(&*next_event)) {
+                        utilities::print_status(status_event->status, m_options.status_output);
+                    }
+                    next_event = m_status_queue.try_pop(std::chrono::milliseconds{0});
+                }
+                return;
+            }
+        }
+    }
+
+    if (is_terminal && not terminal_with_refresh) {
+        while (true) {
+            auto event = m_status_queue.wait_and_pop();
+            if (!event.has_value()) {
+                return;
+            }
+
+            process_event(*event);
+            if (!m_running.load(std::memory_order_acquire)) {
+                auto next_event = m_status_queue.try_pop(std::chrono::milliseconds{0});
+                while (next_event.has_value()) {
+                    process_event(*next_event);
+                    next_event = m_status_queue.try_pop(std::chrono::milliseconds{0});
+                }
+                render_terminal_status();
+                return;
+            }
+
+            render_terminal_status();
+        }
+    }
+
+    while (true) {
+        auto event = m_status_queue.wait_and_pop();
+        if (!event.has_value()) {
+            return;
+        }
+
+        process_event(*event);
+        auto render_deadline = std::chrono::steady_clock::now() + m_options.status_refresh_ms;
+        auto should_render_immediately = has_message_event(*event);
+
+        while (m_running.load(std::memory_order_acquire) && !should_render_immediately) {
+            const auto now = std::chrono::steady_clock::now();
+            if (now >= render_deadline) {
+                break;
+            }
+
+            const auto timeout = std::chrono::duration_cast<std::chrono::milliseconds>(render_deadline - now);
+            const auto next_event = m_status_queue.try_pop(timeout);
+            if (!next_event.has_value()) {
+                break;
+            }
+
+            process_event(*next_event);
+            if (has_message_event(*next_event)) {
+                should_render_immediately = true;
+            }
+        }
+
+        if (!m_running.load(std::memory_order_acquire)) {
+            auto next_event = m_status_queue.try_pop(std::chrono::milliseconds{0});
+            while (next_event.has_value()) {
+                process_event(*next_event);
+                next_event = m_status_queue.try_pop(std::chrono::milliseconds{0});
+            }
+            render_terminal_status();
+            return;
+        }
+
+        render_terminal_status();
+    }
+}
+
+} // namespace charge_bridge

--- a/applications/pionix_chargebridge/src/utilities/logging.cpp
+++ b/applications/pionix_chargebridge/src/utilities/logging.cpp
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
 #include <charge_bridge/utilities/logging.hpp>
+
+#include <everest/util/async/monitor.hpp>
+
 #include <iomanip>
+#include <sstream>
+#include <string>
+
 namespace charge_bridge::utilities {
 
 enum class color {
@@ -37,8 +44,126 @@ std::ostream& operator<<(std::ostream& s, color c) {
     case color::standard:
     default:
         s << "\033[39;49m";
+        break;
     }
     return s;
+}
+
+namespace {
+
+class null_buffer : public std::streambuf {
+public:
+    int overflow(int c) override {
+        return c;
+    }
+};
+
+using print_error_sink_storage = print_error_sink;
+
+everest::lib::util::monitor<print_error_sink_storage> print_error_sink_monitor{print_error_sink{}};
+
+print_error_sink current_print_error_sink() {
+    auto handle = print_error_sink_monitor.handle();
+    return *handle;
+}
+
+class print_error_capture_streambuf : public std::streambuf {
+public:
+    void reset(std::string const& prefix) {
+        publish_line();
+        m_buffer = prefix;
+    }
+
+    int overflow(int c) override {
+        if (c == traits_type::eof()) {
+            return traits_type::not_eof(c);
+        }
+
+        if (m_buffer.size() < k_print_error_max_length) {
+            m_buffer.push_back(static_cast<char>(c));
+        }
+
+        if (c == '\n') {
+            publish_line();
+        }
+
+        return c;
+    }
+
+    int sync() override {
+        publish_line();
+        return 0;
+    }
+
+private:
+    void publish_line() {
+        if (m_buffer.empty()) {
+            m_buffer.clear();
+            return;
+        }
+
+        if (!m_buffer.empty() && m_buffer.back() == '\n') {
+            m_buffer.pop_back();
+        }
+
+        if (!m_buffer.empty()) {
+            auto sink = current_print_error_sink();
+            if (sink) {
+                sink(std::move(m_buffer));
+            }
+        }
+
+        m_buffer.clear();
+    }
+
+    static constexpr std::size_t k_print_error_max_length = 2048;
+    std::string m_buffer;
+};
+
+std::string print_error_prefix_plain(std::string const& device, std::string const& unit, int status) {
+    std::ostringstream oss;
+    oss << "[ " << std::left << std::setw(13) << unit << " ] " << std::left << std::setw(20) << device << " ";
+    if (status == -1) {
+        oss << "WARNING ";
+    } else {
+        oss << "ERROR ( " << status << " ) ";
+    }
+
+    return oss.str();
+}
+
+std::string print_error_prefix_ansi(std::string const& device, std::string const& unit, color level, int status) {
+    std::ostringstream oss;
+    if (status == 0) {
+        return {};
+    }
+
+    oss << "[ " << level << std::setw(13) << std::left << unit << color::terminal << " ] " << color::unit
+        << std::setw(20) << device << color::terminal << " ";
+    if (status == -1) {
+        oss << color::standard << "WARNING ";
+    } else {
+        oss << color::standard << "ERROR ( " << status << " ) ";
+    }
+
+    return oss.str();
+}
+
+} // namespace
+
+inline std::ostream& capture_print_error(std::string const& device, std::string const& unit, int status) {
+    thread_local print_error_capture_streambuf capture_buffer;
+    thread_local std::ostream capture_stream(&capture_buffer);
+
+    auto const prefix = print_error_prefix_plain(device, unit, status);
+    capture_buffer.reset(prefix);
+    return capture_stream;
+}
+
+inline std::ostream& null_stream() {
+    static null_buffer buffer;
+    static std::ostream stream(&buffer);
+    return stream;
 }
 
 std::ostream& print_error(std::string const& device, std::string const& unit, int status) {
@@ -47,18 +172,26 @@ std::ostream& print_error(std::string const& device, std::string const& unit, in
         status == 0 ? color::success :
         status == -1 ? color::warning:
         color::error;
-    std::cout << "[ " << ctrl << std::setw(13) << std::left << unit << color::terminal << " ] "
-              << color::unit << std::setw(20) << device << color::terminal << " ";
-    if(status not_eq 0){
-        if(status == -1){
-            std::cout << color::standard << "WARNING ";
-        }
-        else{
-            std::cout << color::standard << "ERROR ( " << status << " ) ";
-        }
+
+    if (status == 0 ){ return null_stream(); }
+
+    if (current_print_error_sink()) {
+        return capture_print_error(device, unit, status);
     }
+
+    std::cout << print_error_prefix_ansi(device, unit, ctrl, status);
     return std::cout << color::standard;
     // clang-format on
+}
+
+void set_print_error_sink(print_error_sink sink) {
+    auto handle = print_error_sink_monitor.handle();
+    *handle = std::move(sink);
+}
+
+void clear_print_error_sink() {
+    auto handle = print_error_sink_monitor.handle();
+    handle.operator*() = print_error_sink{};
 }
 
 } // namespace charge_bridge::utilities

--- a/applications/pionix_chargebridge/src/utilities/parse_config.cpp
+++ b/applications/pionix_chargebridge/src/utilities/parse_config.cpp
@@ -170,10 +170,16 @@ void parse_config_impl(c4::yml::NodeRef& config, charge_bridge_config& c, std::f
     };
 
     get_node(c.cb_name, "charge_bridge", "name");
-
     get_node(c.cb_remote, "charge_bridge", "ip");
-
     c.cb_port = g_cb_port_management;
+
+    get_block("telemetry", c.telemetry, [&](auto& cfg, auto const& main) {
+        get_node(cfg.mqtt_remote, main, "mqtt_remote");
+        get_node(cfg.mqtt_port, main, "mqtt_port");
+        get_node_or_default(cfg.mqtt_bind, main, "mqtt_bind", "");
+        get_node_or_default(cfg.mqtt_ping_interval_ms, main, "mqtt_ping_interval_ms", default_mqtt_ping_interval_ms);
+        get_node(cfg.telemetry_topic, main, "telemetry_topic");
+    });
 
     get_block("can_0", c.can0, [&](auto& cfg, auto const& main) {
         get_node(cfg.can_device, main, "local");

--- a/applications/pionix_chargebridge/src/utilities/print_status.cpp
+++ b/applications/pionix_chargebridge/src/utilities/print_status.cpp
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+#include <algorithm>
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <charge_bridge/utilities/print_status.hpp>
+
+namespace charge_bridge::utilities {
+
+namespace ansi {
+constexpr const char* reset = "\033[0m";
+constexpr const char* green = "\033[32m";
+constexpr const char* red = "\033[31m";
+constexpr const char* gray = "\033[90m";
+constexpr const char* bright_white = "\033[97m";
+constexpr const char* bold_bright_white = "\033[1;97m";
+constexpr const char* bold_bright_red = "\033[1;91m";
+constexpr const char* bold_green = "\033[1;32m";
+} // namespace ansi
+
+struct Field {
+    const char* name;
+    std::optional<bool> value;
+};
+
+struct NumericField {
+    const char* name;
+    std::optional<int> value;
+};
+
+static std::string center(const std::string& text, std::size_t width) {
+    if (text.size() >= width) {
+        return text.substr(0, width);
+    }
+
+    const std::size_t left = (width - text.size()) / 2;
+    const std::size_t right = width - text.size() - left;
+
+    return std::string(left, ' ') + text + std::string(right, ' ');
+}
+
+static void print_border(std::ostream& os, std::size_t field_count, std::size_t width) {
+    os << '+';
+
+    for (std::size_t i = 0; i < field_count; ++i) {
+        os << std::string(width, '-');
+        os << '+';
+    }
+
+    os << '\n';
+}
+
+static std::string current_timestamp() {
+    const auto now = std::chrono::system_clock::now();
+    const std::time_t now_time = std::chrono::system_clock::to_time_t(now);
+
+    std::tm tm{};
+    localtime_r(&now_time, &tm); // Linux/POSIX
+
+    std::ostringstream oss;
+    oss << std::put_time(&tm, "%H:%M:%S");
+    return oss.str();
+}
+
+namespace {
+
+std::string escape_kv_string(std::string const& value) {
+    std::string escaped;
+    escaped.reserve(value.size() + 4);
+
+    for (char c : value) {
+        switch (c) {
+        case '\\':
+            escaped += "\\\\";
+            break;
+        case '"':
+            escaped += "\\\"";
+            break;
+        default:
+            escaped += c;
+            break;
+        }
+    }
+    return escaped;
+}
+
+void print_status_table(const chargebridge_status& s, std::ostream& os) {
+    constexpr std::size_t W = 12;
+
+    const std::vector<Field> bool_fields{
+        {"discovered", s.discovered}, {"connected", s.connected}, {"can0", s.can0}, {"serial1", s.serial1},
+        {"serial2", s.serial2},       {"serial3", s.serial3},     {"plc", s.plc},   {"bsp", s.bsp},
+        {"heartbeat", s.heartbeat},   {"gpio", s.gpio},
+    };
+    const std::vector<NumericField> numeric_fields{
+        {"mcu_resets", s.mcu_resets},
+    };
+
+    const std::size_t field_count = bool_fields.size() + numeric_fields.size() + 2; // timestamp + cb_name
+
+    print_border(os, field_count, W);
+
+    // Top row: field names
+    os << '|';
+    os << ansi::bold_bright_white << center("timestamp", W) << ansi::reset << '|';
+    os << ansi::bold_bright_white << center("cb_name", W) << ansi::reset << '|';
+
+    for (const auto& f : bool_fields) {
+        os << ansi::bold_bright_white << center(f.name, W) << ansi::reset << '|';
+    }
+    for (const auto& f : numeric_fields) {
+        os << ansi::bold_bright_white << center(f.name, W) << ansi::reset << '|';
+    }
+    os << '\n';
+
+    const bool all_available_fields_good = std::all_of(bool_fields.begin(), bool_fields.end(),
+                                                       [](const Field& f) { return !f.value.has_value() || *f.value; });
+
+    const char* cb_name_color = all_available_fields_good ? ansi::green : ansi::bold_bright_red;
+
+    // Bottom row: timestamp / values
+    os << '|';
+
+    os << ansi::bold_bright_white << center(current_timestamp(), W) << ansi::reset << '|';
+
+    os << cb_name_color << center(s.cb_name, W) << ansi::reset << '|';
+
+    for (const auto& f : bool_fields) {
+        const char* color = ansi::gray;
+        std::string status = "N/A";
+
+        if (f.value.has_value()) {
+            if (*f.value) {
+                color = ansi::green;
+                status = "OK";
+            } else {
+                color = ansi::bold_bright_red;
+                status = "ERROR";
+            }
+        }
+
+        const std::size_t left = (W - status.size()) / 2;
+        const std::size_t right = W - status.size() - left;
+
+        os << std::string(left, ' ') << color << status << ansi::reset << std::string(right, ' ') << '|';
+    }
+    for (const auto& f : numeric_fields) {
+        std::string status = "N/A";
+        auto color = ansi::gray;
+        if (f.value.has_value()) {
+            status = std::to_string(*f.value);
+            color = ansi::bright_white;
+        }
+        const std::size_t left = (W - status.size()) / 2;
+        const std::size_t right = W - status.size() - left;
+
+        os << std::string(left, ' ') << color << status << ansi::reset << std::string(right, ' ') << '|';
+    }
+    os << '\n';
+
+    print_border(os, field_count, W);
+}
+
+void print_status_log(const chargebridge_status& s, std::ostream& os) {
+    os << "chargebridge_status ";
+    os << "cb_name=\"" << escape_kv_string(s.cb_name) << "\" ";
+    os << "discovered=" << (s.discovered.has_value() ? (*s.discovered ? "true" : "false") : "na") << " ";
+    os << "connected=" << (s.connected ? "true" : "false") << " ";
+    os << "can0=" << (s.can0.has_value() ? (*s.can0 ? "true" : "false") : "na") << " ";
+    os << "serial1=" << (s.serial1.has_value() ? (*s.serial1 ? "true" : "false") : "na") << " ";
+    os << "serial2=" << (s.serial2.has_value() ? (*s.serial2 ? "true" : "false") : "na") << " ";
+    os << "serial3=" << (s.serial3.has_value() ? (*s.serial3 ? "true" : "false") : "na") << " ";
+    os << "plc=" << (s.plc.has_value() ? (*s.plc ? "true" : "false") : "na") << " ";
+    os << "bsp=" << (s.bsp.has_value() ? (*s.bsp ? "true" : "false") : "na") << " ";
+    os << "heartbeat=" << (s.heartbeat.has_value() ? (*s.heartbeat ? "true" : "false") : "na") << " ";
+    os << "gpio=" << (s.gpio.has_value() ? (*s.gpio ? "true" : "false") : "na") << " ";
+    os << "mcu_resets=" << (s.mcu_resets.has_value() ? std::to_string(*s.mcu_resets) : "na") << '\n';
+}
+
+} // namespace
+
+void print_status(const chargebridge_status& s, status_output_mode output_mode) {
+    if (output_mode == status_output_mode::off) {
+        return;
+    }
+
+    auto& os = std::cout;
+    if (output_mode == status_output_mode::log) {
+        print_status_log(s, os);
+        return;
+    }
+
+    print_status_table(s, os);
+}
+} // namespace charge_bridge::utilities

--- a/applications/pionix_chargebridge/src/utilities/print_status.cpp
+++ b/applications/pionix_chargebridge/src/utilities/print_status.cpp
@@ -23,7 +23,6 @@ constexpr const char* gray = "\033[90m";
 constexpr const char* bright_white = "\033[97m";
 constexpr const char* bold_bright_white = "\033[1;97m";
 constexpr const char* bold_bright_red = "\033[1;91m";
-constexpr const char* bold_green = "\033[1;32m";
 } // namespace ansi
 
 struct Field {
@@ -170,18 +169,36 @@ void print_status_table(const chargebridge_status& s, std::ostream& os) {
 }
 
 void print_status_log(const chargebridge_status& s, std::ostream& os) {
-    os << "chargebridge_status ";
-    os << "cb_name=\"" << escape_kv_string(s.cb_name) << "\" ";
-    os << "discovered=" << (s.discovered.has_value() ? (*s.discovered ? "true" : "false") : "na") << " ";
-    os << "connected=" << (s.connected ? "true" : "false") << " ";
-    os << "can0=" << (s.can0.has_value() ? (*s.can0 ? "true" : "false") : "na") << " ";
-    os << "serial1=" << (s.serial1.has_value() ? (*s.serial1 ? "true" : "false") : "na") << " ";
-    os << "serial2=" << (s.serial2.has_value() ? (*s.serial2 ? "true" : "false") : "na") << " ";
-    os << "serial3=" << (s.serial3.has_value() ? (*s.serial3 ? "true" : "false") : "na") << " ";
-    os << "plc=" << (s.plc.has_value() ? (*s.plc ? "true" : "false") : "na") << " ";
-    os << "bsp=" << (s.bsp.has_value() ? (*s.bsp ? "true" : "false") : "na") << " ";
-    os << "heartbeat=" << (s.heartbeat.has_value() ? (*s.heartbeat ? "true" : "false") : "na") << " ";
-    os << "gpio=" << (s.gpio.has_value() ? (*s.gpio ? "true" : "false") : "na") << " ";
+    // Overall health: connected plus every known (has_value) sub-status is good.
+    auto good = [](std::optional<bool> const& v) { return !v.has_value() || *v; };
+    const bool all_good = s.connected && good(s.discovered) && good(s.can0) && good(s.serial1) && good(s.serial2) &&
+                          good(s.serial3) && good(s.plc) && good(s.bsp) && good(s.heartbeat) && good(s.gpio);
+
+    // Mirror the "[ <unit> ] <device>  <details>" style of print_error, with the unit colored red while
+    // not everything is connected and green once all services are up. This gives a single line that
+    // turns green when the previously-red "Waiting…" conditions are resolved.
+    const char* unit_color = all_good ? ansi::green : ansi::red;
+    const char* unit_text = all_good ? "CONNECTED" : "CONNECTING";
+
+    os << "[ " << unit_color << std::left << std::setw(13) << unit_text << ansi::reset << " ] " << ansi::bold_bright_white
+       << std::left << std::setw(20) << escape_kv_string(s.cb_name) << ansi::reset << " ";
+
+    // Each service is colored green (OK) / red (FAIL) / gray (N/A).
+    auto col_bool = [](bool ok) { return std::string(ok ? ansi::green : ansi::red) + (ok ? "OK" : "ERROR") + ansi::reset; };
+    auto field = [&col_bool](std::optional<bool> const& v) {
+        return v.has_value() ? col_bool(*v) : std::string(ansi::gray) + "N/A" + ansi::reset;
+    };
+
+    os << "discovered=" << field(s.discovered) << " ";
+    os << "connected=" << col_bool(s.connected) << " ";
+    os << "can0=" << field(s.can0) << " ";
+    os << "serial1=" << field(s.serial1) << " ";
+    os << "serial2=" << field(s.serial2) << " ";
+    os << "serial3=" << field(s.serial3) << " ";
+    os << "plc=" << field(s.plc) << " ";
+    os << "bsp=" << field(s.bsp) << " ";
+    os << "heartbeat=" << field(s.heartbeat) << " ";
+    os << "gpio=" << field(s.gpio) << " ";
     os << "mcu_resets=" << (s.mcu_resets.has_value() ? std::to_string(*s.mcu_resets) : "na") << '\n';
 }
 

--- a/lib/everest/util/include/everest/util/misc/observable.hpp
+++ b/lib/everest/util/include/everest/util/misc/observable.hpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+#pragma once
+
+#include <functional>
+#include <utility>
+
+namespace everest::lib::util {
+
+template <class T, class OnChange = std::function<void(const T&, const T&)>> class observable {
+public:
+    explicit observable(T value, OnChange onChange = {}) : m_value(std::move(value)), m_onChange(std::move(onChange)) {
+    }
+
+    const T& get() const noexcept {
+        return m_value;
+    }
+
+    bool set(T newValue) {
+        if (m_value == newValue) {
+            return false;
+        }
+
+        T oldValue = std::move(m_value);
+        m_value = std::move(newValue);
+
+        if (m_onChange) {
+            m_onChange(oldValue, m_value);
+        }
+
+        return true;
+    }
+
+    void setCallback(OnChange callback) {
+        m_onChange = std::move(callback);
+    }
+
+    void clearCallback() {
+        m_onChange = nullptr;
+    }
+
+    operator const T&() const noexcept {
+        return m_value;
+    }
+
+private:
+    T m_value;
+    OnChange m_onChange;
+};
+} // namespace everest::lib::util


### PR DESCRIPTION
This adds basic telemetry to Pionix ChargeBridge. 

Connection status is published to configurable topic for each functional unit and as a summary.
