### PR TITLE
OCPP opt-in firmware download deferral

### DIFF
--- a/lib/everest/ocpp/config/common/component_config/standardized/ChargingStation.json
+++ b/lib/everest/ocpp/config/common/component_config/standardized/ChargingStation.json
@@ -16,7 +16,6 @@
                     "mutability": "ReadWrite"
                 }
             ],
-            "instance": "BytesPerMessage",
             "description": "Indicates whether new sessions can be started on EVSEs, while Charging Station is waiting for all EVSEs to become Available in order to start a pending firmware update",
             "type": "boolean"
         },

--- a/lib/everest/ocpp/config/common/component_config/standardized/InternalCtrlr.json
+++ b/lib/everest/ocpp/config/common/component_config/standardized/InternalCtrlr.json
@@ -816,6 +816,22 @@
           "default": false,
           "type": "boolean"
       },
+      "DeferFirmwareDownloadDuringTransaction": {
+          "variable_name": "DeferFirmwareDownloadDuringTransaction",
+          "characteristics": {
+            "supportsMonitoring": false,
+            "dataType": "boolean"
+          },
+          "attributes": [
+              {
+                  "type": "Actual",
+                  "mutability": "ReadOnly"
+              }
+          ],
+          "description": "If enabled and a transaction is active, an accepted UpdateFirmware defers the firmware download until the last transaction ends (L01.FR.13). The station reports DownloadScheduled in the meantime.",
+          "default": false,
+          "type": "boolean"
+      },
       "SupportedOcppVersions": {
           "variable_name": "SupportedOcppVersions",
           "characteristics": {

--- a/lib/everest/ocpp/config/common/component_config/standardized/InternalCtrlr.json
+++ b/lib/everest/ocpp/config/common/component_config/standardized/InternalCtrlr.json
@@ -832,6 +832,22 @@
           "default": false,
           "type": "boolean"
       },
+      "DeferFirmwareDownloadDuringTransaction": {
+          "variable_name": "DeferFirmwareDownloadDuringTransaction",
+          "characteristics": {
+            "supportsMonitoring": false,
+            "dataType": "boolean"
+          },
+          "attributes": [
+              {
+                  "type": "Actual",
+                  "mutability": "ReadOnly"
+              }
+          ],
+          "description": "If enabled and a transaction is active, an accepted UpdateFirmware defers the firmware download until the last transaction ends (L01.FR.13). The station reports DownloadScheduled in the meantime. Ships ReadOnly so it is a commissioning-time setting; a deployment that wants the CSMS to control it can declare the Actual attribute ReadWrite in its own component config.",
+          "default": false,
+          "type": "boolean"
+      },
       "SupportedOcppVersions": {
           "variable_name": "SupportedOcppVersions",
           "characteristics": {

--- a/lib/everest/ocpp/include/ocpp/v2/ctrlr_component_variables.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/ctrlr_component_variables.hpp
@@ -156,6 +156,7 @@ extern const ComponentVariable MessageQueueSizeThreshold;
 extern const ComponentVariable MaxMessageSize;
 extern const ComponentVariable ResumeTransactionsOnBoot;
 extern const ComponentVariable AllowSecurityLevelZeroConnections;
+extern const ComponentVariable DeferFirmwareDownloadDuringTransaction;
 extern const RequiredComponentVariable SupportedOcppVersions;
 extern const ComponentVariable AlignedDataCtrlrEnabled;
 extern const ComponentVariable AlignedDataCtrlrAvailable;

--- a/lib/everest/ocpp/include/ocpp/v2/ctrlr_component_variables.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/ctrlr_component_variables.hpp
@@ -157,6 +157,7 @@ extern const ComponentVariable MessageQueueSizeThreshold;
 extern const ComponentVariable MaxMessageSize;
 extern const ComponentVariable ResumeTransactionsOnBoot;
 extern const ComponentVariable AllowSecurityLevelZeroConnections;
+extern const ComponentVariable DeferFirmwareDownloadDuringTransaction;
 extern const RequiredComponentVariable SupportedOcppVersions;
 extern const ComponentVariable AlignedDataCtrlrEnabled;
 extern const ComponentVariable AlignedDataCtrlrAvailable;

--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/firmware_update.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/firmware_update.hpp
@@ -3,16 +3,16 @@
 
 #pragma once
 
+#include <mutex>
+
 #include <ocpp/v2/message_handler.hpp>
+#include <ocpp/v2/messages/UpdateFirmware.hpp>
 
 namespace ocpp::v2 {
 // Formward declarations.
 struct FunctionalBlockContext;
 class AvailabilityInterface;
 class SecurityInterface;
-
-struct UpdateFirmwareRequest;
-struct UpdateFirmwareResponse;
 
 // Typedef
 using UpdateFirmwareRequestCallback = std::function<UpdateFirmwareResponse(const UpdateFirmwareRequest& request)>;
@@ -26,6 +26,7 @@ public:
                                                         const FirmwareStatusEnum& firmware_update_status,
                                                         const bool disable_connectors_during_install = true) = 0;
     virtual void on_firmware_status_notification_request() = 0;
+    virtual void on_transaction_finished() = 0;
 };
 
 class FirmwareUpdate : public FirmwareUpdateInterface {
@@ -42,6 +43,12 @@ private: // Members
     std::optional<std::int32_t> firmware_status_id;
     // The last firmware status which will be posted before the firmware is installed.
     FirmwareStatusEnum firmware_status_before_installing = FirmwareStatusEnum::SignatureVerified;
+    // Download deferred until the last transaction ends (L01.FR.13). This is memory-only and does
+    // not survive a restart: after a reboot while in DownloadScheduled the CSMS must re-send
+    // UpdateFirmware. Written from the message handler thread and read/cleared from the module event
+    // thread, so all access is guarded by deferred_update_firmware_request_mutex.
+    std::optional<UpdateFirmwareRequest> deferred_update_firmware_request;
+    std::mutex deferred_update_firmware_request_mutex;
 
 public:
     FirmwareUpdate(const FunctionalBlockContext& functional_block_context, AvailabilityInterface& availability,
@@ -52,10 +59,15 @@ public:
                                                 const FirmwareStatusEnum& firmware_update_status,
                                                 bool disable_connectors_during_install = true) override;
     void on_firmware_status_notification_request() override;
+    void on_transaction_finished() override;
 
 private: // Functions
     // Functional Block L: Firmware management
     void handle_firmware_update_req(Call<UpdateFirmwareRequest> call);
+
+    /// \brief True if the download shall wait until the last transaction ends (L01.FR.13, gated by
+    /// DeferFirmwareDownloadDuringTransaction)
+    bool is_download_deferral_required() const;
 
     /// \brief Changes all unoccupied connectors to unavailable. If a transaction is running schedule an availabilty
     /// change

--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/firmware_update.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/firmware_update.hpp
@@ -3,16 +3,16 @@
 
 #pragma once
 
+#include <everest/util/async/monitor.hpp>
+
 #include <ocpp/v2/message_handler.hpp>
+#include <ocpp/v2/messages/UpdateFirmware.hpp>
 
 namespace ocpp::v2 {
 // Formward declarations.
 struct FunctionalBlockContext;
 class AvailabilityInterface;
 class SecurityInterface;
-
-struct UpdateFirmwareRequest;
-struct UpdateFirmwareResponse;
 
 // Typedef
 using UpdateFirmwareRequestCallback = std::function<UpdateFirmwareResponse(const UpdateFirmwareRequest& request)>;
@@ -26,6 +26,7 @@ public:
                                                         const FirmwareStatusEnum& firmware_update_status,
                                                         const bool disable_connectors_during_install = true) = 0;
     virtual void on_firmware_status_notification_request() = 0;
+    virtual void on_transaction_finished() = 0;
 };
 
 class FirmwareUpdate : public FirmwareUpdateInterface {
@@ -42,6 +43,11 @@ private: // Members
     std::optional<std::int32_t> firmware_status_id;
     // The last firmware status which will be posted before the firmware is installed.
     FirmwareStatusEnum firmware_status_before_installing = FirmwareStatusEnum::SignatureVerified;
+    // Download deferred until the last transaction ends (L01.FR.13). This is memory-only and does
+    // not survive a restart: after a reboot while in DownloadScheduled the CSMS must re-send
+    // UpdateFirmware. Written from the message handler thread and read/cleared from the module event
+    // thread, so all access goes through the monitor handle.
+    everest::lib::util::monitor<std::optional<UpdateFirmwareRequest>> deferred_update_firmware_request;
 
 public:
     FirmwareUpdate(const FunctionalBlockContext& functional_block_context, AvailabilityInterface& availability,
@@ -52,10 +58,15 @@ public:
                                                 const FirmwareStatusEnum& firmware_update_status,
                                                 bool disable_connectors_during_install = true) override;
     void on_firmware_status_notification_request() override;
+    void on_transaction_finished() override;
 
 private: // Functions
     // Functional Block L: Firmware management
     void handle_firmware_update_req(Call<UpdateFirmwareRequest> call);
+
+    /// \brief True if the download shall wait until the last transaction ends (L01.FR.13, gated by
+    /// DeferFirmwareDownloadDuringTransaction)
+    bool is_download_deferral_required() const;
 
     /// \brief Changes all unoccupied connectors to unavailable. If a transaction is running schedule an availabilty
     /// change

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
@@ -228,6 +228,8 @@ void ChargePoint::on_transaction_finished(const std::int32_t evse_id, const Date
                                           const std::optional<SignedMeterValue>& start_signed_meter_value) {
     this->transaction->on_transaction_finished(evse_id, timestamp, meter_stop, reason, trigger_reason, id_token,
                                                signed_meter_value, charging_state, start_signed_meter_value);
+    // Starts a firmware download deferred by L01.FR.13 once the last transaction ended.
+    this->firmware_update->on_transaction_finished();
 }
 
 void ChargePoint::on_session_finished(const std::int32_t evse_id, const std::int32_t connector_id) {

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
@@ -249,6 +249,8 @@ void ChargePoint::on_transaction_finished(const std::int32_t evse_id, const Date
                                           const std::optional<SignedMeterValue>& start_signed_meter_value) {
     this->transaction->on_transaction_finished(evse_id, timestamp, meter_stop, reason, trigger_reason, id_token,
                                                signed_meter_value, charging_state, start_signed_meter_value);
+    // Starts a firmware download deferred by L01.FR.13 once the last transaction ended.
+    this->firmware_update->on_transaction_finished();
 }
 
 void ChargePoint::on_session_finished(const std::int32_t evse_id, const std::int32_t connector_id) {

--- a/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
@@ -353,6 +353,12 @@ const ComponentVariable AllowSecurityLevelZeroConnections = {
         "AllowSecurityLevelZeroConnections",
     }),
 };
+const ComponentVariable DeferFirmwareDownloadDuringTransaction = {
+    ControllerComponents::InternalCtrlr,
+    std::optional<Variable>({
+        "DeferFirmwareDownloadDuringTransaction",
+    }),
+};
 const RequiredComponentVariable SupportedOcppVersions = {
     ControllerComponents::InternalCtrlr,
     std::optional<Variable>({"SupportedOcppVersions"}),
@@ -491,7 +497,7 @@ const ComponentVariable OfflineTxForUnknownIdEnabled = {
 };
 const ComponentVariable AllowNewSessionsPendingFirmwareUpdate = {
     ControllerComponents::ChargingStation,
-    std::optional<Variable>({"AllowNewSessionsPendingFirmwareUpdate", "BytesPerMessage"}),
+    std::optional<Variable>({"AllowNewSessionsPendingFirmwareUpdate"}),
 };
 const RequiredComponentVariable ChargingStationAvailabilityState = {
     ControllerComponents::ChargingStation,

--- a/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
@@ -359,6 +359,12 @@ const ComponentVariable AllowSecurityLevelZeroConnections = {
         "AllowSecurityLevelZeroConnections",
     }),
 };
+const ComponentVariable DeferFirmwareDownloadDuringTransaction = {
+    ControllerComponents::InternalCtrlr,
+    std::optional<Variable>({
+        "DeferFirmwareDownloadDuringTransaction",
+    }),
+};
 const RequiredComponentVariable SupportedOcppVersions = {
     ControllerComponents::InternalCtrlr,
     std::optional<Variable>({"SupportedOcppVersions"}),
@@ -497,7 +503,7 @@ const ComponentVariable OfflineTxForUnknownIdEnabled = {
 };
 const ComponentVariable AllowNewSessionsPendingFirmwareUpdate = {
     ControllerComponents::ChargingStation,
-    std::optional<Variable>({"AllowNewSessionsPendingFirmwareUpdate", "BytesPerMessage"}),
+    std::optional<Variable>({"AllowNewSessionsPendingFirmwareUpdate"}),
 };
 const RequiredComponentVariable ChargingStationAvailabilityState = {
     ControllerComponents::ChargingStation,

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/firmware_update.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/firmware_update.cpp
@@ -120,6 +120,33 @@ void FirmwareUpdate::on_firmware_status_notification_request() {
     this->context.message_dispatcher.dispatch_call(call, true);
 }
 
+void FirmwareUpdate::on_transaction_finished() {
+    std::optional<UpdateFirmwareRequest> request;
+    {
+        std::lock_guard<std::mutex> lock(this->deferred_update_firmware_request_mutex);
+        if (this->deferred_update_firmware_request.has_value() and
+            !this->context.evse_manager.any_transaction_active(std::nullopt)) {
+            request = this->deferred_update_firmware_request;
+            this->deferred_update_firmware_request.reset();
+        }
+    }
+    if (request.has_value()) {
+        const UpdateFirmwareResponse response = this->update_firmware_request_callback(request.value());
+        if (response.status != UpdateFirmwareStatusEnum::Accepted) {
+            EVLOG_warning << "Deferred firmware update was not accepted after transaction finished: "
+                          << conversions::update_firmware_status_enum_to_string(response.status);
+            this->on_firmware_update_status_notification(request.value().requestId, FirmwareStatusEnum::DownloadFailed);
+        }
+    }
+}
+
+bool FirmwareUpdate::is_download_deferral_required() const {
+    return this->context.device_model
+               .get_optional_value<bool>(ControllerComponentVariables::DeferFirmwareDownloadDuringTransaction)
+               .value_or(false) and
+           this->context.evse_manager.any_transaction_active(std::nullopt);
+}
+
 void FirmwareUpdate::handle_firmware_update_req(Call<UpdateFirmwareRequest> call) {
     EVLOG_debug << "Received UpdateFirmwareRequest: " << call.msg << "\nwith messageId: " << call.uniqueId;
     if (call.msg.firmware.signingCertificate.has_value() or call.msg.firmware.signature.has_value()) {
@@ -141,16 +168,41 @@ void FirmwareUpdate::handle_firmware_update_req(Call<UpdateFirmwareRequest> call
         cert_valid_or_not_set = false;
     }
 
+    bool download_deferred = false;
     if (cert_valid_or_not_set) {
-        // execute firwmare update callback
-        response = update_firmware_request_callback(msg);
+        bool deferral_required = this->is_download_deferral_required();
+        {
+            // Stash and the on_transaction_finished release must not interleave, otherwise a
+            // transaction that ends between the deferral check and the stash write would leave the
+            // request stuck forever. Re-check under the lock and release it if that happened.
+            std::lock_guard<std::mutex> lock(this->deferred_update_firmware_request_mutex);
+            // A newer request supersedes a deferred one; the old one is dropped silently.
+            this->deferred_update_firmware_request.reset();
+            if (deferral_required) {
+                this->deferred_update_firmware_request = msg;
+                if (!this->context.evse_manager.any_transaction_active(std::nullopt)) {
+                    this->deferred_update_firmware_request.reset();
+                    deferral_required = false;
+                }
+            }
+        }
+        if (deferral_required) {
+            // L01.FR.13: busy charging, defer the download until the last transaction ends.
+            response.status = UpdateFirmwareStatusEnum::Accepted;
+            download_deferred = true;
+        } else {
+            response = update_firmware_request_callback(msg);
+        }
     }
 
     const ocpp::CallResult<UpdateFirmwareResponse> call_result(response, call.uniqueId);
     this->context.message_dispatcher.dispatch_call_result(call_result);
 
-    if ((response.status == UpdateFirmwareStatusEnum::InvalidCertificate) or
-        (response.status == UpdateFirmwareStatusEnum::RevokedCertificate)) {
+    if (download_deferred) {
+        this->on_firmware_update_status_notification(msg.requestId, FirmwareStatusEnum::DownloadScheduled);
+        this->change_all_connectors_to_unavailable_for_firmware_update();
+    } else if ((response.status == UpdateFirmwareStatusEnum::InvalidCertificate) or
+               (response.status == UpdateFirmwareStatusEnum::RevokedCertificate)) {
         // L01.FR.02
         this->security.security_event_notification_req(
             CiString<50>(ocpp::security_events::INVALIDFIRMWARESIGNINGCERTIFICATE),

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/firmware_update.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/firmware_update.cpp
@@ -120,6 +120,33 @@ void FirmwareUpdate::on_firmware_status_notification_request() {
     this->context.message_dispatcher.dispatch_call(call, true);
 }
 
+void FirmwareUpdate::on_transaction_finished() {
+    std::optional<UpdateFirmwareRequest> request;
+    {
+        auto handle = this->deferred_update_firmware_request.handle();
+        auto& deferred = *handle;
+        if (deferred.has_value() and !this->context.evse_manager.any_transaction_active(std::nullopt)) {
+            request = std::move(deferred);
+            deferred.reset();
+        }
+    }
+    if (request.has_value()) {
+        const UpdateFirmwareResponse response = this->update_firmware_request_callback(request.value());
+        if (response.status != UpdateFirmwareStatusEnum::Accepted) {
+            EVLOG_warning << "Deferred firmware update was not accepted after transaction finished: "
+                          << conversions::update_firmware_status_enum_to_string(response.status);
+            this->on_firmware_update_status_notification(request.value().requestId, FirmwareStatusEnum::DownloadFailed);
+        }
+    }
+}
+
+bool FirmwareUpdate::is_download_deferral_required() const {
+    return this->context.device_model
+               .get_optional_value<bool>(ControllerComponentVariables::DeferFirmwareDownloadDuringTransaction)
+               .value_or(false) and
+           this->context.evse_manager.any_transaction_active(std::nullopt);
+}
+
 void FirmwareUpdate::handle_firmware_update_req(Call<UpdateFirmwareRequest> call) {
     EVLOG_debug << "Received UpdateFirmwareRequest: " << call.msg << "\nwith messageId: " << call.uniqueId;
     if (call.msg.firmware.signingCertificate.has_value() or call.msg.firmware.signature.has_value()) {
@@ -141,16 +168,51 @@ void FirmwareUpdate::handle_firmware_update_req(Call<UpdateFirmwareRequest> call
         cert_valid_or_not_set = false;
     }
 
+    bool download_deferred = false;
     if (cert_valid_or_not_set) {
-        // execute firwmare update callback
-        response = update_firmware_request_callback(msg);
+        bool deferral_required = this->is_download_deferral_required();
+        bool superseded_deferred_request = false;
+        {
+            // Stash and the on_transaction_finished release must not interleave, otherwise a
+            // transaction that ends between the deferral check and the stash write would leave the
+            // request stuck forever. Re-check under the lock and release it if that happened.
+            auto handle = this->deferred_update_firmware_request.handle();
+            auto& deferred = *handle;
+            // A newer request supersedes a deferred one, which is a firmware update the station was going to
+            // install at a later time.
+            superseded_deferred_request = deferred.has_value();
+            deferred.reset();
+            if (deferral_required) {
+                deferred = msg;
+                if (!this->context.evse_manager.any_transaction_active(std::nullopt)) {
+                    deferred.reset();
+                    deferral_required = false;
+                }
+            }
+        }
+        if (deferral_required) {
+            // L01.FR.13: busy charging, defer the download until the last transaction ends.
+            response.status = UpdateFirmwareStatusEnum::Accepted;
+            download_deferred = true;
+        } else {
+            response = update_firmware_request_callback(msg);
+        }
+        if (superseded_deferred_request and response.status == UpdateFirmwareStatusEnum::Accepted) {
+            // L01.FR.24: the previously deferred update is canceled by this one. Only the response reports it; the
+            // spec leaves a DownloadFailed notification for the canceled request optional, and sending one here
+            // would reach an end state and restore connectors that a re-deferral is about to disable again.
+            response.status = UpdateFirmwareStatusEnum::AcceptedCanceled;
+        }
     }
 
     const ocpp::CallResult<UpdateFirmwareResponse> call_result(response, call.uniqueId);
     this->context.message_dispatcher.dispatch_call_result(call_result);
 
-    if ((response.status == UpdateFirmwareStatusEnum::InvalidCertificate) or
-        (response.status == UpdateFirmwareStatusEnum::RevokedCertificate)) {
+    if (download_deferred) {
+        this->on_firmware_update_status_notification(msg.requestId, FirmwareStatusEnum::DownloadScheduled);
+        this->change_all_connectors_to_unavailable_for_firmware_update();
+    } else if ((response.status == UpdateFirmwareStatusEnum::InvalidCertificate) or
+               (response.status == UpdateFirmwareStatusEnum::RevokedCertificate)) {
         // L01.FR.02
         this->security.security_event_notification_req(
             CiString<50>(ocpp::security_events::INVALIDFIRMWARESIGNINGCERTIFICATE),

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/CMakeLists.txt
@@ -5,6 +5,7 @@ target_include_directories(libocpp_unit_tests PUBLIC
 
 target_sources(libocpp_unit_tests PRIVATE
         test_data_transfer.cpp
+        test_firmware_update.cpp
         test_provisioning.cpp
         test_reservation.cpp
         test_remote_transaction_control.cpp

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/CMakeLists.txt
@@ -5,6 +5,7 @@ target_include_directories(libocpp_unit_tests PUBLIC
 
 target_sources(libocpp_unit_tests PRIVATE
         test_data_transfer.cpp
+        test_firmware_update.cpp
         test_provisioning.cpp
         test_reservation.cpp
         test_smart_charging.cpp)

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_firmware_update.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_firmware_update.cpp
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <future>
+#include <optional>
+#include <vector>
+
+#include <component_state_manager_mock.hpp>
+#include <connectivity_manager_mock.hpp>
+#include <device_model_test_helper.hpp>
+#include <evse_manager_fake.hpp>
+#include <evse_security_mock.hpp>
+#include <message_dispatcher_mock.hpp>
+#include <mocks/database_handler_mock.hpp>
+
+#include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v2/device_model.hpp>
+#include <ocpp/v2/functional_blocks/availability.hpp>
+#include <ocpp/v2/functional_blocks/firmware_update.hpp>
+#include <ocpp/v2/functional_blocks/functional_block_context.hpp>
+#include <ocpp/v2/functional_blocks/security.hpp>
+#include <ocpp/v2/messages/Get15118EVCertificate.hpp>
+#include <ocpp/v2/messages/UpdateFirmware.hpp>
+
+using namespace ocpp;
+using namespace ocpp::v2;
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+namespace {
+
+class AvailabilityMock : public AvailabilityInterface {
+public:
+    MOCK_METHOD(void, handle_message, (const ocpp::EnhancedMessage<MessageType>&), (override));
+    MOCK_METHOD(void, status_notification_req, (std::int32_t, std::int32_t, ConnectorStatusEnum, bool), (override));
+    MOCK_METHOD(void, heartbeat_req, (bool), (override));
+    MOCK_METHOD(void, handle_scheduled_change_availability_requests, (std::int32_t), (override));
+    MOCK_METHOD(void, set_scheduled_change_availability_requests, (std::int32_t, AvailabilityChange), (override));
+    MOCK_METHOD(void, set_heartbeat_timer_interval, (const std::chrono::seconds&), (override));
+    MOCK_METHOD(void, stop_heartbeat_timer, (), (override));
+    MOCK_METHOD(ChangeAvailabilityResponse, change_availability_req, (bool&, const ChangeAvailabilityRequest&),
+                (override));
+    MOCK_METHOD(void, action_change_availability_req,
+                (bool, const ChangeAvailabilityRequest&, const ChangeAvailabilityResponse&), (override));
+};
+
+class SecurityMock : public SecurityInterface {
+public:
+    MOCK_METHOD(void, handle_message, (const ocpp::EnhancedMessage<MessageType>&), (override));
+    MOCK_METHOD(void, security_event_notification_req,
+                (const CiString<50>&, const std::optional<CiString<255>>&, bool, bool, const std::optional<DateTime>&),
+                (override));
+    MOCK_METHOD(void, sign_certificate_req, (const ocpp::CertificateSigningUseEnum&, bool), (override));
+    MOCK_METHOD(bool, is_sign_certificate_possible, (const ocpp::CertificateSigningUseEnum&), (const, override));
+    MOCK_METHOD(void, stop_certificate_signed_timer, (), (override));
+    MOCK_METHOD(void, init_certificate_expiration_check_timers, (), (override));
+    MOCK_METHOD(void, stop_certificate_expiration_check_timers, (), (override));
+    MOCK_METHOD(Get15118EVCertificateResponse, on_get_15118_ev_certificate_request,
+                (const Get15118EVCertificateRequest&), (override));
+};
+
+// L01.FR.13: with the DeferFirmwareDownloadDuringTransaction gate enabled and a transaction active,
+// the download itself must be deferred (DownloadScheduled) until the last transaction ends. With the
+// gate off (default) the download starts immediately, keeping TC_L_14/TC_L_15 behavior unchanged.
+class FirmwareUpdateDeferredDownloadTest : public ::testing::Test {
+protected:
+    DeviceModelTestHelper dm_helper;
+    DeviceModel* dm{nullptr};
+
+    NiceMock<MockMessageDispatcher> mock_dispatcher;
+    NiceMock<ocpp::ConnectivityManagerMock> connectivity_manager;
+    std::unique_ptr<EvseManagerFake> evse_manager;
+    NiceMock<DatabaseHandlerMock> db_handler;
+    ocpp::EvseSecurityMock evse_security;
+    NiceMock<ComponentStateManagerMock> component_state_manager;
+    std::atomic<OcppProtocolVersion> ocpp_version{OcppProtocolVersion::v201};
+
+    NiceMock<AvailabilityMock> availability;
+    NiceMock<SecurityMock> security;
+
+    std::unique_ptr<FunctionalBlockContext> fb_context;
+    std::unique_ptr<FirmwareUpdate> firmware_update;
+
+    std::vector<UpdateFirmwareRequest> callback_invocations;
+    std::vector<json> dispatched_calls;
+    UpdateFirmwareStatusEnum callback_response_status{UpdateFirmwareStatusEnum::Accepted};
+
+    FirmwareUpdateDeferredDownloadTest() : dm_helper() {
+        dm = dm_helper.get_device_model();
+        evse_manager = std::make_unique<EvseManagerFake>(1);
+
+        fb_context =
+            std::make_unique<FunctionalBlockContext>(mock_dispatcher, *dm, connectivity_manager, *evse_manager,
+                                                     db_handler, evse_security, component_state_manager, ocpp_version);
+
+        ON_CALL(mock_dispatcher, dispatch_call(_, _)).WillByDefault(Invoke([this](const json& call, bool) {
+            this->dispatched_calls.push_back(call);
+        }));
+        ON_CALL(mock_dispatcher, dispatch_call_async(_, _)).WillByDefault(Invoke([this](const json& call, bool) {
+            this->dispatched_calls.push_back(call);
+            return std::promise<ocpp::EnhancedMessage<MessageType>>().get_future();
+        }));
+
+        firmware_update = std::make_unique<FirmwareUpdate>(
+            *fb_context, availability, security,
+            [this](const UpdateFirmwareRequest& request) {
+                this->callback_invocations.push_back(request);
+                UpdateFirmwareResponse response;
+                response.status = this->callback_response_status;
+                return response;
+            },
+            std::nullopt);
+    }
+
+    void enable_defer_download_gate() {
+        const auto& cv = ControllerComponentVariables::DeferFirmwareDownloadDuringTransaction;
+        ASSERT_EQ(dm->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "true", "test", true),
+                  SetVariableStatusEnum::Accepted);
+    }
+
+    void disable_defer_download_gate() {
+        const auto& cv = ControllerComponentVariables::DeferFirmwareDownloadDuringTransaction;
+        ASSERT_EQ(dm->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "false", "test", true),
+                  SetVariableStatusEnum::Accepted);
+    }
+
+    void start_transaction() {
+        evse_manager->open_transaction(1, "test-transaction");
+        ON_CALL(*evse_manager, any_transaction_active(_)).WillByDefault(Return(true));
+    }
+
+    void end_transaction() {
+        auto& mock = evse_manager->get_mock(1);
+        EXPECT_CALL(mock, has_active_transaction()).WillRepeatedly(Return(false));
+        ON_CALL(*evse_manager, any_transaction_active(_)).WillByDefault(Return(false));
+    }
+
+    ocpp::EnhancedMessage<MessageType> make_update_firmware_message(std::int32_t request_id) {
+        UpdateFirmwareRequest request;
+        request.requestId = request_id;
+        request.firmware.location = "https://firmware.example.com/firmware.bin";
+        request.firmware.retrieveDateTime = ocpp::DateTime("2024-01-01T00:00:00Z");
+        ocpp::Call<UpdateFirmwareRequest> call(request);
+        ocpp::EnhancedMessage<MessageType> enhanced_message;
+        enhanced_message.messageType = MessageType::UpdateFirmware;
+        enhanced_message.message = call;
+        return enhanced_message;
+    }
+
+    ocpp::EnhancedMessage<MessageType> make_update_firmware_message_with_cert(std::int32_t request_id) {
+        UpdateFirmwareRequest request;
+        request.requestId = request_id;
+        request.firmware.location = "https://firmware.example.com/firmware.bin";
+        request.firmware.retrieveDateTime = ocpp::DateTime("2024-01-01T00:00:00Z");
+        request.firmware.signingCertificate = "invalid-cert";
+        ocpp::Call<UpdateFirmwareRequest> call(request);
+        ocpp::EnhancedMessage<MessageType> enhanced_message;
+        enhanced_message.messageType = MessageType::UpdateFirmware;
+        enhanced_message.message = call;
+        return enhanced_message;
+    }
+
+    std::vector<json> firmware_status_notifications() const {
+        std::vector<json> result;
+        for (const auto& call : dispatched_calls) {
+            if (call.at(CALL_ACTION) == "FirmwareStatusNotification") {
+                result.push_back(call.at(CALL_PAYLOAD));
+            }
+        }
+        return result;
+    }
+};
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, GateOnTransactionActiveDefersDownload) {
+    enable_defer_download_gate();
+    start_transaction();
+
+    EXPECT_CALL(availability, set_scheduled_change_availability_requests(1, _)).Times(1);
+    firmware_update->handle_message(make_update_firmware_message(150));
+
+    EXPECT_TRUE(callback_invocations.empty());
+    const auto notifications = firmware_status_notifications();
+    ASSERT_EQ(notifications.size(), 1);
+    EXPECT_EQ(notifications.at(0).at("status"), "DownloadScheduled");
+    EXPECT_EQ(notifications.at(0).at("requestId"), 150);
+}
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, DeferredDownloadStartsWhenLastTransactionEnds) {
+    enable_defer_download_gate();
+    start_transaction();
+    firmware_update->handle_message(make_update_firmware_message(150));
+    ASSERT_TRUE(callback_invocations.empty());
+
+    end_transaction();
+    firmware_update->on_transaction_finished();
+
+    ASSERT_EQ(callback_invocations.size(), 1);
+    EXPECT_EQ(callback_invocations.at(0).requestId, 150);
+
+    // Deferred request must fire exactly once.
+    firmware_update->on_transaction_finished();
+    EXPECT_EQ(callback_invocations.size(), 1);
+}
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, DeferredDownloadWaitsWhileTransactionStillActive) {
+    enable_defer_download_gate();
+    start_transaction();
+    firmware_update->handle_message(make_update_firmware_message(150));
+
+    // Another transaction is still active, so the download must stay deferred.
+    firmware_update->on_transaction_finished();
+    EXPECT_TRUE(callback_invocations.empty());
+}
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, GateOffTransactionActiveDownloadsImmediately) {
+    disable_defer_download_gate();
+    start_transaction();
+    firmware_update->handle_message(make_update_firmware_message(150));
+
+    ASSERT_EQ(callback_invocations.size(), 1);
+    EXPECT_EQ(callback_invocations.at(0).requestId, 150);
+    EXPECT_TRUE(firmware_status_notifications().empty());
+}
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, GateOnNoTransactionDownloadsImmediately) {
+    enable_defer_download_gate();
+    firmware_update->handle_message(make_update_firmware_message(150));
+
+    ASSERT_EQ(callback_invocations.size(), 1);
+    EXPECT_EQ(callback_invocations.at(0).requestId, 150);
+    EXPECT_TRUE(firmware_status_notifications().empty());
+}
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, SupersedingRequestDropsDeferredSilently) {
+    enable_defer_download_gate();
+    start_transaction();
+    firmware_update->handle_message(make_update_firmware_message(150));
+    firmware_update->handle_message(make_update_firmware_message(151));
+
+    end_transaction();
+    firmware_update->on_transaction_finished();
+
+    // Only the superseding request proceeds; the old one is dropped without any FSN.
+    ASSERT_EQ(callback_invocations.size(), 1);
+    EXPECT_EQ(callback_invocations.at(0).requestId, 151);
+
+    std::size_t old_request_notifications = 0;
+    for (const auto& notification : firmware_status_notifications()) {
+        if (notification.contains("requestId") and notification.at("requestId") == 150) {
+            old_request_notifications++;
+        }
+    }
+    // Only the initial DownloadScheduled for the old request, nothing after the supersede.
+    EXPECT_EQ(old_request_notifications, 1);
+}
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, DeferredRejectedOnFinishSendsDownloadFailed) {
+    enable_defer_download_gate();
+    start_transaction();
+    firmware_update->handle_message(make_update_firmware_message(150));
+    ASSERT_TRUE(callback_invocations.empty());
+
+    // The callback rejects the deferred request when it is finally released.
+    callback_response_status = UpdateFirmwareStatusEnum::Rejected;
+    end_transaction();
+    firmware_update->on_transaction_finished();
+
+    ASSERT_EQ(callback_invocations.size(), 1);
+    bool download_failed_seen = false;
+    for (const auto& notification : firmware_status_notifications()) {
+        if (notification.at("status") == "DownloadFailed" and notification.contains("requestId") and
+            notification.at("requestId") == 150) {
+            download_failed_seen = true;
+        }
+    }
+    EXPECT_TRUE(download_failed_seen);
+}
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, InvalidCertSupersedingRequestLeavesDeferredIntact) {
+    ON_CALL(evse_security, verify_certificate(_, testing::An<const ocpp::LeafCertificateType&>()))
+        .WillByDefault(Return(ocpp::CertificateValidationResult::InvalidSignature));
+
+    enable_defer_download_gate();
+    start_transaction();
+    firmware_update->handle_message(make_update_firmware_message(150));
+
+    // A superseding request with an invalid signing certificate is rejected and must not disturb
+    // the already deferred request.
+    firmware_update->handle_message(make_update_firmware_message_with_cert(151));
+
+    end_transaction();
+    firmware_update->on_transaction_finished();
+
+    ASSERT_EQ(callback_invocations.size(), 1);
+    EXPECT_EQ(callback_invocations.at(0).requestId, 150);
+}
+
+} // namespace

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_firmware_update.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_firmware_update.cpp
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <future>
+#include <optional>
+#include <vector>
+
+#include <component_state_manager_mock.hpp>
+#include <connectivity_manager_mock.hpp>
+#include <device_model_test_helper.hpp>
+#include <evse_manager_fake.hpp>
+#include <evse_security_mock.hpp>
+#include <message_dispatcher_mock.hpp>
+#include <mocks/database_handler_mock.hpp>
+
+#include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v2/device_model.hpp>
+#include <ocpp/v2/functional_blocks/availability.hpp>
+#include <ocpp/v2/functional_blocks/firmware_update.hpp>
+#include <ocpp/v2/functional_blocks/functional_block_context.hpp>
+#include <ocpp/v2/functional_blocks/security.hpp>
+#include <ocpp/v2/messages/Get15118EVCertificate.hpp>
+#include <ocpp/v2/messages/UpdateFirmware.hpp>
+
+using namespace ocpp;
+using namespace ocpp::v2;
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+namespace {
+
+class AvailabilityMock : public AvailabilityInterface {
+public:
+    MOCK_METHOD(void, handle_message, (const ocpp::EnhancedMessage<MessageType>&), (override));
+    MOCK_METHOD(void, status_notification_req, (std::int32_t, std::int32_t, ConnectorStatusEnum, bool), (override));
+    MOCK_METHOD(void, heartbeat_req, (bool), (override));
+    MOCK_METHOD(void, handle_scheduled_change_availability_requests, (std::int32_t), (override));
+    MOCK_METHOD(void, set_scheduled_change_availability_requests, (std::int32_t, AvailabilityChange), (override));
+    MOCK_METHOD(void, set_heartbeat_timer_interval, (const std::chrono::seconds&), (override));
+    MOCK_METHOD(void, stop_heartbeat_timer, (), (override));
+    MOCK_METHOD(ChangeAvailabilityResponse, change_availability_req, (bool&, const ChangeAvailabilityRequest&),
+                (override));
+    MOCK_METHOD(void, action_change_availability_req,
+                (bool, const ChangeAvailabilityRequest&, const ChangeAvailabilityResponse&), (override));
+};
+
+class SecurityMock : public SecurityInterface {
+public:
+    MOCK_METHOD(void, handle_message, (const ocpp::EnhancedMessage<MessageType>&), (override));
+    MOCK_METHOD(void, security_event_notification_req,
+                (const CiString<50>&, const std::optional<CiString<255>>&, bool, bool, const std::optional<DateTime>&),
+                (override));
+    MOCK_METHOD(void, sign_certificate_req, (const ocpp::CertificateSigningUseEnum&, bool), (override));
+    MOCK_METHOD(std::optional<StatusInfo>, is_sign_certificate_possible, (const ocpp::CertificateSigningUseEnum&),
+                (const, override));
+    MOCK_METHOD(void, stop_certificate_signed_timer, (), (override));
+    MOCK_METHOD(void, init_certificate_expiration_check_timers, (), (override));
+    MOCK_METHOD(void, stop_certificate_expiration_check_timers, (), (override));
+    MOCK_METHOD(Get15118EVCertificateResponse, on_get_15118_ev_certificate_request,
+                (const Get15118EVCertificateRequest&), (override));
+};
+
+// L01.FR.13: with the DeferFirmwareDownloadDuringTransaction gate enabled and a transaction active,
+// the download itself must be deferred (DownloadScheduled) until the last transaction ends. With the
+// gate off (default) the download starts immediately, keeping TC_L_14/TC_L_15 behavior unchanged.
+class FirmwareUpdateDeferredDownloadTest : public ::testing::Test {
+protected:
+    DeviceModelTestHelper dm_helper;
+    DeviceModel* dm{nullptr};
+
+    NiceMock<MockMessageDispatcher> mock_dispatcher;
+    NiceMock<ocpp::ConnectivityManagerMock> connectivity_manager;
+    std::unique_ptr<EvseManagerFake> evse_manager;
+    NiceMock<DatabaseHandlerMock> db_handler;
+    ocpp::EvseSecurityMock evse_security;
+    NiceMock<ComponentStateManagerMock> component_state_manager;
+    std::atomic<OcppProtocolVersion> ocpp_version{OcppProtocolVersion::v201};
+
+    NiceMock<AvailabilityMock> availability;
+    NiceMock<SecurityMock> security;
+
+    std::unique_ptr<FunctionalBlockContext> fb_context;
+    std::unique_ptr<FirmwareUpdate> firmware_update;
+
+    std::vector<UpdateFirmwareRequest> callback_invocations;
+    std::vector<json> dispatched_calls;
+    std::vector<json> dispatched_call_results;
+    UpdateFirmwareStatusEnum callback_response_status{UpdateFirmwareStatusEnum::Accepted};
+
+    FirmwareUpdateDeferredDownloadTest() : dm_helper() {
+        dm = dm_helper.get_device_model();
+        evse_manager = std::make_unique<EvseManagerFake>(1);
+
+        fb_context =
+            std::make_unique<FunctionalBlockContext>(mock_dispatcher, *dm, connectivity_manager, *evse_manager,
+                                                     db_handler, evse_security, component_state_manager, ocpp_version);
+
+        ON_CALL(mock_dispatcher, dispatch_call(_, _)).WillByDefault(Invoke([this](const json& call, bool) {
+            this->dispatched_calls.push_back(call);
+        }));
+        ON_CALL(mock_dispatcher, dispatch_call_async(_, _)).WillByDefault(Invoke([this](const json& call, bool) {
+            this->dispatched_calls.push_back(call);
+            return std::promise<ocpp::EnhancedMessage<MessageType>>().get_future();
+        }));
+        ON_CALL(mock_dispatcher, dispatch_call_result(_)).WillByDefault(Invoke([this](const json& call_result) {
+            this->dispatched_call_results.push_back(call_result);
+        }));
+
+        firmware_update = std::make_unique<FirmwareUpdate>(
+            *fb_context, availability, security,
+            [this](const UpdateFirmwareRequest& request) {
+                this->callback_invocations.push_back(request);
+                UpdateFirmwareResponse response;
+                response.status = this->callback_response_status;
+                return response;
+            },
+            std::nullopt);
+    }
+
+    void enable_defer_download_gate() {
+        const auto& cv = ControllerComponentVariables::DeferFirmwareDownloadDuringTransaction;
+        ASSERT_EQ(dm->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "true", "test", true),
+                  SetVariableStatusEnum::Accepted);
+    }
+
+    void disable_defer_download_gate() {
+        const auto& cv = ControllerComponentVariables::DeferFirmwareDownloadDuringTransaction;
+        ASSERT_EQ(dm->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "false", "test", true),
+                  SetVariableStatusEnum::Accepted);
+    }
+
+    void start_transaction() {
+        evse_manager->open_transaction(1, "test-transaction");
+        ON_CALL(*evse_manager, any_transaction_active(_)).WillByDefault(Return(true));
+    }
+
+    void end_transaction() {
+        auto& mock = evse_manager->get_mock(1);
+        EXPECT_CALL(mock, has_active_transaction()).WillRepeatedly(Return(false));
+        ON_CALL(*evse_manager, any_transaction_active(_)).WillByDefault(Return(false));
+    }
+
+    ocpp::EnhancedMessage<MessageType> make_update_firmware_message(std::int32_t request_id) {
+        UpdateFirmwareRequest request;
+        request.requestId = request_id;
+        request.firmware.location = "https://firmware.example.com/firmware.bin";
+        request.firmware.retrieveDateTime = ocpp::DateTime("2024-01-01T00:00:00Z");
+        ocpp::Call<UpdateFirmwareRequest> call(request);
+        ocpp::EnhancedMessage<MessageType> enhanced_message;
+        enhanced_message.messageType = MessageType::UpdateFirmware;
+        enhanced_message.message = call;
+        return enhanced_message;
+    }
+
+    ocpp::EnhancedMessage<MessageType> make_update_firmware_message_with_cert(std::int32_t request_id) {
+        UpdateFirmwareRequest request;
+        request.requestId = request_id;
+        request.firmware.location = "https://firmware.example.com/firmware.bin";
+        request.firmware.retrieveDateTime = ocpp::DateTime("2024-01-01T00:00:00Z");
+        request.firmware.signingCertificate = "invalid-cert";
+        ocpp::Call<UpdateFirmwareRequest> call(request);
+        ocpp::EnhancedMessage<MessageType> enhanced_message;
+        enhanced_message.messageType = MessageType::UpdateFirmware;
+        enhanced_message.message = call;
+        return enhanced_message;
+    }
+
+    std::vector<json> firmware_status_notifications() const {
+        std::vector<json> result;
+        for (const auto& call : dispatched_calls) {
+            if (call.at(CALL_ACTION) == "FirmwareStatusNotification") {
+                result.push_back(call.at(CALL_PAYLOAD));
+            }
+        }
+        return result;
+    }
+
+    std::vector<UpdateFirmwareStatusEnum> update_firmware_response_statuses() const {
+        std::vector<UpdateFirmwareStatusEnum> result;
+        for (const auto& call_result : dispatched_call_results) {
+            result.push_back(call_result.at(CALLRESULT_PAYLOAD).get<UpdateFirmwareResponse>().status);
+        }
+        return result;
+    }
+};
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, GateOnTransactionActiveDefersDownload) {
+    enable_defer_download_gate();
+    start_transaction();
+
+    EXPECT_CALL(availability, set_scheduled_change_availability_requests(1, _)).Times(1);
+    firmware_update->handle_message(make_update_firmware_message(150));
+
+    EXPECT_TRUE(callback_invocations.empty());
+    const auto notifications = firmware_status_notifications();
+    ASSERT_EQ(notifications.size(), 1);
+    EXPECT_EQ(notifications.at(0).at("status"), "DownloadScheduled");
+    EXPECT_EQ(notifications.at(0).at("requestId"), 150);
+}
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, DeferredDownloadStartsWhenLastTransactionEnds) {
+    enable_defer_download_gate();
+    start_transaction();
+    firmware_update->handle_message(make_update_firmware_message(150));
+    ASSERT_TRUE(callback_invocations.empty());
+
+    end_transaction();
+    firmware_update->on_transaction_finished();
+
+    ASSERT_EQ(callback_invocations.size(), 1);
+    EXPECT_EQ(callback_invocations.at(0).requestId, 150);
+
+    // Deferred request must fire exactly once.
+    firmware_update->on_transaction_finished();
+    EXPECT_EQ(callback_invocations.size(), 1);
+}
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, DeferredDownloadWaitsWhileTransactionStillActive) {
+    enable_defer_download_gate();
+    start_transaction();
+    firmware_update->handle_message(make_update_firmware_message(150));
+
+    // Another transaction is still active, so the download must stay deferred.
+    firmware_update->on_transaction_finished();
+    EXPECT_TRUE(callback_invocations.empty());
+}
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, GateOffTransactionActiveDownloadsImmediately) {
+    disable_defer_download_gate();
+    start_transaction();
+    firmware_update->handle_message(make_update_firmware_message(150));
+
+    ASSERT_EQ(callback_invocations.size(), 1);
+    EXPECT_EQ(callback_invocations.at(0).requestId, 150);
+    EXPECT_TRUE(firmware_status_notifications().empty());
+}
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, GateOnNoTransactionDownloadsImmediately) {
+    enable_defer_download_gate();
+    firmware_update->handle_message(make_update_firmware_message(150));
+
+    ASSERT_EQ(callback_invocations.size(), 1);
+    EXPECT_EQ(callback_invocations.at(0).requestId, 150);
+    EXPECT_TRUE(firmware_status_notifications().empty());
+}
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, SupersedingRequestCancelsDeferredWhileStillCharging) {
+    // L01.FR.24: the second request cancels the deferred one, so it is answered AcceptedCanceled rather than
+    // Accepted. It is itself deferred, because a transaction is still active.
+    enable_defer_download_gate();
+    start_transaction();
+    firmware_update->handle_message(make_update_firmware_message(150));
+    firmware_update->handle_message(make_update_firmware_message(151));
+
+    ASSERT_EQ(update_firmware_response_statuses().size(), 2);
+    EXPECT_EQ(update_firmware_response_statuses().at(0), UpdateFirmwareStatusEnum::Accepted);
+    EXPECT_EQ(update_firmware_response_statuses().at(1), UpdateFirmwareStatusEnum::AcceptedCanceled);
+
+    end_transaction();
+    firmware_update->on_transaction_finished();
+
+    // Only the superseding request proceeds.
+    ASSERT_EQ(callback_invocations.size(), 1);
+    EXPECT_EQ(callback_invocations.at(0).requestId, 151);
+
+    std::size_t old_request_notifications = 0;
+    for (const auto& notification : firmware_status_notifications()) {
+        if (notification.contains("requestId") and notification.at("requestId") == 150) {
+            old_request_notifications++;
+        }
+    }
+    // No DownloadFailed is sent for the canceled request: the spec makes it optional, and it would restore
+    // connectors that the re-deferral immediately disables again.
+    EXPECT_EQ(old_request_notifications, 1);
+}
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, SupersedingRequestCancelsDeferredAfterTransactionEnded) {
+    // Same cancellation, but the superseding request arrives once charging has stopped, so it is not deferred and
+    // goes straight to the callback. The response must still report the cancellation.
+    enable_defer_download_gate();
+    start_transaction();
+    firmware_update->handle_message(make_update_firmware_message(150));
+
+    end_transaction();
+    firmware_update->handle_message(make_update_firmware_message(151));
+
+    ASSERT_EQ(callback_invocations.size(), 1);
+    EXPECT_EQ(callback_invocations.at(0).requestId, 151);
+    ASSERT_EQ(update_firmware_response_statuses().size(), 2);
+    EXPECT_EQ(update_firmware_response_statuses().at(1), UpdateFirmwareStatusEnum::AcceptedCanceled);
+}
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, FirstRequestIsAcceptedNotCanceled) {
+    // Guard against reporting a cancellation when there was nothing to cancel.
+    enable_defer_download_gate();
+    start_transaction();
+    firmware_update->handle_message(make_update_firmware_message(150));
+
+    ASSERT_EQ(update_firmware_response_statuses().size(), 1);
+    EXPECT_EQ(update_firmware_response_statuses().at(0), UpdateFirmwareStatusEnum::Accepted);
+}
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, SupersedingRequestRejectedByCallbackKeepsRejection) {
+    // A cancellation must not upgrade a rejection into AcceptedCanceled.
+    enable_defer_download_gate();
+    start_transaction();
+    firmware_update->handle_message(make_update_firmware_message(150));
+
+    end_transaction();
+    callback_response_status = UpdateFirmwareStatusEnum::Rejected;
+    firmware_update->handle_message(make_update_firmware_message(151));
+
+    ASSERT_EQ(update_firmware_response_statuses().size(), 2);
+    EXPECT_EQ(update_firmware_response_statuses().at(1), UpdateFirmwareStatusEnum::Rejected);
+}
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, DeferredRejectedOnFinishSendsDownloadFailed) {
+    enable_defer_download_gate();
+    start_transaction();
+    firmware_update->handle_message(make_update_firmware_message(150));
+    ASSERT_TRUE(callback_invocations.empty());
+
+    // The callback rejects the deferred request when it is finally released.
+    callback_response_status = UpdateFirmwareStatusEnum::Rejected;
+    end_transaction();
+    firmware_update->on_transaction_finished();
+
+    ASSERT_EQ(callback_invocations.size(), 1);
+    bool download_failed_seen = false;
+    for (const auto& notification : firmware_status_notifications()) {
+        if (notification.at("status") == "DownloadFailed" and notification.contains("requestId") and
+            notification.at("requestId") == 150) {
+            download_failed_seen = true;
+        }
+    }
+    EXPECT_TRUE(download_failed_seen);
+}
+
+TEST_F(FirmwareUpdateDeferredDownloadTest, InvalidCertSupersedingRequestLeavesDeferredIntact) {
+    ON_CALL(evse_security, verify_certificate(_, testing::An<const ocpp::LeafCertificateType&>()))
+        .WillByDefault(Return(ocpp::CertificateValidationResult::InvalidSignature));
+
+    enable_defer_download_gate();
+    start_transaction();
+    firmware_update->handle_message(make_update_firmware_message(150));
+
+    // A superseding request with an invalid signing certificate is rejected and must not disturb
+    // the already deferred request.
+    firmware_update->handle_message(make_update_firmware_message_with_cert(151));
+
+    end_transaction();
+    firmware_update->on_transaction_finished();
+
+    ASSERT_EQ(callback_invocations.size(), 1);
+    EXPECT_EQ(callback_invocations.at(0).requestId, 150);
+}
+
+} // namespace

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_remote_transaction_control.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_remote_transaction_control.cpp
@@ -103,6 +103,7 @@ public:
                  const bool disable_connectors_during_install),
                 (override));
     MOCK_METHOD(void, on_firmware_status_notification_request, (), (override));
+    MOCK_METHOD(void, on_transaction_finished, (), (override));
 };
 
 class ProvisioningMock : public ProvisioningInterface {

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_remote_transaction_control.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_remote_transaction_control.cpp
@@ -101,6 +101,7 @@ public:
     MOCK_METHOD(void, on_firmware_update_status_notification, (std::int32_t, const FirmwareStatusEnum&, const bool),
                 (override));
     MOCK_METHOD(void, on_firmware_status_notification_request, (), (override));
+    MOCK_METHOD(void, on_transaction_finished, (), (override));
 };
 
 class ProvisioningMock : public ProvisioningInterface {


### PR DESCRIPTION
## Describe your changes

Rebased onto `main`; no longer stacked on #2475 / #2479.

New opt-in `InternalCtrlr.DeferFirmwareDownloadDuringTransaction` (default
`false`). When enabled and a transaction is active, an accepted `UpdateFirmware`
is stashed, `DownloadScheduled` is sent with the requestId, and idle connectors
go Unavailable; the download starts when the last transaction ends (L01.FR.13,
TC_L_13_CS). The deferred request is held in memory only, so after a restart in
`DownloadScheduled` the CSMS must re-send `UpdateFirmware`.

It ships `ReadOnly`, making it a commissioning-time setting. A deployment that
wants the CSMS to control it declares the attribute `ReadWrite` in its own
component config; libocpp picks that up on the next boot.

Also fixes the `AllowNewSessionsPendingFirmwareUpdate` lookup, where a stray
copy-pasted instance name made every Get/SetVariables miss the variable (a
TC_L_13_CS precondition). Note this only makes the variable reachable, nothing
consumes it yet, so it does not gate new sessions. No device-model migration is
needed: variable identity includes the instance, so the stale row is deleted and
the correct one inserted on boot.

### Addressing @Pietfried's review

On bypassing the `update_firmware_request_callback`: keeping this in libocpp
matches existing precedent in the same function. `firmware_update.cpp:89-95`
already defers the **install** phase on transaction state, with a `FIXME(Kai)`
recording that the System module cannot track transactions, driven by TC_L_15_CS.
Forwarding download to System while install stays here would split one feature
across two owners. Agreed that the unification is the cleaner end state, so it is
recorded as follow-up rather than done here. Deferral being opt-in also means
chargers that can download during a transaction are unaffected, per your point
about TC_L_13_CS not applying to them.

Your comment did surface a real gap: a request superseding a deferred one was
answered `Accepted` and dropped the pending one silently, leaving the CSMS with a
requestId stuck in `DownloadScheduled`. L01.FR.24 requires `AcceptedCanceled`, so
that is now reported (second commit). The optional `FirmwareStatusNotification`
for the canceled request is deliberately not sent: `DownloadFailed` is an end
state and would restore connectors that a re-deferral immediately disables again.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

### Verification

- `ctest` in a libocpp-only build: 158/158 passed.
- `FirmwareUpdate` suite 11/11, covering the gate on/off, deferral while another
  transaction is still active, release on last transaction end, a rejected release
  reporting `DownloadFailed`, an invalid-certificate request leaving a deferred
  one intact, and the `AcceptedCanceled` cases including that a first request is
  not reported as canceled and that a callback rejection is not upgraded.
