### PR TITLE
Fix buffer overflows in EXI bitstream parser

### DIFF
--- a/lib/everest/cbv2g/lib/cbv2g/common/exi_bitstream.c
+++ b/lib/everest/cbv2g/lib/cbv2g/common/exi_bitstream.c
@@ -35,10 +35,11 @@ static int exi_bitstream_has_overflow(exi_bitstream_t* stream)
             stream->byte_pos++;
             stream->bit_count = 0;
         }
-        else
-        {
-            return EXI_ERROR__BITSTREAM_OVERFLOW;
-        }
+    }
+
+    if (stream->byte_pos >= stream->data_size)
+    {
+        return EXI_ERROR__BITSTREAM_OVERFLOW;
     }
 
     return EXI_ERROR__NO_ERROR;

--- a/lib/everest/cbv2g/lib/cbv2g/exi_v2gtp.c
+++ b/lib/everest/cbv2g/lib/cbv2g/exi_v2gtp.c
@@ -65,14 +65,15 @@ int V2GTP20_ReadHeader(const uint8_t* stream_data, uint32_t* stream_payload_leng
     }
 
     /* check payload id */
-    payload_id = (stream_data[2] << 8) | stream_data[3];
+    payload_id = ((uint16_t)stream_data[2] << 8) | stream_data[3];
     if (payload_id != v2gtp20_payload_id)
     {
         return V2GTP_ERROR__PAYLOAD_ID_DOES_NOT_MATCH;
     }
 
     /* determine payload length */
-    *stream_payload_length = (stream_data[4] << 24) | (stream_data[5] << 16) | (stream_data[6] << 8) | stream_data[7];
+    *stream_payload_length = ((uint32_t)stream_data[4] << 24) | ((uint32_t)stream_data[5] << 16) |
+                             ((uint32_t)stream_data[6] << 8)  | stream_data[7];
 
     return V2GTP_ERROR__NO_ERROR;
 }


### PR DESCRIPTION
## Describe your changes
Full description in cbExiGen:
https://github.com/EVerest/cbexigen/pull/129

**This PR only regenerated auto-generated .c files from cbExiGen templates.**

## Fixed issues
exi_bitstream_has_overflow() only advanced and validated byte_pos when bit_count reached a full byte (EXI_BITSTREAM_MAX_BIT_COUNT). It never checked that the byte about to be accessed was within the stream before exi_bitstream_read_bit and exi_bitstream_write_bit dereference data[byte_pos]. This allowed out-of-bounds access.

V2GTP20_ReadHeader() exhibited undefined behavior. When left-shifting uint8_t bytes from stream_data, each operand is implicitly promoted to signed int. Shifting a value into the sign bit (e.g. stream_data[4] << 24) is undefined behavior in C, which can lead to incorrect payload length and payload id values depending on the compiler.

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

