### PR TITLE
EvseSlac: Handle CM_SET_KEY failures, add retries and improve internal key state

### DIFF
--- a/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/context.hpp
+++ b/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/context.hpp
@@ -162,8 +162,12 @@ struct EvseSlacConfig {
     // flag for using 5% PWM in AC mode
     bool ac_mode_five_percent{true};
 
-    // timeout for CM_SET_KEY.REQ
+    // timeout for CM_SET_KEY.REQ; also used as the interval between retries
     int set_key_timeout_ms = 500;
+
+    // maximum number of CM_SET_KEY.REQ attempts before giving up (a new attempt is made every
+    // set_key_timeout_ms if the previous one timed out or was rejected by the modem)
+    int set_key_max_attempts = 10;
 
     // timeout for CM_SLAC_PARM.REQ
     int slac_init_timeout_ms = slac::defs::TT_EVSE_SLAC_INIT_MS;

--- a/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/context.hpp
+++ b/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/context.hpp
@@ -156,7 +156,6 @@ struct EvseSlacConfig {
     uint8_t plc_peer_mac[ETH_ALEN] = {0x00, 0xB0, 0x52, 0x00, 0x00, 0x01};
 
     // FIXME (aw): we probably want to use std::array here
-    void generate_nmk();
     uint8_t session_nmk[slac::defs::NMK_LEN]{};
 
     // flag for using 5% PWM in AC mode

--- a/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/states/others.hpp
+++ b/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/states/others.hpp
@@ -25,6 +25,10 @@ struct ResetState : public FSMSimpleState {
     int set_key_attempts{0};
     // time the last CM_SET_KEY.REQ was sent, used to space out retries
     std::chrono::steady_clock::time_point last_attempt_time{};
+
+    // Candidate NMK currently being programmed into the modem. 
+    // Promoted to slac_config.session_nmk when CM_SET_KEY.CNF succeeds, or else we continue with the old key.
+    uint8_t pending_nmk[slac::defs::NMK_LEN]{};
 };
 
 struct ResetChipState : public FSMSimpleState {
@@ -96,6 +100,7 @@ struct WaitForLinkState : public FSMSimpleState {
 struct InitState : public FSMSimpleState {
     using FSMSimpleState::FSMSimpleState;
 
+    void enter() final;
     HandleEventReturnType handle_event(AllocatorType&, Event) final;
 
     CallbackReturnType callback() final;

--- a/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/states/others.hpp
+++ b/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/states/others.hpp
@@ -26,7 +26,7 @@ struct ResetState : public FSMSimpleState {
     // time the last CM_SET_KEY.REQ was sent, used to space out retries
     std::chrono::steady_clock::time_point last_attempt_time{};
 
-    // Candidate NMK currently being programmed into the modem. 
+    // Candidate NMK currently being programmed into the modem.
     // Promoted to slac_config.session_nmk when CM_SET_KEY.CNF succeeds, or else we continue with the old key.
     uint8_t pending_nmk[slac::defs::NMK_LEN]{};
 };

--- a/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/states/others.hpp
+++ b/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/states/others.hpp
@@ -18,10 +18,13 @@ struct ResetState : public FSMSimpleState {
     void enter() final;
     CallbackReturnType callback() final;
 
-    // for now returns true if CM_SET_KEY_CNF is received
+    // returns true if a CM_SET_KEY_CNF reporting success is received
     bool handle_slac_message(slac::messages::HomeplugMessage&);
 
-    bool setup_has_been_send{false};
+    // number of CM_SET_KEY.REQ messages sent so far in this reset cycle
+    int set_key_attempts{0};
+    // time the last CM_SET_KEY.REQ was sent, used to space out retries
+    std::chrono::steady_clock::time_point last_attempt_time{};
 };
 
 struct ResetChipState : public FSMSimpleState {

--- a/lib/everest/slac/fsm/evse/src/context.cpp
+++ b/lib/everest/slac/fsm/evse/src/context.cpp
@@ -2,23 +2,9 @@
 // Copyright 2023 - 2023 Pionix GmbH and Contributors to EVerest
 #include <everest/slac/fsm/evse/context.hpp>
 
-#include <random>
-
 #include "misc.hpp"
 
 namespace slac::fsm::evse {
-
-void EvseSlacConfig::generate_nmk() {
-    const std::string CHARACTERS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-
-    std::random_device random_device;
-    std::mt19937 generator(random_device());
-    std::uniform_int_distribution<> distribution(0, CHARACTERS.size() - 1);
-
-    for (std::size_t i = 0; i < slac::defs::NMK_LEN; ++i) {
-        session_nmk[i] = (uint8_t)CHARACTERS[distribution(generator)];
-    }
-}
 
 void Context::signal_cm_slac_parm_req(const uint8_t* mac) {
     if (callbacks.signal_ev_mac_address_parm_req) {

--- a/lib/everest/slac/fsm/evse/src/misc.cpp
+++ b/lib/everest/slac/fsm/evse/src/misc.cpp
@@ -3,6 +3,7 @@
 #include "misc.hpp"
 
 #include <net/ethernet.h>
+#include <random>
 
 #include <slac/slac.hpp>
 
@@ -32,4 +33,16 @@ std::string format_mmtype(const uint16_t mmtype) {
     char string_buffer[2 + 2 * 2 + 1];
     snprintf(string_buffer, sizeof(string_buffer), "0x%04hX", mmtype);
     return string_buffer;
+}
+
+void generate_nmk(uint8_t* out) {
+    const std::string CHARACTERS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    std::random_device random_device;
+    std::mt19937 generator(random_device());
+    std::uniform_int_distribution<> distribution(0, CHARACTERS.size() - 1);
+
+    for (std::size_t i = 0; i < slac::defs::NMK_LEN; ++i) {
+        out[i] = (uint8_t)CHARACTERS[distribution(generator)];
+    }
 }

--- a/lib/everest/slac/fsm/evse/src/misc.hpp
+++ b/lib/everest/slac/fsm/evse/src/misc.hpp
@@ -14,4 +14,7 @@ std::string format_run_id(const uint8_t* run_id);
 
 std::string format_mmtype(const uint16_t mmtype);
 
+// Fills the given buffer (slac::defs::NMK_LEN bytes) with a freshly generated random NMK.
+void generate_nmk(uint8_t* out);
+
 #endif // EVSE_SLAC_MISC_HPP

--- a/lib/everest/slac/fsm/evse/src/states/others.cpp
+++ b/lib/everest/slac/fsm/evse/src/states/others.cpp
@@ -32,7 +32,10 @@ static auto create_cm_set_key_req(uint8_t const* session_nmk) {
 void ResetState::enter() {
     ctx.log_info("Entered Reset state");
     if (ctx.slac_config.regenerate_key_on_reset) {
-        ctx.slac_config.generate_nmk();
+        generate_nmk(pending_nmk);
+    } else {
+        // We don't want to regenerate the key, just use the current key as the pending one
+        memcpy(pending_nmk, ctx.slac_config.session_nmk, sizeof(pending_nmk));
     }
 }
 
@@ -88,10 +91,10 @@ FSMSimpleState::CallbackReturnType ResetState::callback() {
         ctx.log_warn("CM_SET_KEY.REQ not confirmed, retrying (attempt " + std::to_string(set_key_attempts + 1) + "/" +
                      std::to_string(cfg.set_key_max_attempts) + ")");
     } else {
-        ctx.log_info("New NMK key: " + format_nmk(cfg.session_nmk));
+        ctx.log_info("New NMK key: " + format_nmk(pending_nmk));
     }
 
-    ctx.send_slac_message(cfg.plc_peer_mac, create_cm_set_key_req(cfg.session_nmk));
+    ctx.send_slac_message(cfg.plc_peer_mac, create_cm_set_key_req(pending_nmk));
 
     set_key_attempts++;
     last_attempt_time = now;
@@ -116,6 +119,10 @@ bool ResetState::handle_slac_message(slac::messages::HomeplugMessage& message) {
     }
 
     ctx.log_info("Received CM_SET_KEY.CNF");
+
+    // CM_SET_KEY.CNF succeeded! Use it for the next session (and CM_SLAC_MATCH.CNF)
+    memcpy(ctx.slac_config.session_nmk, pending_nmk, sizeof(ctx.slac_config.session_nmk));
+
     return true;
 }
 
@@ -348,6 +355,12 @@ bool WaitForLinkState::handle_slac_message(slac::messages::HomeplugMessage& mess
         return false;
     }
     return false;
+}
+
+void InitState::enter() {
+    // Seed an initial NMK once at startup
+    // This is the stable key that is used when regenerate_key_on_reset is disabled
+    generate_nmk(ctx.slac_config.session_nmk);
 }
 
 FSMSimpleState::HandleEventReturnType InitState::handle_event(AllocatorType& sa, Event ev) {

--- a/lib/everest/slac/fsm/evse/src/states/others.cpp
+++ b/lib/everest/slac/fsm/evse/src/states/others.cpp
@@ -74,8 +74,7 @@ FSMSimpleState::CallbackReturnType ResetState::callback() {
         // A request is already in flight. We can get here either because the timeout elapsed
         // or because we were woken up early by a rejected/unexpected CNF. In the latter case we
         // wait for the remainder of the interval so that retries happen at a steady pace.
-        const auto elapsed =
-            std::chrono::duration_cast<std::chrono::milliseconds>(now - last_attempt_time).count();
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_attempt_time).count();
         if (elapsed < cfg.set_key_timeout_ms) {
             return static_cast<int>(cfg.set_key_timeout_ms - elapsed);
         }

--- a/lib/everest/slac/fsm/evse/src/states/others.cpp
+++ b/lib/everest/slac/fsm/evse/src/states/others.cpp
@@ -52,6 +52,12 @@ FSMSimpleState::HandleEventReturnType ResetState::handle_event(AllocatorType& sa
         }
     } else if (ev == Event::RESET) {
         return sa.create_simple<ResetState>(ctx);
+    } else if (ev == Event::FAILED) {
+        if (cfg.chip_reset.enabled) {
+            return sa.create_simple<ResetChipState>(ctx);
+        } else {
+            return sa.create_simple<IdleState>(ctx);
+        }
     } else {
         return sa.PASS_ON;
     }
@@ -59,20 +65,38 @@ FSMSimpleState::HandleEventReturnType ResetState::handle_event(AllocatorType& sa
 
 FSMSimpleState::CallbackReturnType ResetState::callback() {
     const auto& cfg = ctx.slac_config;
-    if (setup_has_been_send == false) {
-        auto set_key_req = create_cm_set_key_req(cfg.session_nmk);
+    const auto now = std::chrono::steady_clock::now();
 
-        ctx.log_info("New NMK key: " + format_nmk(cfg.session_nmk));
+    if (set_key_attempts > 0) {
+        // A request is already in flight. We can get here either because the timeout elapsed
+        // or because we were woken up early by a rejected/unexpected CNF. In the latter case we
+        // wait for the remainder of the interval so that retries happen at a steady pace.
+        const auto elapsed =
+            std::chrono::duration_cast<std::chrono::milliseconds>(now - last_attempt_time).count();
+        if (elapsed < cfg.set_key_timeout_ms) {
+            return static_cast<int>(cfg.set_key_timeout_ms - elapsed);
+        }
 
-        ctx.send_slac_message(cfg.plc_peer_mac, set_key_req);
+        if (set_key_attempts >= cfg.set_key_max_attempts) {
+            ctx.log_error("CM_SET_KEY.REQ failed after " + std::to_string(set_key_attempts) +
+                          " attempts - failed to setup NMK key");
+            // Give up retrying, but don't stay stuck in ResetState. Proceed to Idle or ResetChipState with a
+            // potentially inconsistent NMK rather than blocking the state machine indefinitely.
+            return Event::FAILED;
+        }
 
-        setup_has_been_send = true;
-
-        return cfg.set_key_timeout_ms;
+        ctx.log_warn("CM_SET_KEY.REQ not confirmed, retrying (attempt " + std::to_string(set_key_attempts + 1) + "/" +
+                     std::to_string(cfg.set_key_max_attempts) + ")");
     } else {
-        ctx.log_error("CM_SET_KEY_REQ timeout - failed to setup NMK key");
-        return {};
+        ctx.log_info("New NMK key: " + format_nmk(cfg.session_nmk));
     }
+
+    ctx.send_slac_message(cfg.plc_peer_mac, create_cm_set_key_req(cfg.session_nmk));
+
+    set_key_attempts++;
+    last_attempt_time = now;
+
+    return cfg.set_key_timeout_ms;
 }
 
 bool ResetState::handle_slac_message(slac::messages::HomeplugMessage& message) {
@@ -82,10 +106,17 @@ bool ResetState::handle_slac_message(slac::messages::HomeplugMessage& message) {
         // FIXME (aw): need to also deal with CM_VALIDATE.REQ. It is optional in the standard.
         ctx.log_warn("Received non-expected SLAC message of type " + format_mmtype(mmtype));
         return false;
-    } else {
-        ctx.log_info("Received CM_SET_KEY_CNF");
-        return true;
     }
+
+    const auto result = message.get_payload<slac::messages::cm_set_key_cnf>().result;
+    if (result != slac::defs::CM_SET_KEY_CNF_RESULT_SUCCESS) {
+        // Modem rejected the key. Stay in this state so callback() retries the request.
+        ctx.log_warn("Received CM_SET_KEY.CNF reported failure (result=" + std::to_string(result) + ")");
+        return false;
+    }
+
+    ctx.log_info("Received CM_SET_KEY.CNF");
+    return true;
 }
 
 void ResetChipState::enter() {

--- a/lib/everest/slac/include/slac/slac.hpp
+++ b/lib/everest/slac/include/slac/slac.hpp
@@ -119,7 +119,7 @@ const uint8_t CM_SET_KEY_REQ_PMN_UNUSED = 0x00;
 const uint8_t CM_SET_KEY_REQ_CCO_CAP_NONE = 0x00; // Level-0 CCo Capable, neither QoS nor TDMA
 const uint8_t CM_SET_KEY_REQ_PEKS_NMK_KNOWN_TO_STA = 0x01;
 
-// HPGP documents 0x00 as success, but in practice modems report success 
+// HPGP documents 0x00 as success, but in practice modems report success
 // as 0x01 in the CM_SET_KEY.CNF result field, so we treat 0x01 as success.
 const uint8_t CM_SET_KEY_CNF_RESULT_SUCCESS = 0x01;
 

--- a/lib/everest/slac/include/slac/slac.hpp
+++ b/lib/everest/slac/include/slac/slac.hpp
@@ -119,7 +119,9 @@ const uint8_t CM_SET_KEY_REQ_PMN_UNUSED = 0x00;
 const uint8_t CM_SET_KEY_REQ_CCO_CAP_NONE = 0x00; // Level-0 CCo Capable, neither QoS nor TDMA
 const uint8_t CM_SET_KEY_REQ_PEKS_NMK_KNOWN_TO_STA = 0x01;
 
-const uint8_t CM_SET_KEY_CNF_RESULT_SUCCESS = 0x0;
+// HPGP documents 0x00 as success, but in practice modems report success 
+// as 0x01 in the CM_SET_KEY.CNF result field, so we treat 0x01 as success.
+const uint8_t CM_SET_KEY_CNF_RESULT_SUCCESS = 0x01;
 
 const uint8_t CM_ATTEN_CHAR_RSP_RESULT = 0x00;
 
@@ -323,7 +325,7 @@ typedef struct {
 } __attribute__((packed)) cm_set_key_req;
 
 typedef struct {
-    uint8_t result; // 0x00 = success, 0x01 = failure, 0x02 - 0xFF = reserved
+    uint8_t result; // standard: 0x00 = success; in practice Qualcomm/Lumissil report 0x01 on success
     uint32_t my_nonce;
     uint32_t your_nonce;
     uint8_t pid;

--- a/lib/everest/slac/test/evse_slac_test.cpp
+++ b/lib/everest/slac/test/evse_slac_test.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 - 2023 Pionix GmbH and Contributors to EVerest
+#include <algorithm>
+#include <array>
 #include <chrono>
 #include <cstdio>
 #include <optional>
@@ -102,6 +104,104 @@ static void test_set_key_retries() {
     }
 
     printf("test_set_key_retries passed: gave up after %d attempts and moved to Idle\n", set_key_req_count);
+}
+
+// Verifies that the NMK advertised to the EV (session_nmk, sent in CM_SLAC_MATCH_CNF) is only
+// updated once the modem confirms the key with a successful CM_SET_KEY.CNF. A failed key set must
+// leave the previously confirmed key in place, otherwise we would hand the EV a key the modem is
+// not actually running -> "Link could not be established".
+static void test_nmk_only_committed_on_confirmed_key() {
+    printf("== test_nmk_only_committed_on_confirmed_key ==\n");
+
+    constexpr int max_attempts = 3;
+    constexpr int timeout_ms = 20;
+    // our implementation treats only 0x01 as success, so 0x00 is interpreted as a failure
+    constexpr uint8_t failure_result = 0x00;
+
+    std::array<uint8_t, slac::defs::NMK_LEN> last_req_nmk{};
+    bool got_set_key_req = false;
+
+    slac::fsm::evse::ContextCallbacks callbacks;
+    const auto slac_log = [](const std::string& text) { fmt::print("SLAC LOG: {}\n", text); };
+    callbacks.log_debug = slac_log;
+    callbacks.log_info = slac_log;
+    callbacks.log_warn = slac_log;
+    callbacks.log_error = slac_log;
+    callbacks.send_raw_slac = [&](slac::messages::HomeplugMessage& hp_message) {
+        if (hp_message.get_mmtype() == (slac::defs::MMTYPE_CM_SET_KEY | slac::defs::MMTYPE_MODE_REQ)) {
+            const auto req = hp_message.get_payload<slac::messages::cm_set_key_req>();
+            std::copy(std::begin(req.new_key), std::end(req.new_key), last_req_nmk.begin());
+            got_set_key_req = true;
+        }
+    };
+
+    auto ctx = slac::fsm::evse::Context(callbacks);
+    ctx.slac_config.set_key_timeout_ms = timeout_ms;
+    ctx.slac_config.set_key_max_attempts = max_attempts;
+    ctx.slac_config.chip_reset.enabled = false;
+
+    auto machine = slac::fsm::evse::FSM();
+
+    // --- cycle 1: a successful key set commits the new key as the active session key ---
+    machine.reset<slac::fsm::evse::ResetState>(ctx);
+    machine.feed();
+    if (!got_set_key_req) {
+        printf("Expected a CM_SET_KEY.REQ to be sent on reset\n");
+        exit(EXIT_FAILURE);
+    }
+    const auto confirmed_nmk = last_req_nmk;
+
+    ctx.slac_message_payload = create_cm_set_key_cnf();
+    machine.handle_event(slac::fsm::evse::Event::SLAC_MESSAGE);
+    machine.feed();
+
+    // after a successful CM_SET_KEY.CNF the advertised session key must equal the key we
+    // programmed into the modem
+    if (!std::equal(confirmed_nmk.begin(), confirmed_nmk.end(), ctx.slac_config.session_nmk)) {
+        printf("session_nmk was not updated to the confirmed key after CM_SET_KEY.CNF success\n");
+        exit(EXIT_FAILURE);
+    }
+
+    // --- cycle 2: a failing key set must NOT change the advertised key ---
+    got_set_key_req = false;
+    machine.handle_event(slac::fsm::evse::Event::RESET);
+    auto fr = machine.feed();
+    if (!got_set_key_req) {
+        printf("Expected a CM_SET_KEY.REQ to be sent on the second reset\n");
+        exit(EXIT_FAILURE);
+    }
+
+    // a fresh candidate key should have been generated, distinct from the confirmed one
+    const auto candidate_nmk = last_req_nmk;
+    if (std::equal(candidate_nmk.begin(), candidate_nmk.end(), confirmed_nmk.begin())) {
+        printf("Expected a freshly generated candidate NMK on reset\n");
+        exit(EXIT_FAILURE);
+    }
+
+    // reject every CM_SET_KEY.CNF until the FSM gives up
+    using namespace std::chrono;
+    while (fr.has_value()) {
+        const auto timeout = *fr;
+        if (timeout > 0) {
+            std::this_thread::sleep_for(milliseconds(timeout) + milliseconds(5));
+        }
+        ctx.slac_message_payload = create_cm_set_key_cnf(failure_result);
+        machine.handle_event(slac::fsm::evse::Event::SLAC_MESSAGE);
+        fr = machine.feed();
+    }
+
+    // the key set failed, so the advertised key must still be the previously confirmed one and
+    // must NOT have changed to the unconfirmed candidate
+    if (!std::equal(confirmed_nmk.begin(), confirmed_nmk.end(), ctx.slac_config.session_nmk)) {
+        printf("session_nmk changed after a FAILED CM_SET_KEY - regression!\n");
+        exit(EXIT_FAILURE);
+    }
+    if (std::equal(candidate_nmk.begin(), candidate_nmk.end(), ctx.slac_config.session_nmk)) {
+        printf("session_nmk was set to the unconfirmed candidate key after a FAILED CM_SET_KEY - regression!\n");
+        exit(EXIT_FAILURE);
+    }
+
+    printf("test_nmk_only_committed_on_confirmed_key passed: NMK only updated on confirmed key set\n");
 }
 
 static auto create_cm_validate_req() {
@@ -261,6 +361,7 @@ int main(int argc, char* argv[]) {
     printf("Hi from SLAC!\n");
 
     test_set_key_retries();
+    test_nmk_only_committed_on_confirmed_key();
 
     std::optional<slac::messages::HomeplugMessage> msg_in;
 

--- a/lib/everest/slac/test/evse_slac_test.cpp
+++ b/lib/everest/slac/test/evse_slac_test.cpp
@@ -13,6 +13,7 @@
 static auto create_cm_set_key_cnf() {
     // FIXME (aw): needs to be fully implemented!
     slac::messages::cm_set_key_cnf set_key_cnf;
+    set_key_cnf.result = slac::defs::CM_SET_KEY_CNF_RESULT_SUCCESS;
     slac::messages::HomeplugMessage hp_message;
     hp_message.setup_payload(&set_key_cnf, sizeof(set_key_cnf),
                              (slac::defs::MMTYPE_CM_SET_KEY | slac::defs::MMTYPE_MODE_CNF), slac::defs::MMV::AV_1_1);

--- a/lib/everest/slac/test/evse_slac_test.cpp
+++ b/lib/everest/slac/test/evse_slac_test.cpp
@@ -38,7 +38,7 @@ struct EVSession {
 
     // FIXME (aw): all these create_cm_* need to be fully implemented!
     auto create_cm_slac_parm_req() {
-        slac::messages::cm_slac_parm_req parm_req;
+        slac::messages::cm_slac_parm_req parm_req{};
         std::copy(run_id.begin(), run_id.end(), parm_req.run_id);
 
         slac::messages::HomeplugMessage hp_message;
@@ -51,7 +51,10 @@ struct EVSession {
     }
 
     auto create_cm_start_atten_char_ind() {
-        slac::messages::cm_start_atten_char_ind atten_char_ind;
+        slac::messages::cm_start_atten_char_ind atten_char_ind{};
+        atten_char_ind.num_sounds = slac::defs::CM_SLAC_PARM_CNF_NUM_SOUNDS;
+        atten_char_ind.timeout = slac::defs::CM_SLAC_PARM_CNF_TIMEOUT;
+        atten_char_ind.resp_type = slac::defs::CM_SLAC_PARM_CNF_RESP_TYPE;
         std::copy(run_id.begin(), run_id.end(), atten_char_ind.run_id);
 
         slac::messages::HomeplugMessage hp_message;
@@ -64,7 +67,7 @@ struct EVSession {
     }
 
     auto create_cm_mnbc_sound_ind() {
-        slac::messages::cm_mnbc_sound_ind sound_ind;
+        slac::messages::cm_mnbc_sound_ind sound_ind{};
         std::copy(run_id.begin(), run_id.end(), sound_ind.run_id);
 
         slac::messages::HomeplugMessage hp_message;
@@ -95,7 +98,8 @@ struct EVSession {
     }
 
     auto create_cm_atten_char_rsp() {
-        slac::messages::cm_atten_char_rsp atten_char;
+        slac::messages::cm_atten_char_rsp atten_char{};
+        std::copy(mac.begin(), mac.end(), atten_char.source_address);
         std::copy(run_id.begin(), run_id.end(), atten_char.run_id);
 
         slac::messages::HomeplugMessage hp_message;
@@ -108,7 +112,9 @@ struct EVSession {
     }
 
     auto create_cm_slac_match_req() {
-        slac::messages::cm_slac_match_req match_req;
+        slac::messages::cm_slac_match_req match_req{};
+        match_req.mvf_length = slac::defs::CM_SLAC_MATCH_REQ_MVF_LENGTH;
+        std::copy(mac.begin(), mac.end(), match_req.pev_mac);
         std::copy(run_id.begin(), run_id.end(), match_req.run_id);
 
         slac::messages::HomeplugMessage hp_message;
@@ -173,13 +179,18 @@ int main(int argc, char* argv[]) {
     std::optional<slac::messages::HomeplugMessage> msg_in;
 
     slac::fsm::evse::ContextCallbacks callbacks;
-    callbacks.log = [](const std::string& text) { fmt::print("SLAC LOG: {}\n", text); };
+    const auto slac_log = [](const std::string& text) { fmt::print("SLAC LOG: {}\n", text); };
+    callbacks.log_debug = slac_log;
+    callbacks.log_info = slac_log;
+    callbacks.log_warn = slac_log;
+    callbacks.log_error = slac_log;
 
     callbacks.send_raw_slac = [&msg_in](slac::messages::HomeplugMessage& hp_message) { msg_in = hp_message; };
 
     auto ctx = slac::fsm::evse::Context(callbacks);
     ctx.slac_config.sounding_atten_adjustment = ATTENUATION_ADJUSTMENT;
     ctx.slac_config.chip_reset.enabled = false;
+    memset(ctx.evse_mac, 0, sizeof(ctx.evse_mac));
 
     auto machine = slac::fsm::evse::FSM();
 

--- a/lib/everest/slac/test/evse_slac_test.cpp
+++ b/lib/everest/slac/test/evse_slac_test.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <cstdio>
 #include <optional>
+#include <string>
 #include <thread>
 
 #include <everest/slac/fsm/evse/fsm.hpp>
@@ -10,14 +11,97 @@
 
 #include <fmt/format.h>
 
-static auto create_cm_set_key_cnf() {
+static auto create_cm_set_key_cnf(uint8_t result = slac::defs::CM_SET_KEY_CNF_RESULT_SUCCESS) {
     // FIXME (aw): needs to be fully implemented!
     slac::messages::cm_set_key_cnf set_key_cnf;
-    set_key_cnf.result = slac::defs::CM_SET_KEY_CNF_RESULT_SUCCESS;
+    set_key_cnf.result = result;
     slac::messages::HomeplugMessage hp_message;
     hp_message.setup_payload(&set_key_cnf, sizeof(set_key_cnf),
                              (slac::defs::MMTYPE_CM_SET_KEY | slac::defs::MMTYPE_MODE_CNF), slac::defs::MMV::AV_1_1);
     return hp_message;
+}
+
+// Exercises the CM_SET_KEY.REQ retry logic in ResetState: every CM_SET_KEY.CNF that reports a
+// non-success result must trigger a resend until set_key_max_attempts is reached, after which the
+// FSM gives up (callback returns no value).
+static void test_set_key_retries() {
+    printf("== test_set_key_retries ==\n");
+
+    constexpr int max_attempts = 3;
+    constexpr int timeout_ms = 20;
+    // standard says 0x00 is success, but our implementation treats only 0x01 as success, so 0x00
+    // is interpreted as a failure here
+    constexpr uint8_t failure_result = 0x00;
+
+    int set_key_req_count = 0;
+    std::string last_state;
+
+    slac::fsm::evse::ContextCallbacks callbacks;
+    const auto slac_log = [](const std::string& text) { fmt::print("SLAC LOG: {}\n", text); };
+    callbacks.log_debug = slac_log;
+    callbacks.log_info = slac_log;
+    callbacks.log_warn = slac_log;
+    callbacks.log_error = slac_log;
+    callbacks.signal_state = [&last_state](const std::string& state) { last_state = state; };
+    callbacks.send_raw_slac = [&set_key_req_count](slac::messages::HomeplugMessage& hp_message) {
+        if (hp_message.get_mmtype() == (slac::defs::MMTYPE_CM_SET_KEY | slac::defs::MMTYPE_MODE_REQ)) {
+            set_key_req_count++;
+        }
+    };
+
+    auto ctx = slac::fsm::evse::Context(callbacks);
+    ctx.slac_config.set_key_timeout_ms = timeout_ms;
+    ctx.slac_config.set_key_max_attempts = max_attempts;
+    ctx.slac_config.chip_reset.enabled = false;
+
+    auto machine = slac::fsm::evse::FSM();
+    machine.reset<slac::fsm::evse::ResetState>(ctx);
+
+    // the first feed should send the initial CM_SET_KEY.REQ and request a timeout
+    auto fr = machine.feed();
+    if (set_key_req_count != 1) {
+        printf("Expected the first CM_SET_KEY.REQ to be sent immediately (got %d)\n", set_key_req_count);
+        exit(EXIT_FAILURE);
+    }
+
+    // drive the retry loop: reject every CM_SET_KEY.CNF and let the timeout elapse so the FSM
+    // keeps resending until it gives up. On give-up it transitions to IdleState, so feed() stops
+    // returning a timeout value (has_value() == false).
+    using namespace std::chrono;
+    while (fr.has_value()) {
+        const auto timeout = *fr;
+        if (timeout > 0) {
+            // sleep slightly longer than the timeout to make sure the retry interval has elapsed
+            std::this_thread::sleep_for(milliseconds(timeout) + milliseconds(5));
+        }
+
+        // simulate the modem rejecting the key
+        ctx.slac_message_payload = create_cm_set_key_cnf(failure_result);
+        machine.handle_event(slac::fsm::evse::Event::SLAC_MESSAGE);
+
+        fr = machine.feed();
+
+        // the FSM must never send more than max_attempts requests
+        if (set_key_req_count > max_attempts) {
+            printf("CM_SET_KEY.REQ sent more than max_attempts times (%d > %d)\n", set_key_req_count, max_attempts);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    if (set_key_req_count != max_attempts) {
+        printf("Expected exactly %d CM_SET_KEY.REQ attempts before giving up, got %d\n", max_attempts,
+               set_key_req_count);
+        exit(EXIT_FAILURE);
+    }
+
+    // after giving up, the FSM must not be stuck in ResetState but move on to Idle (UNMATCHED)
+    if (last_state != "UNMATCHED") {
+        printf("Expected FSM to transition to Idle (UNMATCHED) after giving up, last state was '%s'\n",
+               last_state.c_str());
+        exit(EXIT_FAILURE);
+    }
+
+    printf("test_set_key_retries passed: gave up after %d attempts and moved to Idle\n", set_key_req_count);
 }
 
 static auto create_cm_validate_req() {
@@ -175,6 +259,8 @@ void feed_machine_for(slac::fsm::evse::FSM& machine, int period_ms,
 int main(int argc, char* argv[]) {
     const auto ATTENUATION_ADJUSTMENT = 10;
     printf("Hi from SLAC!\n");
+
+    test_set_key_retries();
 
     std::optional<slac::messages::HomeplugMessage> msg_in;
 

--- a/lib/everest/slac/test/evse_vs_ev/plc_emu.cpp
+++ b/lib/everest/slac/test/evse_vs_ev/plc_emu.cpp
@@ -21,6 +21,7 @@ constexpr static uint8_t PLC_SRC_MAC_ADDR[ETH_ALEN] = {0x00, 0x01, 0x87, 0x0e, 0
 
 static void handle_set_key_req(int origin_fd) {
     slac::messages::cm_set_key_cnf set_key_cnf;
+    set_key_cnf.result = slac::defs::CM_SET_KEY_CNF_RESULT_SUCCESS;
     // FIXME (aw): proper message and mac header setup!
     homeplug_message.setup_payload(&set_key_cnf, sizeof(set_key_cnf),
                                    (slac::defs::MMTYPE_CM_SET_KEY | slac::defs::MMTYPE_MODE_CNF),

--- a/modules/EVSE/EvseSlac/main/slacImpl.cpp
+++ b/modules/EVSE/EvseSlac/main/slacImpl.cpp
@@ -108,8 +108,6 @@ void slacImpl::run() {
 
     fsm_ctx.slac_config.regenerate_key_on_reset = !config.hack_disable_regenerate_key_on_reset;
 
-    fsm_ctx.slac_config.generate_nmk();
-
     memcpy(fsm_ctx.evse_mac, slac_io.get_mac_addr(), ETH_ALEN);
 
     fsm_ctrl = std::make_unique<FSMController>(fsm_ctx);

--- a/modules/EVSE/EvseSlac/main/slacImpl.cpp
+++ b/modules/EVSE/EvseSlac/main/slacImpl.cpp
@@ -90,6 +90,7 @@ void slacImpl::run() {
 
     auto fsm_ctx = slac::fsm::evse::Context(callbacks);
     fsm_ctx.slac_config.set_key_timeout_ms = config.set_key_timeout_ms;
+    fsm_ctx.slac_config.set_key_max_attempts = config.set_key_max_attempts;
     fsm_ctx.slac_config.slac_init_timeout_ms = config.slac_init_timeout_ms;
     fsm_ctx.slac_config.ac_mode_five_percent = config.ac_mode_five_percent;
     fsm_ctx.slac_config.sounding_atten_adjustment = config.sounding_attenuation_adjustment;

--- a/modules/EVSE/EvseSlac/main/slacImpl.hpp
+++ b/modules/EVSE/EvseSlac/main/slacImpl.hpp
@@ -24,6 +24,7 @@ struct Conf {
     int number_of_sounds;
     bool ac_mode_five_percent;
     int set_key_timeout_ms;
+    int set_key_max_attempts;
     int sounding_attenuation_adjustment;
     bool publish_mac_on_match_cnf;
     bool publish_mac_on_first_parm_req;

--- a/modules/EVSE/EvseSlac/manifest.yaml
+++ b/modules/EVSE/EvseSlac/manifest.yaml
@@ -20,9 +20,19 @@ provides:
         type: boolean
         default: true
       set_key_timeout_ms:
-        description: Timeout for CM_SET_KEY.REQ. Default works for QCA7000/QCA7005/CG5317.
+        description: >-
+          Timeout for CM_SET_KEY.REQ. Also used as the interval between retries.
+          Default works for QCA7000/QCA7005/CG5317.
         type: integer
         default: 1000
+      set_key_max_attempts:
+        description: >-
+          Maximum number of CM_SET_KEY.REQ attempts before giving up. A new attempt is made every
+          set_key_timeout_ms if the previous one timed out or was rejected by the modem (a
+          CM_SET_KEY.CNF with a non-success result).
+        type: integer
+        minimum: 1
+        default: 10
       sounding_attenuation_adjustment:
         description: Offset in dB that should be added to the calculated sounding attenuation
         type: integer


### PR DESCRIPTION
## Describe your changes

Hello!

We have been doing some tests with EVerest and ISO 15118-2 with EvseV2G and EvseSlac, and sometimes we see CM_SET_KEY fail with our QCA7005.

Right now, EvseSlac doesn't validate if the CM_SET_KEY request is successful or not.
This PR adds validation and retries (up to a configurable amount) if it does fail.

Not only is this more robust to "reset" the PLC network between sessions, 
it also improves failures in conformance tests like TC_SECC_CMN_VTB_PLCLinkStatus_002 
(this conformance test first performs a valid SLAC match, then verifies that the EVSE leaves the PLC network after the EV disconnects/goes to state A).

In our case, this conformance test would fail because the CM_SET_KEY-request was unsuccessful. 
I'm not sure what the exact root cause behind the failure is, but retrying seems to fix it.
The CM_SET_KEY failure isn't consistent either. The first CM_SET_KEY.REQ is often successful, but in the above conformance test it seems to fail consistently.
My theory is that the CM_SET_KEY in this test occurs very quickly after SLAC matching is done, so there might be some timing that the QCA doesn't like when CM_SET_KEY.REQ is sent with this timing.

Also of note is that [Qualcomm](https://github.com/qca/open-plc-utils/blob/46c3506453c15b873fd6ed3e76c9872cea5e143a/slac/evse_cm_set_key.c#L170-L173) INVERTS the result field in CM_SET_KEY.CNF.
While the HomePlugAV GreenPhy specifies 0x00 as success, Qualcomm treats 0x00 as failure and 0x01 as success 🙃
I did consider checking `modem_vendor` for this inversion, but as I understand it, this is the "de-facto" standard for CM_SET_KEY.RES in PLC modems? ([See also](https://github.com/qca/open-plc-utils/issues/161#issuecomment-1130054300))

During our testing, we have also seen occasional cases where SLAC matching succeeds, but the EV & EVSE fails to join the network. 
I think one source of this failure could be caused by EvseSlac and the PLC modem having a mismatching NMK.
I made an improvement where the new NMK isn't "committed" internally until CM_SET_KEY is successful.
(The internal NMK is used in CM_SLAC_MATCH.CNF for the next session)

This _does_ lead to the case where if CM_SET_KEY _always_ fails, then EvseSlac will always use the same NMK.
This could also be improved upon, but I'm not sure if there is any reason to do so? 
Something is clearly wrong if CM_SET_KEY consistently fails, and the NMK isn't really critical for security anyways.

There could also be the reverse case, where CM_SET_KEY _fails_, but the PLC modem _does_ update the key. Then the next SLAC session will have the wrong NMK, but at least there will have been warnings about it in the logs.
A further improvement here could also be to actually read the NMK back out, but I know this might not always be possible (e.g. if you configure the QCA to update the NMK without writing to flash)

This is my first PR in EVerest, so I'm happy to get some feedback!

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

