### PR TITLE
fix(OCPP201): report connector availability on ChangeAvailability(Inoperative)

### DIFF
--- a/modules/EVSE/OCPP201/OCPP201.cpp
+++ b/modules/EVSE/OCPP201/OCPP201.cpp
@@ -564,18 +564,22 @@ void OCPP201::ready() {
 
     callbacks.connector_effective_operative_status_changed_callback =
         [this](const int32_t evse_id, const int32_t connector_id, const ocpp::v2::OperationalStatusEnum new_status) {
-            if (new_status == ocpp::v2::OperationalStatusEnum::Operative) {
-                if (this->r_evse_manager.at(evse_id - 1)
-                        ->call_enable_disable(connector_id, {types::evse_manager::Enable_source::CSMS,
-                                                             types::evse_manager::Enable_state::Enable, 5000})) {
-                    this->charge_point->on_enabled(evse_id, connector_id);
-                }
+            const auto enable_state = (new_status == ocpp::v2::OperationalStatusEnum::Operative)
+                                          ? types::evse_manager::Enable_state::Enable
+                                          : types::evse_manager::Enable_state::Disable;
+            // call_enable_disable() returns the resulting effective enabled state of the connector
+            // (the combined decision across all enable/disable sources), not a success flag. Report the
+            // connector availability to the CSMS based on that effective state. Previously the Disable
+            // branch guarded on_unavailable() with this return value, which is false for a successful
+            // disable, so no StatusNotification (connectorStatus = Unavailable) was ever sent in response
+            // to a ChangeAvailability(Inoperative).
+            const bool is_enabled =
+                this->r_evse_manager.at(evse_id - 1)
+                    ->call_enable_disable(connector_id, {types::evse_manager::Enable_source::CSMS, enable_state, 5000});
+            if (is_enabled) {
+                this->charge_point->on_enabled(evse_id, connector_id);
             } else {
-                if (this->r_evse_manager.at(evse_id - 1)
-                        ->call_enable_disable(connector_id, {types::evse_manager::Enable_source::CSMS,
-                                                             types::evse_manager::Enable_state::Disable, 5000})) {
-                    this->charge_point->on_unavailable(evse_id, connector_id);
-                }
+                this->charge_point->on_unavailable(evse_id, connector_id);
             }
         };
 

--- a/modules/EVSE/OCPPmulti/generic_chargepoint_interface.hpp
+++ b/modules/EVSE/OCPPmulti/generic_chargepoint_interface.hpp
@@ -81,6 +81,8 @@ struct GenericChargePointCallbacks {
     virtual std::future<ocpp::ConfigNetworkResult>
     cb_configure_network_connection_profile(std::int32_t configuration_slot,
                                             const ocpp::v2::NetworkConnectionProfile& network_connection_profile) = 0;
+    /// \brief Applies the requested availability and reports the connector's effective state to the CSMS.
+    /// \return true when the effective state matches the requested one.
     virtual bool cb_connector_effective_operative_status(std::int32_t evse_id, std::int32_t connector_id,
                                                          ocpp::v2::OperationalStatusEnum new_status) = 0;
     virtual void cb_connection_state_changed(bool is_connected, ocpp::OcppProtocolVersion protocol_version) = 0;

--- a/modules/EVSE/OCPPmulti/generic_ocpp.cpp
+++ b/modules/EVSE/OCPPmulti/generic_ocpp.cpp
@@ -998,20 +998,24 @@ bool GenericOcpp::cb_connector_effective_operative_status(std::int32_t evse_id, 
 
     if (evse_id > 0) {
         auto& evse = mv_requires.evse_manager.at(evse_id - 1);
+        const bool enable_requested = new_status == ocpp::v2::OperationalStatusEnum::Operative;
+        const auto enable_state =
+            enable_requested ? types::evse_manager::Enable_state::Enable : types::evse_manager::Enable_state::Disable;
 
-        if (new_status == ocpp::v2::OperationalStatusEnum::Operative) {
-            if (evse->call_enable_disable(connector_id, {types::evse_manager::Enable_source::CSMS,
-                                                         types::evse_manager::Enable_state::Enable, 5000})) {
-                mv_charge_point.on_enabled(evse_id, connector_id);
-                result = true;
-            }
+        // call_enable_disable() returns the connector's effective enabled state after the command
+        // (a higher priority source may decide otherwise), not whether the command succeeded.
+        // Report that effective state: guarding on_unavailable() with the return value meant a
+        // successful disable - which returns false - never reported connectorStatus Unavailable.
+        const bool is_enabled =
+            evse->call_enable_disable(connector_id, {types::evse_manager::Enable_source::CSMS, enable_state, 5000});
+
+        if (is_enabled) {
+            mv_charge_point.on_enabled(evse_id, connector_id);
         } else {
-            if (evse->call_enable_disable(connector_id, {types::evse_manager::Enable_source::CSMS,
-                                                         types::evse_manager::Enable_state::Disable, 5000})) {
-                mv_charge_point.on_unavailable(evse_id, connector_id);
-                result = true;
-            }
+            mv_charge_point.on_unavailable(evse_id, connector_id);
         }
+
+        result = is_enabled == enable_requested;
     } else {
         EVLOG_warning << "cb_connector_effective_operative_status: invalid evse_id: " << evse_id;
     }

--- a/modules/EVSE/OCPPmulti/tests/evse_managerIntf_tests.cpp
+++ b/modules/EVSE/OCPPmulti/tests/evse_managerIntf_tests.cpp
@@ -56,6 +56,7 @@ using ::testing::Return;
 
 TEST_F(GenericOcppRequiresTester, callEnableDisable) {
     // call_enable_disable() used in cb_connector_effective_operative_status
+    // it returns the effective enabled state after the command, not a success flag
 
     using ocpp::v2::OperationalStatusEnum;
 
@@ -63,21 +64,23 @@ TEST_F(GenericOcppRequiresTester, callEnableDisable) {
     interfaces->subscribe_var("evse_manager", "call_enable_disable",
                               [&received](const auto&, const auto&, const auto& data) { received.push_back(data); });
 
-    interfaces->add_cmd_result("true"_json);
-
     std::int32_t evse_id = 1;
     std::int32_t connector_id = 2;
-    auto new_status{OperationalStatusEnum::Inoperative};
 
+    // a successful disable leaves the connector disabled: report Unavailable
+    interfaces->add_cmd_result("false"_json);
     EXPECT_CALL(chargepoint, on_enabled(_, _)).Times(0);
     EXPECT_CALL(chargepoint, on_unavailable(evse_id, connector_id)).Times(1);
 
-    ocpp->cb_connector_effective_operative_status(evse_id, connector_id, new_status);
+    EXPECT_TRUE(
+        ocpp->cb_connector_effective_operative_status(evse_id, connector_id, OperationalStatusEnum::Inoperative));
 
-    interfaces->add_cmd_result("false"_json);
-    EXPECT_CALL(chargepoint, on_unavailable(evse_id, connector_id)).Times(0);
+    // a successful enable leaves the connector enabled: report enabled
+    interfaces->add_cmd_result("true"_json);
+    EXPECT_CALL(chargepoint, on_unavailable(_, _)).Times(0);
+    EXPECT_CALL(chargepoint, on_enabled(evse_id, connector_id)).Times(1);
 
-    ocpp->cb_connector_effective_operative_status(evse_id, connector_id, OperationalStatusEnum::Operative);
+    EXPECT_TRUE(ocpp->cb_connector_effective_operative_status(evse_id, connector_id, OperationalStatusEnum::Operative));
 
     ASSERT_EQ(received.size(), 2);
     EXPECT_EQ(
@@ -86,6 +89,47 @@ TEST_F(GenericOcppRequiresTester, callEnableDisable) {
     EXPECT_EQ(
         received[1],
         R"({"cmd_source":{"enable_priority":5000,"enable_source":"CSMS","enable_state":"Enable"},"connector_id":2})"_json);
+}
+
+TEST_F(GenericOcppRequiresTester, callEnableDisableOverriddenBySource) {
+    // a higher priority enable/disable source can override the CSMS request:
+    // the effective state is reported, and the request is not signalled as applied
+
+    using ocpp::v2::OperationalStatusEnum;
+
+    std::int32_t evse_id = 1;
+    std::int32_t connector_id = 0;
+
+    // disable requested, but the connector stays enabled
+    interfaces->add_cmd_result("true"_json);
+    EXPECT_CALL(chargepoint, on_unavailable(_, _)).Times(0);
+    EXPECT_CALL(chargepoint, on_enabled(evse_id, connector_id)).Times(1);
+
+    EXPECT_FALSE(
+        ocpp->cb_connector_effective_operative_status(evse_id, connector_id, OperationalStatusEnum::Inoperative));
+
+    // enable requested, but the connector stays disabled
+    interfaces->add_cmd_result("false"_json);
+    EXPECT_CALL(chargepoint, on_enabled(_, _)).Times(0);
+    EXPECT_CALL(chargepoint, on_unavailable(evse_id, connector_id)).Times(1);
+
+    EXPECT_FALSE(
+        ocpp->cb_connector_effective_operative_status(evse_id, connector_id, OperationalStatusEnum::Operative));
+}
+
+TEST_F(GenericOcppRequiresTester, callEnableDisableInvalidEvse) {
+    using ocpp::v2::OperationalStatusEnum;
+
+    std::vector<json> received;
+    interfaces->subscribe_var("evse_manager", "call_enable_disable",
+                              [&received](const auto&, const auto&, const auto& data) { received.push_back(data); });
+
+    EXPECT_CALL(chargepoint, on_enabled(_, _)).Times(0);
+    EXPECT_CALL(chargepoint, on_unavailable(_, _)).Times(0);
+
+    EXPECT_FALSE(ocpp->cb_connector_effective_operative_status(0, 1, OperationalStatusEnum::Inoperative));
+
+    EXPECT_TRUE(received.empty());
 }
 
 TEST_F(GenericOcppRequiresTester, callForceUnlock) {


### PR DESCRIPTION
## Describe your changes

`OCPP201`'s `connector_effective_operative_status_changed_callback` gated `charge_point->on_unavailable()` behind the return value of `call_enable_disable(..., Disable)`:

```cpp
} else {
    if (this->r_evse_manager.at(evse_id - 1)
            ->call_enable_disable(connector_id, {..., Enable_state::Disable, 5000})) {
        this->charge_point->on_unavailable(evse_id, connector_id);
    }
}
```

But `EvseManager::enable_disable()` returns the **resulting effective enabled state** of the connector (the combined decision across all enable/disable sources), not a success flag — see `Charger::enable_disable()` (`return is_enabled;`). A *successful* disable therefore returns `false`, the guard fails, and `on_unavailable()` is never called, so **no `StatusNotification` with `connectorStatus = Unavailable` is sent** in response to a `ChangeAvailability` request that sets an EVSE/connector `Inoperative`. The `Operative` branch happened to work because enable returns `true`.

This change reads `call_enable_disable()`'s return as what it is — the effective enabled state — and reports connector availability from it in both directions: a disable now emits `on_unavailable()` (Unavailable) and an enable emits `on_enabled()` (Available). As a side benefit, a CSMS `Operative` request that is overruled by a higher-priority disable source is now correctly reported as Unavailable rather than Available.

Per OCPP 2.0.1 an accepted `ChangeAvailability` must be reflected by a `StatusNotification` reporting the new connector status; today a CSMS setting a connector `Inoperative` receives `Accepted` but never sees it transition to `Unavailable`.

## Issue ticket number and link

N/A — no pre-existing upstream issue. Found during OCPP 2.0.1 remote-control/availability verification against a CSMS.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (no doc changes needed — behavioral bug fix)
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

## Testing

Verified in SIL (native build of this branch, `config-sil-ocpp201`, against an OCPP 2.0.1 CSMS, on a healthy simulated connector):

- **Before (stock main):** `ChangeAvailability(Inoperative)` for an EVSE → `Accepted`, but **no `StatusNotification`** — the connector never reports `Unavailable`.
- **After (this change):** `ChangeAvailability(Inoperative)` → `StatusNotification(connectorStatus = Unavailable)`; `ChangeAvailability(Operative)` → `StatusNotification(connectorStatus = Available)`.
