### PR TITLE
OCPP websocket reconnect and reset fixes

### DIFF
--- a/lib/everest/ocpp/config/common/component_config/standardized/NetworkConfiguration_1.json
+++ b/lib/everest/ocpp/config/common/component_config/standardized/NetworkConfiguration_1.json
@@ -89,7 +89,7 @@
       ],
       "description": "Message timeout in seconds",
       "type": "integer",
-      "default": 30
+      "default": 60
     },
     "Identity": {
       "variable_name": "Identity",

--- a/lib/everest/ocpp/include/ocpp/common/connectivity_manager.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/connectivity_manager.hpp
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <functional>
 #include <future>
+#include <mutex>
 #include <optional>
 
 namespace ocpp {
@@ -22,6 +23,31 @@ struct ConfigNetworkResult {
     std::optional<std::string> interface_address; ///< ip address or interface string
     bool success;                                 ///< true if the configuration was successful
 };
+
+/// \brief The next configuration slot to dial after the active slot's attempts were exhausted.
+struct NextSlotSelection {
+    std::int32_t slot; ///< configuration slot to attempt next
+    bool is_fallback;  ///< true when this is the B10.FR.07 last-successful fallback target
+};
+
+/// \brief Decide which configuration slot to dial after the active slot exhausted its attempts.
+///
+/// Implements OCPP 2.0.1 B10.FR.07: once every entry of the priority list has been tried since the
+/// last successful connection (\p failed_slots_since_success reached the list size), fall back to
+/// \p last_successful_slot independent of the priority list and keep reconnecting to it. Otherwise
+/// the next entry in the priority list is selected (wrapping around).
+///
+/// \param priority_slots Ordered configuration slots (highest priority first).
+/// \param current_slot The slot whose attempts were just exhausted.
+/// \param failed_slots_since_success Number of slots exhausted since the last successful connection,
+///        including \p current_slot.
+/// \param last_successful_slot Slot of the last successful connection, or std::nullopt if none.
+/// \param in_fallback True if the manager is already reconnecting to the fallback profile.
+/// \return The next slot to dial, or std::nullopt if \p priority_slots is empty.
+std::optional<NextSlotSelection> select_next_network_slot(const std::vector<std::int32_t>& priority_slots,
+                                                          std::int32_t current_slot, int failed_slots_since_success,
+                                                          std::optional<std::int32_t> last_successful_slot,
+                                                          bool in_fallback);
 
 using WebsocketConnectionCallback =
     std::function<void(int configuration_slot, const ocpp::v2::NetworkConnectionProfile& network_connection_profile,
@@ -120,6 +146,25 @@ public:
     ///
     virtual void disconnect() = 0;
 
+    /// \brief Stop delivering connected/disconnected notifications to the registered callbacks.
+    ///
+    /// Called during teardown after disconnect(). A late websocket-thread callback would otherwise
+    /// reach into a ChargePoint whose members are already being destroyed (use-after-free). This
+    /// blocks until any in-flight callback returns, then suppresses all further ones.
+    virtual void disarm_connection_callbacks() = 0;
+
+    /// \brief Suppress automatic reconnection without closing the current websocket.
+    ///
+    /// Unlike disconnect(), this does NOT close the live websocket: it only clears the internal
+    /// "wants to be connected" intent and cancels any pending reconnect timer. A subsequent close
+    /// initiated elsewhere (e.g. the CSMS closing the socket, or the regular post-transaction
+    /// shutdown path) will therefore not trigger an auto-reconnect. Used just before an imminent
+    /// whole-station reset so that any in-flight messages (e.g. the graceful
+    /// TransactionEvent(Ended) of an ongoing transaction) can still be flushed on the live
+    /// connection before it is closed for the reboot.
+    ///
+    virtual void suppress_reconnect() = 0;
+
     /// \brief send a \p message over the websocket
     /// \returns true if the message was sent successfully
     ///
@@ -178,7 +223,14 @@ private:
     std::optional<ConfigureNetworkConnectionProfileCallback> configure_network_connection_profile_callback;
 
     Everest::SteadyTimer websocket_timer;
-    bool wants_to_be_connected;
+
+    // Serializes invocation of the connected/disconnected callbacks (websocket thread) with
+    // disarm_connection_callbacks() (teardown thread). Once disarmed, the callbacks are suppressed.
+    std::mutex connection_callbacks_mutex;
+    bool connection_callbacks_disarmed{false};
+    // Written from the OCPP message-handler thread (suppress_reconnect/disconnect) and read from the
+    // websocket callback and websocket_timer threads, so it must be atomic.
+    std::atomic<bool> wants_to_be_connected;
     OcppProtocolVersion connected_ocpp_version;
 
     /// @brief Mutable shared state, accessed concurrently from the OCPP message-handling thread,
@@ -195,6 +247,18 @@ private:
         std::optional<std::int32_t> pending_configuration_slot;
         /// Last SecurityProfile value observed when pruning invalid profiles from the cache.
         int last_known_security_level{0};
+        /// Slot of the last successful connection, used as the B10.FR.07 fallback target.
+        std::optional<std::int32_t> last_successful_slot;
+        /// Number of slots whose attempts were exhausted since the last successful connection.
+        int failed_slots_since_success{0};
+        /// True while reconnecting to the fallback (last-successful) profile after full-list exhaustion.
+        bool in_fallback{false};
+        /// Consecutive failed reconnect cycles since the last successful connection, used to drive the
+        /// OCPP part 4 section 5.3 backoff between cross-attempt/fallback re-dials. Reset to 0 on success.
+        int reconnect_attempts{0};
+        /// Backoff (milliseconds) computed for the most recent reconnect cycle; base that get_reconnect_backoff_ms
+        /// doubles for the next cycle. Reset to 0 on success.
+        long reconnect_backoff_ms{0};
     };
     mutable everest::lib::util::monitor<NetworkProfileCacheState, std::recursive_mutex> m_state;
 
@@ -225,6 +289,8 @@ public:
     std::chrono::time_point<std::chrono::steady_clock> get_time_disconnected() const override;
     void connect(std::optional<std::int32_t> network_profile_slot = std::nullopt) override;
     void disconnect() override;
+    void disarm_connection_callbacks() override;
+    void suppress_reconnect() override;
     bool send_to_websocket(const std::string& message) override;
     void on_network_disconnected(ocpp::v2::OCPPInterfaceEnum ocpp_interface) override;
     void on_charging_station_certificate_changed() override;
@@ -301,6 +367,20 @@ private:
 
     /// \brief Append the given slot to NetworkConfigurationPriority if it is not already listed.
     void append_slot_to_network_configuration_priority_if_absent(int32_t slot, const std::string& source);
+
+    /// \brief Ensure the fallback slot is present in the in-memory working set (slots + cached
+    ///        profiles) so try_connect_websocket() can dial it even when it is absent from the
+    ///        current NetworkConfigurationPriority list. Reads the profile from the configuration
+    ///        when not already cached. Caller must hold the state lock.
+    void ensure_slot_in_working_set(NetworkProfileCacheState& state, std::int32_t slot);
+
+    /// \brief Advance the section 5.3 reconnect-backoff counter for one failed reconnect cycle and return the
+    ///        wait before the next re-dial. Reads RetryBackOff* from the connection options of \p slot
+    ///        (these are global device-model values, identical across slots) and mutates
+    ///        \c state.reconnect_attempts / \c state.reconnect_backoff_ms. The returned delay is
+    ///        max(WEBSOCKET_INIT_DELAY, computed backoff) so genuine reconnection waits never dip below
+    ///        the quick-advance floor. Caller must hold the state lock.
+    std::chrono::milliseconds advance_reconnect_backoff(NetworkProfileCacheState& state, std::int32_t slot);
 
     /// \brief Cache all the network connection profiles
     void cache_network_connection_profiles();

--- a/lib/everest/ocpp/include/ocpp/common/connectivity_manager_configuration.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/connectivity_manager_configuration.hpp
@@ -65,6 +65,10 @@ public:
     /// \brief Persist the currently active network-profile slot.
     virtual void set_active_network_profile_slot(std::int32_t slot, const std::string& source) = 0;
 
+    /// \brief Read the persisted active network-profile slot, or std::nullopt if none is stored.
+    ///        Survives reboot, used to seed the last-successful profile for B10.FR.07 fallback.
+    virtual std::optional<std::int32_t> get_active_network_profile_slot() = 0;
+
     /// \brief Persist the negotiated OCPP protocol version for a specific slot.
     virtual void set_per_slot_ocpp_version(std::int32_t slot, const std::string& version,
                                            const std::string& source) = 0;

--- a/lib/everest/ocpp/include/ocpp/common/message_queue.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/message_queue.hpp
@@ -1024,6 +1024,7 @@ public:
 
     /// \brief Set message_timeout to given \p timeout (in seconds)
     void update_message_timeout(const int timeout) {
+        const std::lock_guard<std::recursive_mutex> lk(this->message_mutex);
         this->config.message_timeout_seconds = timeout;
     }
 

--- a/lib/everest/ocpp/include/ocpp/common/websocket/websocket.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/websocket/websocket.hpp
@@ -38,6 +38,10 @@ public:
     /// \brief disconnect the websocket
     void disconnect(const WebsocketCloseReason code);
 
+    /// \brief suppress the internal reconnect loop without closing the live socket
+    /// (see WebsocketBase::suppress_reconnect)
+    void suppress_reconnect();
+
     // \brief reconnects the websocket after the delay
     void reconnect(long delay);
 

--- a/lib/everest/ocpp/include/ocpp/common/websocket/websocket_base.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/websocket/websocket_base.hpp
@@ -42,6 +42,21 @@ struct WebsocketConnectionOptions {
     std::optional<std::string> everest_version;
 };
 
+/// \brief Decide whether another connection attempt should be made after a failure.
+/// \param attempts_made Attempts already made on the current profile (1 after the first).
+/// \param max_connection_attempts Allowed attempts per profile; -1 means unlimited.
+/// \return true if another attempt is allowed, so N allowed attempts yield exactly N attempts.
+bool should_attempt_reconnect(int attempts_made, int max_connection_attempts);
+
+/// \brief Compute the reconnect backoff wait in milliseconds per OCPP 2.0.1 part 4 section 5.3:
+/// RetryBackOffWaitMinimum plus random jitter in [0, RetryBackOffRandomRange], doubled per attempt
+/// up to RetryBackOffRepeatTimes doublings. Shared by WebsocketBase and ConnectivityManager.
+/// \param attempt_number 1-based attempt index; values <= 1 yield the first wait.
+/// \param previous_backoff_ms Result for the previous attempt; the base that is doubled.
+/// \param retry_backoff_random_range_s 0 makes the result deterministic (used by tests).
+long get_reconnect_backoff_ms(int attempt_number, long previous_backoff_ms, int retry_backoff_wait_minimum_s,
+                              int retry_backoff_repeat_times, int retry_backoff_random_range_s);
+
 ///
 /// \brief contains a websocket abstraction
 ///
@@ -64,6 +79,15 @@ protected:
     std::atomic_int reconnect_backoff_ms;
     std::atomic_int connection_attempts;
     std::atomic_bool shutting_down;
+    /// \brief When set, the internal retry loop schedules no further connection attempts, even for
+    /// a peer-initiated close. Ownership contract: armed only by suppress_reconnect(), cleared only
+    /// by clear_reconnect_suppression() (called from every subclass start_connecting), read only by
+    /// should_reconnect(). Subclasses must not touch the flag directly.
+    std::atomic_bool reconnect_suppressed;
+
+    /// \brief Clear the reconnect-suppression flag. Subclass start_connecting() must call this so a
+    /// fresh connect always resumes normal auto-reconnect and no subclass can forget the reset.
+    void clear_reconnect_suppression();
 
     /// \brief Indicates if the required callbacks are registered
     /// \returns true if the websocket is properly initialized
@@ -109,6 +133,14 @@ public:
 
     /// \brief disconnect the websocket
     void disconnect(const WebsocketCloseReason code);
+
+    /// \brief Suppress the internal reconnect loop without closing the live socket, so queued
+    /// messages can still flush. The flag is cleared on the next fresh connect.
+    void suppress_reconnect();
+
+    /// \brief Whether the internal retry loop should schedule another attempt: the attempt budget
+    /// is not exhausted and reconnect has not been suppressed.
+    bool should_reconnect() const;
 
     /// \brief indicates if the websocket is connected
     bool is_connected();

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_connectivity.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_connectivity.hpp
@@ -27,6 +27,7 @@ public:
     std::optional<WebsocketConnectionOptions> get_websocket_connection_options(int32_t slot) override;
     void set_active_security_profile(int32_t security_profile, const std::string& source) override;
     void set_active_network_profile_slot(int32_t slot, const std::string& source) override;
+    std::optional<int32_t> get_active_network_profile_slot() override;
     void set_per_slot_ocpp_version(int32_t slot, const std::string& version, const std::string& source) override;
     void set_security_ctrl_security_profile(int32_t security_profile, const std::string& source) override;
     void set_security_ctrl_identity(const std::string& identity, const std::string& source) override;

--- a/lib/everest/ocpp/include/ocpp/v2/device_model.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/device_model.hpp
@@ -180,6 +180,7 @@ public:
     std::optional<WebsocketConnectionOptions> get_websocket_connection_options(std::int32_t slot) override;
     void set_active_security_profile(std::int32_t security_profile, const std::string& source) override;
     void set_active_network_profile_slot(std::int32_t slot, const std::string& source) override;
+    std::optional<std::int32_t> get_active_network_profile_slot() override;
     void set_per_slot_ocpp_version(std::int32_t slot, const std::string& version, const std::string& source) override;
     void set_security_ctrl_security_profile(std::int32_t security_profile, const std::string& source) override;
     void set_security_ctrl_identity(const std::string& identity, const std::string& source) override;

--- a/lib/everest/ocpp/lib/ocpp/common/connectivity_manager.cpp
+++ b/lib/everest/ocpp/lib/ocpp/common/connectivity_manager.cpp
@@ -4,6 +4,7 @@
 #include <ocpp/common/connectivity_manager.hpp>
 
 #include <fstream>
+#include <mutex>
 
 #include <everest/logging.hpp>
 
@@ -21,6 +22,33 @@ using NetworkConnectionProfile = ocpp::v2::NetworkConnectionProfile;
 using OCPPInterfaceEnum = ocpp::v2::OCPPInterfaceEnum;
 using SetNetworkProfileRequest = ocpp::v2::SetNetworkProfileRequest;
 
+std::optional<NextSlotSelection> select_next_network_slot(const std::vector<std::int32_t>& priority_slots,
+                                                          std::int32_t current_slot, int failed_slots_since_success,
+                                                          std::optional<std::int32_t> last_successful_slot,
+                                                          bool in_fallback) {
+    if (priority_slots.empty()) {
+        return std::nullopt;
+    }
+
+    // B10.FR.07: enter fallback once every priority entry has been tried since the last successful
+    // connection, and stay pinned to the last-successful profile while in fallback. The pin is
+    // sticky: a failed dial to the fallback target keeps re-dialing that same slot on the configured
+    // RetryBackOff schedule (OCTT TC_B_49_CS rejects the first fallback attempt on purpose).
+    if (last_successful_slot.has_value() &&
+        (in_fallback || failed_slots_since_success >= static_cast<int>(priority_slots.size()))) {
+        return NextSlotSelection{last_successful_slot.value(), true};
+    }
+
+    // Otherwise advance to the next entry in the priority list, wrapping around.
+    const auto it = std::find(priority_slots.begin(), priority_slots.end(), current_slot);
+    std::size_t next_index = 0;
+    if (it != priority_slots.end()) {
+        const auto current_index = static_cast<std::size_t>(it - priority_slots.begin());
+        next_index = (current_index + 1) % priority_slots.size();
+    }
+    return NextSlotSelection{priority_slots[next_index], false};
+}
+
 ConnectivityManager::ConnectivityManager(ocpp::ConnectivityManagerConfiguration& configuration,
                                          std::shared_ptr<EvseSecurity> evse_security, const fs::path& share_path) :
     configuration{configuration},
@@ -33,6 +61,13 @@ ConnectivityManager::ConnectivityManager(ocpp::ConnectivityManagerConfiguration&
     wants_to_be_connected{false},
     connected_ocpp_version{OcppProtocolVersion::Unknown} {
     cache_network_connection_profiles();
+    // Seed the B10.FR.07 fallback target from the persisted active network profile so a fallback
+    // can happen after a reboot, when the last successful connection was made in a prior process
+    // lifetime. Reuses the already-persisted OCPPCommCtrlr.ActiveNetworkProfile device-model value.
+    if (const auto persisted_slot = this->configuration.get_active_network_profile_slot(); persisted_slot.has_value()) {
+        auto state = this->m_state.handle();
+        state->last_successful_slot = persisted_slot;
+    }
 }
 
 void ConnectivityManager::set_message_callback(const std::function<void(const std::string& message)>& callback) {
@@ -196,6 +231,23 @@ void ConnectivityManager::disconnect() {
     }
 }
 
+void ConnectivityManager::disarm_connection_callbacks() {
+    std::lock_guard<std::mutex> lock(this->connection_callbacks_mutex);
+    this->connection_callbacks_disarmed = true;
+}
+
+void ConnectivityManager::suppress_reconnect() {
+    // Like disconnect() this clears the connect intent and cancels any pending reconnect timer, but
+    // leaves the live socket open so queued messages can still flush. The websocket's own internal
+    // retry loop reconnects independently on a peer-initiated close, so its suppression flag must
+    // be armed as well (TC_B_45_CS).
+    this->wants_to_be_connected = false;
+    this->websocket_timer.stop();
+    if (this->websocket != nullptr) {
+        this->websocket->suppress_reconnect();
+    }
+}
+
 void ConnectivityManager::confirm_successful_connection() {
     const auto config_slot = this->get_active_network_configuration_slot();
     if (!config_slot.has_value()) {
@@ -208,6 +260,20 @@ void ConnectivityManager::confirm_successful_connection() {
     if (network_connection_profile.has_value()) {
         this->configuration.set_active_security_profile(network_connection_profile.value().securityProfile,
                                                         VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
+    }
+
+    // Persist ActiveNetworkProfile on actual success, not at dial time: the persisted value then
+    // means "profile in use", which is also what the B10.FR.07 fallback seed and the B09 readers
+    // (per-slot Identity / MessageTimeout / SetVariables gating) assume.
+    this->configuration.set_active_network_profile_slot(config_slot.value(), VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
+
+    // Remember the slot of the last successful connection (B10.FR.07) and clear the fallback state,
+    // mirroring how the active security profile is remembered above.
+    {
+        auto state = this->m_state.handle();
+        state->last_successful_slot = config_slot.value();
+        state->failed_slots_since_success = 0;
+        state->in_fallback = false;
     }
 
     this->remove_network_connection_profiles_below_actual_security_profile();
@@ -290,9 +356,6 @@ void ConnectivityManager::try_connect_websocket() {
     // for human-readable parity with how the priority list is described in the OCPP spec and configs.
     EVLOG_info << "Open websocket with NetworkConfigurationPriority: " << priority_to_set.value() + 1
                << " which is configurationSlot " << configuration_slot_to_set;
-
-    this->configuration.set_active_network_profile_slot(configuration_slot_to_set,
-                                                        VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
 
     if (this->websocket == nullptr) {
         this->websocket = std::make_unique<Websocket>(connection_options.value(), this->evse_security, this->logging);
@@ -451,11 +514,24 @@ void ConnectivityManager::on_websocket_connected(OcppProtocolVersion protocol) {
         }
     }
 
-    if (this->websocket_connected_callback.has_value() and network_connection_profile.has_value()) {
-        this->websocket_connected_callback.value()(actual_configuration_slot.value(),
-                                                   network_connection_profile.value(), this->connected_ocpp_version);
+    {
+        std::lock_guard<std::mutex> lock(this->connection_callbacks_mutex);
+        if (!this->connection_callbacks_disarmed and this->websocket_connected_callback.has_value() and
+            network_connection_profile.has_value()) {
+            this->websocket_connected_callback.value()(
+                actual_configuration_slot.value(), network_connection_profile.value(), this->connected_ocpp_version);
+        }
     }
     this->time_disconnected = std::chrono::time_point<std::chrono::steady_clock>();
+
+    // A successful websocket connection ends the reconnection sequence: reset the OCPP part 4 section 5.3
+    // backoff so the next reconnect (if any) starts again at RetryBackOffWaitMinimum. Mirrors how
+    // WebsocketBase resets its own connection_attempts on connect.
+    {
+        auto state = this->m_state.handle();
+        state->reconnect_attempts = 0;
+        state->reconnect_backoff_ms = 0;
+    }
 }
 
 void ConnectivityManager::mark_disconnected_at_now() {
@@ -473,7 +549,9 @@ void ConnectivityManager::on_websocket_disconnected() {
         this->get_network_connection_profile(actual_configuration_slot.value());
     this->mark_disconnected_at_now();
 
-    if (this->websocket_disconnected_callback.has_value() and network_connection_profile.has_value()) {
+    std::lock_guard<std::mutex> lock(this->connection_callbacks_mutex);
+    if (!this->connection_callbacks_disarmed and this->websocket_disconnected_callback.has_value() and
+        network_connection_profile.has_value()) {
         this->websocket_disconnected_callback.value()(actual_configuration_slot.value(),
                                                       network_connection_profile.value(), this->connected_ocpp_version);
     }
@@ -490,22 +568,95 @@ void ConnectivityManager::on_websocket_stopped_connecting(ocpp::WebsocketCloseRe
     }
 
     if (this->wants_to_be_connected) {
+        // A stopped-connecting event means the active slot exhausted its per-profile attempts, so
+        // the OCPP part 4 section 5.3 backoff between re-dials applies here. A ServiceRestart is an
+        // intentional close, not a failed reconnect, so it does not grow the backoff.
+        std::chrono::milliseconds delay = WEBSOCKET_INIT_DELAY;
+        if (reason != WebsocketCloseReason::ServiceRestart) {
+            const auto current = get_active_network_configuration_slot();
+            if (current.has_value()) {
+                auto state = this->m_state.handle();
+                delay = this->advance_reconnect_backoff(*state, current.value());
+            }
+        }
+
         this->websocket_timer.timeout(
             [this, reason] {
                 if (reason != WebsocketCloseReason::ServiceRestart) {
                     const auto current = get_active_network_configuration_slot();
                     if (current.has_value()) {
-                        const auto next_slot = get_next_configuration_slot(current.value());
-                        if (next_slot.has_value()) {
-                            auto state = this->m_state.handle();
-                            state->pending_configuration_slot = next_slot.value();
+                        auto state = this->m_state.handle();
+                        // Each stopped-connecting event means the active slot exhausted its attempts.
+                        if (!state->in_fallback) {
+                            state->failed_slots_since_success += 1;
+                        }
+                        const auto selection =
+                            select_next_network_slot(state->slots, current.value(), state->failed_slots_since_success,
+                                                     state->last_successful_slot, state->in_fallback);
+                        if (selection.has_value()) {
+                            if (selection->is_fallback) {
+                                EVLOG_info << "All network profiles exhausted, falling back to last successful "
+                                              "configurationSlot "
+                                           << selection->slot;
+                                state->in_fallback = true;
+                                this->ensure_slot_in_working_set(*state, selection->slot);
+                            }
+                            state->pending_configuration_slot = selection->slot;
                         }
                     }
                 }
                 this->try_connect_websocket();
             },
-            WEBSOCKET_INIT_DELAY);
+            delay);
     }
+}
+
+std::chrono::milliseconds ConnectivityManager::advance_reconnect_backoff(NetworkProfileCacheState& state,
+                                                                         std::int32_t slot) {
+    // Combined section 5.3 schedule: two counters cooperate. WebsocketBase runs the backoff for the
+    // per-profile internal retries (up to NetworkProfileConnectionAttempts, its connection_attempts
+    // resets to 1 on each start_connecting). This CM-side counter runs the backoff between the
+    // cross-profile / fallback re-dials that happen after a profile exhausts its internal attempts,
+    // and resets to 0 only on a confirmed successful connection. The intended combined effect is a
+    // monotonically non-decreasing wait across a full reconnection sequence until success.
+    int wait_minimum_s = 0;
+    int repeat_times = 0;
+    int random_range_s = 0;
+    if (const auto opts = this->get_ws_connection_options(slot); opts.has_value()) {
+        wait_minimum_s = opts->retry_backoff_wait_minimum_s;
+        repeat_times = opts->retry_backoff_repeat_times;
+        random_range_s = opts->retry_backoff_random_range_s;
+    }
+
+    // The counter is reset only on a successful connection, not when switching profiles: resetting
+    // per profile switch would let a station cycle profiles and re-dial with no backoff (TC_B_49_CS).
+    state.reconnect_attempts += 1;
+    state.reconnect_backoff_ms = get_reconnect_backoff_ms(state.reconnect_attempts, state.reconnect_backoff_ms,
+                                                          wait_minimum_s, repeat_times, random_range_s);
+
+    return std::max<std::chrono::milliseconds>(WEBSOCKET_INIT_DELAY,
+                                               std::chrono::milliseconds(state.reconnect_backoff_ms));
+}
+
+void ConnectivityManager::ensure_slot_in_working_set(NetworkProfileCacheState& state, std::int32_t slot) {
+    if (std::find(state.slots.begin(), state.slots.end(), slot) != state.slots.end()) {
+        return;
+    }
+    const auto profile = this->configuration.read_network_connection_profile(slot);
+    if (!profile.has_value()) {
+        EVLOG_warning << "Fallback slot " << slot << " has no stored network connection profile";
+        return;
+    }
+    const bool already_cached =
+        std::any_of(state.cached_profiles.begin(), state.cached_profiles.end(),
+                    [slot](const SetNetworkProfileRequest& p) { return p.configurationSlot == slot; });
+    if (!already_cached) {
+        SetNetworkProfileRequest req;
+        req.configurationSlot = slot;
+        req.connectionData = profile.value();
+        state.cached_profiles.push_back(req);
+    }
+    state.slots.push_back(slot);
 }
 
 void ConnectivityManager::append_slot_to_network_configuration_priority_if_absent(const int32_t slot,
@@ -533,6 +684,10 @@ void ConnectivityManager::cache_network_connection_profiles() {
     auto state = this->m_state.handle();
     state->cached_profiles.clear();
     state->slots.clear();
+    // The working set is rebuilt here, so any fallback selection derived from the old set is stale.
+    // Reset it (keep last_successful_slot, which survives profile-list changes as the fallback seed).
+    state->in_fallback = false;
+    state->failed_slots_since_success = 0;
 
     // Build profiles and priority-ordered slot list from NetworkConfiguration DM components
     for (const std::string& str : ocpp::split_string(this->configuration.get_network_configuration_priority(), ',')) {

--- a/lib/everest/ocpp/lib/ocpp/common/websocket/websocket.cpp
+++ b/lib/everest/ocpp/lib/ocpp/common/websocket/websocket.cpp
@@ -38,6 +38,10 @@ void Websocket::disconnect(const WebsocketCloseReason code) {
     this->websocket->disconnect(code);
 }
 
+void Websocket::suppress_reconnect() {
+    this->websocket->suppress_reconnect();
+}
+
 void Websocket::reconnect(long delay) {
     this->logging->sys("Reconnecting");
     this->websocket->reconnect(delay);

--- a/lib/everest/ocpp/lib/ocpp/common/websocket/websocket_base.cpp
+++ b/lib/everest/ocpp/lib/ocpp/common/websocket/websocket_base.cpp
@@ -7,6 +7,34 @@
 #include <websocketpp_utils/base64.hpp>
 namespace ocpp {
 
+bool should_attempt_reconnect(int attempts_made, int max_connection_attempts) {
+    // -1 indicates to always attempt to reconnect
+    return max_connection_attempts == -1 or attempts_made < max_connection_attempts;
+}
+
+long get_reconnect_backoff_ms(int attempt_number, long previous_backoff_ms, int retry_backoff_wait_minimum_s,
+                              int retry_backoff_repeat_times, int retry_backoff_random_range_s) {
+    // OCPP 2.0.1 part 4 section 5.3: after RetryBackOffRepeatTimes doublings the wait stays flat. The first
+    // attempt (attempt_number == 1) is the initial wait, so doubling stops once attempt_number
+    // exceeds retry_backoff_repeat_times + 1.
+    if (attempt_number > retry_backoff_repeat_times + 1) {
+        return previous_backoff_ms;
+    }
+
+    int random_number_s = 0;
+    if (retry_backoff_random_range_s > 0) {
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_int_distribution<> distr(0, retry_backoff_random_range_s);
+        random_number_s = distr(gen);
+    }
+
+    if (attempt_number <= 1) {
+        return (static_cast<long>(retry_backoff_wait_minimum_s) + random_number_s) * 1000L;
+    }
+    return (previous_backoff_ms * 2) + (static_cast<long>(random_number_s) * 1000L);
+}
+
 WebsocketBase::WebsocketBase() :
     m_is_connected(false),
     connected_callback(nullptr),
@@ -18,7 +46,8 @@ WebsocketBase::WebsocketBase() :
     ping_elapsed_s(0),
     pong_elapsed_s(0),
     reconnect_backoff_ms(0),
-    shutting_down(false) {
+    shutting_down(false),
+    reconnect_suppressed(false) {
 
     set_connection_options_base(connection_options);
 
@@ -106,6 +135,21 @@ void WebsocketBase::disconnect(const WebsocketCloseReason code) {
     this->close(code, "");
 }
 
+void WebsocketBase::suppress_reconnect() {
+    this->reconnect_suppressed = true;
+}
+
+void WebsocketBase::clear_reconnect_suppression() {
+    this->reconnect_suppressed = false;
+}
+
+bool WebsocketBase::should_reconnect() const {
+    if (this->reconnect_suppressed) {
+        return false;
+    }
+    return should_attempt_reconnect(this->connection_attempts, this->connection_options.max_connection_attempts);
+}
+
 bool WebsocketBase::is_connected() {
     return this->m_is_connected;
 }
@@ -137,24 +181,12 @@ void WebsocketBase::log_on_fail(const std::error_code& ec, const boost::system::
 }
 
 long WebsocketBase::get_reconnect_interval() {
-
-    // We need to add 1 to the repeat times since the first try is already connection_attempt 1
-    if (this->connection_attempts > (this->connection_options.retry_backoff_repeat_times + 1)) {
-        return this->reconnect_backoff_ms;
-    }
-
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_int_distribution<> distr(0, this->connection_options.retry_backoff_random_range_s);
-
-    const int random_number = distr(gen);
-
-    if (this->connection_attempts == 1) {
-        this->reconnect_backoff_ms = (this->connection_options.retry_backoff_wait_minimum_s + random_number) * 1000;
-        return this->reconnect_backoff_ms;
-    }
-
-    this->reconnect_backoff_ms = (this->reconnect_backoff_ms * 2) + (random_number * 1000);
+    // Delegate to the shared section 5.3 backoff formula so the per-profile attempt loop here and the
+    // ConnectivityManager cross-attempt/fallback scheduling stay in lockstep. connection_attempts is
+    // 1 on the first try, matching get_reconnect_backoff_ms()'s attempt_number convention.
+    this->reconnect_backoff_ms = static_cast<int>(get_reconnect_backoff_ms(
+        this->connection_attempts, this->reconnect_backoff_ms, this->connection_options.retry_backoff_wait_minimum_s,
+        this->connection_options.retry_backoff_repeat_times, this->connection_options.retry_backoff_random_range_s));
     return this->reconnect_backoff_ms;
 }
 

--- a/lib/everest/ocpp/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/everest/ocpp/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -130,7 +130,11 @@ struct ConnectionData {
     }
 
     /// \brief Requests the threads that are processing to exit as soon as possible
-    /// in a ordered manner
+    /// in a ordered manner.
+    /// Note: this only flips is_running (behind this->mutex); it does not wake the recv thread,
+    /// which waits on the recv_message_queue condition variable behind a different lock. Callers
+    /// must follow this with recv_message_queue notification (safe_close_threads() does so via
+    /// clear_all_queues()) or the recv thread only observes the interrupt on its next poll timeout.
     void do_interrupt_and_exit() {
         if (std::this_thread::get_id() == this->websocket_client_thread_id) {
             EVLOG_AND_THROW(std::runtime_error("Attempted to interrupt connection from websocket thread!"));
@@ -610,7 +614,11 @@ void WebsocketLibwebsockets::thread_websocket_message_recv_loop(std::shared_ptr<
         // if we receive a certain message type that will cause the implementation
         // in the charge point to attempt a reconnect (BasicAuthPass for example)
         if (!local_data->is_interupted()) {
-            recv_message_queue.wait_on_queue_element(1s);
+            // Wake immediately when interrupted: the interrupt flag lives behind a different lock, so
+            // without this predicate a teardown that races the thread into the wait is only observed
+            // when the poll times out, stalling disconnect() for the poll interval.
+            recv_message_queue.wait_on_queue_element_or_predicate([&local_data] { return local_data->is_interupted(); },
+                                                                  1s);
         }
     }
 
@@ -832,9 +840,7 @@ void WebsocketLibwebsockets::thread_websocket_client_loop(std::shared_ptr<Connec
         } else if (local_data->get_state() != EConnectionState::CONNECTED) {
             // Any other failure than a successful connect
 
-            // -1 indicates to always attempt to reconnect
-            if (this->connection_options.max_connection_attempts == -1 or
-                this->connection_attempts <= this->connection_options.max_connection_attempts) {
+            if (this->should_reconnect()) {
                 local_data->update_state(EConnectionState::RECONNECTING);
                 reconnect_delay = this->get_reconnect_interval();
                 try_reconnect = true;
@@ -857,13 +863,17 @@ void WebsocketLibwebsockets::thread_websocket_client_loop(std::shared_ptr<Connec
         if (local_data->get_state() == EConnectionState::RECONNECTING) {
             auto end_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(reconnect_delay);
 
-            while ((std::chrono::steady_clock::now() < end_time) && (false == local_data->is_interupted())) {
+            // Exit the wait early on interrupt or if reconnect gets suppressed mid-wait, so a
+            // suppress_reconnect() landing during the backoff cancels the scheduled re-dial. Only
+            // suppression is re-checked here: the attempt budget cannot change during the wait.
+            while ((std::chrono::steady_clock::now() < end_time) && (false == local_data->is_interupted()) &&
+                   (false == this->reconnect_suppressed)) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
 
-            if (true == local_data->is_interupted()) {
+            if (local_data->is_interupted() || this->reconnect_suppressed) {
                 try_reconnect = false;
-                EVLOG_info << "Interrupred reconnect attempt, not reconnecting!";
+                EVLOG_info << "Interrupted or suppressed reconnect attempt, not reconnecting!";
             } else {
                 EVLOG_info << "Attempting reconnect after a wait of: " << reconnect_delay << "ms";
             }
@@ -972,6 +982,10 @@ bool WebsocketLibwebsockets::start_connecting() {
     // Clear shutting down so we allow to reconnect again as well
     this->shutting_down = false;
 
+    // A fresh connect is the single point that clears any reconnect suppression armed before a
+    // reset, mirroring the connection_attempts reset below.
+    this->clear_reconnect_suppression();
+
     EVLOG_info << "Starting connection attempts to uri: " << this->connection_options.csms_uri.string()
                << " with security-profile " << this->connection_options.security_profile
                << (this->connection_options.use_tpm_tls ? " with TPM keys" : "");
@@ -1029,6 +1043,10 @@ void WebsocketLibwebsockets::close_internal(const WebsocketCloseReason code, con
     if (!trying_connecting) {
         EVLOG_warning << "Trying to close inactive websocket with code: " << (int)code << " and reason: " << reason
                       << ", returning";
+        // The client loop can self-exit once reconnect attempts are exhausted, leaving its worker
+        // threads finished but still joinable. Join them here so a later close or destruction cannot
+        // destroy a joinable std::thread and terminate.
+        safe_close_threads();
         return;
     }
 

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_connectivity.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_connectivity.cpp
@@ -116,6 +116,11 @@ void ChargePointConfigurationConnectivity::set_active_network_profile_slot(int32
                   << slot;
 }
 
+std::optional<int32_t> ChargePointConfigurationConnectivity::get_active_network_profile_slot() {
+    // OCPP 1.6 does not support multiple network connection profiles, so there is no fallback target.
+    return std::nullopt;
+}
+
 void ChargePointConfigurationConnectivity::set_per_slot_ocpp_version(int32_t /*slot*/, const std::string& /*version*/,
                                                                      const std::string& /*source*/) {
     EVLOG_warning

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -1293,6 +1293,9 @@ bool ChargePointImpl::stop() {
 
         this->database_handler->close_connection();
         this->connectivity_manager->disconnect();
+        // Disarm before tearing down the message queue: a late websocket-thread disconnect callback
+        // must not reach into members being destroyed.
+        this->connectivity_manager->disarm_connection_callbacks();
         this->message_queue->stop();
 
         this->stopped = true;

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
@@ -162,6 +162,9 @@ void ChargePoint::stop() {
     this->availability->stop_heartbeat_timer();
     this->provisioning->stop_bootnotification_timer();
     this->connectivity_manager->disconnect();
+    // Disarm before tearing down the message queue: a late websocket-thread disconnect callback
+    // must not reach into members being destroyed.
+    this->connectivity_manager->disarm_connection_callbacks();
     this->security->stop_certificate_expiration_check_timers();
     this->diagnostics->stop_monitoring();
     this->message_queue->stop();

--- a/lib/everest/ocpp/lib/ocpp/v2/device_model.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/device_model.cpp
@@ -1228,6 +1228,10 @@ void DeviceModel::set_active_network_profile_slot(int32_t slot, const std::strin
     }
 }
 
+std::optional<std::int32_t> DeviceModel::get_active_network_profile_slot() {
+    return this->get_optional_value<std::int32_t>(ControllerComponentVariables::ActiveNetworkProfile);
+}
+
 void DeviceModel::set_per_slot_ocpp_version(int32_t slot, const std::string& version, const std::string& source) {
     const auto nc_cv = NetworkConfigurationComponentVariables::get_component_variable(
         slot, NetworkConfigurationComponentVariables::OcppVersion);

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/provisioning.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/provisioning.cpp
@@ -555,6 +555,12 @@ void Provisioning::handle_reset_req(Call<ResetRequest> call) {
     }
 
     if (response.status == ResetStatusEnum::Accepted) {
+        if (!call.msg.evseId.has_value()) {
+            // Imminent whole-station reset: suppress auto-reconnect so a CSMS-side close in the
+            // pre-reset window is not redialed (TC_A_10_CS). The socket stays open so a queued
+            // TransactionEvent(Ended, ImmediateReset) can still flush before the reboot.
+            this->context.connectivity_manager.suppress_reconnect();
+        }
         this->reset_callback(call.msg.evseId, ResetEnum::Immediate);
     }
 }
@@ -626,6 +632,24 @@ void Provisioning::handle_variable_changed(const SetVariableData& set_variable_d
         if (component_variable.variable.has_value()) {
             this->message_queue.update_transaction_message_attempts(
                 this->context.device_model.get_value<int>(ControllerComponentVariables::MessageAttempts));
+        }
+    }
+
+    if (set_variable_data.component.name == "NetworkConfiguration" and
+        set_variable_data.component.instance.has_value() and
+        set_variable_data.variable.name == NetworkConfigurationComponentVariables::MessageTimeout.name) {
+        // Apply a per-slot MessageTimeout to the live connection when it targets the active slot.
+        // Writes to other slots are picked up on the next connect.
+        try {
+            const std::int32_t slot = std::stoi(set_variable_data.component.instance.value().get());
+            const auto active_slot_opt =
+                this->context.device_model.get_optional_value<int>(ControllerComponentVariables::ActiveNetworkProfile);
+            if (active_slot_opt.has_value() and active_slot_opt.value() == slot) {
+                this->message_queue.update_message_timeout(std::stoi(set_variable_data.attributeValue.get()));
+                this->context.connectivity_manager.set_websocket_connection_options_without_reconnect();
+            }
+        } catch (const std::exception& e) {
+            EVLOG_warning << "Could not apply per-slot MessageTimeout change: " << e.what();
         }
     }
 

--- a/lib/everest/ocpp/tests/lib/ocpp/common/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/lib/ocpp/common/CMakeLists.txt
@@ -1,6 +1,8 @@
 target_sources(libocpp_unit_tests PRIVATE
+    test_connectivity_manager.cpp
     test_database_migration_files.cpp
     test_message_queue.cpp
+    test_websocket_teardown.cpp
     test_websocket_uri.cpp
 )
 

--- a/lib/everest/ocpp/tests/lib/ocpp/common/mocks/connectivity_manager_mock.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/common/mocks/connectivity_manager_mock.hpp
@@ -30,6 +30,8 @@ public:
     MOCK_METHOD(std::chrono::time_point<std::chrono::steady_clock>, get_time_disconnected, (), (const));
     MOCK_METHOD(void, connect, (std::optional<std::int32_t> network_profile_slot));
     MOCK_METHOD(void, disconnect, ());
+    MOCK_METHOD(void, disarm_connection_callbacks, ());
+    MOCK_METHOD(void, suppress_reconnect, ());
     MOCK_METHOD(bool, send_to_websocket, (const std::string& message));
     MOCK_METHOD(void, on_network_disconnected, (ocpp::v2::OCPPInterfaceEnum ocpp_interface));
     MOCK_METHOD(void, on_charging_station_certificate_changed, ());

--- a/lib/everest/ocpp/tests/lib/ocpp/common/test_connectivity_manager.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/common/test_connectivity_manager.cpp
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+// Unit tests for the ConnectivityManager slot-selection and websocket attempt-budget decision
+// logic, covering OCPP 2.0.1 B10.FR.07 (fallback to the last-successful network profile) and the
+// NetworkProfileConnectionAttempts off-by-one fix. The connect loop itself creates a real
+// Websocket, so the pure decision helpers are exercised in isolation here.
+
+#include <gtest/gtest.h>
+
+#include <ocpp/common/connectivity_manager.hpp>
+#include <ocpp/common/websocket/websocket_base.hpp>
+
+namespace ocpp {
+namespace {
+
+// ---------------------------------------------------------------------------
+// select_next_network_slot (B10.FR.07 fallback)
+// ---------------------------------------------------------------------------
+
+// Acceptance: connected on slot 1 -> priority becomes [2], slot 2 fails its single attempt ->
+// after exactly one exhausted slot the manager falls back to slot 1 (last successful).
+TEST(SelectNextNetworkSlot, FallsBackToLastSuccessfulAfterSingleEntryExhausted) {
+    const std::vector<std::int32_t> priority_slots{2};
+    const auto selection = select_next_network_slot(priority_slots, /*current_slot=*/2,
+                                                    /*failed_slots_since_success=*/1,
+                                                    /*last_successful_slot=*/2 - 1, /*in_fallback=*/false);
+    ASSERT_TRUE(selection.has_value());
+    EXPECT_EQ(selection->slot, 1);
+    EXPECT_TRUE(selection->is_fallback);
+}
+
+// With a two-entry list, the fallback only fires once BOTH entries have been exhausted.
+TEST(SelectNextNetworkSlot, CyclesThroughListBeforeFallingBack) {
+    const std::vector<std::int32_t> priority_slots{1, 2};
+
+    // Slot 1 exhausted first: not yet a full pass, advance to slot 2.
+    auto after_first = select_next_network_slot(priority_slots, /*current_slot=*/1,
+                                                /*failed_slots_since_success=*/1,
+                                                /*last_successful_slot=*/1, /*in_fallback=*/false);
+    ASSERT_TRUE(after_first.has_value());
+    EXPECT_EQ(after_first->slot, 2);
+    EXPECT_FALSE(after_first->is_fallback);
+
+    // Slot 2 exhausted next: full pass done, fall back to last successful (slot 1).
+    auto after_second = select_next_network_slot(priority_slots, /*current_slot=*/2,
+                                                 /*failed_slots_since_success=*/2,
+                                                 /*last_successful_slot=*/1, /*in_fallback=*/false);
+    ASSERT_TRUE(after_second.has_value());
+    EXPECT_EQ(after_second->slot, 1);
+    EXPECT_TRUE(after_second->is_fallback);
+}
+
+// While in fallback but not yet dialing the fallback target, stay pinned to the last-successful
+// profile regardless of the list.
+TEST(SelectNextNetworkSlot, StaysPinnedWhileTargetNotYetTried) {
+    const std::vector<std::int32_t> priority_slots{2};
+    const auto selection = select_next_network_slot(priority_slots, /*current_slot=*/2,
+                                                    /*failed_slots_since_success=*/99,
+                                                    /*last_successful_slot=*/1, /*in_fallback=*/true);
+    ASSERT_TRUE(selection.has_value());
+    EXPECT_EQ(selection->slot, 1);
+    EXPECT_TRUE(selection->is_fallback);
+}
+
+// Sticky pin (B10.FR.07 / OCTT TC_B_49_CS): a failed dial to the fallback target keeps re-dialing
+// that same last-successful slot rather than resuming priority-list cycling. The tool deliberately
+// rejects the first fallback connection attempt; the pin must survive it.
+TEST(SelectNextNetworkSlot, StaysPinnedWhenFallbackTargetFails) {
+    const std::vector<std::int32_t> priority_slots{1, 2};
+    const auto selection = select_next_network_slot(priority_slots, /*current_slot=*/1,
+                                                    /*failed_slots_since_success=*/99,
+                                                    /*last_successful_slot=*/1, /*in_fallback=*/true);
+    ASSERT_TRUE(selection.has_value());
+    EXPECT_EQ(selection->slot, 1);
+    EXPECT_TRUE(selection->is_fallback);
+}
+
+// Without a known last-successful slot there is no fallback target: keep cycling the list.
+TEST(SelectNextNetworkSlot, NoFallbackWithoutLastSuccessful) {
+    const std::vector<std::int32_t> priority_slots{2};
+    const auto selection = select_next_network_slot(priority_slots, /*current_slot=*/2,
+                                                    /*failed_slots_since_success=*/5,
+                                                    /*last_successful_slot=*/std::nullopt, /*in_fallback=*/false);
+    ASSERT_TRUE(selection.has_value());
+    EXPECT_EQ(selection->slot, 2);
+    EXPECT_FALSE(selection->is_fallback);
+}
+
+// The normal (pre-exhaustion) path advances to the next entry, wrapping around the list.
+TEST(SelectNextNetworkSlot, WrapsAroundList) {
+    const std::vector<std::int32_t> priority_slots{1, 2, 3};
+    auto next = select_next_network_slot(priority_slots, /*current_slot=*/3, /*failed_slots_since_success=*/1,
+                                         /*last_successful_slot=*/std::nullopt, /*in_fallback=*/false);
+    ASSERT_TRUE(next.has_value());
+    EXPECT_EQ(next->slot, 1);
+    EXPECT_FALSE(next->is_fallback);
+}
+
+TEST(SelectNextNetworkSlot, EmptyListReturnsNullopt) {
+    const std::vector<std::int32_t> priority_slots{};
+    EXPECT_FALSE(select_next_network_slot(priority_slots, /*current_slot=*/1, /*failed_slots_since_success=*/1,
+                                          /*last_successful_slot=*/1, /*in_fallback=*/false)
+                     .has_value());
+}
+
+// ---------------------------------------------------------------------------
+// should_attempt_reconnect (NetworkProfileConnectionAttempts budget)
+// ---------------------------------------------------------------------------
+
+// N == 1 must yield exactly one attempt: after the first attempt (attempts_made == 1) no reconnect.
+TEST(ShouldAttemptReconnect, ExactlyOneAttemptWhenBudgetIsOne) {
+    EXPECT_FALSE(should_attempt_reconnect(/*attempts_made=*/1, /*max_connection_attempts=*/1));
+}
+
+// N == 3 must yield exactly three attempts.
+TEST(ShouldAttemptReconnect, ExactlyNAttempts) {
+    EXPECT_TRUE(should_attempt_reconnect(1, 3));  // after attempt 1 -> retry
+    EXPECT_TRUE(should_attempt_reconnect(2, 3));  // after attempt 2 -> retry
+    EXPECT_FALSE(should_attempt_reconnect(3, 3)); // after attempt 3 -> stop
+}
+
+// -1 means unlimited attempts.
+TEST(ShouldAttemptReconnect, UnlimitedWhenNegativeOne) {
+    EXPECT_TRUE(should_attempt_reconnect(1, -1));
+    EXPECT_TRUE(should_attempt_reconnect(1000, -1));
+}
+
+// get_reconnect_backoff_ms (OCPP 2.0.1 part 4 section 5.3 reconnect backoff): these tests replay
+// the ConnectivityManager loop, feeding the previous result back in as previous_backoff_ms, with
+// RandomRange pinned to 0 for determinism.
+
+// WaitMinimum=13, Random=0, Repeat=0: no doublings, so every interval is exactly 13s. This is the
+// TC_B_49_CS configuration, where the regression scheduled re-dials 2s apart instead of >= 13s.
+TEST(GetReconnectBackoffMs, ConstantWhenRepeatIsZero) {
+    long prev = 0;
+    for (int attempt = 1; attempt <= 5; ++attempt) {
+        prev = get_reconnect_backoff_ms(attempt, prev, /*wait_minimum_s=*/13, /*repeat_times=*/0,
+                                        /*random_range_s=*/0);
+        EXPECT_EQ(prev, 13000) << "attempt " << attempt;
+    }
+}
+
+// WaitMinimum=13, Random=0, Repeat=2: doubles twice (13, 26, 52) then stays flat at 52s.
+TEST(GetReconnectBackoffMs, DoublesUpToRepeatTimesThenFlat) {
+    const long expected[] = {13000, 26000, 52000, 52000, 52000};
+    long prev = 0;
+    for (int attempt = 1; attempt <= 5; ++attempt) {
+        prev = get_reconnect_backoff_ms(attempt, prev, /*wait_minimum_s=*/13, /*repeat_times=*/2,
+                                        /*random_range_s=*/0);
+        EXPECT_EQ(prev, expected[attempt - 1]) << "attempt " << attempt;
+    }
+}
+
+// The first attempt (attempt_number == 1) always yields exactly WaitMinimum regardless of the base,
+// which is what makes an attempt-counter reset on a successful connection restart the sequence at
+// WaitMinimum. Simulate a reset by feeding attempt_number == 1 again with a stale previous value.
+TEST(GetReconnectBackoffMs, FirstAttemptIgnoresPreviousBackoff) {
+    // Ramp up a few attempts...
+    long prev = get_reconnect_backoff_ms(1, 0, 13, 5, 0);
+    prev = get_reconnect_backoff_ms(2, prev, 13, 5, 0);
+    EXPECT_EQ(prev, 26000);
+    // ...then a reset (counter back to 1) starts over at WaitMinimum, ignoring the stale 26000.
+    const long after_reset = get_reconnect_backoff_ms(1, prev, 13, 5, 0);
+    EXPECT_EQ(after_reset, 13000);
+}
+
+// attempt_number <= 0 is treated as the first wait (defensive; the counter is 1-based in practice).
+TEST(GetReconnectBackoffMs, NonPositiveAttemptTreatedAsFirst) {
+    EXPECT_EQ(get_reconnect_backoff_ms(0, 999999, 13, 3, 0), 13000);
+}
+
+// With a positive RandomRange the jitter stays within [0, range] seconds on top of the schedule.
+TEST(GetReconnectBackoffMs, RandomRangeStaysWithinBounds) {
+    for (int i = 0; i < 50; ++i) {
+        const long first = get_reconnect_backoff_ms(1, 0, /*wait_minimum_s=*/13, /*repeat_times=*/3,
+                                                    /*random_range_s=*/5);
+        EXPECT_GE(first, 13000);
+        EXPECT_LE(first, 13000 + 5000);
+    }
+}
+
+// WebsocketBase reconnect suppression (TC_B_45_CS / TC_A_10_CS): the full drop-and-redial loop
+// needs a live server, so the decision is exercised through should_reconnect(), the single gate
+// the client loop consults before scheduling another attempt.
+
+class FakeWebsocket : public WebsocketBase {
+public:
+    // Mirror the real connection options setup and the fresh-connect clear of the suppression flag
+    // (WebsocketLibwebsockets::start_connecting clears reconnect_suppressed next to shutting_down).
+    void configure(int max_connection_attempts) {
+        WebsocketConnectionOptions options{};
+        options.max_connection_attempts = max_connection_attempts;
+        this->set_connection_options_base(options);
+    }
+    bool start_connecting() override {
+        this->connection_attempts = 1;
+        this->clear_reconnect_suppression();
+        return true;
+    }
+    void set_connection_options(const WebsocketConnectionOptions& options) override {
+        this->set_connection_options_base(options);
+    }
+    void reconnect(long /*delay*/) override {
+    }
+    void close(const WebsocketCloseReason /*code*/, const std::string& /*reason*/) override {
+    }
+    bool send(const std::string& /*message*/) override {
+        return true;
+    }
+
+private:
+    void ping() override {
+    }
+};
+
+// Baseline: with attempts left and no suppression, the loop is allowed to reconnect.
+TEST(WebsocketReconnectSuppression, ReconnectsWhenBudgetLeftAndNotSuppressed) {
+    FakeWebsocket ws;
+    ws.configure(/*max_connection_attempts=*/-1); // unlimited
+    EXPECT_TRUE(ws.should_reconnect());
+}
+
+// TC_B_45_CS / TC_A_10_CS: once suppressed, should_reconnect() is false even with attempts left and
+// even for the "always reconnect" peer-close path, so the loop finalizes instead of re-dialing.
+TEST(WebsocketReconnectSuppression, SuppressBlocksReconnectDespiteBudget) {
+    FakeWebsocket ws;
+    ws.configure(/*max_connection_attempts=*/-1); // unlimited: budget alone would always retry
+    ws.suppress_reconnect();
+    EXPECT_FALSE(ws.should_reconnect());
+}
+
+// A fresh connect (post-reboot, or a within-process re-connect) clears the suppression so normal
+// auto-reconnect resumes; the flag is armed only for the imminent-reset window.
+TEST(WebsocketReconnectSuppression, FreshConnectClearsSuppression) {
+    FakeWebsocket ws;
+    ws.configure(/*max_connection_attempts=*/-1);
+    ws.suppress_reconnect();
+    ASSERT_FALSE(ws.should_reconnect());
+    ws.start_connecting(); // fresh connect clears the flag (mirrors start_connecting)
+    EXPECT_TRUE(ws.should_reconnect());
+}
+
+// Suppression is orthogonal to the section 5.3 attempt budget: an exhausted budget still stops reconnect
+// regardless of the flag (TC_B_49/B_46 backoff path untouched).
+TEST(WebsocketReconnectSuppression, ExhaustedBudgetStopsRegardlessOfFlag) {
+    FakeWebsocket ws;
+    ws.configure(/*max_connection_attempts=*/1); // exactly one attempt allowed
+    // connection_attempts starts at 1 -> after the first attempt the budget is spent.
+    EXPECT_FALSE(ws.should_reconnect());
+}
+
+} // namespace
+} // namespace ocpp

--- a/lib/everest/ocpp/tests/lib/ocpp/common/test_websocket_teardown.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/common/test_websocket_teardown.cpp
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+// Regression test for the reset-teardown stall in TC_B_49_CS: while the websocket dials a dead
+// port, the receive thread parked in SafeQueue::wait_on_queue_element() could miss the interrupt
+// wakeup and stall the teardown join for a full poll interval. Drives a real in-flight connection
+// to an unresponsive endpoint and asserts disconnect() returns well under the poll interval.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <ocpp/common/websocket/websocket_libwebsockets.hpp>
+
+#include "evse_security_mock.hpp"
+
+using namespace std::chrono_literals;
+
+namespace ocpp {
+namespace {
+
+// 198.51.100.0/24 is TEST-NET-2 (RFC 5737): not assigned, so a SYN is dropped and the connection
+// attempt stays in flight (state is still "trying"), which is what keeps the receive thread alive
+// through teardown. If an environment fails the connect immediately the connection finalizes and
+// the teardown returns even sooner, so the test still holds.
+constexpr auto DEAD_PORT_URI = "ws://198.51.100.1:9999";
+
+WebsocketConnectionOptions make_options() {
+    WebsocketConnectionOptions options;
+    options.csms_uri = Uri::parse_and_validate(DEAD_PORT_URI, "cp001", 1);
+    options.security_profile = 1;
+    options.ocpp_versions = {OcppProtocolVersion::v201};
+    options.authorization_key = "DummyAuthorizationKey123";
+    options.message_timeout = 5s;
+    options.retry_backoff_random_range_s = 0;
+    options.retry_backoff_repeat_times = 0;
+    options.retry_backoff_wait_minimum_s = 0;
+    options.max_connection_attempts = 1;
+    options.supported_ciphers_12 = "";
+    options.supported_ciphers_13 = "";
+    options.ping_interval_s = 0;
+    options.ping_payload = "";
+    options.pong_timeout_s = 0;
+    options.use_ssl_default_verify_paths = false;
+    options.verify_csms_common_name = false;
+    options.use_tpm_tls = false;
+    options.verify_csms_allow_wildcards = false;
+    return options;
+}
+
+} // namespace
+
+// Acceptance: teardown while a connection to an unresponsive endpoint is in flight must return
+// promptly. The receive thread's poll interval is 1 s, so the unfixed code takes about that long
+// (the interrupt does not wake the parked receive thread); the fix wakes it at once. The 900 ms
+// bound sits safely below the 1 s stall it guards against while staying tolerant of CI scheduling
+// jitter (a tight 500 ms bound flaked under load).
+TEST(WebsocketTeardown, DisconnectReturnsPromptlyWhileConnectingToDeadPort) {
+    auto evse_security = std::make_shared<testing::NiceMock<EvseSecurityMock>>();
+    auto ws = std::make_shared<WebsocketLibwebsockets>(make_options(), evse_security);
+
+    ws->register_connected_callback([](OcppProtocolVersion) {});
+    ws->register_stopped_connecting_callback([](WebsocketCloseReason) {});
+    ws->register_message_callback([](const std::string&) {});
+
+    ASSERT_TRUE(ws->start_connecting());
+
+    // Let the client dial and the receive thread settle into its wait while the connect is in flight.
+    std::this_thread::sleep_for(300ms);
+
+    const auto start = std::chrono::steady_clock::now();
+    ws->disconnect(WebsocketCloseReason::Normal);
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_LT(elapsed, 900ms) << "disconnect() stalled for "
+                              << std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count()
+                              << " ms: the receive thread was not woken on interrupt";
+}
+
+} // namespace ocpp

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/test_charge_point_connectivity.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/test_charge_point_connectivity.cpp
@@ -129,6 +129,21 @@ TEST_F(ChargePointConnectivityTest, StartConnectsStopDisconnects) {
     charge_point->stop();
 }
 
+// Closing the socket is not enough: a disconnect callback already in flight on the websocket thread would
+// still reach on_websocket_disconnected() and touch the message queue and timers that stop() is about to
+// tear down. stop() therefore disarms the connection callbacks right after disconnect().
+TEST_F(ChargePointConnectivityTest, StopDisarmsConnectionCallbacksAfterDisconnect) {
+    ON_CALL(*this->connectivity_manager, is_websocket_connected()).WillByDefault(Return(false));
+
+    const ::testing::InSequence seq;
+    EXPECT_CALL(*this->connectivity_manager, disconnect()).Times(AtLeast(1));
+    EXPECT_CALL(*this->connectivity_manager, disarm_connection_callbacks()).Times(1);
+
+    auto charge_point = make_charge_point();
+    charge_point->start({}, BootReasonEnum::PowerUp, {});
+    charge_point->stop();
+}
+
 // Once the charge point observes a successful connection (connected callback -> message queue resume), queued
 // outgoing OCPP messages such as the BootNotification.req are handed to the websocket via send_to_websocket().
 TEST_F(ChargePointConnectivityTest, OutgoingMessageGoesToSendToWebsocket) {

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/CMakeLists.txt
@@ -5,6 +5,7 @@ target_include_directories(libocpp_unit_tests PUBLIC
 
 target_sources(libocpp_unit_tests PRIVATE
         test_data_transfer.cpp
+        test_provisioning.cpp
         test_reservation.cpp
         test_smart_charging.cpp)
 

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_provisioning.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_provisioning.cpp
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <optional>
+
+#include <boost/asio/io_context.hpp>
+
+#include <component_state_manager_mock.hpp>
+#include <connectivity_manager_mock.hpp>
+#include <device_model_test_helper.hpp>
+#include <evse_manager_fake.hpp>
+#include <evse_security_mock.hpp>
+#include <message_dispatcher_mock.hpp>
+#include <mocks/database_handler_mock.hpp>
+#include <ocsp_updater_mock.hpp>
+
+#include <ocpp/common/message_queue.hpp>
+#include <ocpp/common/types.hpp>
+#include <ocpp/v2/device_model.hpp>
+#include <ocpp/v2/functional_blocks/availability.hpp>
+#include <ocpp/v2/functional_blocks/diagnostics.hpp>
+#include <ocpp/v2/functional_blocks/functional_block_context.hpp>
+#include <ocpp/v2/functional_blocks/meter_values.hpp>
+#include <ocpp/v2/functional_blocks/provisioning.hpp>
+#include <ocpp/v2/functional_blocks/security.hpp>
+#include <ocpp/v2/functional_blocks/tariff_and_cost.hpp>
+#include <ocpp/v2/functional_blocks/transaction.hpp>
+#include <ocpp/v2/messages/Get15118EVCertificate.hpp>
+#include <ocpp/v2/messages/Reset.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
+
+using namespace ocpp;
+using namespace ocpp::v2;
+
+namespace {
+
+class AvailabilityMock : public AvailabilityInterface {
+public:
+    MOCK_METHOD(void, handle_message, (const ocpp::EnhancedMessage<MessageType>&), (override));
+    MOCK_METHOD(void, status_notification_req, (std::int32_t, std::int32_t, ConnectorStatusEnum, bool), (override));
+    MOCK_METHOD(void, heartbeat_req, (bool), (override));
+    MOCK_METHOD(void, handle_scheduled_change_availability_requests, (std::int32_t), (override));
+    MOCK_METHOD(void, set_scheduled_change_availability_requests, (std::int32_t, AvailabilityChange), (override));
+    MOCK_METHOD(void, set_heartbeat_timer_interval, (const std::chrono::seconds&), (override));
+    MOCK_METHOD(void, stop_heartbeat_timer, (), (override));
+    MOCK_METHOD(ChangeAvailabilityResponse, change_availability_req, (bool&, const ChangeAvailabilityRequest&),
+                (override));
+    MOCK_METHOD(void, action_change_availability_req,
+                (bool, const ChangeAvailabilityRequest&, const ChangeAvailabilityResponse&), (override));
+};
+
+class MeterValuesMock : public MeterValuesInterface {
+public:
+    MOCK_METHOD(void, handle_message, (const ocpp::EnhancedMessage<MessageType>&), (override));
+    MOCK_METHOD(void, update_aligned_data_interval, (), (override));
+    MOCK_METHOD(void, on_meter_value, (std::int32_t, const MeterValue&), (override));
+    MOCK_METHOD(MeterValue, get_latest_meter_value_filtered,
+                (const MeterValue&, ReadingContextEnum, const RequiredComponentVariable&), (override));
+    MOCK_METHOD(void, meter_values_req, (std::int32_t, const std::vector<MeterValue>&, bool), (override));
+};
+
+class SecurityMock : public SecurityInterface {
+public:
+    MOCK_METHOD(void, handle_message, (const ocpp::EnhancedMessage<MessageType>&), (override));
+    MOCK_METHOD(void, security_event_notification_req,
+                (const CiString<50>&, const std::optional<CiString<255>>&, bool, bool, const std::optional<DateTime>&),
+                (override));
+    MOCK_METHOD(void, sign_certificate_req, (const ocpp::CertificateSigningUseEnum&, bool), (override));
+    MOCK_METHOD(void, stop_certificate_signed_timer, (), (override));
+    MOCK_METHOD(void, init_certificate_expiration_check_timers, (), (override));
+    MOCK_METHOD(void, stop_certificate_expiration_check_timers, (), (override));
+    MOCK_METHOD(Get15118EVCertificateResponse, on_get_15118_ev_certificate_request,
+                (const Get15118EVCertificateRequest&), (override));
+};
+
+class DiagnosticsMock : public DiagnosticsInterface {
+public:
+    MOCK_METHOD(void, handle_message, (const ocpp::EnhancedMessage<MessageType>&), (override));
+    MOCK_METHOD(void, notify_event_req, (const std::vector<EventData>&), (override));
+    MOCK_METHOD(void, stop_monitoring, (), (override));
+    MOCK_METHOD(void, start_monitoring, (), (override));
+    MOCK_METHOD(void, process_triggered_monitors, (), (override));
+};
+
+class TransactionMock : public TransactionInterface {
+public:
+    MOCK_METHOD(void, handle_message, (const ocpp::EnhancedMessage<MessageType>&), (override));
+    MOCK_METHOD(void, on_transaction_started,
+                (std::int32_t, std::int32_t, const std::string&, const DateTime&, TriggerReasonEnum, const MeterValue&,
+                 const std::optional<IdToken>&, const std::optional<IdToken>&, const std::optional<std::int32_t>&,
+                 const std::optional<std::int32_t>&, ChargingStateEnum),
+                (override));
+    MOCK_METHOD(void, on_transaction_finished,
+                (std::int32_t, const DateTime&, const MeterValue&, ReasonEnum, TriggerReasonEnum,
+                 const std::optional<IdToken>&, const std::optional<std::string>&, ChargingStateEnum,
+                 const std::optional<SignedMeterValue>&),
+                (override));
+    MOCK_METHOD(void, transaction_event_req,
+                (const TransactionEventEnum&, const DateTime&, const Transaction&, const TriggerReasonEnum&,
+                 std::int32_t, const std::optional<std::int32_t>&, const std::optional<EVSE>&,
+                 const std::optional<IdToken>&, const std::optional<std::vector<MeterValue>>&,
+                 const std::optional<std::int32_t>&, bool, const std::optional<std::int32_t>&, bool),
+                (override));
+    MOCK_METHOD(void, set_remote_start_id_for_evse, (std::int32_t, IdToken, std::int32_t), (override));
+    MOCK_METHOD(void, schedule_reset, (std::optional<std::int32_t>), (override));
+};
+
+// An accepted, imminent whole-station reset must suppress auto-reconnect (TC_A_10_CS) without
+// closing the live websocket, so a queued TransactionEvent(Ended) can still flush before the
+// reboot. Scheduled and rejected resets must leave the connection untouched.
+class ProvisioningResetTest : public ::testing::Test {
+protected:
+    DeviceModelTestHelper dm_helper;
+    DeviceModel* dm{nullptr};
+
+    ::testing::NiceMock<MockMessageDispatcher> mock_dispatcher;
+    ::testing::NiceMock<ocpp::ConnectivityManagerMock> connectivity_manager;
+    std::unique_ptr<EvseManagerFake> evse_manager;
+    ::testing::NiceMock<DatabaseHandlerMock> db_handler;
+    ocpp::EvseSecurityMock evse_security;
+    ::testing::NiceMock<ComponentStateManagerMock> component_state_manager;
+    std::atomic<OcppProtocolVersion> ocpp_version{OcppProtocolVersion::v201};
+
+    ::testing::NiceMock<OcspUpdaterMock> ocsp_updater;
+    ::testing::NiceMock<AvailabilityMock> availability;
+    ::testing::NiceMock<MeterValuesMock> meter_values;
+    ::testing::NiceMock<SecurityMock> security;
+    ::testing::NiceMock<DiagnosticsMock> diagnostics;
+    ::testing::NiceMock<TransactionMock> transaction;
+    std::atomic<RegistrationStatusEnum> registration_status{RegistrationStatusEnum::Accepted};
+
+    boost::asio::io_context io_context;
+    std::optional<TariffMessageCallback> tariff_message_cb;
+    std::optional<SetRunningCostCallback> set_running_cost_cb;
+    std::optional<DefaultPriceCallback> default_price_cb;
+
+    std::unique_ptr<FunctionalBlockContext> fb_context;
+    std::unique_ptr<MessageQueue<MessageType>> message_queue;
+    std::unique_ptr<TariffAndCost> tariff_and_cost;
+    std::unique_ptr<Provisioning> provisioning;
+
+    // Controls / observations for the reset path.
+    bool allow_reset{true};
+    std::optional<std::optional<std::int32_t>> reset_callback_evse_id;
+
+    ProvisioningResetTest() : dm_helper() {
+        dm = dm_helper.get_device_model();
+        evse_manager = std::make_unique<EvseManagerFake>(1);
+
+        fb_context =
+            std::make_unique<FunctionalBlockContext>(mock_dispatcher, *dm, connectivity_manager, *evse_manager,
+                                                     db_handler, evse_security, component_state_manager, ocpp_version);
+
+        MessageQueueConfig<MessageType> mq_config;
+        message_queue = std::make_unique<MessageQueue<MessageType>>([](json) { return false; }, mq_config, nullptr);
+
+        tariff_and_cost = std::make_unique<TariffAndCost>(*fb_context, meter_values, tariff_message_cb,
+                                                          set_running_cost_cb, default_price_cb, io_context);
+
+        provisioning = std::make_unique<Provisioning>(
+            *fb_context, *message_queue, ocsp_updater, availability, meter_values, security, diagnostics, transaction,
+            std::nullopt, // time_sync_callback
+            std::nullopt, // boot_notification_callback
+            std::nullopt, // validate_network_profile_callback
+            [this](auto, auto) { return this->allow_reset; },
+            [this](std::optional<std::int32_t> evse_id, auto) { this->reset_callback_evse_id = evse_id; },
+            [](auto, auto) { return RequestStartStopStatusEnum::Accepted; }, // stop_transaction
+            std::nullopt,                                                    // variable_changed_callback
+            *tariff_and_cost, registration_status);
+    }
+
+    ocpp::EnhancedMessage<MessageType> make_reset_message(ResetEnum type,
+                                                          std::optional<std::int32_t> evse_id = std::nullopt) {
+        ResetRequest request;
+        request.type = type;
+        request.evseId = evse_id;
+        ocpp::Call<ResetRequest> call(request);
+        ocpp::EnhancedMessage<MessageType> enhanced_message;
+        enhanced_message.messageType = MessageType::Reset;
+        enhanced_message.message = call;
+        return enhanced_message;
+    }
+};
+
+// TC_A_10_CS: Reset(Immediate) whole-station accepted with no active transaction. Auto-reconnect must be suppressed
+// (via suppress_reconnect()) so the CSMS-side close after ResetResponse is not redialed before the reboot. The live
+// socket must NOT be force-closed here (that is disconnect()'s job); the reboot path closes it.
+TEST_F(ProvisioningResetTest, ImmediateWholeStationResetSuppressesReconnect) {
+    EXPECT_CALL(connectivity_manager, suppress_reconnect()).Times(1);
+    EXPECT_CALL(connectivity_manager, disconnect()).Times(0);
+    provisioning->handle_message(make_reset_message(ResetEnum::Immediate));
+    EXPECT_TRUE(reset_callback_evse_id.has_value()) << "reset_callback must still fire for an accepted reset";
+}
+
+// K01 / TC_B_22_CS regression guard: Reset(Immediate) whole-station accepted WITH an ongoing transaction. The
+// transaction is stopped (ImmediateReset) and reconnect is suppressed, but the websocket must stay open so the
+// graceful TransactionEvent(Ended) can flush before the reboot. Therefore disconnect() (which closes the socket
+// immediately) must NOT be called, only suppress_reconnect().
+TEST_F(ProvisioningResetTest, ImmediateWholeStationResetWithTransactionKeepsSocketOpen) {
+    evse_manager->open_transaction(1, "test-transaction");
+    EXPECT_CALL(connectivity_manager, suppress_reconnect()).Times(1);
+    EXPECT_CALL(connectivity_manager, disconnect()).Times(0);
+    provisioning->handle_message(make_reset_message(ResetEnum::Immediate));
+    EXPECT_TRUE(reset_callback_evse_id.has_value()) << "reset_callback must still fire for an accepted reset";
+}
+
+// Reset(OnIdle) with an active transaction is scheduled, not imminent: connection must stay fully up (no suppression).
+TEST_F(ProvisioningResetTest, ScheduledResetKeepsConnectionAlive) {
+    evse_manager->open_transaction(1, "test-transaction");
+    EXPECT_CALL(connectivity_manager, suppress_reconnect()).Times(0);
+    EXPECT_CALL(connectivity_manager, disconnect()).Times(0);
+    EXPECT_CALL(transaction, schedule_reset(::testing::_)).Times(1);
+    provisioning->handle_message(make_reset_message(ResetEnum::OnIdle));
+    EXPECT_FALSE(reset_callback_evse_id.has_value()) << "scheduled reset must not fire the reset callback yet";
+}
+
+// Evse-specific reset does not reboot the whole station, so the CSMS connection must not be touched.
+TEST_F(ProvisioningResetTest, EvseSpecificResetDoesNotSuppressReconnect) {
+    EXPECT_CALL(connectivity_manager, suppress_reconnect()).Times(0);
+    EXPECT_CALL(connectivity_manager, disconnect()).Times(0);
+    provisioning->handle_message(make_reset_message(ResetEnum::Immediate, 1));
+}
+
+// Rejected reset must leave the connection untouched (regression guard for the no-reset baseline).
+TEST_F(ProvisioningResetTest, RejectedResetDoesNotSuppressReconnect) {
+    allow_reset = false;
+    EXPECT_CALL(connectivity_manager, suppress_reconnect()).Times(0);
+    EXPECT_CALL(connectivity_manager, disconnect()).Times(0);
+    provisioning->handle_message(make_reset_message(ResetEnum::Immediate));
+    EXPECT_FALSE(reset_callback_evse_id.has_value()) << "rejected reset must not fire the reset callback";
+}
+
+// Hot reconfiguration of the per-slot MessageTimeout: a write to the active NetworkConfiguration
+// slot must be applied to the live connection immediately (no reconnect), a write to any other
+// slot is only picked up on the next connect.
+using ProvisioningVariableChangedTest = ProvisioningResetTest;
+
+namespace {
+SetVariableData make_slot_message_timeout(const std::string& slot, const std::string& value) {
+    SetVariableData data;
+    data.component.name = "NetworkConfiguration";
+    data.component.instance = slot;
+    data.variable.name = "MessageTimeout";
+    data.attributeValue = value;
+    return data;
+}
+
+void set_active_network_profile(DeviceModel& dm, const std::string& slot) {
+    ASSERT_TRUE(ControllerComponentVariables::ActiveNetworkProfile.variable.has_value());
+    ASSERT_EQ(dm.set_read_only_value(ControllerComponentVariables::ActiveNetworkProfile.component,
+                                     ControllerComponentVariables::ActiveNetworkProfile.variable.value(),
+                                     AttributeEnum::Actual, slot, "test"),
+              SetVariableStatusEnum::Accepted);
+}
+} // namespace
+
+TEST_F(ProvisioningVariableChangedTest, MessageTimeoutOnActiveSlotAppliesWithoutReconnect) {
+    set_active_network_profile(*dm, "1");
+    EXPECT_CALL(connectivity_manager, set_websocket_connection_options_without_reconnect()).Times(1);
+    provisioning->on_variable_changed(make_slot_message_timeout("1", "45"));
+}
+
+TEST_F(ProvisioningVariableChangedTest, MessageTimeoutOnInactiveSlotIsDeferred) {
+    set_active_network_profile(*dm, "1");
+    EXPECT_CALL(connectivity_manager, set_websocket_connection_options_without_reconnect()).Times(0);
+    provisioning->on_variable_changed(make_slot_message_timeout("2", "45"));
+}
+
+} // namespace

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_network_config_sync.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_network_config_sync.cpp
@@ -1005,6 +1005,24 @@ TEST_F(ConnectivityManagerCacheTest, CheckCacheInvalidSecurityProfilesPrunesCach
     EXPECT_EQ(std::find(slots.begin(), slots.end(), 1), slots.end()) << "Slot 1 must be removed from priority list";
 }
 
+// H3: ActiveNetworkProfile is persisted on a confirmed successful connection, not at dial time.
+// Persisting on success means a station that dials a broken slot and reboots does not seed the
+// broken slot as the fallback target.
+TEST_F(ConnectivityManagerCacheTest, ConfirmSuccessfulConnectionPersistsActiveSlot) {
+    // The active slot is slot 1 (from the fixture priority list). Seed ActiveNetworkProfile with a
+    // stale value so we can prove confirm_successful_connection() overwrites it with the slot that
+    // is actually in use, rather than the value being left over from a dial.
+    ASSERT_EQ(cm->get_network_connection_slots().at(0), 1);
+    dm->set_active_network_profile_slot(999, "test");
+    ASSERT_EQ(dm->get_optional_value<int>(ControllerComponentVariables::ActiveNetworkProfile).value(), 999);
+
+    cm->confirm_successful_connection();
+
+    const auto persisted = dm->get_optional_value<int>(ControllerComponentVariables::ActiveNetworkProfile);
+    ASSERT_TRUE(persisted.has_value()) << "ActiveNetworkProfile must be persisted after a confirmed connection";
+    EXPECT_EQ(persisted.value(), 1) << "confirm_successful_connection() must persist the active slot";
+}
+
 // ---------------------------------------------------------------------------
 // Provisioning block — reject active slot modification (B09.FR.21/22)
 // Verifies that validate_set_variable() rejects SetVariables targeting the


### PR DESCRIPTION
## Describe your changes

OCPP 2.0.1 websocket reconnect and reset-window fixes from OCTT
certification, plus two teardown races found while testing them.

- Honor the section 5.3 RetryBackOff on every re-dial, not just inside
  the per-profile attempt loop (TC_B_49_CS).
- Fall back to the last-successful network profile once the priority
  list is exhausted; N connection attempts now means exactly N.
- Persist ActiveNetworkProfile on a confirmed connection (not on dial)
  and seed the post-reboot fallback from it.
- Suppress auto-reconnect during the pre-reset window of an accepted
  immediate Reset without closing the socket (TC_A_10, TC_B_45, TC_B_22).
- Slot-1 MessageTimeout default 60s; per-slot MessageTimeout now hot
  applies on SetVariables (TC_E_41/42).
- Wake the recv thread on interrupt and join self-exited worker threads
  on close, so a failed dial cannot stall or terminate the process.
- Disarm connection callbacks in ChargePoint::stop(), fixing a
  pre-existing teardown use-after-free.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

### Verification
- Full libocpp unit test suite green (1376 passed); teardown race
  reproduced (2-core taskset) and clean over 50 repeats after the fix.
