### PR TITLE
fix(Huawei_V100R023C10): initialize externally provided connector data

### DIFF
--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/connector_base/base.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/connector_base/base.hpp
@@ -102,7 +102,7 @@ private:
     std::string log_prefix;
     std::string telemetry_subtopic;
 
-    std::atomic<bool> module_placeholder_allocation_failure_raised;
+    std::atomic<bool> module_placeholder_allocation_failure_raised{false};
 
     std::mutex connector_mutex;
 
@@ -114,17 +114,17 @@ private:
     Everest::PtrContainer<Huawei_V100R023C10> mod;
 
     types::power_supply_DC::Capabilities caps;
-    types::power_supply_DC::Mode last_mode;
-    types::power_supply_DC::ChargingPhase last_phase;
+    types::power_supply_DC::Mode last_mode{types::power_supply_DC::Mode::Off};
+    types::power_supply_DC::ChargingPhase last_phase{types::power_supply_DC::ChargingPhase::Other};
 
     double export_voltage{0.};
     double export_current_limit{0.};
 
     struct {
-        std::atomic<float> upstream_voltage;
-        std::atomic<float> output_voltage;
-        std::atomic<float> output_current;
-        std::atomic<ContactorStatus> contactor_status;
+        std::atomic<float> upstream_voltage{0.0f};
+        std::atomic<float> output_voltage{0.0f};
+        std::atomic<float> output_current{0.0f};
+        std::atomic<ContactorStatus> contactor_status{ContactorStatus::OFF};
     } external_provided_data;
 };
 

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/connector_base/base.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/connector_base/base.hpp
@@ -121,10 +121,10 @@ private:
     double export_current_limit{0.};
 
     struct {
-        std::atomic<float> upstream_voltage;
-        std::atomic<float> output_voltage;
-        std::atomic<float> output_current;
-        std::atomic<ContactorStatus> contactor_status;
+        std::atomic<float> upstream_voltage{0.0f};
+        std::atomic<float> output_voltage{0.0f};
+        std::atomic<float> output_current{0.0f};
+        std::atomic<ContactorStatus> contactor_status{ContactorStatus::OFF};
     } external_provided_data;
 };
 

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/connector_base/base.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/connector_base/base.hpp
@@ -102,7 +102,7 @@ private:
     std::string log_prefix;
     std::string telemetry_subtopic;
 
-    std::atomic<bool> module_placeholder_allocation_failure_raised;
+    std::atomic<bool> module_placeholder_allocation_failure_raised{false};
 
     std::mutex connector_mutex;
 
@@ -114,8 +114,8 @@ private:
     Everest::PtrContainer<Huawei_V100R023C10> mod;
 
     types::power_supply_DC::Capabilities caps;
-    types::power_supply_DC::Mode last_mode;
-    types::power_supply_DC::ChargingPhase last_phase;
+    types::power_supply_DC::Mode last_mode{types::power_supply_DC::Mode::Off};
+    types::power_supply_DC::ChargingPhase last_phase{types::power_supply_DC::ChargingPhase::Other};
 
     double export_voltage{0.};
     double export_current_limit{0.};


### PR DESCRIPTION

## Describe your changes

Members of external_provided_data were default-constructed so the dispenser could potentially report a garbage contactor status and voltage/current readings to the PSU between module start and the first BSP PowerOn/PowerOff event. This could fail the power unit's boot self-check with Gun Contactor Abnormal. Initialize to contactors off / 0 V / 0 A.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

