### PR TITLE
OCPP: flush pending messages before reset teardown

### DIFF
--- a/lib/everest/ocpp/include/ocpp/common/message_queue.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/message_queue.hpp
@@ -986,6 +986,16 @@ public:
         return this->transaction_message_queue.empty();
     }
 
+    /// \brief Returns true if there is no outgoing message waiting to be sent or awaiting a response, i.e. both the
+    /// normal and the transaction message queues are empty and no message is currently in flight. This is used to
+    /// determine when it is safe to tear down the connection (e.g. before a reset) without losing queued messages
+    /// such as a final TransactionEvent(Ended) or a FirmwareStatusNotification.
+    bool is_idle() {
+        const std::lock_guard<std::recursive_mutex> lk(this->message_mutex);
+        return this->normal_message_queue.empty() && this->transaction_message_queue.empty() &&
+               this->in_flight == nullptr;
+    }
+
     bool contains_transaction_messages(const CiString<36>& transaction_id) {
         const std::lock_guard<std::recursive_mutex> lk(this->message_mutex);
         for (const auto& control_message : this->transaction_message_queue) {

--- a/lib/everest/ocpp/include/ocpp/v2/charge_point.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/charge_point.hpp
@@ -77,6 +77,11 @@ public:
     /// \brief Stops the ChargePoint. Disconnects the websocket connection and stops MessageQueue and all timers
     virtual void stop() = 0;
 
+    /// \brief Returns true if the outgoing message queue is idle, i.e. there is no message queued or in flight. Can be
+    /// used to determine whether it is safe to tear down the connection without dropping a pending message (e.g. a
+    /// final TransactionEvent(Ended) or a FirmwareStatusNotification) right before a reset.
+    virtual bool is_message_queue_idle() = 0;
+
     /// \brief Initializes the websocket and connects to a CSMS. Provide a network_profile_slot to connect to that
     /// specific slot.
     ///
@@ -583,6 +588,8 @@ public:
     void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp, bool start_connecting = true) override;
 
     void stop() override;
+
+    bool is_message_queue_idle() override;
 
     void connect_websocket(std::optional<std::int32_t> network_profile_slot = std::nullopt) override;
     void disconnect_websocket() override;

--- a/lib/everest/ocpp/include/ocpp/v2/charge_point.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/charge_point.hpp
@@ -81,6 +81,11 @@ public:
     /// \brief Stops the ChargePoint. Disconnects the websocket connection and stops MessageQueue and all timers
     virtual void stop() = 0;
 
+    /// \brief Returns true if the outgoing message queue is idle, i.e. there is no message queued or in flight. Can be
+    /// used to determine whether it is safe to tear down the connection without dropping a pending message (e.g. a
+    /// final TransactionEvent(Ended) or a FirmwareStatusNotification) right before a reset.
+    virtual bool is_message_queue_idle() = 0;
+
     /// \brief Initializes the websocket and connects to a CSMS. Provide a network_profile_slot to connect to that
     /// specific slot.
     ///
@@ -599,6 +604,8 @@ public:
     void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp, bool start_connecting = true) override;
 
     void stop() override;
+
+    bool is_message_queue_idle() override;
 
     void connect_websocket(std::optional<std::int32_t> network_profile_slot = std::nullopt) override;
     void disconnect_websocket() override;

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
@@ -168,6 +168,10 @@ void ChargePoint::stop() {
     this->security->stop_certificate_signed_timer();
 }
 
+bool ChargePoint::is_message_queue_idle() {
+    return this->message_queue == nullptr || this->message_queue->is_idle();
+}
+
 void ChargePoint::disconnect_websocket() {
     this->connectivity_manager->disconnect();
 }

--- a/lib/everest/ocpp/tests/lib/ocpp/common/test_message_queue.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/common/test_message_queue.cpp
@@ -280,6 +280,37 @@ TEST_F(MessageQueueTest, test_non_transactional_message_is_sent) {
     wait_for_calls();
 }
 
+// \brief Test that is_idle() reflects whether there are messages queued or in flight. This is relied upon by the
+// OCPP module to bound-wait for a final TransactionEvent(Ended) or FirmwareStatusNotification to be flushed before
+// tearing the connection down for a reset/shutdown.
+TEST_F(MessageQueueTest, test_is_idle_reflects_pending_and_flushed_messages) {
+    // A freshly started, empty queue is idle.
+    EXPECT_TRUE(message_queue->is_idle());
+
+    EXPECT_CALL(send_callback_mock, Call(testing::_)).WillRepeatedly(MarkAndReturn(true, true));
+    EXPECT_CALL(*db, insert_message_queue_message(testing::_, testing::_)).Times(testing::AnyNumber());
+    EXPECT_CALL(*db, remove_message_queue_message(testing::_, testing::_)).Times(testing::AnyNumber());
+
+    // While paused, a pushed transactional message stays queued -> not idle.
+    message_queue->pause();
+    push_message_call(TestMessageType::TRANSACTIONAL);
+    EXPECT_FALSE(message_queue->is_idle());
+
+    // After resuming, the message is sent, acknowledged, and the queue becomes idle again.
+    message_queue->resume(std::chrono::seconds(0));
+    wait_for_calls(1);
+
+    // in_flight is cleared asynchronously once the (mocked) response is received; poll briefly for it.
+    bool idle = false;
+    for (int i = 0; i < 200 && !idle; ++i) {
+        idle = message_queue->is_idle();
+        if (!idle) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+    EXPECT_TRUE(idle);
+}
+
 // \brief Test transactional messages that are sent while being offline are sent afterwards
 TEST_F(MessageQueueTest, test_queuing_up_of_transactional_messages) {
 

--- a/modules/EVSE/OCPPmulti/generic_chargepoint.cpp
+++ b/modules/EVSE/OCPPmulti/generic_chargepoint.cpp
@@ -90,6 +90,14 @@ void GenericChargePoint::stop() {
     m_active_ptr->stop();
 }
 
+bool GenericChargePoint::is_message_queue_idle() {
+    // Called during teardown; if not configured there is nothing left to flush.
+    if (m_active_ptr == nullptr) {
+        return true;
+    }
+    return m_active_ptr->is_message_queue_idle();
+}
+
 std::optional<ocpp::v2::DataTransferResponse>
 GenericChargePoint::data_transfer_req(const ocpp::v2::DataTransferRequest& request) {
     check_configured("data_transfer_req");

--- a/modules/EVSE/OCPPmulti/generic_chargepoint.hpp
+++ b/modules/EVSE/OCPPmulti/generic_chargepoint.hpp
@@ -57,6 +57,7 @@ public:
     void start(ocpp::v2::BootReasonEnum bootreason, const std::set<std::string>& resuming_session_ids,
                bool start_connecting) override;
     void stop() override;
+    bool is_message_queue_idle() override;
 
     std::optional<ocpp::v2::DataTransferResponse>
     data_transfer_req(const ocpp::v2::DataTransferRequest& request) override;

--- a/modules/EVSE/OCPPmulti/generic_chargepoint_interface.hpp
+++ b/modules/EVSE/OCPPmulti/generic_chargepoint_interface.hpp
@@ -224,6 +224,14 @@ struct GenericChargePointInterface {
                        bool start_connecting) = 0;
     virtual void stop() = 0;
 
+    /// \brief Returns true if the underlying OCPP message queue has no message queued or in flight. Used to bound-wait
+    /// for pending messages (e.g. a final TransactionEvent(Ended) or a FirmwareStatusNotification) to be flushed to the
+    /// CSMS before the connection is torn down for a reset or shutdown. Defaults to true for backends that do not track
+    /// this (e.g. OCPP1.6), so callers never block on them.
+    virtual bool is_message_queue_idle() {
+        return true;
+    }
+
     virtual std::optional<ocpp::v2::DataTransferResponse>
     data_transfer_req(const ocpp::v2::DataTransferRequest& request) = 0;
 

--- a/modules/EVSE/OCPPmulti/generic_chargepoint_interface.hpp
+++ b/modules/EVSE/OCPPmulti/generic_chargepoint_interface.hpp
@@ -239,6 +239,14 @@ struct GenericChargePointInterface {
                        bool start_connecting) = 0;
     virtual void stop() = 0;
 
+    /// \brief Returns true if the underlying OCPP message queue has no message queued or in flight. Used to bound-wait
+    /// for pending messages (e.g. a final TransactionEvent(Ended) or a FirmwareStatusNotification) to be flushed to the
+    /// CSMS before the connection is torn down for a reset or shutdown. Defaults to true for backends that do not track
+    /// this (e.g. OCPP1.6), so callers never block on them.
+    virtual bool is_message_queue_idle() {
+        return true;
+    }
+
     virtual std::optional<ocpp::v2::DataTransferResponse>
     data_transfer_req(const ocpp::v2::DataTransferRequest& request) = 0;
 

--- a/modules/EVSE/OCPPmulti/generic_ocpp.cpp
+++ b/modules/EVSE/OCPPmulti/generic_ocpp.cpp
@@ -29,6 +29,13 @@ constexpr const auto TX_STOP_POINT_VAR_NAME = "TxStopPoint";
 constexpr std::int32_t LOWEST_SETPOINT_PRIORITY = 1000;
 constexpr std::int32_t HIGHEST_SETPOINT_PRIORITY = 0;
 
+// Upper bound on how long a reset/shutdown teardown waits for the OCPP message queue to flush a pending
+// TransactionEvent(Ended) or FirmwareStatusNotification before closing the connection anyway. Generous enough
+// to cover a slow transaction stop yet bounded so a wedged or offline queue can never block the reset.
+constexpr auto RESET_DRAIN_TIMEOUT = std::chrono::seconds(10);
+// Polling granularity while waiting for the queue to drain.
+constexpr auto DRAIN_POLL_INTERVAL = std::chrono::milliseconds(50);
+
 std::optional<ocpp::v2::IdToken> get_authorised_id_token(const types::evse_manager::SessionEvent& session_event) {
     using namespace module::conversions;
 
@@ -1202,6 +1209,38 @@ ocpp::v2::ReserveNowStatusEnum GenericOcpp::cb_reserve_now(const ocpp::v2::Reser
     return result;
 }
 
+bool GenericOcpp::any_transaction_active() {
+    const auto n_managers = static_cast<std::int32_t>(mv_requires.evse_manager.size());
+    for (std::int32_t evse_id = 1; evse_id <= n_managers; ++evse_id) {
+        if (transaction_data(evse_id) != nullptr) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void GenericOcpp::wait_for_message_queue_drained(std::chrono::milliseconds timeout, bool await_transactions) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        // The queue is drained once it is empty and nothing is in flight. On the reset path we additionally wait
+        // for any ongoing transaction to finish first, so its TransactionEvent(Ended) has been enqueued before we
+        // conclude the queue is drained (otherwise we could observe a momentarily-empty queue too early).
+        const bool transactions_settled = !await_transactions || !any_transaction_active();
+        if (transactions_settled && mv_charge_point.is_message_queue_idle()) {
+            return;
+        }
+        // If the link is already down there is no point waiting: queued messages cannot be sent and will be
+        // persisted/retried after the reboot instead.
+        if (mv_ocpp_protocol_version.load() == ocpp::OcppProtocolVersion::Unknown) {
+            EVLOG_info << "Not waiting for OCPP message queue to drain: connection is down";
+            return;
+        }
+        std::this_thread::sleep_for(DRAIN_POLL_INTERVAL);
+    }
+    EVLOG_warning << "Timed out waiting for OCPP message queue to drain before teardown; "
+                     "pending messages may be delivered after reconnect";
+}
+
 void GenericOcpp::cb_reset(const std::optional<const std::int32_t>& evse_id, ResetType type) {
     if (evse_id.has_value()) {
         EVLOG_warning << "Reset of EVSE is currently not supported";
@@ -1229,8 +1268,23 @@ void GenericOcpp::cb_reset(const std::optional<const std::int32_t>& evse_id, Res
         }
 
         if (do_reset) {
+            // If this reset stopped an ongoing transaction, its TransactionEvent(Ended) is generated
+            // asynchronously once the EvseManager reports the transaction finished. Snapshot that here so we
+            // only pay the extra drain wait when there actually was a transaction to flush (a Reset on an idle
+            // charge point must not be delayed).
+            const bool had_active_transaction = any_transaction_active();
+
             // small delay before stopping the charge point to make sure all responses are received
             std::this_thread::sleep_for(std::chrono::seconds(mv_config.getResetStopDelay()));
+
+            if (had_active_transaction) {
+                // Wait (bounded) for the stopped transaction(s) to actually finish and for the resulting
+                // TransactionEvent(Ended) to be handed to the websocket before tearing the connection down.
+                // Without this the reboot path can close the socket while the Ended event is still queued,
+                // which makes the CSMS time out waiting for it (OCTT TC_B_22_CS).
+                wait_for_message_queue_drained(RESET_DRAIN_TIMEOUT, /*await_transactions=*/true);
+            }
+
             mv_charge_point.stop();
             mv_requires.system.call_reset(r_type, scheduled);
         }
@@ -1659,6 +1713,12 @@ void GenericOcpp::shutdown() {
     mv_started.store(false);
     mv_shutting_down.store(true);
     charging_schedules_timer_stop();
+    // Flush any message the CSMS is still waiting on (e.g. a FirmwareStatusNotification{InstallRebooting}
+    // emitted right before a post-install reboot) before GenericChargePoint::shutdown() closes the socket,
+    // so the CSMS does not miss it (OCTT TC_L_13_CS). Bounded and a no-op when already idle or offline.
+    // await_transactions is false: a transaction interrupted by shutdown never produces an Ended event, so we
+    // only flush what is already queued rather than block for a transaction that will never finish.
+    wait_for_message_queue_drained(RESET_DRAIN_TIMEOUT, /*await_transactions=*/false);
     std::lock_guard<std::mutex> lock(recompute_mutex);
 }
 

--- a/modules/EVSE/OCPPmulti/generic_ocpp.cpp
+++ b/modules/EVSE/OCPPmulti/generic_ocpp.cpp
@@ -32,6 +32,13 @@ constexpr const auto TX_STOP_POINT_VAR_NAME = "TxStopPoint";
 constexpr std::int32_t LOWEST_SETPOINT_PRIORITY = 1000;
 constexpr std::int32_t HIGHEST_SETPOINT_PRIORITY = 0;
 
+// Upper bound on how long a reset/shutdown teardown waits for the OCPP message queue to flush a pending
+// TransactionEvent(Ended) or FirmwareStatusNotification before closing the connection anyway. Generous enough
+// to cover a slow transaction stop yet bounded so a wedged or offline queue can never block the reset.
+constexpr auto RESET_DRAIN_TIMEOUT = std::chrono::seconds(10);
+// Polling granularity while waiting for the queue to drain.
+constexpr auto DRAIN_POLL_INTERVAL = std::chrono::milliseconds(50);
+
 std::optional<ocpp::v2::IdToken> get_authorised_id_token(const types::evse_manager::SessionEvent& session_event) {
     using namespace module::conversions;
 
@@ -1378,6 +1385,38 @@ ocpp::v2::ReserveNowStatusEnum GenericOcpp::cb_reserve_now(const ocpp::v2::Reser
     return result;
 }
 
+bool GenericOcpp::any_transaction_active() {
+    const auto n_managers = static_cast<std::int32_t>(mv_requires.evse_manager.size());
+    for (std::int32_t evse_id = 1; evse_id <= n_managers; ++evse_id) {
+        if (transaction_data(evse_id) != nullptr) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void GenericOcpp::wait_for_message_queue_drained(std::chrono::milliseconds timeout, bool await_transactions) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        // The queue is drained once it is empty and nothing is in flight. On the reset path we additionally wait
+        // for any ongoing transaction to finish first, so its TransactionEvent(Ended) has been enqueued before we
+        // conclude the queue is drained (otherwise we could observe a momentarily-empty queue too early).
+        const bool transactions_settled = !await_transactions || !any_transaction_active();
+        if (transactions_settled && mv_charge_point.is_message_queue_idle()) {
+            return;
+        }
+        // If the link is already down there is no point waiting: queued messages cannot be sent and will be
+        // persisted/retried after the reboot instead.
+        if (mv_ocpp_protocol_version.load() == ocpp::OcppProtocolVersion::Unknown) {
+            EVLOG_info << "Not waiting for OCPP message queue to drain: connection is down";
+            return;
+        }
+        std::this_thread::sleep_for(DRAIN_POLL_INTERVAL);
+    }
+    EVLOG_warning << "Timed out waiting for OCPP message queue to drain before teardown; "
+                     "pending messages may be delivered after reconnect";
+}
+
 void GenericOcpp::cb_reset(const std::optional<const std::int32_t>& evse_id, ResetType type) {
     if (evse_id.has_value()) {
         EVLOG_warning << "Reset of EVSE is currently not supported";
@@ -1405,8 +1444,23 @@ void GenericOcpp::cb_reset(const std::optional<const std::int32_t>& evse_id, Res
         }
 
         if (do_reset) {
+            // If this reset stopped an ongoing transaction, its TransactionEvent(Ended) is generated
+            // asynchronously once the EvseManager reports the transaction finished. Snapshot that here so we
+            // only pay the extra drain wait when there actually was a transaction to flush (a Reset on an idle
+            // charge point must not be delayed).
+            const bool had_active_transaction = any_transaction_active();
+
             // small delay before stopping the charge point to make sure all responses are received
             std::this_thread::sleep_for(std::chrono::seconds(mv_config.getResetStopDelay()));
+
+            if (had_active_transaction) {
+                // Wait (bounded) for the stopped transaction(s) to actually finish and for the resulting
+                // TransactionEvent(Ended) to be handed to the websocket before tearing the connection down.
+                // Without this the reboot path can close the socket while the Ended event is still queued,
+                // which makes the CSMS time out waiting for it (OCTT TC_B_22_CS).
+                wait_for_message_queue_drained(RESET_DRAIN_TIMEOUT, /*await_transactions=*/true);
+            }
+
             mv_charge_point.stop();
             mv_requires.system.call_reset(r_type, scheduled);
         }
@@ -1850,6 +1904,12 @@ void GenericOcpp::shutdown() {
     mv_shutting_down.store(true);
     charging_schedules_timer_stop();
     grid_support_heartbeat_timer_stop();
+    // Flush any message the CSMS is still waiting on (e.g. a FirmwareStatusNotification{InstallRebooting}
+    // emitted right before a post-install reboot) before GenericChargePoint::shutdown() closes the socket,
+    // so the CSMS does not miss it (OCTT TC_L_13_CS). Bounded and a no-op when already idle or offline.
+    // await_transactions is false: a transaction interrupted by shutdown never produces an Ended event, so we
+    // only flush what is already queued rather than block for a transaction that will never finish.
+    wait_for_message_queue_drained(RESET_DRAIN_TIMEOUT, /*await_transactions=*/false);
     { std::lock_guard<std::mutex> lock(recompute_mutex); }
 
     // Unblock any ConnectivityManager thread waiting on a pending configure_network future.

--- a/modules/EVSE/OCPPmulti/generic_ocpp.hpp
+++ b/modules/EVSE/OCPPmulti/generic_ocpp.hpp
@@ -6,6 +6,8 @@
 #include "generic_chargepoint_interface.hpp"
 #include "ocpp_module_common_aliases.hpp"
 
+#include <chrono>
+
 #include <generated/interfaces/auth/Interface.hpp>
 #include <generated/interfaces/auth_token_provider/Implementation.hpp>
 #include <generated/interfaces/auth_token_validator/Implementation.hpp>
@@ -278,6 +280,18 @@ protected:
     }
 
     EventInfo convert_error(const Everest::error::Error& error);
+
+    /// \brief Returns true if the module currently tracks an ongoing transaction on any EVSE. Used before a reset to
+    /// detect whether a stopped transaction still needs its TransactionEvent(Ended) to be generated and flushed.
+    bool any_transaction_active();
+
+    /// \brief Bounded wait until the OCPP message queue has flushed all pending messages (no message queued or in
+    /// flight), the connection is lost, or \p timeout elapses. Used before tearing the connection down for a reset or
+    /// shutdown so that a final TransactionEvent(Ended) or a FirmwareStatusNotification is not dropped.
+    /// \param await_transactions when true, also waits for any ongoing transaction to finish first, so its
+    /// TransactionEvent(Ended) is generated and enqueued before draining (used by the reset path). Must be false for
+    /// plain shutdown, where a transaction interrupted by process exit will never produce an Ended event.
+    void wait_for_message_queue_drained(std::chrono::milliseconds timeout, bool await_transactions);
 
     void init_check_energy_sink();
     void init_error_handlers();

--- a/modules/EVSE/OCPPmulti/generic_ocpp.hpp
+++ b/modules/EVSE/OCPPmulti/generic_ocpp.hpp
@@ -7,6 +7,8 @@
 #include "grid_support/grid_support_state.hpp"
 #include "ocpp_module_common_aliases.hpp"
 
+#include <chrono>
+
 #include <generated/interfaces/auth/Interface.hpp>
 #include <generated/interfaces/auth_token_provider/Implementation.hpp>
 #include <generated/interfaces/auth_token_validator/Implementation.hpp>
@@ -313,6 +315,18 @@ protected:
     }
 
     EventInfo convert_error(const Everest::error::Error& error);
+
+    /// \brief Returns true if the module currently tracks an ongoing transaction on any EVSE. Used before a reset to
+    /// detect whether a stopped transaction still needs its TransactionEvent(Ended) to be generated and flushed.
+    bool any_transaction_active();
+
+    /// \brief Bounded wait until the OCPP message queue has flushed all pending messages (no message queued or in
+    /// flight), the connection is lost, or \p timeout elapses. Used before tearing the connection down for a reset or
+    /// shutdown so that a final TransactionEvent(Ended) or a FirmwareStatusNotification is not dropped.
+    /// \param await_transactions when true, also waits for any ongoing transaction to finish first, so its
+    /// TransactionEvent(Ended) is generated and enqueued before draining (used by the reset path). Must be false for
+    /// plain shutdown, where a transaction interrupted by process exit will never produce an Ended event.
+    void wait_for_message_queue_drained(std::chrono::milliseconds timeout, bool await_transactions);
 
     void init_check_energy_sink();
     void init_error_handlers();

--- a/modules/EVSE/OCPPmulti/tests/stubs/v2_chargepoint_stub.hpp
+++ b/modules/EVSE/OCPPmulti/tests/stubs/v2_chargepoint_stub.hpp
@@ -16,6 +16,7 @@ namespace stubs {
 struct Ocpp2ChargePointMock : public ocpp::v2::ChargePointInterface {
     MOCK_METHOD(void, start, (ocpp::v2::BootReasonEnum bootreason, bool start_connecting), (override));
     MOCK_METHOD(void, stop, (), (override));
+    MOCK_METHOD(bool, is_message_queue_idle, (), (override));
     MOCK_METHOD(void, connect_websocket, (std::optional<std::int32_t> network_profile_slot), (override));
     MOCK_METHOD(void, disconnect_websocket, (), (override));
     MOCK_METHOD(void, on_websocket_connected,

--- a/modules/EVSE/OCPPmulti/v2_chargepoint.cpp
+++ b/modules/EVSE/OCPPmulti/v2_chargepoint.cpp
@@ -494,6 +494,12 @@ void ChargePointV2::stop() {
     check_configured("stop");
     m_charge_point->stop();
 }
+bool ChargePointV2::is_message_queue_idle() {
+    if (m_charge_point == nullptr) {
+        return true;
+    }
+    return m_charge_point->is_message_queue_idle();
+}
 
 std::optional<ocpp::v2::DataTransferResponse>
 ChargePointV2::data_transfer_req(const ocpp::v2::DataTransferRequest& request) {

--- a/modules/EVSE/OCPPmulti/v2_chargepoint.cpp
+++ b/modules/EVSE/OCPPmulti/v2_chargepoint.cpp
@@ -513,6 +513,12 @@ void ChargePointV2::stop() {
     check_configured("stop");
     m_charge_point->stop();
 }
+bool ChargePointV2::is_message_queue_idle() {
+    if (m_charge_point == nullptr) {
+        return true;
+    }
+    return m_charge_point->is_message_queue_idle();
+}
 
 std::optional<ocpp::v2::DataTransferResponse>
 ChargePointV2::data_transfer_req(const ocpp::v2::DataTransferRequest& request) {

--- a/modules/EVSE/OCPPmulti/v2_chargepoint.hpp
+++ b/modules/EVSE/OCPPmulti/v2_chargepoint.hpp
@@ -79,6 +79,7 @@ public:
     void start(ocpp::v2::BootReasonEnum bootreason, const std::set<std::string>& resuming_session_ids,
                bool start_connecting) override;
     void stop() override;
+    bool is_message_queue_idle() override;
 
     std::optional<ocpp::v2::DataTransferResponse>
     data_transfer_req(const ocpp::v2::DataTransferRequest& request) override;


### PR DESCRIPTION
## Describe your changes

A Reset or post-firmware reboot could close the websocket while a final
message (TransactionEvent(Ended), FirmwareStatusNotification) was still
queued, so the CSMS timed out (TC_B_22_CS, TC_L_13_CS).

Expose MessageQueue::is_idle() and bound-wait for the queue to drain in
the OCPPmulti reset callback and module shutdown before tearing the
connection down. Skipped when idle or offline; OCPP 1.6 backend
unaffected.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

### Verification
- libocpp MessageQueue tests and OCPPmulti module tests green.
