### PR TITLE
OCPP: no transient Available on inoperative connector

### DIFF
--- a/lib/everest/ocpp/include/ocpp/v2/component_state_manager.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/component_state_manager.hpp
@@ -54,11 +54,6 @@ struct FullConnectorStatus {
     bool occupied;
     /// \brief True if the connector is explicitly set to unavailable
     bool unavailable;
-
-    /// \brief Translates the individual state to an Available/Unavailable/Occupied/Reserved/Faulted state
-    /// This does NOT take into account the state of the EVSE or CS,
-    /// and is intended to be used internally by the ComponentStateManagerInterface.
-    ConnectorStatusEnum to_connector_status() const;
 };
 
 class ComponentStateManagerInterface {

--- a/lib/everest/ocpp/lib/ocpp/v2/component_state_manager.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/component_state_manager.cpp
@@ -6,6 +6,32 @@
 
 namespace ocpp::v2 {
 
+namespace {
+/// \brief Single definition of the connector-status precedence:
+/// faulted > inoperative > unavailable > occupied > reserved > available.
+/// \p effective_operational_status is the connector's effective operational status; pass Operative to skip the
+/// inoperative rung (used by the raw session-flag mapping which has no operational-status concept).
+ConnectorStatusEnum derive_connector_status(OperationalStatusEnum effective_operational_status,
+                                            const FullConnectorStatus& status) {
+    if (status.faulted) {
+        return ConnectorStatusEnum::Faulted;
+    }
+    if (effective_operational_status == OperationalStatusEnum::Inoperative) {
+        return ConnectorStatusEnum::Unavailable;
+    }
+    if (status.unavailable) {
+        return ConnectorStatusEnum::Unavailable;
+    }
+    if (status.occupied) {
+        return ConnectorStatusEnum::Occupied;
+    }
+    if (status.reserved) {
+        return ConnectorStatusEnum::Reserved;
+    }
+    return ConnectorStatusEnum::Available;
+}
+} // namespace
+
 ComponentStateManagerInterface::~ComponentStateManagerInterface() = default;
 
 void ComponentStateManager::read_all_states_from_database_or_set_defaults(
@@ -48,8 +74,7 @@ void ComponentStateManager::initialize_reported_state_cache() {
 
         const OperationalStatusEnum evse_effective = this->get_evse_effective_operational_status(evse_id);
         for (int connector_id = 1; connector_id <= num_connectors; connector_id++) {
-            const ConnectorStatusEnum connector_status =
-                this->individual_connector_status(evse_id, connector_id).to_connector_status();
+            const ConnectorStatusEnum connector_status = this->get_connector_effective_status(evse_id, connector_id);
             connector_statuses.push_back(connector_status);
             connector_op_statuses.push_back(this->get_connector_effective_operational_status(evse_id, connector_id));
         }
@@ -229,20 +254,8 @@ void ComponentStateManager::set_connector_individual_operational_status(std::int
 }
 
 ConnectorStatusEnum FullConnectorStatus::to_connector_status() const {
-    // faulted has precedence over unavailable
-    if (this->faulted) {
-        return ConnectorStatusEnum::Faulted;
-    }
-    if (this->unavailable) {
-        return ConnectorStatusEnum::Unavailable;
-    }
-    if (this->occupied) {
-        return ConnectorStatusEnum::Occupied;
-    }
-    if (this->reserved) {
-        return ConnectorStatusEnum::Reserved;
-    }
-    return ConnectorStatusEnum::Available;
+    // Raw session-flag mapping: no operational-status concept, so pass Operative.
+    return derive_connector_status(OperationalStatusEnum::Operative, *this);
 }
 
 OperationalStatusEnum ComponentStateManager::get_evse_effective_operational_status(std::int32_t evse_id) {
@@ -255,11 +268,17 @@ OperationalStatusEnum ComponentStateManager::get_evse_effective_operational_stat
 ConnectorStatusEnum ComponentStateManager::get_connector_effective_status(std::int32_t evse_id,
                                                                           std::int32_t connector_id) {
     this->check_evse_and_connector_id(evse_id, connector_id);
+    const FullConnectorStatus& connector = this->individual_connector_status(evse_id, connector_id);
+    // The EVSE or CS being Inoperative hides every other connector state, including faults.
     if (this->get_evse_effective_operational_status(evse_id) == OperationalStatusEnum::Inoperative) {
         return ConnectorStatusEnum::Unavailable;
     }
-
-    return this->individual_connector_status(evse_id, connector_id).to_connector_status();
+    // Connector-scoped fault still has precedence over a connector-scoped Inoperative (G03.FR.06); the shared
+    // precedence in derive_connector_status handles that.
+    // Ordering contract: a caller clearing the Unavailable session flag (ConnectorEvent::UnavailableCleared) must
+    // first restore individual_operational_status to Operative, otherwise this Inoperative rung keeps the effective
+    // status at Unavailable and the Available notification is suppressed.
+    return derive_connector_status(connector.individual_operational_status, connector);
 }
 OperationalStatusEnum ComponentStateManager::get_connector_effective_operational_status(std::int32_t evse_id,
                                                                                         std::int32_t connector_id) {
@@ -316,8 +335,7 @@ void ComponentStateManager::send_status_notification_single_connector_internal(s
                                                                                std::int32_t connector_id,
                                                                                bool only_if_changed,
                                                                                bool intiated_by_trigger_message) {
-    const ConnectorStatusEnum connector_status =
-        this->individual_connector_status(evse_id, connector_id).to_connector_status();
+    const ConnectorStatusEnum connector_status = this->get_connector_effective_status(evse_id, connector_id);
     ConnectorStatusEnum& last_reported_status = this->last_connector_reported_status(evse_id, connector_id);
     if (!only_if_changed || last_reported_status != connector_status) {
         if (this->send_connector_status_notification_callback(evse_id, connector_id, connector_status,

--- a/lib/everest/ocpp/lib/ocpp/v2/component_state_manager.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/component_state_manager.cpp
@@ -48,8 +48,7 @@ void ComponentStateManager::initialize_reported_state_cache() {
 
         const OperationalStatusEnum evse_effective = this->get_evse_effective_operational_status(evse_id);
         for (int connector_id = 1; connector_id <= num_connectors; connector_id++) {
-            const ConnectorStatusEnum connector_status =
-                this->individual_connector_status(evse_id, connector_id).to_connector_status();
+            const ConnectorStatusEnum connector_status = this->get_connector_effective_status(evse_id, connector_id);
             connector_statuses.push_back(connector_status);
             connector_op_statuses.push_back(this->get_connector_effective_operational_status(evse_id, connector_id));
         }
@@ -228,23 +227,6 @@ void ComponentStateManager::set_connector_individual_operational_status(std::int
     this->trigger_callbacks_connector(evse_id, connector_id, true);
 }
 
-ConnectorStatusEnum FullConnectorStatus::to_connector_status() const {
-    // faulted has precedence over unavailable
-    if (this->faulted) {
-        return ConnectorStatusEnum::Faulted;
-    }
-    if (this->unavailable) {
-        return ConnectorStatusEnum::Unavailable;
-    }
-    if (this->occupied) {
-        return ConnectorStatusEnum::Occupied;
-    }
-    if (this->reserved) {
-        return ConnectorStatusEnum::Reserved;
-    }
-    return ConnectorStatusEnum::Available;
-}
-
 OperationalStatusEnum ComponentStateManager::get_evse_effective_operational_status(std::int32_t evse_id) {
     this->check_evse_id(evse_id);
     if (this->cs_individual_status == OperationalStatusEnum::Inoperative) {
@@ -255,11 +237,25 @@ OperationalStatusEnum ComponentStateManager::get_evse_effective_operational_stat
 ConnectorStatusEnum ComponentStateManager::get_connector_effective_status(std::int32_t evse_id,
                                                                           std::int32_t connector_id) {
     this->check_evse_and_connector_id(evse_id, connector_id);
-    if (this->get_evse_effective_operational_status(evse_id) == OperationalStatusEnum::Inoperative) {
+    const FullConnectorStatus& connector = this->individual_connector_status(evse_id, connector_id);
+    // A fault has precedence over Inoperative at any scope: G03.FR.06 exempts Faulted connectors from the rule that
+    // an Inoperative EVSE turns its connectors Unavailable.
+    if (connector.faulted) {
+        return ConnectorStatusEnum::Faulted;
+    }
+    if (this->get_connector_effective_operational_status(evse_id, connector_id) == OperationalStatusEnum::Inoperative) {
         return ConnectorStatusEnum::Unavailable;
     }
-
-    return this->individual_connector_status(evse_id, connector_id).to_connector_status();
+    if (connector.unavailable) {
+        return ConnectorStatusEnum::Unavailable;
+    }
+    if (connector.occupied) {
+        return ConnectorStatusEnum::Occupied;
+    }
+    if (connector.reserved) {
+        return ConnectorStatusEnum::Reserved;
+    }
+    return ConnectorStatusEnum::Available;
 }
 OperationalStatusEnum ComponentStateManager::get_connector_effective_operational_status(std::int32_t evse_id,
                                                                                         std::int32_t connector_id) {
@@ -316,8 +312,7 @@ void ComponentStateManager::send_status_notification_single_connector_internal(s
                                                                                std::int32_t connector_id,
                                                                                bool only_if_changed,
                                                                                bool intiated_by_trigger_message) {
-    const ConnectorStatusEnum connector_status =
-        this->individual_connector_status(evse_id, connector_id).to_connector_status();
+    const ConnectorStatusEnum connector_status = this->get_connector_effective_status(evse_id, connector_id);
     ConnectorStatusEnum& last_reported_status = this->last_connector_reported_status(evse_id, connector_id);
     if (!only_if_changed || last_reported_status != connector_status) {
         if (this->send_connector_status_notification_callback(evse_id, connector_id, connector_status,

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_component_state_manager.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_component_state_manager.cpp
@@ -473,4 +473,130 @@ TEST_F(ComponentStateManagerTest, test_send_status_notification_single_connector
     state_mgr.send_status_notification_changed_connectors();
 }
 
+/// \brief Connector-scope scheduled Inoperative (TC_G_17_CS): when a transaction ends on a connector that has been
+/// individually set Inoperative, the connector must report Unavailable directly, never a transient Available.
+TEST_F(ComponentStateManagerTest, test_no_transient_available_connector_scope) {
+    // Prepare
+    std::shared_ptr<DatabaseHandler> mock_database = std::make_shared<DatabaseHandlerMock>();
+    auto state_mgr = this->component_state_manager(mock_database, {1});
+
+    // Set up mock expectations
+    EXPECT_CALL(this->callbacks, connector_status_update(testing::_, testing::_, "Available")).Times(0);
+    testing::Sequence seq;
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Occupied"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(true));
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Unavailable"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(true));
+
+    // Act & Verify
+    // Transaction active: connector occupied, reported Occupied
+    state_mgr.set_connector_occupied(1, 1, true);
+    // Scheduled ChangeAvailability(Inoperative) applied while occupied (no notification yet)
+    state_mgr.set_connector_individual_operational_status(1, 1, OperationalStatusEnum::Inoperative, true);
+    // Transaction ends: occupied cleared -> must report Unavailable, not Available
+    state_mgr.set_connector_occupied(1, 1, false);
+}
+
+/// \brief EVSE-scope scheduled Inoperative (TC_G_11_CS): when a transaction ends on a connector whose EVSE has been
+/// set Inoperative, the connector must report Unavailable directly, never a transient Available.
+TEST_F(ComponentStateManagerTest, test_no_transient_available_evse_scope) {
+    // Prepare
+    std::shared_ptr<DatabaseHandler> mock_database = std::make_shared<DatabaseHandlerMock>();
+    auto state_mgr = this->component_state_manager(mock_database, {1});
+
+    // Set up mock expectations
+    EXPECT_CALL(this->callbacks, connector_status_update(testing::_, testing::_, "Available")).Times(0);
+    testing::Sequence seq;
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Occupied"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(true));
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Unavailable"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(true));
+
+    // Act & Verify
+    state_mgr.set_connector_occupied(1, 1, true);
+    state_mgr.set_evse_individual_operational_status(1, OperationalStatusEnum::Inoperative, true);
+    state_mgr.set_connector_occupied(1, 1, false);
+}
+
+/// \brief CS-scope scheduled Inoperative (TC_G_14_CS): when a transaction ends while the charging station has been set
+/// Inoperative, the connector must report Unavailable directly, never a transient Available.
+TEST_F(ComponentStateManagerTest, test_no_transient_available_cs_scope) {
+    // Prepare
+    std::shared_ptr<DatabaseHandler> mock_database = std::make_shared<DatabaseHandlerMock>();
+    auto state_mgr = this->component_state_manager(mock_database, {1});
+
+    // Set up mock expectations
+    EXPECT_CALL(this->callbacks, connector_status_update(testing::_, testing::_, "Available")).Times(0);
+    testing::Sequence seq;
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Occupied"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(true));
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Unavailable"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(true));
+
+    // Act & Verify
+    state_mgr.set_connector_occupied(1, 1, true);
+    state_mgr.set_cs_individual_operational_status(OperationalStatusEnum::Inoperative, true);
+    state_mgr.set_connector_occupied(1, 1, false);
+}
+
+/// \brief Ordering contract (L2): restoring individual_operational_status to Operative before the Unavailable session
+/// flag is cleared yields the Available notification. This pins the in-tree op-status-then-event ordering.
+TEST_F(ComponentStateManagerTest, test_available_after_op_status_restored_then_flag_cleared) {
+    // Prepare
+    std::shared_ptr<DatabaseHandler> mock_database = std::make_shared<DatabaseHandlerMock>();
+    auto state_mgr = this->component_state_manager(mock_database, {1});
+
+    testing::Sequence seq;
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Unavailable"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(true));
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Available"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(true));
+
+    // Act & Verify
+    // Connector made Inoperative and its Unavailable session flag set: reported Unavailable.
+    state_mgr.set_connector_individual_operational_status(1, 1, OperationalStatusEnum::Inoperative, true);
+    state_mgr.set_connector_unavailable(1, 1, true);
+    // Restore op-status to Operative first (still Unavailable, flag holds it), then clear the flag: now Available.
+    state_mgr.set_connector_individual_operational_status(1, 1, OperationalStatusEnum::Operative, true);
+    state_mgr.set_connector_unavailable(1, 1, false);
+}
+
+/// \brief Reversed ordering (L2): clearing the Unavailable session flag before restoring individual_operational_status
+/// to Operative suppresses the Available StatusNotification entirely. Restoring op-status afterwards drives only the
+/// operational-status callback, not a StatusNotification, so Available is never sent. This documents why callers must
+/// restore op-status first.
+TEST_F(ComponentStateManagerTest, test_available_suppressed_when_flag_cleared_before_op_status) {
+    // Prepare
+    std::shared_ptr<DatabaseHandler> mock_database = std::make_shared<DatabaseHandlerMock>();
+    auto state_mgr = this->component_state_manager(mock_database, {1});
+
+    // Available must never be reported in the reversed order.
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Available")).Times(0);
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Unavailable")).Times(1).WillOnce(testing::Return(true));
+
+    // Act & Verify
+    state_mgr.set_connector_individual_operational_status(1, 1, OperationalStatusEnum::Inoperative, true);
+    state_mgr.set_connector_unavailable(1, 1, true);
+    // Reversed: clear the flag while still Inoperative (stays Unavailable, no StatusNotification) ...
+    state_mgr.set_connector_unavailable(1, 1, false);
+    // ... then restore op-status. This does not emit a StatusNotification, so Available stays suppressed.
+    state_mgr.set_connector_individual_operational_status(1, 1, OperationalStatusEnum::Operative, true);
+}
+
 } // namespace ocpp::v2

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_component_state_manager.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_component_state_manager.cpp
@@ -234,6 +234,7 @@ TEST_F(ComponentStateManagerTest, test_effective_state_getters_cs_inoperative) {
     // These state changes should be hidden
     state_mgr.set_connector_occupied(1, 1, true);
     state_mgr.set_connector_reserved(2, 1, true);
+    // A fault is not hidden: G03.FR.06 exempts Faulted connectors
     state_mgr.set_connector_faulted(2, 2, true);
 
     // Verify
@@ -244,7 +245,7 @@ TEST_F(ComponentStateManagerTest, test_effective_state_getters_cs_inoperative) {
     ASSERT_EQ(state_mgr.get_connector_effective_operational_status(2, 2), OperationalStatusEnum::Inoperative);
     ASSERT_EQ(state_mgr.get_connector_effective_status(1, 1), ConnectorStatusEnum::Unavailable);
     ASSERT_EQ(state_mgr.get_connector_effective_status(2, 1), ConnectorStatusEnum::Unavailable);
-    ASSERT_EQ(state_mgr.get_connector_effective_status(2, 2), ConnectorStatusEnum::Unavailable);
+    ASSERT_EQ(state_mgr.get_connector_effective_status(2, 2), ConnectorStatusEnum::Faulted);
 }
 
 /// \brief Test the ComponentStateManager's effective state getters when an EVSE is inoperative
@@ -471,6 +472,240 @@ TEST_F(ComponentStateManagerTest, test_send_status_notification_single_connector
     state_mgr.set_connector_occupied(1, 1, true);
     state_mgr.send_status_notification_single_connector(1, 1);
     state_mgr.send_status_notification_changed_connectors();
+}
+
+/// \brief Connector-scope scheduled Inoperative (TC_G_17_CS): when a transaction ends on a connector that has been
+/// individually set Inoperative, the connector must report Unavailable directly, never a transient Available.
+TEST_F(ComponentStateManagerTest, test_no_transient_available_connector_scope) {
+    // Prepare
+    std::shared_ptr<DatabaseHandler> mock_database = std::make_shared<DatabaseHandlerMock>();
+    auto state_mgr = this->component_state_manager(mock_database, {1});
+
+    // Set up mock expectations
+    EXPECT_CALL(this->callbacks, connector_status_update(testing::_, testing::_, "Available")).Times(0);
+    testing::Sequence seq;
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Occupied"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(true));
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Unavailable"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(true));
+
+    // Act & Verify
+    // Transaction active: connector occupied, reported Occupied
+    state_mgr.set_connector_occupied(1, 1, true);
+    // Scheduled ChangeAvailability(Inoperative) applied while occupied (no notification yet)
+    state_mgr.set_connector_individual_operational_status(1, 1, OperationalStatusEnum::Inoperative, true);
+    // Transaction ends: occupied cleared -> must report Unavailable, not Available
+    state_mgr.set_connector_occupied(1, 1, false);
+}
+
+/// \brief EVSE-scope scheduled Inoperative (TC_G_11_CS): when a transaction ends on a connector whose EVSE has been
+/// set Inoperative, the connector must report Unavailable directly, never a transient Available.
+TEST_F(ComponentStateManagerTest, test_no_transient_available_evse_scope) {
+    // Prepare
+    std::shared_ptr<DatabaseHandler> mock_database = std::make_shared<DatabaseHandlerMock>();
+    auto state_mgr = this->component_state_manager(mock_database, {1});
+
+    // Set up mock expectations
+    EXPECT_CALL(this->callbacks, connector_status_update(testing::_, testing::_, "Available")).Times(0);
+    testing::Sequence seq;
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Occupied"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(true));
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Unavailable"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(true));
+
+    // Act & Verify
+    state_mgr.set_connector_occupied(1, 1, true);
+    state_mgr.set_evse_individual_operational_status(1, OperationalStatusEnum::Inoperative, true);
+    state_mgr.set_connector_occupied(1, 1, false);
+}
+
+/// \brief CS-scope scheduled Inoperative (TC_G_14_CS): when a transaction ends while the charging station has been set
+/// Inoperative, the connector must report Unavailable directly, never a transient Available.
+TEST_F(ComponentStateManagerTest, test_no_transient_available_cs_scope) {
+    // Prepare
+    std::shared_ptr<DatabaseHandler> mock_database = std::make_shared<DatabaseHandlerMock>();
+    auto state_mgr = this->component_state_manager(mock_database, {1});
+
+    // Set up mock expectations
+    EXPECT_CALL(this->callbacks, connector_status_update(testing::_, testing::_, "Available")).Times(0);
+    testing::Sequence seq;
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Occupied"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(true));
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Unavailable"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(true));
+
+    // Act & Verify
+    state_mgr.set_connector_occupied(1, 1, true);
+    state_mgr.set_cs_individual_operational_status(OperationalStatusEnum::Inoperative, true);
+    state_mgr.set_connector_occupied(1, 1, false);
+}
+
+/// \brief Reversed ordering (L2): clearing the Unavailable session flag before restoring individual_operational_status
+/// to Operative suppresses the Available StatusNotification entirely. Restoring op-status afterwards drives only the
+/// operational-status callback, not a StatusNotification, so Available is never sent. This documents why callers must
+/// restore op-status first.
+TEST_F(ComponentStateManagerTest, test_available_suppressed_when_flag_cleared_before_op_status) {
+    // Prepare
+    std::shared_ptr<DatabaseHandler> mock_database = std::make_shared<DatabaseHandlerMock>();
+    auto state_mgr = this->component_state_manager(mock_database, {1});
+
+    // Available must never be reported in the reversed order.
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Available")).Times(0);
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Unavailable")).Times(1).WillOnce(testing::Return(true));
+
+    // Act & Verify
+    state_mgr.set_connector_individual_operational_status(1, 1, OperationalStatusEnum::Inoperative, true);
+    state_mgr.set_connector_unavailable(1, 1, true);
+    // Reversed: clear the flag while still Inoperative (stays Unavailable, no StatusNotification) ...
+    state_mgr.set_connector_unavailable(1, 1, false);
+    // ... then restore op-status. This does not emit a StatusNotification, so Available stays suppressed.
+    state_mgr.set_connector_individual_operational_status(1, 1, OperationalStatusEnum::Operative, true);
+}
+
+/// \brief The module applies a disable asynchronously: it calls the blocking evse_manager enable_disable() and only
+/// then feeds ConnectorEvent::Unavailable back in, so the session flag lands after the transaction-end notification has
+/// already reported Unavailable from the operational status alone. That late flag must not put a second, duplicate
+/// Unavailable on the wire. This is what the certification tests assert, they count StatusNotifications rather than
+/// inspecting internal state.
+TEST_F(ComponentStateManagerTest, test_late_unavailable_flag_sends_no_duplicate) {
+    // Prepare
+    std::shared_ptr<DatabaseHandler> mock_database = std::make_shared<DatabaseHandlerMock>();
+    auto state_mgr = this->component_state_manager(mock_database, {1});
+
+    // Set up mock expectations
+    EXPECT_CALL(this->callbacks, connector_status_update(testing::_, testing::_, "Available")).Times(0);
+    testing::Sequence seq;
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Occupied"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(true));
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Unavailable"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(true));
+
+    // Act & Verify
+    state_mgr.set_connector_occupied(1, 1, true);
+    state_mgr.set_connector_individual_operational_status(1, 1, OperationalStatusEnum::Inoperative, true);
+    // Transaction ends: reports Unavailable off the operational status, the session flag is not set yet.
+    state_mgr.set_connector_occupied(1, 1, false);
+    // The module's on_unavailable() lands afterwards. Already reported Unavailable, so nothing more is sent.
+    state_mgr.set_connector_unavailable(1, 1, true);
+}
+
+/// \brief Boot with a connector persisted Inoperative: the reported-status cache must be seeded from the effective
+/// status (Unavailable), not from the raw session flags (Available). Seeding it Available would make the cache agree
+/// with the real status only by accident, and the genuine Available notification would be dropped as unchanged once
+/// the connector is restored to Operative.
+TEST_F(ComponentStateManagerTest, test_boot_reported_cache_seeded_from_effective_status) {
+    // Prepare
+    std::shared_ptr<DatabaseHandler> mock_database = std::make_shared<DatabaseHandlerMock>();
+    mock_database->insert_connector_availability(1, 1, OperationalStatusEnum::Inoperative, false);
+    auto state_mgr = this->component_state_manager(mock_database, {1});
+
+    // Set up mock expectations
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Unavailable")).Times(0);
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, "Available")).Times(1).WillOnce(testing::Return(true));
+
+    // Act & Verify
+    // Nothing has changed since boot, so no StatusNotification is due.
+    state_mgr.send_status_notification_changed_connectors();
+    // Restore the connector to Operative. The operational-status setter sends nothing itself, so the change only
+    // surfaces on the next pass, and only if the cache was seeded Unavailable.
+    state_mgr.set_connector_individual_operational_status(1, 1, OperationalStatusEnum::Operative, true);
+    state_mgr.send_status_notification_changed_connectors();
+}
+
+/// \brief A fault on a connector whose EVSE is Inoperative must still be reported as Faulted (G03.FR.06 exempts
+/// Faulted connectors from the "become Unavailable" rule), and clearing that fault must fall back to Unavailable
+/// rather than emitting a transient Available.
+TEST_F(ComponentStateManagerTest, test_faulted_has_precedence_over_evse_inoperative) {
+    // Prepare
+    std::shared_ptr<DatabaseHandler> mock_database = std::make_shared<DatabaseHandlerMock>();
+    auto state_mgr = this->component_state_manager(mock_database, {1});
+
+    std::vector<std::string> reported;
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, testing::_))
+        .WillRepeatedly([&reported](std::int32_t, std::int32_t, std::string status) {
+            reported.push_back(std::move(status));
+            return true;
+        });
+
+    // Act
+    // The operational-status setter sends nothing itself; the module round-trips the disable back in as
+    // ConnectorEvent::Unavailable, which is what puts Unavailable on the wire and into the reported cache.
+    state_mgr.set_evse_individual_operational_status(1, OperationalStatusEnum::Inoperative, true);
+    state_mgr.set_connector_unavailable(1, 1, true);
+    // A ground fault while the EVSE is Inoperative must reach the CSMS.
+    state_mgr.set_connector_faulted(1, 1, true);
+    // Fault cleared: back under the Inoperative rung, so Unavailable and never Available.
+    state_mgr.set_connector_faulted(1, 1, false);
+
+    // Verify
+    ASSERT_EQ(state_mgr.get_connector_effective_status(1, 1), ConnectorStatusEnum::Unavailable);
+    EXPECT_THAT(reported, testing::ElementsAre("Unavailable", "Faulted", "Unavailable"));
+}
+
+/// \brief Same precedence at connector scope, with the Unavailable session flag deliberately left unset so the
+/// fallback after the fault clears can only come from individual_operational_status. That rung is new to the
+/// notification path: the reported status used to be derived from the session flags alone.
+TEST_F(ComponentStateManagerTest, test_faulted_has_precedence_over_connector_inoperative) {
+    // Prepare
+    std::shared_ptr<DatabaseHandler> mock_database = std::make_shared<DatabaseHandlerMock>();
+    auto state_mgr = this->component_state_manager(mock_database, {1});
+
+    std::vector<std::string> reported;
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, testing::_))
+        .WillRepeatedly([&reported](std::int32_t, std::int32_t, std::string status) {
+            reported.push_back(std::move(status));
+            return true;
+        });
+
+    // Act
+    state_mgr.set_connector_individual_operational_status(1, 1, OperationalStatusEnum::Inoperative, true);
+    state_mgr.set_connector_faulted(1, 1, true);
+    // Fault cleared with no Unavailable flag set: only the Inoperative operational status keeps this off Available.
+    state_mgr.set_connector_faulted(1, 1, false);
+
+    // Verify
+    ASSERT_EQ(state_mgr.get_connector_effective_status(1, 1), ConnectorStatusEnum::Unavailable);
+    EXPECT_THAT(reported, testing::ElementsAre("Faulted", "Unavailable"));
+}
+
+/// \brief Reverse arrival order: the fault lands before the EVSE goes Inoperative. The reported status stays Faulted,
+/// so neither the operational-status change nor the module's late Unavailable flag may put Unavailable on the wire.
+TEST_F(ComponentStateManagerTest, test_inoperative_does_not_override_existing_fault) {
+    // Prepare
+    std::shared_ptr<DatabaseHandler> mock_database = std::make_shared<DatabaseHandlerMock>();
+    auto state_mgr = this->component_state_manager(mock_database, {1});
+
+    std::vector<std::string> reported;
+    EXPECT_CALL(this->callbacks, connector_status_update(1, 1, testing::_))
+        .WillRepeatedly([&reported](std::int32_t, std::int32_t, std::string status) {
+            reported.push_back(std::move(status));
+            return true;
+        });
+
+    // Act
+    state_mgr.set_connector_faulted(1, 1, true);
+    state_mgr.set_evse_individual_operational_status(1, OperationalStatusEnum::Inoperative, true);
+    state_mgr.set_connector_unavailable(1, 1, true);
+
+    // Verify
+    ASSERT_EQ(state_mgr.get_connector_effective_status(1, 1), ConnectorStatusEnum::Faulted);
+    EXPECT_THAT(reported, testing::ElementsAre("Faulted"));
 }
 
 } // namespace ocpp::v2


### PR DESCRIPTION
## Describe your changes

Derive the reported connector status from the effective operational
status, so a scheduled or applied Inoperative connector cannot report a
transient Available when a transaction ends (TC_G_11/14/17). The status
precedence is now stated in one place.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

### Verification
- Full libocpp unit test suite green.
