### PR TITLE
feat(EvseV2G/Evse15118D20): make ports configurable via manifest

### DIFF
--- a/docs/source/how-to-guides/security-best-practices.rst
+++ b/docs/source/how-to-guides/security-best-practices.rst
@@ -111,7 +111,8 @@ set the capabilities as needed.
 
 According to the standard, port 15118 is used for SDP messages.
 :ref:`EvseV2G <everest_modules_EvseV2G>`  uses the following ports: TCP (61341), TLS (64109).
-:ref:`Evse15118D20 <everest_modules_Evse15118D20>` integrates libiso15118 which uses port 50000 for TCP and TLS1.2/1.3.
+:ref:`Evse15118D20 <everest_modules_Evse15118D20>` integrates libiso15118 and uses the configured
+``tcp_port`` value for TCP and TLS1.2/1.3. The default is ``50000``.
 
 General (non-EVerest-related) security aspects
 ====================================================================

--- a/lib/everest/iso15118/include/iso15118/io/connection_plain.hpp
+++ b/lib/everest/iso15118/include/iso15118/io/connection_plain.hpp
@@ -11,7 +11,7 @@ namespace iso15118::io {
 
 class ConnectionPlain : public IConnection {
 public:
-    ConnectionPlain(PollManager&, const std::string& interface_name);
+    ConnectionPlain(PollManager&, const std::string& interface_name, uint16_t tcp_port);
 
     void set_event_callback(const ConnectionEventCallback&) final;
     Ipv6EndPoint get_public_endpoint() const final;

--- a/lib/everest/iso15118/include/iso15118/io/connection_ssl.hpp
+++ b/lib/everest/iso15118/include/iso15118/io/connection_ssl.hpp
@@ -16,7 +16,7 @@ namespace iso15118::io {
 struct SSLContext;
 class ConnectionSSL : public IConnection {
 public:
-    ConnectionSSL(PollManager&, const std::string& interface_name, const config::SSLConfig&);
+    ConnectionSSL(PollManager&, const std::string& interface_name, const config::SSLConfig&, uint16_t tcp_port);
 
     void set_event_callback(const ConnectionEventCallback&) final;
     Ipv6EndPoint get_public_endpoint() const final;

--- a/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
+++ b/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
@@ -24,6 +24,7 @@ namespace iso15118 {
 struct TbdConfig {
     config::SSLConfig ssl{config::CertificateBackend::EVEREST_LAYOUT, {}, {}, {}, {}, {}, {}};
     std::string interface_name;
+    uint16_t tcp_port{50000};
     config::TlsNegotiationStrategy tls_negotiation_strategy{config::TlsNegotiationStrategy::ACCEPT_CLIENT_OFFER};
     bool enable_sdp_server{true};
 };

--- a/lib/everest/iso15118/src/iso15118/io/connection_plain.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_plain.cpp
@@ -18,7 +18,7 @@ namespace iso15118::io {
 
 static constexpr auto DEFAULT_SOCKET_BACKLOG = 4;
 
-ConnectionPlain::ConnectionPlain(PollManager& poll_manager_, const std::string& interface_name) :
+ConnectionPlain::ConnectionPlain(PollManager& poll_manager_, const std::string& interface_name, uint16_t tcp_port) :
     poll_manager(poll_manager_) {
     sockaddr_in6 address;
     if (not get_first_sockaddr_in6_for_interface(interface_name, address)) {
@@ -27,7 +27,7 @@ ConnectionPlain::ConnectionPlain(PollManager& poll_manager_, const std::string& 
     }
 
     // setup end point information
-    end_point.port = 50000;
+    end_point.port = tcp_port;
     memcpy(&end_point.address, &address.sin6_addr, sizeof(address.sin6_addr));
 
     fd = socket(AF_INET6, SOCK_STREAM, 0);

--- a/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
@@ -59,7 +59,6 @@ struct SSLContext {
 namespace {
 
 constexpr auto DEFAULT_SOCKET_BACKLOG = 4;
-constexpr auto TLS_PORT = 50000;
 constexpr auto NAME_LENGTH = 256;
 
 int ssl_keylog_server_index{-1};
@@ -302,7 +301,7 @@ SSL_CTX* init_ssl(const config::SSLConfig& ssl_config) {
 } // namespace
 
 ConnectionSSL::ConnectionSSL(PollManager& poll_manager_, const std::string& interface_name_,
-                             const config::SSLConfig& ssl_config) :
+                             const config::SSLConfig& ssl_config, uint16_t tcp_port) :
     poll_manager(poll_manager_), ssl(std::make_unique<SSLContext>()) {
 
     ssl->interface_name = interface_name_;
@@ -323,7 +322,7 @@ ConnectionSSL::ConnectionSSL(PollManager& poll_manager_, const std::string& inte
         log_and_throw(msg.c_str());
     }
 
-    end_point.port = TLS_PORT;
+    end_point.port = tcp_port;
     memcpy(&end_point.address, &address.sin6_addr, sizeof(address.sin6_addr));
 
     const auto address_name = sockaddr_in6_to_name(address);

--- a/lib/everest/iso15118/src/iso15118/tbd_controller.cpp
+++ b/lib/everest/iso15118/src/iso15118/tbd_controller.cpp
@@ -47,7 +47,7 @@ void TbdController::loop() {
     bool shutdown_signaled{false};
 
     if (not config.enable_sdp_server) {
-        auto connection = std::make_unique<io::ConnectionPlain>(poll_manager, interface_name);
+        auto connection = std::make_unique<io::ConnectionPlain>(poll_manager, interface_name, config.tcp_port);
         session =
             std::make_unique<Session>(std::move(connection), d20::SessionConfig(evse_setup), callbacks, pause_ctx);
     }
@@ -94,7 +94,8 @@ void TbdController::loop() {
                 session.reset();
 
                 if (not shutdown_active.load() and not config.enable_sdp_server) {
-                    auto connection = std::make_unique<io::ConnectionPlain>(poll_manager, interface_name);
+                    auto connection =
+                        std::make_unique<io::ConnectionPlain>(poll_manager, interface_name, config.tcp_port);
                     session = std::make_unique<Session>(std::move(connection), d20::SessionConfig(evse_setup),
                                                         callbacks, pause_ctx);
                 }
@@ -234,9 +235,9 @@ void TbdController::handle_sdp_server_input() {
     auto connection = [this](bool secure_connection) -> std::unique_ptr<io::IConnection> {
         try {
             if (secure_connection) {
-                return std::make_unique<io::ConnectionSSL>(poll_manager, interface_name, config.ssl);
+                return std::make_unique<io::ConnectionSSL>(poll_manager, interface_name, config.ssl, config.tcp_port);
             }
-            return std::make_unique<io::ConnectionPlain>(poll_manager, interface_name);
+            return std::make_unique<io::ConnectionPlain>(poll_manager, interface_name, config.tcp_port);
         } catch (const std::runtime_error& e) {
             logf_error("%s", e.what());
             return nullptr;

--- a/lib/everest/iso15118/test/iso15118/io/connection_openssl.cpp
+++ b/lib/everest/iso15118/test/iso15118/io/connection_openssl.cpp
@@ -16,7 +16,7 @@ static constexpr auto POLL_MANAGER_TIMEOUT_MS = 50;
 static constexpr auto STOP_TIME = 30;
 
 const char* short_opts = "hi:";
-std::string interface {};
+std::string interface{};
 
 void parse_options(int argc, char** argv) {
     int c{0};
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
                                 false,   // enforce_tls_1_3
                                 "/tmp"}; // tls_key_log_file_path
 
-    auto connection = io::ConnectionSSL(poll_manager, interface_name, ssl);
+    auto connection = io::ConnectionSSL(poll_manager, interface_name, ssl, 50000);
     connection.set_event_callback([](io::ConnectionEvent event) { handle_connection_event(event); });
 
     auto next_event = get_current_time_point();

--- a/modules/EVSE/Evse15118D20/Evse15118D20.hpp
+++ b/modules/EVSE/Evse15118D20/Evse15118D20.hpp
@@ -26,6 +26,7 @@ namespace module {
 
 struct Conf {
     std::string device;
+    int tcp_port;
     std::string logging_path;
     std::string tls_negotiation_strategy;
     bool enforce_tls_1_3;

--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -222,6 +222,7 @@ void ISO15118_chargerImpl::ready() {
             mod->config.tls_key_logging_path,   ///< tls_key_logging_path
         },
         mod->config.device,
+        static_cast<uint16_t>(mod->config.tcp_port),
         convert_tls_negotiation_strategy(mod->config.tls_negotiation_strategy),
         mod->config.enable_sdp_server,
     };

--- a/modules/EVSE/Evse15118D20/manifest.yaml
+++ b/modules/EVSE/Evse15118D20/manifest.yaml
@@ -44,6 +44,11 @@ config:
       Enable the built-in SDP server
     type: boolean
     default: true
+  tcp_port:
+    description: >-
+      TCP port used for ISO 15118-20 session communication
+    type: integer
+    default: 50000
   supported_dynamic_mode:
     description: The EVSE should support dynamic mode
     type: boolean

--- a/modules/EVSE/EvseV2G/EvseV2G.hpp
+++ b/modules/EVSE/EvseV2G/EvseV2G.hpp
@@ -28,6 +28,8 @@ namespace module {
 
 struct Conf {
     std::string device;
+    int tcp_port;
+    int tls_port;
     bool supported_DIN70121;
     bool supported_ISO15118_2;
     std::string tls_security;

--- a/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -54,6 +54,8 @@ void ISO15118_chargerImpl::init() {
 
     v2g_ctx->tls_key_logging = mod->config.tls_key_logging;
     v2g_ctx->tls_key_logging_path = mod->config.tls_key_logging_path;
+    v2g_ctx->tcp_port = static_cast<uint16_t>(mod->config.tcp_port);
+    v2g_ctx->tls_port = static_cast<uint16_t>(mod->config.tls_port);
 
     if (mod->config.tls_key_logging == true) {
         dlog(DLOG_LEVEL_DEBUG, "tls-key-logging enabled (path: %s)", mod->config.tls_key_logging_path.c_str());

--- a/modules/EVSE/EvseV2G/connection/connection.cpp
+++ b/modules/EVSE/EvseV2G/connection/connection.cpp
@@ -30,8 +30,6 @@
 #include <unistd.h>
 
 #define DEFAULT_SOCKET_BACKLOG        3
-#define DEFAULT_TCP_PORT              61341
-#define DEFAULT_TLS_PORT              64109
 #define ERROR_SESSION_ALREADY_STARTED 2
 #define CLIENT_FIN_TIMEOUT            3000
 
@@ -181,7 +179,7 @@ int connection_init(struct v2g_context* v2g_ctx) {
              * hand out a port which is not "range compatible".
              * To fulfill the ISO15118 standard, we simply try to bind to static port numbers.
              */
-            v2g_ctx->local_tcp_addr->sin6_port = htons(DEFAULT_TCP_PORT);
+            v2g_ctx->local_tcp_addr->sin6_port = htons(v2g_ctx->tcp_port);
             v2g_ctx->tcp_socket = connection_create_socket(v2g_ctx->local_tcp_addr);
             if (v2g_ctx->tcp_socket < 0) {
                 /* retry until interface is ready */
@@ -203,7 +201,7 @@ int connection_init(struct v2g_context* v2g_ctx) {
             char buffer[INET6_ADDRSTRLEN];
 
             /* see comment above for reason */
-            v2g_ctx->local_tls_addr->sin6_port = htons(DEFAULT_TLS_PORT);
+            v2g_ctx->local_tls_addr->sin6_port = htons(v2g_ctx->tls_port);
 
             v2g_ctx->tls_socket.fd = connection_create_socket(v2g_ctx->local_tls_addr);
             if (v2g_ctx->tls_socket.fd < 0) {

--- a/modules/EVSE/EvseV2G/manifest.yaml
+++ b/modules/EVSE/EvseV2G/manifest.yaml
@@ -8,6 +8,16 @@ config:
       link-local and a MAC addr will work
     type: string
     default: eth0
+  tcp_port:
+    description: >-
+      TCP port used for unencrypted ISO 15118 communication
+    type: integer
+    default: 61341
+  tls_port:
+    description: >-
+      TCP port used for TLS-protected ISO 15118 communication
+    type: integer
+    default: 64109
   supported_DIN70121:
     description: The EVSE supports the DIN SPEC
     type: boolean

--- a/modules/EVSE/EvseV2G/tests/v2g_ctx_test.cpp
+++ b/modules/EVSE/EvseV2G/tests/v2g_ctx_test.cpp
@@ -129,6 +129,11 @@ TEST_F(V2gCtxTest, v2g_ctx_init_charging_stateFalse) {
     EXPECT_FALSE(ctx->is_connection_terminated);
 }
 
+TEST_F(V2gCtxTest, v2g_ctx_create_initializes_default_ports) {
+    EXPECT_EQ(ctx->tcp_port, 61341);
+    EXPECT_EQ(ctx->tls_port, 64109);
+}
+
 #if 0
 // v2g_ctx_init_charging_session() is a trivial implementation
 TEST_F(V2gCtxTest, v2g_ctx_init_charging_sessionTrue) {

--- a/modules/EVSE/EvseV2G/v2g.hpp
+++ b/modules/EVSE/EvseV2G/v2g.hpp
@@ -207,6 +207,8 @@ struct v2g_context {
 
     std::string tls_key_logging_path;
 
+    uint16_t tcp_port;
+    uint16_t tls_port;
     uint32_t network_read_timeout;     /* in milli seconds */
     uint32_t network_read_timeout_tls; /* in milli seconds */
 

--- a/modules/EVSE/EvseV2G/v2g_ctx.cpp
+++ b/modules/EVSE/EvseV2G/v2g_ctx.cpp
@@ -294,6 +294,8 @@ struct v2g_context* v2g_ctx_create(ISO15118_chargerImplBase* p_chargerImplBase,
     /* interface from config file or options */
     ctx->if_name = "eth1";
 
+    ctx->tcp_port = 61341;
+    ctx->tls_port = 64109;
     ctx->network_read_timeout = 1000;
     ctx->network_read_timeout_tls = 5000;
 


### PR DESCRIPTION
## Describe your changes

When IsoMux module is used, a common configuration variant is to bind EvseV2G and Evse15118D20 to loopback interface and only the IsoMux to the real CP powerline interface. 
On multiport chargers such a setup is currently not possible because multiple EvseV2G instance and Evse15118D20 instances would try to allocate the same ports on the loopback interface.
To circumvent this, allow configuration of ports via manifest for each module.
For backwards compatibility, the new config options have the previous static values as defaults.

## Issue ticket number and link

none

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
