### PR TITLE
SIL modules and device-model config fixes

### DIFF
--- a/lib/everest/ocpp/config/common/component_config/standardized/AlignedDataCtrlr.json
+++ b/lib/everest/ocpp/config/common/component_config/standardized/AlignedDataCtrlr.json
@@ -65,7 +65,7 @@
         {
           "type": "Actual",
           "mutability": "ReadWrite",
-          "value": "Energy.Active.Import.Register,Voltage,Frequency"
+          "value": "Energy.Active.Import.Register,Voltage"
         }
       ],
       "description": "Clock-aligned measurand(s) to be included in MeterValuesRequest, every AlignedDataInterval seconds.",

--- a/lib/everest/ocpp/config/common/component_config/standardized/ISO15118Ctrlr.json
+++ b/lib/everest/ocpp/config/common/component_config/standardized/ISO15118Ctrlr.json
@@ -133,7 +133,8 @@
       "attributes": [
         {
           "type": "Actual",
-          "mutability": "ReadWrite"
+          "mutability": "ReadWrite",
+          "value": "DE"
         }
       ],
       "description": "The countryName of the SECC in the ISO 3166-1 format. It is used as the countryName (C) of the SECC leaf certificate. Example: \"DE\"",

--- a/lib/everest/ocpp/config/common/component_config/standardized/InternalCtrlr.json
+++ b/lib/everest/ocpp/config/common/component_config/standardized/InternalCtrlr.json
@@ -29,11 +29,11 @@
               {
                   "type": "Actual",
                   "mutability": "ReadWrite",
-                  "value": "[{\"configurationSlot\": 1, \"connectionData\": {\"messageTimeout\": 30, \"ocppCsmsUrl\": \"ws://localhost:9000\", \"ocppInterface\": \"Wired0\", \"ocppTransport\": \"JSON\", \"ocppVersion\": \"OCPP20\", \"securityProfile\": 1}}]"
+                  "value": "[{\"configurationSlot\": 1, \"connectionData\": {\"messageTimeout\": 60, \"ocppCsmsUrl\": \"ws://localhost:9000\", \"ocppInterface\": \"Wired0\", \"ocppTransport\": \"JSON\", \"ocppVersion\": \"OCPP20\", \"securityProfile\": 1}}]"
               }
           ],
           "description": "List of NetworkConnectionProfiles that define the functional and technical parameters of a communication link. Must be a (JSON) string with the format of SetNetworkProfileRequest",
-          "default": "[{\\\"configurationSlot\\\": 1, \\\"connectionData\\\": {\\\"messageTimeout\\\": 30, \\\"ocppCsmsUrl\\\": \\\"ws://localhost:9000/cp001\\\", \\\"ocppInterface\\\": \\\"Wired0\\\", \\\"ocppTransport\\\": \\\"JSON\\\", \\\"ocppVersion\\\": \\\"OCPP20\\\", \\\"securityProfile\\\": 1}}]\n",
+          "default": "[{\\\"configurationSlot\\\": 1, \\\"connectionData\\\": {\\\"messageTimeout\\\": 60, \\\"ocppCsmsUrl\\\": \\\"ws://localhost:9000/cp001\\\", \\\"ocppInterface\\\": \\\"Wired0\\\", \\\"ocppTransport\\\": \\\"JSON\\\", \\\"ocppVersion\\\": \\\"OCPP20\\\", \\\"securityProfile\\\": 1}}]\n",
           "type": "string"
       },
       "ChargeBoxSerialNumber": {

--- a/lib/everest/ocpp/config/common/component_config/standardized/SampledDataCtrlr.json
+++ b/lib/everest/ocpp/config/common/component_config/standardized/SampledDataCtrlr.json
@@ -135,11 +135,11 @@
         {
           "type": "Actual",
           "mutability": "ReadWrite",
-          "value": "Energy.Active.Import.Register,Current.Import,Voltage,Power.Active.Import,Power.Reactive.Import,Frequency,SoC"
+          "value": "Energy.Active.Import.Register,Current.Import,Voltage,Power.Active.Import"
         }
       ],
       "description": "Sampled measurands to be included in the meterValues element of TransactionEventRequest (eventType = Ended)",
-      "default": "Energy.Active.Import.Register,Current.Import,Voltage,Power.Active.Import,Power.Reactive.Import,Frequency",
+      "default": "Energy.Active.Import.Register,Current.Import,Voltage,Power.Active.Import",
       "type": "string"
     },
     "RegisterValuesWithoutPhases": {

--- a/modules/EV/EvManager/BUILD.bazel
+++ b/modules/EV/EvManager/BUILD.bazel
@@ -22,6 +22,8 @@ cc_test(
         exclude = [
             "main/car_simulatorImpl.*",
             "main/car_simulation.*",
+            "main/simulation_data.hpp",
+            "tests/SimulationDataTest.cpp",
         ],
     ),
     includes = ["."],

--- a/modules/EV/EvManager/main/car_simulation.cpp
+++ b/modules/EV/EvManager/main/car_simulation.cpp
@@ -352,6 +352,7 @@ bool CarSimulation::iso_start_v2g_session(const CmdArguments& arguments, bool th
     } else {
         return false;
     }
+    sim_data.v2g_session_active = true;
     return true;
 }
 
@@ -374,6 +375,8 @@ bool CarSimulation::iso_stop_charging(const CmdArguments& arguments) {
     r_ev_board_support->call_allow_power_on(false);
     if (sim_data.state != SimState::UNPLUGGED) {
         sim_data.state = SimState::PLUGGED_IN;
+    } else {
+        EVLOG_warning << "iso_stop_charging: sim state is UNPLUGGED, staying unplugged (no suspend)";
     }
     charge_mode = ChargeMode::None;
     return true;
@@ -431,11 +434,11 @@ bool CarSimulation::iso_wait_for_stop(const CmdArguments& arguments, size_t loop
 }
 
 bool CarSimulation::iso_wait_v2g_session_stopped(const CmdArguments& arguments) {
-    if (sim_data.v2g_finished) {
-        sim_data.v2g_finished = false;
+    if (not sim_data.v2g_session_active) {
+        EVLOG_warning << "iso_wait_v2g_session_stopped: no active V2G session, skipping wait";
         return true;
     }
-    return false;
+    return sim_data.advance_wait_v2g_session_stopped();
 }
 
 bool CarSimulation::iso_pause_charging(const CmdArguments& arguments) {

--- a/modules/EV/EvManager/main/car_simulation.hpp
+++ b/modules/EV/EvManager/main/car_simulation.hpp
@@ -28,8 +28,8 @@ public:
         timepoint_last_update(std::chrono::steady_clock::now()){};
     ~CarSimulation() = default;
 
-    void reset() {
-        sim_data = SimulationData();
+    void reset(ResetBehavior behavior = ResetBehavior::Full) {
+        sim_data.reset(behavior);
         sim_data.battery_capacity_wh = config.dc_energy_capacity;
         double soc = config.soc;
         sim_data.battery_charge_wh = config.dc_energy_capacity * (soc / 100.0);

--- a/modules/EV/EvManager/main/car_simulatorImpl.cpp
+++ b/modules/EV/EvManager/main/car_simulatorImpl.cpp
@@ -128,7 +128,11 @@ void car_simulatorImpl::run() {
                 EVLOG_info << "Finished simulation.";
                 set_execution_active(false);
 
-                reset_car_simulation_defaults();
+                // Keep the sim plug/CP state consistent with the physical CP line, which stays
+                // frozen (state machine is no longer ticked once execution is inactive). Reverting
+                // to the UNPLUGGED default here would make a later modify command act on a phantom
+                // state and silently drive a physical unplug.
+                reset_car_simulation_defaults(ResetBehavior::KeepPlugState);
 
                 // If we have auto_exec_infinite configured, restart simulation when it is done
                 if (mod->config.auto_exec && mod->config.auto_exec_infinite) {
@@ -417,9 +421,9 @@ void car_simulatorImpl::subscribe_to_external_mqtt() {
                    });
 }
 
-void car_simulatorImpl::reset_car_simulation_defaults() {
+void car_simulatorImpl::reset_car_simulation_defaults(ResetBehavior behavior) {
     const std::lock_guard<std::mutex> lock{car_simulation_mutex};
-    car_simulation->reset();
+    car_simulation->reset(behavior);
 }
 
 void car_simulatorImpl::update_command_queue(std::string& value) {

--- a/modules/EV/EvManager/main/car_simulatorImpl.hpp
+++ b/modules/EV/EvManager/main/car_simulatorImpl.hpp
@@ -61,7 +61,7 @@ private:
     void setup_ev_parameters();
     void call_ev_board_support_functions();
     void subscribe_to_external_mqtt();
-    void reset_car_simulation_defaults();
+    void reset_car_simulation_defaults(ResetBehavior behavior = ResetBehavior::Full);
     void update_command_queue(std::string& value);
     void set_execution_active(bool value);
     void cancel_charging_session();

--- a/modules/EV/EvManager/main/simulation_data.hpp
+++ b/modules/EV/EvManager/main/simulation_data.hpp
@@ -31,6 +31,11 @@ enum class EnergyMode {
     DC,
 };
 
+enum class ResetBehavior {
+    Full,
+    KeepPlugState,
+};
+
 struct SimulationData {
 
     SimulationData() = default;
@@ -41,6 +46,7 @@ struct SimulationData {
     std::optional<size_t> sleep_ticks_left{};
 
     bool v2g_finished{false};
+    bool v2g_session_active{false};
     bool iso_stopped{false};
     bool iso_charger_paused{false};
     size_t evse_maxcurrent{0};
@@ -66,4 +72,34 @@ struct SimulationData {
     double battery_capacity_wh{0};
 
     types::board_support_common::Event actual_bsp_event{types::board_support_common::Event::Disconnected};
+
+    // Reset per-session simulation data to defaults. With ResetBehavior::KeepPlugState keep the
+    // CP/plug state (state + last_state) so it stays consistent with the frozen physical CP line
+    // after a simulation queue completes instead of silently reverting to UNPLUGGED.
+    // The V2G/SLAC session flags are always cleared: this reset only runs once the command queue
+    // has finished and execution is inactive, so the logical session is over even though the
+    // physical CP line stays frozen. Preserving v2g_session_active without a matching future
+    // v2g_finished event would wedge iso_wait_v2g_session_stopped forever, and slac_state is
+    // re-driven continuously by the real SLAC state subscription, so both are safe to drop.
+    void reset(ResetBehavior behavior) {
+        const auto saved_state = state;
+        const auto saved_last_state = last_state;
+        *this = SimulationData();
+        if (behavior == ResetBehavior::KeepPlugState) {
+            state = saved_state;
+            last_state = saved_last_state;
+        }
+    }
+
+    // Advance the "wait for V2G session stopped" step. Returns true when the command should
+    // complete: either the active V2G session has now stopped, or no V2G session is active
+    // (IEC session) so waiting would block the queue forever.
+    bool advance_wait_v2g_session_stopped() {
+        const bool session_stopped = v2g_session_active and v2g_finished;
+        if (session_stopped) {
+            v2g_finished = false;
+            v2g_session_active = false;
+        }
+        return session_stopped or not v2g_session_active;
+    }
 };

--- a/modules/EV/EvManager/tests/CMakeLists.txt
+++ b/modules/EV/EvManager/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(${TEST_TARGET_NAME}
     PRIVATE
         CommandRegistryTest.cpp
         SimCommandTest.cpp
+        SimulationDataTest.cpp
         ../main/simulation_command.cpp
 )
 

--- a/modules/EV/EvManager/tests/SimulationDataTest.cpp
+++ b/modules/EV/EvManager/tests/SimulationDataTest.cpp
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "../main/simulation_data.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+SCENARIO("SimulationData reset keeps plug state consistent with the physical CP line", "[SimulationData]") {
+    GIVEN("A simulation that finished mid-charging") {
+        auto sim_data = SimulationData();
+        sim_data.state = SimState::CHARGING_REGULATED;
+        sim_data.last_state = SimState::CHARGING_REGULATED;
+        sim_data.v2g_finished = true;
+        sim_data.v2g_session_active = true;
+
+        WHEN("reset preserves the plug state (simulation-queue completion)") {
+            sim_data.reset(ResetBehavior::KeepPlugState);
+
+            THEN("the CP/plug state stays as it was on the frozen physical line") {
+                CHECK(sim_data.state == SimState::CHARGING_REGULATED);
+                CHECK(sim_data.last_state == SimState::CHARGING_REGULATED);
+            }
+            THEN("per-session flags are cleared back to defaults") {
+                CHECK(sim_data.v2g_finished == false);
+                CHECK(sim_data.v2g_session_active == false);
+            }
+        }
+
+        WHEN("reset does not preserve the plug state (enable / execute)") {
+            sim_data.reset(ResetBehavior::Full);
+
+            THEN("the state reverts to the UNPLUGGED default") {
+                CHECK(sim_data.state == SimState::UNPLUGGED);
+                CHECK(sim_data.last_state == SimState::UNDEFINED);
+            }
+        }
+    }
+}
+
+SCENARIO("iso_wait_v2g_session_stopped does not block the queue in IEC sessions", "[SimulationData]") {
+    GIVEN("No V2G session was ever started (IEC session)") {
+        auto sim_data = SimulationData();
+        REQUIRE(sim_data.v2g_session_active == false);
+
+        WHEN("the wait step is advanced") {
+            const auto done = sim_data.advance_wait_v2g_session_stopped();
+
+            THEN("it completes immediately instead of blocking forever") {
+                CHECK(done == true);
+            }
+        }
+    }
+
+    GIVEN("A V2G session is active but not yet stopped") {
+        auto sim_data = SimulationData();
+        sim_data.v2g_session_active = true;
+        sim_data.v2g_finished = false;
+
+        WHEN("the wait step is advanced") {
+            const auto done = sim_data.advance_wait_v2g_session_stopped();
+
+            THEN("it blocks until the session stops") {
+                CHECK(done == false);
+            }
+        }
+    }
+
+    GIVEN("A V2G session is active and has stopped") {
+        auto sim_data = SimulationData();
+        sim_data.v2g_session_active = true;
+        sim_data.v2g_finished = true;
+
+        WHEN("the wait step is advanced") {
+            const auto done = sim_data.advance_wait_v2g_session_stopped();
+
+            THEN("it completes and clears the session flags") {
+                CHECK(done == true);
+                CHECK(sim_data.v2g_finished == false);
+                CHECK(sim_data.v2g_session_active == false);
+            }
+        }
+    }
+}

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -1624,8 +1624,18 @@ bool Charger::deauthorize() {
 
 bool Charger::deauthorize_internal() {
     if (shared_context.session_active) {
+        const auto s = shared_context.current_state;
+
+        // A timeout withdrawal and an explicit one before plug-in are indistinguishable here;
+        // report any authorized, not-yet-plugged-in idle deauthorization as a Timeout stop.
+        if (s == EvseState::Idle and shared_context.flag_authorized and not shared_context.flag_ev_plugged_in and
+            not shared_context.flag_transaction_active) {
+            shared_context.last_stop_transaction_reason = types::evse_manager::StopTransactionReason::Timeout;
+            signal_transaction_finished_event(types::evse_manager::StopTransactionReason::Timeout,
+                                              shared_context.id_token);
+        }
+
         signal_simple_event(types::evse_manager::SessionEventEnum::Deauthorized);
-        auto s = shared_context.current_state;
 
         if (s == EvseState::Disabled or s == EvseState::Idle or s == EvseState::WaitingForAuthentication) {
 

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -503,6 +503,9 @@ protected:
     constexpr auto& get_shared_context() {
         return shared_context;
     }
+    constexpr auto& get_config_context() {
+        return config_context;
+    }
     constexpr const auto& get_enable_disable_source_table() const {
         return enable_disable_source_table;
     }

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -18,6 +18,7 @@ using namespace types::evse_manager;
 // class that provides access to internal state from the Charger class
 struct ChargerDerived : public Charger {
     using Charger::Charger;
+    using Charger::get_config_context;
     using Charger::get_enable_disable_source_table;
     using Charger::get_shared_context;
     using Charger::run_state_machine;
@@ -75,6 +76,7 @@ struct ChargerTest : public testing::Test {
             charger_bsp, charger_error_handling, charger_powermeter_billing, charger_store,
             types::evse_board_support::Connector_type::IEC62196Type2Socket, "EVSETEST");
         charger->signal_simple_event.connect(&ChargerTest::session_event, this);
+        charger->signal_transaction_finished_event.connect(&ChargerTest::transaction_finished_event, this);
     }
 
     void TearDown() override {
@@ -85,13 +87,20 @@ struct ChargerTest : public testing::Test {
         last_event = event;
     }
 
+    void transaction_finished_event(StopTransactionReason reason,
+                                    std::optional<types::authorization::ProvidedIdToken> /*token*/) {
+        last_transaction_finished_reason = reason;
+    }
+
     static constexpr SessionEventEnum default_event{SessionEventEnum::SessionFinished};
     static constexpr EnableDisableSource default_source{Enable_source::Unspecified, Enable_state::Unassigned, 10000};
 
     SessionEventEnum last_event{default_event};
+    std::optional<StopTransactionReason> last_transaction_finished_reason;
 
-    constexpr void reset_last_event() {
+    void reset_last_event() {
         last_event = default_event;
+        last_transaction_finished_reason.reset();
     }
 };
 
@@ -759,6 +768,87 @@ TEST_F(ChargerTest, DisableDuringIdle) {
     // Must immediately transition to Disabled
     EXPECT_EQ(ctx.current_state, Charger::EvseState::Disabled);
     EXPECT_EQ(last_event, SessionEventEnum::Disabled);
+}
+
+// tests for deauthorize() and the Timeout stop on connect timeout
+
+// Authorization was granted but the EV never connected before the connection timeout.
+// A deauthorization in the authorized, not-yet-plugged-in idle state must surface
+// StopTransactionReason::Timeout, not a generic stop.
+TEST_F(ChargerTest, ConnectTimeoutAfterAuthorizationStopsWithTimeout) {
+    auto& ctx = charger->get_shared_context();
+
+    // Authorized first, no plug-in, no local transaction started yet.
+    ctx.current_state = Charger::EvseState::Idle;
+    ctx.session_active = true;
+    ctx.flag_authorized = true;
+    ctx.flag_ev_plugged_in = false;
+    ctx.flag_transaction_active = false;
+
+    reset_last_event();
+    EXPECT_TRUE(charger->deauthorize());
+
+    ASSERT_TRUE(last_transaction_finished_reason.has_value());
+    EXPECT_EQ(last_transaction_finished_reason.value(), StopTransactionReason::Timeout);
+    EXPECT_FALSE(ctx.flag_authorized);
+    EXPECT_FALSE(ctx.session_active);
+}
+
+// The EV is already plugged in, so this is not the connect-timeout case: the generic
+// deauthorized flow applies and no Timeout transaction-finished event may be emitted.
+TEST_F(ChargerTest, DeauthorizeWhilePluggedInIdleDoesNotStopWithTimeout) {
+    auto& ctx = charger->get_shared_context();
+
+    ctx.current_state = Charger::EvseState::Idle;
+    ctx.session_active = true;
+    ctx.flag_authorized = true;
+    ctx.flag_ev_plugged_in = true;
+    ctx.flag_transaction_active = false;
+
+    reset_last_event();
+    EXPECT_TRUE(charger->deauthorize());
+
+    EXPECT_FALSE(last_transaction_finished_reason.has_value());
+    EXPECT_FALSE(ctx.flag_authorized);
+    EXPECT_FALSE(ctx.session_active);
+}
+
+// The EV is plugged in (WaitingForAuthentication is only entered via CarPluggedIn), so a
+// deauthorization here is outside the idle connect-timeout case: no transaction-finished
+// event with reason Timeout may be emitted, the generic path applies.
+TEST_F(ChargerTest, DeauthorizeWhilePluggedInDoesNotStopWithTimeout) {
+    auto& ctx = charger->get_shared_context();
+
+    ctx.current_state = Charger::EvseState::WaitingForAuthentication;
+    ctx.session_active = true;
+    ctx.flag_ev_plugged_in = true;
+    ctx.flag_authorized = true;
+    ctx.flag_transaction_active = false;
+
+    reset_last_event();
+    EXPECT_TRUE(charger->deauthorize());
+
+    EXPECT_FALSE(last_transaction_finished_reason.has_value());
+    EXPECT_FALSE(ctx.flag_authorized);
+    EXPECT_FALSE(ctx.session_active);
+}
+
+// No authorization was ever granted: deauthorize() must keep emitting a PluginTimeout event
+// and must not emit a transaction-finished event.
+TEST_F(ChargerTest, ConnectTimeoutWithoutAuthorizationRaisesPluginTimeout) {
+    auto& ctx = charger->get_shared_context();
+    charger->get_config_context().raise_mrec9 = false;
+
+    ctx.current_state = Charger::EvseState::WaitingForAuthentication;
+    ctx.session_active = true;
+    ctx.flag_authorized = false;
+    ctx.flag_transaction_active = false;
+
+    reset_last_event();
+    EXPECT_FALSE(charger->deauthorize());
+
+    EXPECT_EQ(last_event, SessionEventEnum::PluginTimeout);
+    EXPECT_FALSE(last_transaction_finished_reason.has_value());
 }
 
 } // namespace


### PR DESCRIPTION
## Describe your changes

SIL module and device-model config fixes from OCTT certification.

- EvseManager: a granted authorization with no EV connection before the
  connection timeout now ends the transaction with
  StopTransactionReason::Timeout instead of a generic stop (TC_F_04_CS).
- EvManager: preserve the simulated plug state on reset completion so
  later commands act on the real line, and fail fast when waiting on a
  V2G session that never started.
- Config: trim advertised measurands (values and defaults) to what the
  SIL powermeter produces (TC_J_01/02/09); seed
  ISO15118Ctrlr.CountryName=DE (ReadWrite) to unblock CSR generation
  (TC_M_23_CS); align NetworkConnectionProfiles messageTimeout with the
  device model (TC_E_41/42).

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

### Verification
- EvseManagerCharger and EvManager ctest suites green; JSON validated.
