### PR TITLE
Send `message` error property from the stable API to the CSMS

### DIFF
--- a/applications/utils/everest-testing/src/everest/testing/core_utils/_configuration/everest_configuration_strategies/evse_board_support_api_configuration_strategy.py
+++ b/applications/utils/everest-testing/src/everest/testing/core_utils/_configuration/everest_configuration_strategies/evse_board_support_api_configuration_strategy.py
@@ -1,0 +1,25 @@
+from copy import deepcopy
+from typing import Dict
+
+from everest.testing.core_utils._configuration.everest_configuration_strategies.everest_configuration_strategy import \
+    EverestConfigAdjustmentStrategy
+
+
+class EvseBoardSupportApiConfigAdjustment(EverestConfigAdjustmentStrategy):
+    """ Adjusts the Everest configuration to route connector_1's board support
+    through an evse_board_support_API module (`bsp_1`), so tests can drive
+    board support (e.g. raise/clear errors) via the stable external API instead
+    of the YetiSimulator's built-in board support. """
+
+    def adjust_everest_configuration(self, everest_config: Dict) -> Dict:
+        adjusted_config = deepcopy(everest_config)
+        active_modules = adjusted_config["active_modules"]
+        active_modules["bsp_1"] = {
+            "module": "evse_board_support_API",
+            "mapping": {"module": {"evse": 1}},
+            "config_module": {"cfg_communication_check_to_s": 0},
+        }
+        active_modules["connector_1"]["connections"]["bsp"] = [
+            {"module_id": "bsp_1", "implementation_id": "main"}
+        ]
+        return adjusted_config

--- a/docs/source/reference/EVerest_API/ev_board_support_API.yaml
+++ b/docs/source/reference/EVerest_API/ev_board_support_API.yaml
@@ -449,7 +449,10 @@ components:
           description: The subtype of the error
           type: string
         message:
-          description: Addition information about the error
+          description: |-
+            Optional additional information about the error
+            OCPP 1.6: Sets `info` on MREC errors and `vendorId` otherwise
+            OCPP 2.x: Sets `techInfo`
           type: string
 
     CommunicationCheck:

--- a/docs/source/reference/EVerest_API/ev_board_support_API.yaml
+++ b/docs/source/reference/EVerest_API/ev_board_support_API.yaml
@@ -297,7 +297,7 @@ components:
       examples:
         - summary: "Report cable ampicity of 32A and some RCD current + PWM duty cycle"
           payload:
-            proximity_pilot:  
+            proximity_pilot:
               "ampacity": "A_32"
             rcd_current_mA: 5
             cp_pwm_duty_cycle: 53
@@ -411,7 +411,7 @@ components:
         - cp_pwm_duty_cycle
         - proximity_pilot
       properties:
-        proximity_pilot:  
+        proximity_pilot:
           description: Current capability of the cable
           type: object
           $ref: 'evse_board_support_API.yaml#/components/schemas/ProximityPilot'
@@ -449,7 +449,19 @@ components:
           description: The subtype of the error
           type: string
         message:
-          description: Addition information about the error
+          description: |-
+            Optional free-text detail about this specific occurrence of the error,
+            e.g. a measured value or a diagnostic string from the hardware. Unlike
+            the fixed per-error-type description, this is chosen by the caller.
+            If an OCPP module is part of the EVerest configuration, the message is
+            forwarded to the CSMS:
+            * OCPP 1.6 (`StatusNotification.req`):
+              * MREC errors: sent as `info`, truncated to 50 characters.
+                Omitted entirely when the message is empty.
+              * all other errors: sent as `vendorId`, truncated to 255 characters.
+            * OCPP 2.x (`NotifyEvent.req`): sent as `techInfo`, truncated to 500
+              characters. When the message is empty, the error description is sent
+              instead.
           type: string
 
     CommunicationCheck:

--- a/docs/source/reference/EVerest_API/evse_board_support_API.yaml
+++ b/docs/source/reference/EVerest_API/evse_board_support_API.yaml
@@ -832,7 +832,10 @@ components:
           description: The subtype of the error
           type: string
         message:
-          description: Addition information about the error
+          description: |-
+            Optional additional information about the error
+            OCPP 1.6: Sets `info` on MREC errors and `vendorId` otherwise
+            OCPP 2.x: Sets `techInfo`
           type: string
 
     CommunicationCheck:

--- a/docs/source/reference/EVerest_API/evse_board_support_API.yaml
+++ b/docs/source/reference/EVerest_API/evse_board_support_API.yaml
@@ -834,7 +834,19 @@ components:
           description: The subtype of the error
           type: string
         message:
-          description: Addition information about the error
+          description: |-
+            Optional free-text detail about this specific occurrence of the error,
+            e.g. a measured value or a diagnostic string from the hardware. Unlike
+            the fixed per-error-type description, this is chosen by the caller.
+            If an OCPP module is part of the EVerest configuration, the message is
+            forwarded to the CSMS:
+            * OCPP 1.6 (`StatusNotification.req`):
+              * MREC errors: sent as `info`, truncated to 50 characters.
+                Omitted entirely when the message is empty.
+              * all other errors: sent as `vendorId`, truncated to 255 characters.
+            * OCPP 2.x (`NotifyEvent.req`): sent as `techInfo`, truncated to 500
+              characters. When the message is empty, the error description is sent
+              instead.
           type: string
 
     CommunicationCheck:

--- a/docs/source/reference/EVerest_API/generic_error_raiser_API.yaml
+++ b/docs/source/reference/EVerest_API/generic_error_raiser_API.yaml
@@ -157,7 +157,10 @@ components:
           description: The subtype of the error
           type: string
         message:
-          description: Addition information about the error
+          description: |-
+            Optional additional information about the error
+            OCPP 1.6: Sets `info` on MREC errors and `vendorId` otherwise
+            OCPP 2.x: Sets `techInfo`
           type: string
 
     CommunicationCheck:

--- a/docs/source/reference/EVerest_API/generic_error_raiser_API.yaml
+++ b/docs/source/reference/EVerest_API/generic_error_raiser_API.yaml
@@ -157,7 +157,19 @@ components:
           description: The subtype of the error
           type: string
         message:
-          description: Addition information about the error
+          description: |-
+            Optional free-text detail about this specific occurrence of the error,
+            e.g. a measured value or a diagnostic string from the hardware. Unlike
+            the fixed per-error-type description, this is chosen by the caller.
+            If an OCPP module is part of the EVerest configuration, the message is
+            forwarded to the CSMS:
+            * OCPP 1.6 (`StatusNotification.req`):
+              * MREC errors: sent as `info`, truncated to 50 characters.
+                Omitted entirely when the message is empty.
+              * all other errors: sent as `vendorId`, truncated to 255 characters.
+            * OCPP 2.x (`NotifyEvent.req`): sent as `techInfo`, truncated to 500
+              characters. When the message is empty, the error description is sent
+              instead.
           type: string
 
     CommunicationCheck:

--- a/docs/source/reference/EVerest_API/isolation_monitor_API.yaml
+++ b/docs/source/reference/EVerest_API/isolation_monitor_API.yaml
@@ -304,7 +304,10 @@ components:
           description: The subtype of the error
           type: string
         message:
-          description: Addition information about the error
+          description: |-
+            Optional additional information about the error
+            OCPP 1.6: Sets `info` on MREC errors and `vendorId` otherwise
+            OCPP 2.x: Sets `techInfo`
           type: string
 
     CommunicationCheck:

--- a/docs/source/reference/EVerest_API/isolation_monitor_API.yaml
+++ b/docs/source/reference/EVerest_API/isolation_monitor_API.yaml
@@ -304,7 +304,19 @@ components:
           description: The subtype of the error
           type: string
         message:
-          description: Addition information about the error
+          description: |-
+            Optional free-text detail about this specific occurrence of the error,
+            e.g. a measured value or a diagnostic string from the hardware. Unlike
+            the fixed per-error-type description, this is chosen by the caller.
+            If an OCPP module is part of the EVerest configuration, the message is
+            forwarded to the CSMS:
+            * OCPP 1.6 (`StatusNotification.req`):
+              * MREC errors: sent as `info`, truncated to 50 characters.
+                Omitted entirely when the message is empty.
+              * all other errors: sent as `vendorId`, truncated to 255 characters.
+            * OCPP 2.x (`NotifyEvent.req`): sent as `techInfo`, truncated to 500
+              characters. When the message is empty, the error description is sent
+              instead.
           type: string
 
     CommunicationCheck:

--- a/docs/source/reference/EVerest_API/over_voltage_monitor_API.yaml
+++ b/docs/source/reference/EVerest_API/over_voltage_monitor_API.yaml
@@ -321,7 +321,10 @@ components:
           description: The severity of the error
           $ref: '#/components/schemas/ErrorSeverityEnum'
         message:
-          description: Addition information about the error
+          description: |-
+            Optional additional information about the error
+            OCPP 1.6: Sets `info` on MREC errors and `vendorId` otherwise
+            OCPP 2.x: Sets `techInfo`
           type: string
     ErrorEnum:
       description: |

--- a/docs/source/reference/EVerest_API/over_voltage_monitor_API.yaml
+++ b/docs/source/reference/EVerest_API/over_voltage_monitor_API.yaml
@@ -321,7 +321,19 @@ components:
           description: The severity of the error
           $ref: '#/components/schemas/ErrorSeverityEnum'
         message:
-          description: Addition information about the error
+          description: |-
+            Optional free-text detail about this specific occurrence of the error,
+            e.g. a measured value or a diagnostic string from the hardware. Unlike
+            the fixed per-error-type description, this is chosen by the caller.
+            If an OCPP module is part of the EVerest configuration, the message is
+            forwarded to the CSMS:
+            * OCPP 1.6 (`StatusNotification.req`):
+              * MREC errors: sent as `info`, truncated to 50 characters.
+                Omitted entirely when the message is empty.
+              * all other errors: sent as `vendorId`, truncated to 255 characters.
+            * OCPP 2.x (`NotifyEvent.req`): sent as `techInfo`, truncated to 500
+              characters. When the message is empty, the error description is sent
+              instead.
           type: string
     ErrorEnum:
       description: |

--- a/docs/source/reference/EVerest_API/power_supply_DC_API.yaml
+++ b/docs/source/reference/EVerest_API/power_supply_DC_API.yaml
@@ -491,7 +491,10 @@ components:
           description: The subtype of the error
           type: string
         message:
-          description: Addition information about the error
+          description: |-
+            Optional additional information about the error
+            OCPP 1.6: Sets `info` on MREC errors and `vendorId` otherwise
+            OCPP 2.x: Sets `techInfo`
           type: string
 
     CommunicationCheck:

--- a/docs/source/reference/EVerest_API/power_supply_DC_API.yaml
+++ b/docs/source/reference/EVerest_API/power_supply_DC_API.yaml
@@ -491,7 +491,19 @@ components:
           description: The subtype of the error
           type: string
         message:
-          description: Addition information about the error
+          description: |-
+            Optional free-text detail about this specific occurrence of the error,
+            e.g. a measured value or a diagnostic string from the hardware. Unlike
+            the fixed per-error-type description, this is chosen by the caller.
+            If an OCPP module is part of the EVerest configuration, the message is
+            forwarded to the CSMS:
+            * OCPP 1.6 (`StatusNotification.req`):
+              * MREC errors: sent as `info`, truncated to 50 characters.
+                Omitted entirely when the message is empty.
+              * all other errors: sent as `vendorId`, truncated to 255 characters.
+            * OCPP 2.x (`NotifyEvent.req`): sent as `techInfo`, truncated to 500
+              characters. When the message is empty, the error description is sent
+              instead.
           type: string
 
     CommunicationCheck:

--- a/docs/source/reference/EVerest_API/slac_API.yaml
+++ b/docs/source/reference/EVerest_API/slac_API.yaml
@@ -361,7 +361,10 @@ components:
           description: Sub-type of the error.
         message:
           type: string
-          description: Addition information about the error
+          description: |-
+            Optional additional information about the error
+            OCPP 1.6: Sets `info` on MREC errors and `vendorId` otherwise
+            OCPP 2.x: Sets `techInfo`
     ErrorEnum:
       type: string
       description: |

--- a/docs/source/reference/EVerest_API/slac_API.yaml
+++ b/docs/source/reference/EVerest_API/slac_API.yaml
@@ -354,7 +354,10 @@ components:
           description: Sub-type of the error.
         message:
           type: string
-          description: Addition information about the error
+          description: |-
+            Optional additional information about the error
+            OCPP 1.6: Sets `info` on MREC errors and `vendorId` otherwise
+            OCPP 2.x: Sets `techInfo`
     ErrorEnum:
       description: |
         Type of Error

--- a/lib/everest/ocpp_module_common/src/error_handling.cpp
+++ b/lib/everest/ocpp_module_common/src/error_handling.cpp
@@ -114,7 +114,11 @@ ocpp::v2::EventData get_event_data(const Everest::error::Error& error, const boo
         event_data.techCode = error.type;
     }
 
-    event_data.techInfo = error.description;
+    if (!error.message.empty()) {
+        event_data.techInfo = ocpp::CiString<500>(error.message, ocpp::StringTooLarge::Truncate);
+    } else {
+        event_data.techInfo = ocpp::CiString<500>(error.description, ocpp::StringTooLarge::Truncate);
+    }
     event_data.cleared = cleared;
     event_data.transactionId = std::nullopt;        // TODO: Do we need to set this here?
     event_data.variableMonitoringId = std::nullopt; // We dont need to set this for HardwiredNotification

--- a/lib/everest/ocpp_module_common/tests/error_handling_tests.cpp
+++ b/lib/everest/ocpp_module_common/tests/error_handling_tests.cpp
@@ -17,7 +17,96 @@ std::filesystem::path test_data_path(std::string_view name) {
 }
 } // namespace
 
+TEST(GetEventData, NonEmptyMessageSetsTechInfoOnRaisedEvent) {
+    // A non-empty `message` on the error is carried to the CSMS in the `techInfo` field
+    const auto error = Everest::error::Error{"evse_board_support/MREC2GroundFailure",
+                                             "SomeSubType",
+                                             "test error message",
+                                             "some description",
+                                             "evse_board_support",
+                                             "main"};
+
+    const auto event_data = get_event_data(error, false, 1, MREC_ERROR_MAP);
+
+    ASSERT_TRUE(event_data.techInfo.has_value());
+    EXPECT_EQ(event_data.techInfo.value().get(), "test error message");
+    ASSERT_TRUE(event_data.techCode.has_value());
+    EXPECT_EQ(event_data.techCode.value().get(), "CX002");
+    ASSERT_TRUE(event_data.cleared.has_value());
+    EXPECT_FALSE(event_data.cleared.value());
+}
+
+TEST(GetEventData, ClearedEventEchoesSameTechInfoAsRaisedEvent) {
+    // The cleared event repeats the same `techInfo` that was sent when the error was raised
+    const auto error = Everest::error::Error{"evse_board_support/MREC2GroundFailure",
+                                             "SomeSubType",
+                                             "test error message",
+                                             "some description",
+                                             "evse_board_support",
+                                             "main"};
+
+    const auto raised_event_data = get_event_data(error, false, 1, MREC_ERROR_MAP);
+    const auto cleared_event_data = get_event_data(error, true, 2, MREC_ERROR_MAP);
+
+    ASSERT_TRUE(raised_event_data.techInfo.has_value());
+    ASSERT_TRUE(cleared_event_data.techInfo.has_value());
+    EXPECT_EQ(cleared_event_data.techInfo.value().get(), raised_event_data.techInfo.value().get());
+    EXPECT_EQ(cleared_event_data.techInfo.value().get(), "test error message");
+    ASSERT_TRUE(cleared_event_data.cleared.has_value());
+    EXPECT_TRUE(cleared_event_data.cleared.value());
+}
+
+TEST(GetEventData, EmptyMessageFallsBackToErrorDescription) {
+    // When the error has no `message`, `techInfo` falls back to the static error `description`
+    const auto error = Everest::error::Error{
+        "evse_board_support/MREC2GroundFailure", "SomeSubType", "", "some description", "evse_board_support", "main"};
+
+    const auto event_data = get_event_data(error, false, 1, MREC_ERROR_MAP);
+
+    ASSERT_TRUE(event_data.techInfo.has_value());
+    EXPECT_EQ(event_data.techInfo.value().get(), "some description");
+    ASSERT_TRUE(event_data.techCode.has_value());
+    EXPECT_EQ(event_data.techCode.value().get(), "CX002");
+}
+
+TEST(GetEventData, OverlongMessageTruncatesTechInfoTo500Chars) {
+    // A `message` longer than the `techInfo` limit is truncated to 500 chars, but still sent
+    const std::string long_message(600, 'x');
+    const auto error = Everest::error::Error{"evse_board_support/MREC2GroundFailure",
+                                             "SomeSubType",
+                                             long_message,
+                                             "some description",
+                                             "evse_board_support",
+                                             "main"};
+
+    const auto event_data = get_event_data(error, false, 1, MREC_ERROR_MAP);
+
+    ASSERT_TRUE(event_data.techInfo.has_value());
+    EXPECT_EQ(event_data.techInfo.value().get(), long_message.substr(0, 500));
+    EXPECT_EQ(event_data.techInfo.value().get().size(), 500U);
+    ASSERT_TRUE(event_data.techCode.has_value());
+    EXPECT_EQ(event_data.techCode.value().get(), "CX002");
+}
+
+TEST(GetEventData, NonMrecErrorWithMessageAlsoSetsTechInfo) {
+    // OCPP 2.0.1's mapping is uniform across all error types (unlike OCPP 1.6's MREC-only rule).
+    const auto error = Everest::error::Error{"some_module/SomeGenericError",
+                                             "SomeSubType",
+                                             "custom diagnostic text",
+                                             "some description",
+                                             "some_module",
+                                             "main"};
+
+    const auto event_data = get_event_data(error, false, 1, MREC_ERROR_MAP);
+
+    ASSERT_TRUE(event_data.techInfo.has_value());
+    EXPECT_EQ(event_data.techInfo.value().get(), "custom diagnostic text");
+    ASSERT_TRUE(event_data.techCode.has_value());
+    EXPECT_EQ(event_data.techCode.value().get(), "some_module/SomeGenericError");
+}
+
 TEST(LoadMrecErrorMapOverrides, OverridesAndAddsEntries) {
+    // An overrides file replaces existing mappings and adds new ones, keeping the untouched defaults
     const auto map = load_mrec_error_map_overrides(test_data_path("valid_overrides.json"));
 
     EXPECT_EQ(map.at("evse_manager/MREC4OverCurrentFailure"), "OVERRIDE_CX004");
@@ -26,6 +115,7 @@ TEST(LoadMrecErrorMapOverrides, OverridesAndAddsEntries) {
 }
 
 TEST(LoadMrecErrorMapOverrides, EmptyObjectReturnsDefaults) {
+    // An empty overrides object leaves the built-in default map unchanged
     const auto map = load_mrec_error_map_overrides(test_data_path("empty_object.json"));
     EXPECT_EQ(map, MREC_ERROR_MAP);
 }
@@ -33,6 +123,7 @@ TEST(LoadMrecErrorMapOverrides, EmptyObjectReturnsDefaults) {
 class LoadMrecErrorMapOverridesThrowsTest : public ::testing::TestWithParam<std::string_view> {};
 
 TEST_P(LoadMrecErrorMapOverridesThrowsTest, Throws) {
+    // A missing, malformed, or wrongly-typed overrides file is rejected rather than silently ignored
     EXPECT_THROW(load_mrec_error_map_overrides(test_data_path(GetParam())), std::runtime_error);
 }
 

--- a/modules/EVSE/OCPP/OCPP.cpp
+++ b/modules/EVSE/OCPP/OCPP.cpp
@@ -75,7 +75,7 @@ static ocpp::v16::ErrorInfo get_error_info(const Everest::error::Error& error) {
     if (ocpp_it != OCPP_ERROR_MAP.end()) {
         // lambda to create OCPP error info
         auto make_ocpp_error_info = [&](ocpp::v16::ChargePointErrorCode code) {
-            return ocpp::v16::ErrorInfo{uuid, code, false, std::nullopt};
+            return ocpp::v16::ErrorInfo{uuid, code, false, std::nullopt, error.message};
         };
         return make_ocpp_error_info(ocpp_it->second);
     }

--- a/modules/EVSE/OCPP/OCPP.cpp
+++ b/modules/EVSE/OCPP/OCPP.cpp
@@ -59,7 +59,11 @@ static ocpp::v16::ErrorInfo get_error_info(const Everest::error::Error& error) {
     if (mrec_it != MREC_ERROR_MAP.end()) {
         // lambda to create MREC error info
         auto make_mrec_error_info = [&](ocpp::v16::ChargePointErrorCode code, const std::string& vendor_error_code) {
-            return ocpp::v16::ErrorInfo{uuid, code, false, std::nullopt, CHARGE_X_MREC_VENDOR_ID, vendor_error_code};
+            std::optional<std::string> info = std::nullopt;
+            if (!error.message.empty()) {
+                info = error.message;
+            }
+            return ocpp::v16::ErrorInfo{uuid, code, false, info, CHARGE_X_MREC_VENDOR_ID, vendor_error_code};
         };
         return make_mrec_error_info(mrec_it->second.first, mrec_it->second.second);
     }

--- a/modules/EVSE/OCPP/OCPP.cpp
+++ b/modules/EVSE/OCPP/OCPP.cpp
@@ -59,7 +59,11 @@ static ocpp::v16::ErrorInfo get_error_info(const Everest::error::Error& error) {
     if (mrec_it != MREC_ERROR_MAP.end()) {
         // lambda to create MREC error info
         auto make_mrec_error_info = [&](ocpp::v16::ChargePointErrorCode code, const std::string& vendor_error_code) {
-            return ocpp::v16::ErrorInfo{uuid, code, false, std::nullopt, CHARGE_X_MREC_VENDOR_ID, vendor_error_code};
+            std::optional<std::string> info = std::nullopt;
+            if (!error.message.empty()) {
+                info = error.message;
+            }
+            return ocpp::v16::ErrorInfo{uuid, code, false, info, CHARGE_X_MREC_VENDOR_ID, vendor_error_code};
         };
         return make_mrec_error_info(mrec_it->second.first, mrec_it->second.second);
     }
@@ -71,7 +75,7 @@ static ocpp::v16::ErrorInfo get_error_info(const Everest::error::Error& error) {
     if (ocpp_it != OCPP_ERROR_MAP.end()) {
         // lambda to create OCPP error info
         auto make_ocpp_error_info = [&](ocpp::v16::ChargePointErrorCode code) {
-            return ocpp::v16::ErrorInfo{uuid, code, false, std::nullopt};
+            return ocpp::v16::ErrorInfo{uuid, code, false, std::nullopt, error.message};
         };
         return make_ocpp_error_info(ocpp_it->second);
     }

--- a/modules/EVSE/OCPP/docs/index.rst
+++ b/modules/EVSE/OCPP/docs/index.rst
@@ -354,9 +354,11 @@ This module currently deviates from the MREC specification in the following poin
 * Simultaneous errors: MREC requires reporting simultaneous errors by reporting them in a single **StatusNotification.req** by separating 
   the information of the fields **vendorId** and **info** by a semicolon. This module sends one **StatusNotification.req** per individual error 
   because of the limited maximum characters of the **info** field.
-* MREC requires always using the value **Faulted** for the **status** field when reporting an error. The OCPP1.6 specification defines the 
-  **Faulted** value as follows: "When a Charge Point or connector has reported an error and is not available for energy delivery.  
+* MREC requires always using the value **Faulted** for the **status** field when reporting an error. The OCPP1.6 specification defines the
+  **Faulted** value as follows: "When a Charge Point or connector has reported an error and is not available for energy delivery.
   (Inoperative)." This module, therefore, only reports **Faulted** when the Charge Point is not available for energy delivery.
+
+  When an MREC error is raised, the EVerest error message is written to the ``info`` property instead of ``vendorId``.
 
 Energy Management and Smart Charging Integration
 ================================================

--- a/modules/EVSE/OCPP201/docs/index.rst
+++ b/modules/EVSE/OCPP201/docs/index.rst
@@ -303,6 +303,18 @@ This indicates that the EVSE is inoperative (not ready for energy transfer).
 
 In OCPP2 errors can be reported using the **NotifyEventRequest.req**. This message is used to report all other errros received.  
 
+NotifyEvent
+^^^^^^^^^^^
+
+The **eventData** property of the **NotifyEvent.req** carries the details of the reported error:
+
+* ``techCode`` is set to the MREC techCode if the EVerest error type has an MREC mapping, and to the EVerest error
+  type itself otherwise.
+* ``techInfo`` is set to the message of the EVerest error, truncated to 500 characters. If the error was raised
+  without a message, the description of the error type is sent instead.
+* ``actualValue`` is ``"true"`` when the error is raised and ``"false"`` when it is cleared. The ``cleared``
+  property is set accordingly.
+
 Current Limitation
 ^^^^^^^^^^^^^^^^^^
 

--- a/modules/EVSE/OCPPmulti/docs/index.rst
+++ b/modules/EVSE/OCPPmulti/docs/index.rst
@@ -523,8 +523,10 @@ as follows:
 
 * If the EVerest error type has a (built-in) MREC mapping, ``errorCode`` is taken from that mapping, ``vendorId`` is
   set to the MREC vendor id, and ``vendorErrorCode`` carries the MREC techCode. (The OCPP 1.6 path uses a fixed
-  built-in table; ``CustomMrecErrorMapPath`` is not applied here.)
-* Otherwise, if it maps to a standard OCPP 1.6 error code, ``errorCode`` is set accordingly.
+  built-in table; ``CustomMrecErrorMapPath`` is not applied here.) The error message is written to ``info`` instead
+  of ``vendorId``, truncated to 50 characters; if the error was raised without a message, ``info`` is omitted.
+* Otherwise, if it maps to a standard OCPP 1.6 error code, ``errorCode`` is set accordingly and ``vendorId`` carries
+  the error message (up to 255 characters).
 * Otherwise, ``errorCode`` is ``OtherError``, ``info`` carries the error origin, ``vendorId`` the error message
   (up to 255 characters, the largest field), and ``vendorErrorCode`` a code derived from the EVerest error type
   (``info`` and ``vendorErrorCode`` are limited to 50 characters).
@@ -549,6 +551,15 @@ status **Faulted** for the Inoperative case above). All other errors are reporte
 
 The variable is constantly set to **Problem** for now; a more fine-grained mapping of errors to component-variable
 combinations may be added in the future.
+
+The remaining **eventData** properties are filled as follows:
+
+* ``techCode`` is set to the MREC techCode if the EVerest error type has an MREC mapping, and to the EVerest error
+  type itself otherwise.
+* ``techInfo`` is set to the message of the EVerest error, truncated to 500 characters. If the error was raised
+  without a message, the description of the error type is sent instead.
+* ``actualValue`` is ``"true"`` when the error is raised and ``"false"`` when it is cleared. The ``cleared``
+  property is set accordingly.
 
 .. _handwritten_ocppmulti_suspend-reason-reporting:
 

--- a/modules/EVSE/OCPPmulti/v16_chargepoint.cpp
+++ b/modules/EVSE/OCPPmulti/v16_chargepoint.cpp
@@ -416,6 +416,9 @@ ocpp::v16::ErrorInfo ChargePointV16::convert_error(const Everest::error::Error& 
         result.error_code = error_code;
         result.vendor_id = ocpp_module_common::v16::CHARGE_X_MREC_VENDOR_ID;
         result.vendor_error_code = ocpp::CiString<50>(vendor_error_code, ocpp::StringTooLarge::Truncate);
+        if (not error.message.empty()) {
+            result.info = ocpp::CiString<50>(error.message, ocpp::StringTooLarge::Truncate);
+        }
         incomplete = false;
     }
 
@@ -429,6 +432,7 @@ ocpp::v16::ErrorInfo ChargePointV16::convert_error(const Everest::error::Error& 
         if (ocpp_it != ocpp_module_common::v16::OCPP_ERROR_MAP.end()) {
             // update the result
             result.error_code = ocpp_it->second;
+            result.vendor_id = ocpp::CiString<255>(error.message, ocpp::StringTooLarge::Truncate);
             incomplete = false;
         }
     }

--- a/modules/EVSE/OCPPmulti/v16_chargepoint.cpp
+++ b/modules/EVSE/OCPPmulti/v16_chargepoint.cpp
@@ -393,6 +393,9 @@ ocpp::v16::ErrorInfo ChargePointV16::convert_error(const Everest::error::Error& 
         result.error_code = error_code;
         result.vendor_id = ocpp_module_common::v16::CHARGE_X_MREC_VENDOR_ID;
         result.vendor_error_code = ocpp::CiString<50>(vendor_error_code, ocpp::StringTooLarge::Truncate);
+        if (not error.message.empty()) {
+            result.info = ocpp::CiString<50>(error.message, ocpp::StringTooLarge::Truncate);
+        }
         incomplete = false;
     }
 
@@ -406,6 +409,7 @@ ocpp::v16::ErrorInfo ChargePointV16::convert_error(const Everest::error::Error& 
         if (ocpp_it != ocpp_module_common::v16::OCPP_ERROR_MAP.end()) {
             // update the result
             result.error_code = ocpp_it->second;
+            result.vendor_id = ocpp::CiString<255>(error.message, ocpp::StringTooLarge::Truncate);
             incomplete = false;
         }
     }

--- a/tests/ocpp_tests/test_sets/ocpp16/error_reporting_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/error_reporting_tests.py
@@ -1,0 +1,307 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Pionix GmbH and Contributors to EVerest
+
+import json
+import logging
+
+import pytest
+
+from everest.testing.core_utils.controller.test_controller_interface import TestController
+from everest.testing.ocpp_utils.fixtures import charge_point_v16, central_system_v16
+from everest.testing.ocpp_utils.charge_point_v16 import ChargePoint16
+from everest.testing.ocpp_utils.charge_point_utils import TestUtility, wait_for_and_validate
+from everest_test_utils import get_everest_config_path_str
+from everest.testing.core_utils._configuration.everest_configuration_strategies.evse_board_support_api_configuration_strategy import \
+    EvseBoardSupportApiConfigAdjustment
+
+from ocpp.v16.enums import ChargePointErrorCode
+
+MREC_MODULE_ID = "bsp_1"
+MREC_ERROR_TYPE = "MREC2GroundFailure"
+MREC_VENDOR_ID = "https://chargex.inl.gov"
+MREC_VENDOR_ERROR_CODE = "CX002"
+
+# The `info` field on a cleared error is generated from `vendorErrorCode`
+MREC_CLEARED_INFO = f"Error {MREC_VENDOR_ERROR_CODE} resolved"
+
+NON_MREC_ORIGIN = f"{MREC_MODULE_ID}->main"
+NON_MREC_ERROR_TYPE = "VendorError"
+
+# vendorId used by the evse_manager/Inoperative error sent by the EVSEManager
+# to mark the connector as Faulted
+INOPERATIVE_VENDOR_ID = "EVerest"
+
+
+def _raise_error_topic(test_controller: TestController) -> str:
+    return f"{test_controller._mqtt_external_prefix}everest_api/1/evse_board_support/{MREC_MODULE_ID}/m2e/raise_error"
+
+
+def _clear_error_topic(test_controller: TestController) -> str:
+    return f"{test_controller._mqtt_external_prefix}everest_api/1/evse_board_support/{MREC_MODULE_ID}/m2e/clear_error"
+
+
+async def _validate_inoperative_raised(
+    test_utility: TestUtility, charge_point_v16: ChargePoint16, caused_by: str, vendor_error_code: str
+):
+    """The board-support error drives EvseManager to raise evse_manager/Inoperative (a fault)."""
+    return await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "error_code": ChargePointErrorCode.other_error,
+            "info": f"caused_by:{caused_by}",
+            "vendor_id": INOPERATIVE_VENDOR_ID,
+            "vendor_error_code": vendor_error_code,
+        },
+    )
+
+
+async def _validate_inoperative_cleared(
+    test_utility: TestUtility, charge_point_v16: ChargePoint16, vendor_error_code: str
+):
+    """Clearing the underlying error clears Inoperative too; the connector returns to NoError."""
+    return await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "error_code": ChargePointErrorCode.no_error,
+            "info": f"Error {vendor_error_code} resolved",
+            "vendor_id": INOPERATIVE_VENDOR_ID,
+            "vendor_error_code": vendor_error_code,
+        },
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-sil-ocpp.yaml")
+)
+@pytest.mark.everest_config_adaptions(EvseBoardSupportApiConfigAdjustment())
+async def test_mrec_error_with_message_sets_status_notification_info(
+    charge_point_v16: ChargePoint16,
+    test_utility: TestUtility,
+    test_controller: TestController,
+):
+    logging.info("######### test_mrec_error_with_message_sets_status_notification_info #########")
+
+    # The `message` on an MREC error is sent to the CSMS in the `info` field
+    message = "test error message"
+    test_controller.publish(
+        _raise_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE, "message": message}),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "error_code": ChargePointErrorCode.ground_failure,
+            "info": message,
+            "vendor_id": MREC_VENDOR_ID,
+            "vendor_error_code": MREC_VENDOR_ERROR_CODE,
+        },
+    )
+
+    # The ground fault also renders the EVSE inoperative
+    assert await _validate_inoperative_raised(
+        test_utility, charge_point_v16, f"evse_board_support/{MREC_ERROR_TYPE}", MREC_ERROR_TYPE
+    )
+
+    test_controller.publish(
+        _clear_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE}),
+    )
+
+    # The MREC error is cleared first, leaving the EVSEManager's Inoperative error
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "info": MREC_CLEARED_INFO,
+            "vendor_id": MREC_VENDOR_ID,
+            "vendor_error_code": MREC_VENDOR_ERROR_CODE,
+        },
+    )
+
+    # Inoperative clears too and the connector returns to NoError
+    assert await _validate_inoperative_cleared(test_utility, charge_point_v16, MREC_ERROR_TYPE)
+
+
+@pytest.mark.asyncio
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-sil-ocpp.yaml")
+)
+@pytest.mark.everest_config_adaptions(EvseBoardSupportApiConfigAdjustment())
+async def test_mrec_error_without_message_is_unchanged_from_baseline(
+    charge_point_v16: ChargePoint16,
+    test_utility: TestUtility,
+    test_controller: TestController,
+):
+    logging.info("######### test_mrec_error_without_message_is_unchanged_from_baseline #########")
+
+    # Raising an MREC error with an empty message results in no `info` value being sent
+    test_controller.publish(
+        _raise_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE}),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "error_code": ChargePointErrorCode.ground_failure,
+            "info": None,
+            "vendor_id": MREC_VENDOR_ID,
+            "vendor_error_code": MREC_VENDOR_ERROR_CODE,
+        },
+    )
+
+    assert await _validate_inoperative_raised(
+        test_utility, charge_point_v16, f"evse_board_support/{MREC_ERROR_TYPE}", MREC_ERROR_TYPE
+    )
+
+    test_controller.publish(
+        _clear_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE}),
+    )
+
+    # Even when there is no `message` on the original error, the `info` value that is generated from
+    # the `vendor_error_code` should still be present
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "info": MREC_CLEARED_INFO,
+            "vendor_id": MREC_VENDOR_ID,
+            "vendor_error_code": MREC_VENDOR_ERROR_CODE,
+        },
+    )
+
+    assert await _validate_inoperative_cleared(test_utility, charge_point_v16, MREC_ERROR_TYPE)
+
+
+@pytest.mark.asyncio
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-sil-ocpp.yaml")
+)
+@pytest.mark.everest_config_adaptions(EvseBoardSupportApiConfigAdjustment())
+async def test_non_mrec_error_with_message_is_unchanged_from_baseline(
+    charge_point_v16: ChargePoint16,
+    test_utility: TestUtility,
+    test_controller: TestController,
+):
+    logging.info("######### test_non_mrec_error_with_message_is_unchanged_from_baseline #########")
+
+    # On non-MREC errors, the `message` gets sent in the `vendorId` field, `info` carries the error origin
+    sub_type = "some_subtype"
+    message = "some vendor diagnostic text"
+    non_mrec_vendor_error_code = f"{NON_MREC_ERROR_TYPE}/{sub_type}"
+    test_controller.publish(
+        _raise_error_topic(test_controller),
+        json.dumps({"type": NON_MREC_ERROR_TYPE, "sub_type": sub_type, "message": message}),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "error_code": ChargePointErrorCode.other_error,
+            "info": NON_MREC_ORIGIN,
+            "vendor_id": message,
+            "vendor_error_code": non_mrec_vendor_error_code,
+        },
+    )
+
+    assert await _validate_inoperative_raised(
+        test_utility, charge_point_v16, f"evse_board_support/{NON_MREC_ERROR_TYPE}", non_mrec_vendor_error_code
+    )
+
+    test_controller.publish(
+        _clear_error_topic(test_controller),
+        json.dumps({"type": NON_MREC_ERROR_TYPE, "sub_type": sub_type}),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "info": f"Error {non_mrec_vendor_error_code} resolved",
+            "vendor_id": message,
+            "vendor_error_code": non_mrec_vendor_error_code,
+        },
+    )
+
+    assert await _validate_inoperative_cleared(test_utility, charge_point_v16, non_mrec_vendor_error_code)
+
+
+@pytest.mark.asyncio
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-sil-ocpp.yaml")
+)
+@pytest.mark.everest_config_adaptions(EvseBoardSupportApiConfigAdjustment())
+async def test_mrec_error_with_overlong_message_is_truncated(
+    charge_point_v16: ChargePoint16,
+    test_utility: TestUtility,
+    test_controller: TestController,
+):
+    logging.info("######### test_mrec_error_with_overlong_message_is_truncated #########")
+
+    # Too long `message` values on MREC errors are truncated, but still sent
+    long_message = "x" * 60
+    test_controller.publish(
+        _raise_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE, "message": long_message}),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "error_code": ChargePointErrorCode.ground_failure,
+            "info": long_message[:50],
+            "vendor_id": MREC_VENDOR_ID,
+            "vendor_error_code": MREC_VENDOR_ERROR_CODE,
+        },
+    )
+
+    assert await _validate_inoperative_raised(
+        test_utility, charge_point_v16, f"evse_board_support/{MREC_ERROR_TYPE}", MREC_ERROR_TYPE
+    )
+
+    test_controller.publish(
+        _clear_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE}),
+    )
+
+    # The synthesized clear `info` is derived from the vendorErrorCode, unaffected by the truncated message
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "info": MREC_CLEARED_INFO,
+            "vendor_id": MREC_VENDOR_ID,
+            "vendor_error_code": MREC_VENDOR_ERROR_CODE,
+        },
+    )
+
+    assert await _validate_inoperative_cleared(test_utility, charge_point_v16, MREC_ERROR_TYPE)

--- a/tests/ocpp_tests/test_sets/ocpp16/error_reporting_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/error_reporting_tests.py
@@ -13,6 +13,7 @@ from everest.testing.ocpp_utils.charge_point_utils import TestUtility, wait_for_
 from everest_test_utils import get_everest_config_path_str
 from everest.testing.core_utils._configuration.everest_configuration_strategies.evse_board_support_api_configuration_strategy import \
     EvseBoardSupportApiConfigAdjustment
+from everest.testing.core_utils._configuration.libocpp_configuration_helper import GenericOCPP16ConfigAdjustment
 
 from ocpp.v16.enums import ChargePointErrorCode
 
@@ -81,6 +82,9 @@ async def _validate_inoperative_cleared(
     get_everest_config_path_str("everest-config-sil-ocpp.yaml")
 )
 @pytest.mark.everest_config_adaptions(EvseBoardSupportApiConfigAdjustment())
+@pytest.mark.ocpp_config_adaptions(
+    GenericOCPP16ConfigAdjustment([("Internal", "ReportClearedErrors", True)])
+)
 async def test_mrec_error_with_message_sets_status_notification_info(
     charge_point_v16: ChargePoint16,
     test_utility: TestUtility,
@@ -140,6 +144,9 @@ async def test_mrec_error_with_message_sets_status_notification_info(
     get_everest_config_path_str("everest-config-sil-ocpp.yaml")
 )
 @pytest.mark.everest_config_adaptions(EvseBoardSupportApiConfigAdjustment())
+@pytest.mark.ocpp_config_adaptions(
+    GenericOCPP16ConfigAdjustment([("Internal", "ReportClearedErrors", True)])
+)
 async def test_mrec_error_without_message_is_unchanged_from_baseline(
     charge_point_v16: ChargePoint16,
     test_utility: TestUtility,
@@ -197,6 +204,9 @@ async def test_mrec_error_without_message_is_unchanged_from_baseline(
     get_everest_config_path_str("everest-config-sil-ocpp.yaml")
 )
 @pytest.mark.everest_config_adaptions(EvseBoardSupportApiConfigAdjustment())
+@pytest.mark.ocpp_config_adaptions(
+    GenericOCPP16ConfigAdjustment([("Internal", "ReportClearedErrors", True)])
+)
 async def test_non_mrec_error_with_message_is_unchanged_from_baseline(
     charge_point_v16: ChargePoint16,
     test_utility: TestUtility,
@@ -255,6 +265,9 @@ async def test_non_mrec_error_with_message_is_unchanged_from_baseline(
     get_everest_config_path_str("everest-config-sil-ocpp.yaml")
 )
 @pytest.mark.everest_config_adaptions(EvseBoardSupportApiConfigAdjustment())
+@pytest.mark.ocpp_config_adaptions(
+    GenericOCPP16ConfigAdjustment([("Internal", "ReportClearedErrors", True)])
+)
 async def test_mrec_error_with_overlong_message_is_truncated(
     charge_point_v16: ChargePoint16,
     test_utility: TestUtility,
@@ -305,3 +318,76 @@ async def test_mrec_error_with_overlong_message_is_truncated(
     )
 
     assert await _validate_inoperative_cleared(test_utility, charge_point_v16, MREC_ERROR_TYPE)
+
+
+@pytest.mark.asyncio
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-sil-ocpp.yaml")
+)
+@pytest.mark.everest_config_adaptions(EvseBoardSupportApiConfigAdjustment())
+async def test_mrec_error_cleared_reports_nothing_while_still_faulted_by_default(
+    charge_point_v16: ChargePoint16,
+    test_utility: TestUtility,
+    test_controller: TestController,
+):
+    """ReportClearedErrors defaults to false: no ocpp_config_adaptions marker is applied here."""
+    logging.info("######### test_mrec_error_cleared_reports_nothing_while_still_faulted_by_default #########")
+
+    test_controller.publish(
+        _raise_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE, "message": "test error message"}),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "error_code": ChargePointErrorCode.ground_failure,
+            "vendor_id": MREC_VENDOR_ID,
+            "vendor_error_code": MREC_VENDOR_ERROR_CODE,
+        },
+    )
+
+    # The ground fault also renders the EVSE inoperative, keeping the connector Faulted
+    assert await _validate_inoperative_raised(
+        test_utility, charge_point_v16, f"evse_board_support/{MREC_ERROR_TYPE}", MREC_ERROR_TYPE
+    )
+
+    test_utility.messages.clear()
+
+    test_controller.publish(
+        _clear_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE}),
+    )
+
+    # The cleared error should not be reported, because the connector remains faulted
+    # until the internal evse_manager/Inoperative error also clears
+    assert not await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "info": MREC_CLEARED_INFO,
+            "vendor_id": MREC_VENDOR_ID,
+            "vendor_error_code": MREC_VENDOR_ERROR_CODE,
+        },
+        timeout=5,
+    ), "No cleared-error StatusNotification should be sent while the connector is still Faulted and ReportClearedErrors is disabled"
+
+    # Clearing the inoperative error returns the connector to NoError
+    # There is no synthetic `info` value because ReportClearedErrors is false
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "error_code": ChargePointErrorCode.no_error,
+            "info": None,
+            "vendor_id": None,
+            "vendor_error_code": None,
+        },
+    )

--- a/tests/ocpp_tests/test_sets/ocpp16/error_reporting_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/error_reporting_tests.py
@@ -23,7 +23,7 @@ MREC_VENDOR_ID = "https://chargex.inl.gov"
 MREC_VENDOR_ERROR_CODE = "CX002"
 
 # The `info` field on a cleared error is generated from `vendorErrorCode`
-MREC_CLEARED_INFO = f"Error {MREC_VENDOR_ERROR_CODE} resolved"
+MREC_CLEARED_INFO = f"{MREC_VENDOR_ERROR_CODE} resolved"
 
 NON_MREC_ORIGIN = f"{MREC_MODULE_ID}->main"
 NON_MREC_ERROR_TYPE = "VendorError"
@@ -70,7 +70,7 @@ async def _validate_inoperative_cleared(
         {
             "connector_id": 1,
             "error_code": ChargePointErrorCode.no_error,
-            "info": f"Error {vendor_error_code} resolved",
+            "info": f"{vendor_error_code} resolved",
             "vendor_id": INOPERATIVE_VENDOR_ID,
             "vendor_error_code": vendor_error_code,
         },
@@ -251,7 +251,7 @@ async def test_non_mrec_error_with_message_is_unchanged_from_baseline(
         "StatusNotification",
         {
             "connector_id": 1,
-            "info": f"Error {non_mrec_vendor_error_code} resolved",
+            "info": f"{non_mrec_vendor_error_code} resolved",
             "vendor_id": message,
             "vendor_error_code": non_mrec_vendor_error_code,
         },

--- a/tests/ocpp_tests/test_sets/ocpp16/error_reporting_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/error_reporting_tests.py
@@ -1,0 +1,393 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Pionix GmbH and Contributors to EVerest
+
+import json
+import logging
+
+import pytest
+
+from everest.testing.core_utils.controller.test_controller_interface import TestController
+from everest.testing.ocpp_utils.fixtures import charge_point_v16, central_system_v16
+from everest.testing.ocpp_utils.charge_point_v16 import ChargePoint16
+from everest.testing.ocpp_utils.charge_point_utils import TestUtility, wait_for_and_validate
+from everest_test_utils import get_everest_config_path_str
+from everest.testing.core_utils._configuration.everest_configuration_strategies.evse_board_support_api_configuration_strategy import \
+    EvseBoardSupportApiConfigAdjustment
+from everest.testing.core_utils._configuration.libocpp_configuration_helper import GenericOCPP16ConfigAdjustment
+
+from ocpp.v16.enums import ChargePointErrorCode
+
+MREC_MODULE_ID = "bsp_1"
+MREC_ERROR_TYPE = "MREC2GroundFailure"
+MREC_VENDOR_ID = "https://chargex.inl.gov"
+MREC_VENDOR_ERROR_CODE = "CX002"
+
+# The `info` field on a cleared error is generated from `vendorErrorCode`
+MREC_CLEARED_INFO = f"{MREC_VENDOR_ERROR_CODE} resolved"
+
+NON_MREC_ORIGIN = f"{MREC_MODULE_ID}->main"
+NON_MREC_ERROR_TYPE = "VendorError"
+
+# vendorId used by the evse_manager/Inoperative error sent by the EVSEManager
+# to mark the connector as Faulted
+INOPERATIVE_VENDOR_ID = "EVerest"
+
+
+def _raise_error_topic(test_controller: TestController) -> str:
+    return f"{test_controller._mqtt_external_prefix}everest_api/1/evse_board_support/{MREC_MODULE_ID}/m2e/raise_error"
+
+
+def _clear_error_topic(test_controller: TestController) -> str:
+    return f"{test_controller._mqtt_external_prefix}everest_api/1/evse_board_support/{MREC_MODULE_ID}/m2e/clear_error"
+
+
+async def _validate_inoperative_raised(
+    test_utility: TestUtility, charge_point_v16: ChargePoint16, caused_by: str, vendor_error_code: str
+):
+    """The board-support error drives EvseManager to raise evse_manager/Inoperative (a fault)."""
+    return await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "error_code": ChargePointErrorCode.other_error,
+            "info": f"caused_by:{caused_by}",
+            "vendor_id": INOPERATIVE_VENDOR_ID,
+            "vendor_error_code": vendor_error_code,
+        },
+    )
+
+
+async def _validate_inoperative_cleared(
+    test_utility: TestUtility, charge_point_v16: ChargePoint16, vendor_error_code: str
+):
+    """Clearing the underlying error clears Inoperative too; the connector returns to NoError."""
+    return await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "error_code": ChargePointErrorCode.no_error,
+            "info": f"{vendor_error_code} resolved",
+            "vendor_id": INOPERATIVE_VENDOR_ID,
+            "vendor_error_code": vendor_error_code,
+        },
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-sil-ocpp.yaml")
+)
+@pytest.mark.everest_config_adaptions(EvseBoardSupportApiConfigAdjustment())
+@pytest.mark.ocpp_config_adaptions(
+    GenericOCPP16ConfigAdjustment([("Internal", "ReportClearedErrors", True)])
+)
+async def test_mrec_error_with_message_sets_status_notification_info(
+    charge_point_v16: ChargePoint16,
+    test_utility: TestUtility,
+    test_controller: TestController,
+):
+    logging.info("######### test_mrec_error_with_message_sets_status_notification_info #########")
+
+    # The `message` on an MREC error is sent to the CSMS in the `info` field
+    message = "test error message"
+    test_controller.publish(
+        _raise_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE, "message": message}),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "error_code": ChargePointErrorCode.ground_failure,
+            "info": message,
+            "vendor_id": MREC_VENDOR_ID,
+            "vendor_error_code": MREC_VENDOR_ERROR_CODE,
+        },
+    )
+
+    # The ground fault also renders the EVSE inoperative
+    assert await _validate_inoperative_raised(
+        test_utility, charge_point_v16, f"evse_board_support/{MREC_ERROR_TYPE}", MREC_ERROR_TYPE
+    )
+
+    test_controller.publish(
+        _clear_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE}),
+    )
+
+    # The MREC error is cleared first, leaving the EVSEManager's Inoperative error
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "info": MREC_CLEARED_INFO,
+            "vendor_id": MREC_VENDOR_ID,
+            "vendor_error_code": MREC_VENDOR_ERROR_CODE,
+        },
+    )
+
+    # Inoperative clears too and the connector returns to NoError
+    assert await _validate_inoperative_cleared(test_utility, charge_point_v16, MREC_ERROR_TYPE)
+
+
+@pytest.mark.asyncio
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-sil-ocpp.yaml")
+)
+@pytest.mark.everest_config_adaptions(EvseBoardSupportApiConfigAdjustment())
+@pytest.mark.ocpp_config_adaptions(
+    GenericOCPP16ConfigAdjustment([("Internal", "ReportClearedErrors", True)])
+)
+async def test_mrec_error_without_message_is_unchanged_from_baseline(
+    charge_point_v16: ChargePoint16,
+    test_utility: TestUtility,
+    test_controller: TestController,
+):
+    logging.info("######### test_mrec_error_without_message_is_unchanged_from_baseline #########")
+
+    # Raising an MREC error with an empty message results in no `info` value being sent
+    test_controller.publish(
+        _raise_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE}),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "error_code": ChargePointErrorCode.ground_failure,
+            "info": None,
+            "vendor_id": MREC_VENDOR_ID,
+            "vendor_error_code": MREC_VENDOR_ERROR_CODE,
+        },
+    )
+
+    assert await _validate_inoperative_raised(
+        test_utility, charge_point_v16, f"evse_board_support/{MREC_ERROR_TYPE}", MREC_ERROR_TYPE
+    )
+
+    test_controller.publish(
+        _clear_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE}),
+    )
+
+    # Even when there is no `message` on the original error, the `info` value that is generated from
+    # the `vendor_error_code` should still be present
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "info": MREC_CLEARED_INFO,
+            "vendor_id": MREC_VENDOR_ID,
+            "vendor_error_code": MREC_VENDOR_ERROR_CODE,
+        },
+    )
+
+    assert await _validate_inoperative_cleared(test_utility, charge_point_v16, MREC_ERROR_TYPE)
+
+
+@pytest.mark.asyncio
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-sil-ocpp.yaml")
+)
+@pytest.mark.everest_config_adaptions(EvseBoardSupportApiConfigAdjustment())
+@pytest.mark.ocpp_config_adaptions(
+    GenericOCPP16ConfigAdjustment([("Internal", "ReportClearedErrors", True)])
+)
+async def test_non_mrec_error_with_message_is_unchanged_from_baseline(
+    charge_point_v16: ChargePoint16,
+    test_utility: TestUtility,
+    test_controller: TestController,
+):
+    logging.info("######### test_non_mrec_error_with_message_is_unchanged_from_baseline #########")
+
+    # On non-MREC errors, the `message` gets sent in the `vendorId` field, `info` carries the error origin
+    sub_type = "some_subtype"
+    message = "some vendor diagnostic text"
+    non_mrec_vendor_error_code = f"{NON_MREC_ERROR_TYPE}/{sub_type}"
+    test_controller.publish(
+        _raise_error_topic(test_controller),
+        json.dumps({"type": NON_MREC_ERROR_TYPE, "sub_type": sub_type, "message": message}),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "error_code": ChargePointErrorCode.other_error,
+            "info": NON_MREC_ORIGIN,
+            "vendor_id": message,
+            "vendor_error_code": non_mrec_vendor_error_code,
+        },
+    )
+
+    assert await _validate_inoperative_raised(
+        test_utility, charge_point_v16, f"evse_board_support/{NON_MREC_ERROR_TYPE}", non_mrec_vendor_error_code
+    )
+
+    test_controller.publish(
+        _clear_error_topic(test_controller),
+        json.dumps({"type": NON_MREC_ERROR_TYPE, "sub_type": sub_type}),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "info": f"{non_mrec_vendor_error_code} resolved",
+            "vendor_id": message,
+            "vendor_error_code": non_mrec_vendor_error_code,
+        },
+    )
+
+    assert await _validate_inoperative_cleared(test_utility, charge_point_v16, non_mrec_vendor_error_code)
+
+
+@pytest.mark.asyncio
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-sil-ocpp.yaml")
+)
+@pytest.mark.everest_config_adaptions(EvseBoardSupportApiConfigAdjustment())
+@pytest.mark.ocpp_config_adaptions(
+    GenericOCPP16ConfigAdjustment([("Internal", "ReportClearedErrors", True)])
+)
+async def test_mrec_error_with_overlong_message_is_truncated(
+    charge_point_v16: ChargePoint16,
+    test_utility: TestUtility,
+    test_controller: TestController,
+):
+    logging.info("######### test_mrec_error_with_overlong_message_is_truncated #########")
+
+    # Too long `message` values on MREC errors are truncated, but still sent
+    long_message = "x" * 60
+    test_controller.publish(
+        _raise_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE, "message": long_message}),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "error_code": ChargePointErrorCode.ground_failure,
+            "info": long_message[:50],
+            "vendor_id": MREC_VENDOR_ID,
+            "vendor_error_code": MREC_VENDOR_ERROR_CODE,
+        },
+    )
+
+    assert await _validate_inoperative_raised(
+        test_utility, charge_point_v16, f"evse_board_support/{MREC_ERROR_TYPE}", MREC_ERROR_TYPE
+    )
+
+    test_controller.publish(
+        _clear_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE}),
+    )
+
+    # The synthesized clear `info` is derived from the vendorErrorCode, unaffected by the truncated message
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "info": MREC_CLEARED_INFO,
+            "vendor_id": MREC_VENDOR_ID,
+            "vendor_error_code": MREC_VENDOR_ERROR_CODE,
+        },
+    )
+
+    assert await _validate_inoperative_cleared(test_utility, charge_point_v16, MREC_ERROR_TYPE)
+
+
+@pytest.mark.asyncio
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-sil-ocpp.yaml")
+)
+@pytest.mark.everest_config_adaptions(EvseBoardSupportApiConfigAdjustment())
+async def test_mrec_error_cleared_reports_nothing_while_still_faulted_by_default(
+    charge_point_v16: ChargePoint16,
+    test_utility: TestUtility,
+    test_controller: TestController,
+):
+    """ReportClearedErrors defaults to false: no ocpp_config_adaptions marker is applied here."""
+    logging.info("######### test_mrec_error_cleared_reports_nothing_while_still_faulted_by_default #########")
+
+    test_controller.publish(
+        _raise_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE, "message": "test error message"}),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "error_code": ChargePointErrorCode.ground_failure,
+            "vendor_id": MREC_VENDOR_ID,
+            "vendor_error_code": MREC_VENDOR_ERROR_CODE,
+        },
+    )
+
+    # The ground fault also renders the EVSE inoperative, keeping the connector Faulted
+    assert await _validate_inoperative_raised(
+        test_utility, charge_point_v16, f"evse_board_support/{MREC_ERROR_TYPE}", MREC_ERROR_TYPE
+    )
+
+    test_utility.messages.clear()
+
+    test_controller.publish(
+        _clear_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE}),
+    )
+
+    # The cleared error should not be reported, because the connector remains faulted
+    # until the internal evse_manager/Inoperative error also clears
+    assert not await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "info": MREC_CLEARED_INFO,
+            "vendor_id": MREC_VENDOR_ID,
+            "vendor_error_code": MREC_VENDOR_ERROR_CODE,
+        },
+        timeout=5,
+    ), "No cleared-error StatusNotification should be sent while the connector is still Faulted and ReportClearedErrors is disabled"
+
+    # Clearing the inoperative error returns the connector to NoError
+    # There is no synthetic `info` value because ReportClearedErrors is false
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {
+            "connector_id": 1,
+            "error_code": ChargePointErrorCode.no_error,
+            "info": None,
+            "vendor_id": None,
+            "vendor_error_code": None,
+        },
+    )

--- a/tests/ocpp_tests/test_sets/ocpp201/error_reporting_tests201.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/error_reporting_tests201.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Pionix GmbH and Contributors to EVerest
+
+import json
+import logging
+
+import pytest
+
+from everest.testing.core_utils.controller.test_controller_interface import TestController
+from everest.testing.ocpp_utils.fixtures import charge_point_v201
+from everest.testing.ocpp_utils.charge_point_v201 import ChargePoint201
+from everest.testing.ocpp_utils.charge_point_utils import TestUtility, wait_for_and_validate
+from everest_test_utils import get_everest_config_path_str
+from everest.testing.core_utils._configuration.everest_configuration_strategies.evse_board_support_api_configuration_strategy import \
+    EvseBoardSupportApiConfigAdjustment
+
+MREC_MODULE_ID = "bsp_1"
+MREC_ERROR_TYPE = "MREC2GroundFailure"
+
+
+def _raise_error_topic(test_controller: TestController) -> str:
+    return f"{test_controller._mqtt_external_prefix}everest_api/1/evse_board_support/{MREC_MODULE_ID}/m2e/raise_error"
+
+
+def _clear_error_topic(test_controller: TestController) -> str:
+    return f"{test_controller._mqtt_external_prefix}everest_api/1/evse_board_support/{MREC_MODULE_ID}/m2e/clear_error"
+
+
+def _validate_notify_event_tech_info(expected_tech_info, expected_cleared):
+    """Returns a validate_payload_func for wait_for_and_validate that inspects the raw
+    NotifyEvent.req `eventData` entries for a `techInfo`/`cleared` match, ignoring all
+    other fields (e.g. eventId/timestamp/component/variable) that are not relevant to
+    this test."""
+
+    def _validate(meta_data, msg, exp_payload):
+        if msg.action != "NotifyEvent":
+            return False
+        for event_data in msg.payload.get("eventData", []):
+            if (
+                event_data.get("techInfo") == expected_tech_info
+                and event_data.get("cleared") == expected_cleared
+            ):
+                return True
+        return False
+
+    return _validate
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-ocpp201.yaml")
+)
+@pytest.mark.everest_config_adaptions(EvseBoardSupportApiConfigAdjustment())
+async def test_error_with_message_sets_notify_event_tech_info_and_echoes_on_clear(
+    charge_point_v201: ChargePoint201,
+    test_utility: TestUtility,
+    test_controller: TestController,
+):
+    logging.info(
+        "######### test_error_with_message_sets_notify_event_tech_info_and_echoes_on_clear #########"
+    )
+
+    # An error that has a `message` value carries it in `techInfo` when sent to the CSMS
+    message = "test error message"
+    test_controller.publish(
+        _raise_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE, "message": message}),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "NotifyEvent",
+        {},
+        validate_payload_func=_validate_notify_event_tech_info(message, False),
+    )
+
+    test_controller.publish(
+        _clear_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE}),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "NotifyEvent",
+        {},
+        validate_payload_func=_validate_notify_event_tech_info(message, True),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-ocpp201.yaml")
+)
+@pytest.mark.everest_config_adaptions(EvseBoardSupportApiConfigAdjustment())
+async def test_error_without_message_sets_notify_event_tech_info_to_description_and_echoes_on_clear(
+    charge_point_v201: ChargePoint201,
+    test_utility: TestUtility,
+    test_controller: TestController,
+):
+    logging.info(
+        "######### test_error_without_message_sets_notify_event_tech_info_to_description_and_echoes_on_clear #########"
+    )
+
+    # An error without a `message` value carries EVerests default description for this error type in `techInfo`
+    expected_tech_info = "Ground fault circuit interrupter has been activated."
+    test_controller.publish(
+        _raise_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE}),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "NotifyEvent",
+        {},
+        validate_payload_func=_validate_notify_event_tech_info(expected_tech_info, False),
+    )
+
+    test_controller.publish(
+        _clear_error_topic(test_controller),
+        json.dumps({"type": MREC_ERROR_TYPE}),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "NotifyEvent",
+        {},
+        validate_payload_func=_validate_notify_event_tech_info(expected_tech_info, True),
+    )


### PR DESCRIPTION
## Describe your changes

Sends the `message` that can be set when raising an error via the stable APIs to the CSMS via the `info` field on an MREC error or `vendorId` otherwise (this was the case before) for OCPP 1.6 and in the `techInfo` field for OCPP 2.x

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
---

This PR is part of a stack

- `2` #2456 👈 you are here
- `1` #2455