### PR TITLE
System: firmware update and diagnostics upload fixes

### DIFF
--- a/modules/Misc/System/diagnostics_uploader.sh
+++ b/modules/Misc/System/diagnostics_uploader.sh
@@ -8,8 +8,7 @@
 . "${1}"
 
 echo "$UPLOADING"
-sleep 2
-curl --progress-bar --ssl --proto =ftp,ftps,http,https --proto-default https --connect-timeout "$CONNECTION_TIMEOUT" -T "${4}" "${2}"
+curl --progress-bar --ssl --proto =sftp,ftp,ftps,http,https --proto-default https --connect-timeout "$CONNECTION_TIMEOUT" -T "${4}" "${2%/}/${3}"
 curl_exit_code=$?
 if [[ $curl_exit_code -eq 0 ]]; then
     echo "$UPLOADED"

--- a/modules/Misc/System/docs/index.rst
+++ b/modules/Misc/System/docs/index.rst
@@ -14,6 +14,9 @@ Currently this includes the following commands:
 
 Corresponding variables signal the state of Log Uploads and Firmware Updates.
 
+The bundled simulation installer stub treats firmware URLs whose basename ends in
+``-bad.pnx`` as installation failures, which is useful for exercising failure handling.
+
 Integration in EVerest
 ======================
 

--- a/modules/Misc/System/main/systemImpl.cpp
+++ b/modules/Misc/System/main/systemImpl.cpp
@@ -29,6 +29,14 @@ const std::string SIGNED_FIRMWARE_DOWNLOADER = "signed_firmware_downloader.sh";
 const std::string SIGNED_FIRMWARE_METADATA_PARSER = "signed_firmware_metadata_parser.sh";
 const std::string SIGNED_FIRMWARE_INSTALLER = "signed_firmware_installer.sh";
 
+// Grace period after publishing FirmwareStatusNotification{InstallRebooting} and before triggering the
+// post-install reboot. The System module cannot observe when the OCPP layer has actually transmitted the
+// notification, so this bounded pause gives the (asynchronous) publish time to reach the CSMS before the
+// reboot tears the connection down. Without it the socket can close before InstallRebooting is sent and the
+// CSMS aborts the firmware-update test (OCTT TC_L_13_CS). The OCPP module additionally drains its message
+// queue during shutdown, so this only needs to cover the cross-module publish latency.
+constexpr auto INSTALL_REBOOTING_NOTIFICATION_GRACE = std::chrono::seconds(2);
+
 namespace fs = std::filesystem;
 
 // FIXME (aw): this function needs to be refactored into some kind of utility library
@@ -60,6 +68,7 @@ bool split_key_value(const std::string& key_value, std::string& key, std::string
 
 void systemImpl::init() {
     this->scripts_path = mod->info.paths.libexec;
+    this->interrupt_firmware_download = std::make_shared<std::atomic_bool>(false);
     this->log_upload_running = false;
     this->firmware_download_running = false;
     this->firmware_installation_running = false;
@@ -242,7 +251,7 @@ void systemImpl::download_signed_firmware(const types::system::FirmwareUpdateReq
     if (this->firmware_download_running) {
         EVLOG_info
             << "Received Firmware update request and firmware update already running - cancelling firmware update";
-        this->interrupt_firmware_download.exchange(true);
+        this->interrupt_firmware_download->exchange(true);
         EVLOG_info << "Waiting for other firmware download to finish...";
         std::unique_lock<std::mutex> lk(this->firmware_update_mutex);
         this->firmware_update_cv.wait(lk, [this]() { return !this->firmware_download_running; });
@@ -251,7 +260,7 @@ void systemImpl::download_signed_firmware(const types::system::FirmwareUpdateReq
 
     std::lock_guard<std::mutex> lg(this->firmware_update_mutex);
     EVLOG_info << "Starting Firmware update";
-    this->interrupt_firmware_download.exchange(false);
+    this->interrupt_firmware_download->exchange(false);
     this->firmware_download_running = true;
 
     // // create temporary file
@@ -276,30 +285,45 @@ void systemImpl::download_signed_firmware(const types::system::FirmwareUpdateReq
     firmware_status.firmware_update_status = firmware_status_enum;
 
     while (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::DownloadFailed &&
-           retries < total_retries && !this->interrupt_firmware_download) {
-        run_application(
-            firmware_downloader.string(), download_args, [this, &firmware_status](const std::string& output_line) {
-                firmware_status.firmware_update_status =
-                    types::system::string_to_firmware_update_status_enum(output_line);
-                // Defer sending the SignatureVerified message because it needs to have the metadata attached to it
-                if (firmware_status.firmware_update_status !=
-                    types::system::FirmwareUpdateStatusEnum::SignatureVerified) {
-                    this->publish_firmware_update_status(firmware_status);
-                }
-                if (this->interrupt_firmware_download) {
-                    EVLOG_info << "Updating firmware was interrupted, terminating firmware update script, requestId: "
-                               << firmware_status.request_id;
-                    return CmdControl::Terminate;
-                }
-                return CmdControl::Continue;
-            });
+           retries < total_retries && !this->interrupt_firmware_download->load()) {
+        RunOptions run_options;
+        // Hand the interrupt flag to run_application so a cancel actively SIGTERM/SIGKILLs the running
+        // download script rather than only being sampled on its next output line. The download script
+        // emits no progress lines while curl is running, so without this the first checkpoint would be
+        // the terminal line and the cancel could never suppress a success status.
+        run_options.stop_requested = this->interrupt_firmware_download;
+        run_options.callback = [this, &firmware_status](const std::string& output_line) {
+            // Honor the cancel before publishing: a superseded download must never leak the script's
+            // terminal "Downloaded" success status; a canceled request is torn down silently, with
+            // no status notification.
+            if (this->interrupt_firmware_download->load()) {
+                return CmdControl::Terminate;
+            }
+            firmware_status.firmware_update_status = types::system::string_to_firmware_update_status_enum(output_line);
+            // Defer sending the SignatureVerified message because it needs to have the metadata attached to it
+            if (firmware_status.firmware_update_status != types::system::FirmwareUpdateStatusEnum::SignatureVerified) {
+                this->publish_firmware_update_status(firmware_status);
+            }
+            return CmdControl::Continue;
+        };
+        run_application(firmware_downloader.string(), download_args, run_options);
         retries += 1;
-        if (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::DownloadFailed &&
-            retries < total_retries) {
+        if (this->interrupt_firmware_download->load()) {
+            // A newer request superseded this download; tear it down silently, without a status
+            // notification.
+            EVLOG_info << "Firmware update was interrupted by a newer request; tearing down the canceled "
+                          "download without a status notification, requestId: "
+                       << firmware_status.request_id;
+        } else if (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::DownloadFailed &&
+                   retries < total_retries) {
             std::this_thread::sleep_for(std::chrono::seconds(retry_interval));
         }
     }
-    if (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::SignatureVerified) {
+    // A cancel can land after the script emitted SignatureVerified but before the loop exited; the
+    // metadata parse below would then publish a status and schedule an install for the canceled
+    // request, so skip all downstream publishing when interrupted.
+    if (!this->interrupt_firmware_download->load() &&
+        firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::SignatureVerified) {
         const std::vector<std::string> parser_args = {constants.string(), firmware_update_request.location,
                                                       firmware_file_path.string()};
         std::map<std::string, std::string> parsed_metadata;
@@ -384,6 +408,9 @@ void systemImpl::install_signed_firmware(const types::system::FirmwareUpdateRequ
             if (this->mod->config.ResetAfterUpdate) {
                 firmware_status.firmware_update_status = types::system::FirmwareUpdateStatusEnum::InstallRebooting;
                 this->publish_firmware_update_status(firmware_status);
+
+                // Give the asynchronous notification time to be transmitted to the CSMS before rebooting.
+                std::this_thread::sleep_for(INSTALL_REBOOTING_NOTIFICATION_GRACE);
 
                 if (!this->mod->r_store.empty()) {
                     this->mod->r_store.at(0)->call_store(

--- a/modules/Misc/System/main/systemImpl.hpp
+++ b/modules/Misc/System/main/systemImpl.hpp
@@ -14,7 +14,9 @@
 
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 // insert your custom include headers here
+#include <atomic>
 #include <filesystem>
+#include <memory>
 
 #include <everest/timer.hpp>
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
@@ -62,7 +64,9 @@ private:
 
     std::filesystem::path scripts_path;
 
-    std::atomic<bool> interrupt_firmware_download;
+    // Shared with run_application as its stop_requested watcher: a cancel both interrupts the
+    // download callback and actively SIGTERM/SIGKILLs the running download script.
+    std::shared_ptr<std::atomic_bool> interrupt_firmware_download;
     std::atomic<bool> interrupt_log_upload;
 
     bool log_upload_running;

--- a/modules/Misc/System/signed_firmware_downloader.sh
+++ b/modules/Misc/System/signed_firmware_downloader.sh
@@ -7,8 +7,15 @@ sleep 2
 echo "$DOWNLOADING"
 
 sleep 2
-curl --progress-bar --ssl --connect-timeout "$CONNECTION_TIMEOUT" "${2}" -o "${3}"
+# Run the transfer in the background and wait on it so a TERM/INT reaching this
+# script is forwarded to curl instead of being deferred until curl exits. Without
+# this the cancelled transfer keeps its output pipe open and stalls the caller.
+trap 'kill "$curl_pid" 2>/dev/null' TERM INT
+curl --progress-bar --ssl --connect-timeout "$CONNECTION_TIMEOUT" "${2}" -o "${3}" &
+curl_pid=$!
+wait "$curl_pid"
 curl_exit_code=$?
+trap - TERM INT
 sleep 2
 if [[ $curl_exit_code -eq 0 ]]; then
     echo "$DOWNLOADED"

--- a/modules/Misc/System/signed_firmware_installer.sh
+++ b/modules/Misc/System/signed_firmware_installer.sh
@@ -5,4 +5,17 @@
 echo "$INSTALLING"
 test -f "${3}"
 sleep 2
+
+# A firmware artifact whose remote filename ends in -bad.pnx is designated
+# to fail installation. "${2}" is the remote location URI; strip any query
+# or fragment before taking the basename. Callers that omit it fall through
+# to the success path unchanged.
+location="${2%%[?#]*}"
+case "${location##*/}" in
+    *-bad.pnx)
+        echo "$INSTALL_VERIFICATION_FAILED"
+        exit 0
+        ;;
+esac
+
 echo "$INSTALLED"


### PR DESCRIPTION
## Describe your changes

Protocol-neutral System module fixes for firmware update and diagnostics
flows.

- Tear down a canceled firmware download silently; the downloader
  forwards termination signals to curl so a cancel does not wait for the
  transfer to finish.
- Guard the post-verification install block so a late cancel cannot
  publish a status or schedule an install.
- Fail installation for *-bad.pnx artifacts to make the
  install-verification-failure path testable.
- Bounded grace between publishing InstallRebooting and rebooting so the
  notification reaches the backend.
- Diagnostics upload: allow sftp://, append the generated file name to
  the location, drop the extra per-attempt sleep.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

### Verification
- Module builds; bash -n clean on all changed scripts.
