### PR TITLE
Add RsModDefMeter: a profile-driven generic powermeter module

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -170,6 +170,7 @@ everest_crate_index.from_cargo(
     manifests = [
         "@everest-core//modules:Cargo.toml",
         "@everest-core//modules/HardwareDrivers/PowerMeters/RsIskraMeter:Cargo.toml",
+        "@everest-core//modules/HardwareDrivers/PowerMeters/RsModDefMeter:Cargo.toml",
         "@everest-core//modules/HardwareDrivers/Payment/RsPaymentTerminal:Cargo.toml",
         "@everest-core//modules/Examples/RustExamples/RsExample:Cargo.toml",
         "@everest-core//modules/Examples/RustExamples/RsExampleUser:Cargo.toml",

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -38,6 +38,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "RsModDefMeter"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "everestrs",
+ "everestrs-build",
+ "log",
+ "mockall 0.12.1",
+ "mockall_double",
+ "moddef-core",
+ "pollster",
+]
+
+[[package]]
 name = "RsPaymentTerminal"
 version = "0.1.0"
 dependencies = [
@@ -264,6 +279,18 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bitflags"
@@ -511,6 +538,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "everestrs"
 version = "0.25.0"
 dependencies = [
@@ -557,6 +594,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "float-cmp"
@@ -683,6 +726,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -892,6 +946,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,10 +992,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
+name = "logos"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7251356ef8cb7aec833ddf598c6cb24d17b689d20b993f9d11a3d764e34e6458"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f80069600c0d66734f5ff52cc42f2dabd6b29d205f333d61fd7832e9e9963f"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24fb722b06a9dc12adb0963ed585f19fc61dc5413e6a9be9422ef92c091e731d"
+dependencies = [
+ "logos-codegen",
+]
 
 [[package]]
 name = "matchit"
@@ -945,6 +1047,28 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
 
 [[package]]
 name = "mime"
@@ -1065,6 +1189,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "moddef-core"
+version = "0.1.0"
+source = "git+https://github.com/ModDefOrg/moddef-rs#7ef99d09ade7c6806d50f7ad3c06ab7de4db1bdf"
+dependencies = [
+ "pbjson",
+ "pbjson-build",
+ "prost 0.13.5",
+ "prost-build",
+ "protox",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,10 +1260,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "pbjson"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e6349fa080353f4a597daffd05cb81572a9c031a6d4fff7e504947496fcc68"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+]
+
+[[package]]
+name = "pbjson-build"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eea3058763d6e656105d1403cb04e0a41b7bbac6362d413e7c33be0c32279c9"
+dependencies = [
+ "heck",
+ "itertools 0.13.0",
+ "prost 0.13.5",
+ "prost-types",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.12.1",
+]
 
 [[package]]
 name = "pin-project"
@@ -1153,6 +1330,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pollster"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,7 +1358,7 @@ checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
  "float-cmp",
- "itertools",
+ "itertools 0.10.5",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -1214,6 +1397,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc83ee4a840062f368f9096d80077a9841ec117e17e7f700df81958f1451254"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,7 +1422,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools 0.10.5",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost 0.13.5",
+ "prost-types",
+ "regex",
+ "syn 2.0.98",
+ "tempfile",
 ]
 
 [[package]]
@@ -1239,10 +1462,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5edd582b62f5cde844716e66d92565d7faf7ab1445c8cebce6e00fba83ddb2"
+dependencies = [
+ "logos",
+ "miette",
+ "once_cell",
+ "prost 0.13.5",
+ "prost-types",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
+]
+
+[[package]]
+name = "protox"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f352af331bf637b8ecc720f7c87bf903d2571fa2e14a66e9b2558846864b54a"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost 0.13.5",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a462d115462c080ae000c29a47f0b3985737e5d3a995fcdbcaa5c782068dde"
+dependencies = [
+ "logos",
+ "miette",
+ "prost-types",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1253,6 +1538,12 @@ checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1281,7 +1572,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1318,6 +1609,19 @@ name = "rust-fuzzy-search"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a157657054ffe556d8858504af8a672a054a6e0bd9e8ee531059100c0fa11bb2"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "rustversion"
@@ -1450,6 +1754,19 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "termcolor"
@@ -1605,7 +1922,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -1616,8 +1933,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
- "prost-derive",
+ "prost 0.11.9",
+ "prost-derive 0.11.9",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
    "HardwareDrivers/PowerMeters/RsIskraMeter",
+   "HardwareDrivers/PowerMeters/RsModDefMeter",
    "HardwareDrivers/Payment/RsPaymentTerminal",
    "Examples/RustExamples/RsExample",
    "Examples/RustExamples/RsExampleUser",

--- a/modules/HardwareDrivers/PowerMeters/CMakeLists.txt
+++ b/modules/HardwareDrivers/PowerMeters/CMakeLists.txt
@@ -8,4 +8,5 @@ ev_add_module(CarloGavazzi_EM580)
 
 if(${EVEREST_ENABLE_RS_SUPPORT})
     ev_add_module(RsIskraMeter)
+    ev_add_module(RsModDefMeter)
 endif()

--- a/modules/HardwareDrivers/PowerMeters/RsModDefMeter/BUILD.bazel
+++ b/modules/HardwareDrivers/PowerMeters/RsModDefMeter/BUILD.bazel
@@ -1,0 +1,70 @@
+# NOTE: The Bazel build additionally requires `moddef-core` (git) and `pollster`
+# to be present in the EVerest crate universe so `all_crate_deps` can resolve
+# them. Until the crate index is updated, build via cargo:
+#   EVEREST_CORE_ROOT=<repo root> cargo build   (from this module directory)
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
+load("@everest_crate_index//:defs.bzl", "all_crate_deps")
+load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
+
+cargo_build_script(
+    name = "build_script",
+    srcs = ["build.rs"],
+    edition = "2021",
+    build_script_env = {
+        "EVEREST_CORE_ROOT": "../../../..",
+    },
+    data = [
+        "manifest.yaml",
+        "@everest-core//errors",
+        "@everest-core//interfaces",
+        "@everest-core//types",
+    ],
+    deps = all_crate_deps(build = True) + [
+        "//lib/everest/framework/everestrs/everestrs-build",
+    ],
+)
+
+rust_binary(
+    name = "RsModDefMeterBinary",
+    srcs = glob(["src/*.rs"]),
+    edition = "2021",
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    visibility = ["//visibility:public"],
+    deps = all_crate_deps(normal = True) + [
+        ":build_script",
+        "//lib/everest/framework/everestrs/everestrs",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_sys",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_bridge",
+    ],
+)
+
+rust_test(
+    name = "RsModDefMeterTest",
+    edition = "2021",
+    srcs = [],
+    crate = ":RsModDefMeterBinary",
+)
+
+binary = ":RsModDefMeterBinary"
+manifest = ":manifest.yaml"
+name = "RsModDefMeter"
+
+genrule(
+    name = "copy_to_subdir",
+    srcs = [binary, manifest],
+    outs = [
+        "{}/manifest.yaml".format(name),
+        "{}/{}".format(name, name),
+    ],
+    cmd = "mkdir -p $(RULEDIR)/{} && ".format(name) +
+          "cp $(location {}) $(RULEDIR)/{}/{} && ".format(binary, name, name) +
+          "cp $(location {}) $(RULEDIR)/{}/".format(manifest, name),
+)
+
+filegroup(
+    name = name,
+    srcs = [
+        ":copy_to_subdir",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/modules/HardwareDrivers/PowerMeters/RsModDefMeter/BUILD.bazel
+++ b/modules/HardwareDrivers/PowerMeters/RsModDefMeter/BUILD.bazel
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 ModDefOrg and Contributors to EVerest
+#
 # NOTE: The Bazel build additionally requires `moddef-core` (git) and `pollster`
 # to be present in the EVerest crate universe so `all_crate_deps` can resolve
 # them. Until the crate index is updated, build via cargo:

--- a/modules/HardwareDrivers/PowerMeters/RsModDefMeter/Cargo.toml
+++ b/modules/HardwareDrivers/PowerMeters/RsModDefMeter/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 ModDefOrg and Contributors to EVerest
+
 [package]
 name = "RsModDefMeter"
 version = "0.1.0"

--- a/modules/HardwareDrivers/PowerMeters/RsModDefMeter/Cargo.toml
+++ b/modules/HardwareDrivers/PowerMeters/RsModDefMeter/Cargo.toml
@@ -18,3 +18,11 @@ pollster = "0.3"
 anyhow = "1.0"
 log = "0.4"
 chrono = "0.4"
+# Optional, mirrors RsIskraMeter: the everestrs-generated code gates its mock
+# publisher behind these, so declaring them keeps `cfg(feature = "mockall")`
+# known (no warnings) and enables mock-based unit tests.
+mockall = { version = "0.12.1", optional = true }
+mockall_double = { version = "0.3.1", optional = true }
+
+[features]
+default = ["mockall", "mockall_double"]

--- a/modules/HardwareDrivers/PowerMeters/RsModDefMeter/Cargo.toml
+++ b/modules/HardwareDrivers/PowerMeters/RsModDefMeter/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "RsModDefMeter"
+version = "0.1.0"
+edition = "2021"
+
+[build-dependencies]
+everestrs-build = { workspace = true }
+
+[dependencies]
+everestrs = { workspace = true }
+# ModDef runtime: profile loading, the Device facade, run_command and the
+# Transport trait we bridge onto the serial_communication_hub.
+moddef-core = { git = "https://github.com/ModDefOrg/moddef-rs" }
+# Minimal futures executor: drives moddef-core's async Device/Transport methods
+# to completion synchronously on the calling thread (all awaits complete without
+# a reactor because the transport and delay are blocking).
+pollster = "0.3"
+anyhow = "1.0"
+log = "0.4"
+chrono = "0.4"

--- a/modules/HardwareDrivers/PowerMeters/RsModDefMeter/README.md
+++ b/modules/HardwareDrivers/PowerMeters/RsModDefMeter/README.md
@@ -1,0 +1,65 @@
+# RsModDefMeter
+
+A generic EVerest `powermeter` driver backed by a [ModDef](https://github.com/ModDefOrg/moddef)
+device profile. One binary drives **any** conforming meter: the register map, framing, scaling,
+polling and (where supported) the signed-transaction procedure all come from the profile, not from
+per-model code.
+
+## What it does
+
+- **Metering (all profiles).** Publishes the `powermeter` variable by querying the profile's
+  measurand-tagged points (`base_quantity` + phase / direction / aggregation) and rescaling each to
+  the unit the EVerest `Powermeter` field expects (Wh, W, var, V, A, Hz). Points the profile doesn't
+  provide are left absent.
+- **Signed transactions (typed-register OCMF profiles).** If the profile declares a start/stop
+  command — matched by the `command_ref` role tag `ocmf:start_transaction` / `ocmf:stop_transaction`,
+  or by the command id `start_transaction` / `stop_transaction` — the module maps the EVerest
+  `TransactionReq` onto that command's typed params and runs it through ModDef's command construct
+  (issue [moddef#2](https://github.com/ModDefOrg/moddef/issues/2)). Enum fields are resolved against
+  the profile's own enum tables (OCMF value names match), and the OCMF identification flags are routed
+  to their per-group registers. The stop command's OCMF result becomes a `SignedMeterValue`.
+- **Capability discovery.** A profile with no transaction commands publishes plain metering and
+  returns `NOT_SUPPORTED` from `start`/`stop_transaction`.
+
+Exemplar profile: **Carlo Gavazzi EM580** (`devices/energy-meter/carlo-gavazzi-em580` in the ModDef
+`devices` repo), which exposes each OCMF field as its own register.
+
+## Scope & limitations
+
+- Transactions require a **typed-register OCMF** profile (each OCMF field is a register), matching the
+  EVerest `TransactionReq` field names. Opaque-blob meters (Bauer BSM, Iskra WM3M4C) need caller-side
+  payload composition, which is not declarative — those keep their bespoke drivers, and this module
+  returns `NOT_SUPPORTED` for them (see moddef#3 for the rationale).
+- Access is **Modbus RTU via `serial_communication_hub`** only. Modbus TCP / an owned transport is a
+  future option (moddef-tokio-modbus can back the same `Transport` trait).
+- Discrete-input reads aren't offered by the hub; `COMPOSED` (multi-register mantissa/exponent)
+  measurand points aren't readable through the ModDef facade yet — such fields publish as absent.
+
+## Configuration
+
+| key | type | default | meaning |
+|---|---|---|---|
+| `profile` | string | — | path to the ModDef profile (`.moddef`, `.moddef.yaml`, `.moddef.json`) |
+| `device_id` | string | `""` | device to select when the profile has more than one |
+| `powermeter_device_id` | int | 1 | Modbus unit id on the bus |
+| `read_meter_values_interval_ms` | int | 5000 | metering publish interval |
+| `communication_errors_threshold` | int | 10 | consecutive read failures before `CommunicationFault` |
+
+## Build
+
+Needs the EVerest workspace (framework crates, interface/type YAML). From this directory:
+
+```sh
+EVEREST_CORE_ROOT=<path to everest-core repo root> cargo build
+```
+
+`moddef-core` is pulled as a git dependency, so the build needs network access. The Bazel target needs
+`moddef-core`/`pollster` added to the EVerest crate index first (see `BUILD.bazel`).
+
+## Design notes
+
+everestrs command handlers are synchronous; `moddef-core`'s `Device` is async and `&mut`. The module
+drives it with `pollster::block_on` on the metering thread and the handler threads, serialising all
+bus access behind a `Mutex<Device>`. The `Device`'s `Transport` is a thin bridge (`HubBridge`) that
+forwards `read_holding` / `read_input` / `read_coils` / `write_holding` / `write_coil` to the
+`serial_communication_hub` commands.

--- a/modules/HardwareDrivers/PowerMeters/RsModDefMeter/manifest.yaml
+++ b/modules/HardwareDrivers/PowerMeters/RsModDefMeter/manifest.yaml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 ModDefOrg and Contributors to EVerest
+
 description: >-
   Generic ModDef-driven powermeter. Loads a ModDef device profile and drives the
   EVerest powermeter interface from it: publishes the `powermeter` variable from

--- a/modules/HardwareDrivers/PowerMeters/RsModDefMeter/manifest.yaml
+++ b/modules/HardwareDrivers/PowerMeters/RsModDefMeter/manifest.yaml
@@ -1,0 +1,46 @@
+description: >-
+  Generic ModDef-driven powermeter. Loads a ModDef device profile and drives the
+  EVerest powermeter interface from it: publishes the `powermeter` variable from
+  measurand-tagged points, and (for profiles that declare transaction commands)
+  implements signed OCMF start/stop transactions via the ModDef command construct.
+  Modbus RTU access goes through a required serial_communication_hub.
+config:
+  profile:
+    description: >-
+      Path to the ModDef device profile to drive. Supports the binary (.moddef),
+      YAML (.moddef.yaml) and JSON (.moddef.json) forms; the format is chosen by
+      the file extension.
+    type: string
+  device_id:
+    description: >-
+      Selects the device within the profile when it declares more than one.
+      Empty string selects the first/only device.
+    type: string
+    default: ""
+  powermeter_device_id:
+    description: Modbus unit id of the meter on the serial bus (target_device_id)
+    type: integer
+    minimum: 0
+    maximum: 255
+    default: 1
+  read_meter_values_interval_ms:
+    description: How often to read and publish the powermeter variable, in milliseconds
+    type: integer
+    default: 5000
+    minimum: 1000
+  communication_errors_threshold:
+    description: Consecutive read failures tolerated before CommunicationFault is raised
+    type: integer
+    default: 10
+provides:
+  meter:
+    description: Generic ModDef-driven powermeter implementation
+    interface: powermeter
+requires:
+  serial_comm_hub:
+    interface: serial_communication_hub
+metadata:
+  license: https://opensource.org/licenses/Apache-2.0
+  authors:
+    - ModDefOrg
+enable_external_mqtt: false

--- a/modules/HardwareDrivers/PowerMeters/RsModDefMeter/src/main.rs
+++ b/modules/HardwareDrivers/PowerMeters/RsModDefMeter/src/main.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 ModDefOrg and Contributors to EVerest
 //
 // RsModDefMeter — a generic EVerest powermeter driven by a ModDef device profile.
 //

--- a/modules/HardwareDrivers/PowerMeters/RsModDefMeter/src/main.rs
+++ b/modules/HardwareDrivers/PowerMeters/RsModDefMeter/src/main.rs
@@ -1,0 +1,847 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// RsModDefMeter — a generic EVerest powermeter driven by a ModDef device profile.
+//
+// * Metering: publishes the `powermeter` variable for ANY profile by querying
+//   measurand-tagged points (base_quantity + phase/direction/aggregation), so no
+//   per-model code is needed.
+// * Transactions: for profiles that declare a start/stop transaction command
+//   (matched by `command_ref` role tag "ocmf:start_transaction" /
+//   "ocmf:stop_transaction", else by command_id), maps the EVerest TransactionReq
+//   onto the command's typed params and runs it via ModDef's command construct.
+//   Profiles without such commands advertise plain metering and return
+//   NOT_SUPPORTED. This works for typed-register OCMF meters (e.g. Carlo Gavazzi
+//   EM580) where each OCMF field is its own register; opaque-blob meters that need
+//   caller-side payload composition are out of scope (see the module README).
+//
+// Modbus RTU goes through the required serial_communication_hub. ModDef-core's
+// async Device/Transport methods are driven with `pollster::block_on`: the hub
+// calls and the delay are blocking, so every await completes without a reactor.
+
+include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use generated::errors::powermeter::{Error, PowermeterError};
+use generated::types::powermeter::{
+    Powermeter, TransactionReq, TransactionRequestStatus, TransactionStartResponse,
+    TransactionStopResponse,
+};
+use generated::types::serial_comm_hub_requests::{StatusCodeEnum, VectorUint16};
+use generated::types::units::{Current, Energy, Frequency, Power, ReactivePower, Voltage};
+use generated::types::units_signed::SignedMeterValue;
+use generated::{Module, SerialCommunicationHubClientPublisher};
+
+use moddef_core::measurand::measurand_matches;
+use moddef_core::schema::{Accumulation, Aggregation, Direction, ModDefDocument, PhaseRef};
+use moddef_core::{DecodedValue, Device, MeasurandQuery, ParamValue, Value};
+
+/// Role tags a profile's commands may carry (`Command.command_ref`).
+const ROLE_START: &str = "ocmf:start_transaction";
+const ROLE_STOP: &str = "ocmf:stop_transaction";
+/// Fallback command ids when a profile doesn't set `command_ref`.
+const ID_START: &str = "start_transaction";
+const ID_STOP: &str = "stop_transaction";
+
+// ---------------------------------------------------------------------------
+// Transport bridge: moddef_core::Transport over the serial_communication_hub.
+// ---------------------------------------------------------------------------
+
+/// Error surface of the hub-backed transport.
+#[derive(Debug)]
+enum HubError {
+    /// The hub command itself failed (framework/transport error).
+    Everest(::everestrs::Error),
+    /// The device replied with a non-Success Modbus status.
+    Status(StatusCodeEnum),
+    /// The reply had fewer/more words than requested, or no payload.
+    ShortResponse,
+    /// The Modbus function is not offered by the serial_communication_hub.
+    Unsupported(&'static str),
+}
+
+impl std::fmt::Display for HubError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HubError::Everest(e) => write!(f, "serial_comm_hub error: {e:?}"),
+            HubError::Status(s) => write!(f, "modbus status {s:?}"),
+            HubError::ShortResponse => write!(f, "short/empty modbus response"),
+            HubError::Unsupported(what) => write!(f, "unsupported by serial_comm_hub: {what}"),
+        }
+    }
+}
+impl std::error::Error for HubError {}
+
+/// Bridges ModDef register reads/writes onto the required serial hub. Holds a
+/// clone of the hub publisher and the target Modbus unit id.
+struct HubBridge {
+    hub: SerialCommunicationHubClientPublisher,
+    unit_id: i64,
+}
+
+impl HubBridge {
+    fn status(sc: StatusCodeEnum) -> Result<(), HubError> {
+        match sc {
+            StatusCodeEnum::Success => Ok(()),
+            other => Err(HubError::Status(other)),
+        }
+    }
+}
+
+// Note: the everestrs-generated hub command arguments are ordered ALPHABETICALLY
+// by argument name, not in manifest order — e.g.
+// modbus_read_holding_registers(first_register_address, num_registers_to_read,
+// target_device_id). Matches the RsIskraMeter usage.
+impl moddef_core::Transport for HubBridge {
+    type Error = HubError;
+
+    async fn read_holding(&mut self, offset: u16, out: &mut [u16]) -> Result<(), HubError> {
+        let res = self
+            .hub
+            .modbus_read_holding_registers(offset as i64, out.len() as i64, self.unit_id)
+            .map_err(HubError::Everest)?;
+        HubBridge::status(res.status_code)?;
+        copy_words(res.value, out)
+    }
+
+    async fn read_input(&mut self, offset: u16, out: &mut [u16]) -> Result<(), HubError> {
+        let res = self
+            .hub
+            .modbus_read_input_registers(offset as i64, out.len() as i64, self.unit_id)
+            .map_err(HubError::Everest)?;
+        HubBridge::status(res.status_code)?;
+        copy_words(res.value, out)
+    }
+
+    async fn read_coils(&mut self, offset: u16, out: &mut [bool]) -> Result<(), HubError> {
+        let res = self
+            .hub
+            .modbus_read_coils(offset as i64, out.len() as i64, self.unit_id)
+            .map_err(HubError::Everest)?;
+        HubBridge::status(res.status_code)?;
+        match res.value {
+            Some(v) if v.len() == out.len() => {
+                out.copy_from_slice(&v);
+                Ok(())
+            }
+            _ => Err(HubError::ShortResponse),
+        }
+    }
+
+    async fn read_discrete(&mut self, _offset: u16, _out: &mut [bool]) -> Result<(), HubError> {
+        Err(HubError::Unsupported("read discrete inputs"))
+    }
+
+    async fn write_holding(&mut self, offset: u16, regs: &[u16]) -> Result<(), HubError> {
+        let data = VectorUint16 {
+            data: regs.iter().map(|w| *w as i64).collect(),
+        };
+        let sc = self
+            .hub
+            .modbus_write_multiple_registers(data, offset as i64, self.unit_id)
+            .map_err(HubError::Everest)?;
+        HubBridge::status(sc)
+    }
+
+    async fn write_coil(&mut self, offset: u16, on: bool) -> Result<(), HubError> {
+        let sc = self
+            .hub
+            .modbus_write_single_coil(offset as i64, on, self.unit_id)
+            .map_err(HubError::Everest)?;
+        HubBridge::status(sc)
+    }
+}
+
+fn copy_words(value: Option<Vec<i64>>, out: &mut [u16]) -> Result<(), HubError> {
+    match value {
+        Some(v) if v.len() == out.len() => {
+            for (dst, src) in out.iter_mut().zip(v) {
+                *dst = src as u16;
+            }
+            Ok(())
+        }
+        _ => Err(HubError::ShortResponse),
+    }
+}
+
+/// Blocking delay for `run_command` poll steps. Because we drive the Device with
+/// `pollster::block_on` on a dedicated (metering or handler) thread, sleeping the
+/// thread is exactly the intended behaviour. ModDef derives command timeouts from
+/// the sum of these delays, so no wall clock is needed.
+struct BlockingDelay;
+impl moddef_core::Delay for BlockingDelay {
+    async fn delay_ms(&mut self, ms: u32) {
+        std::thread::sleep(std::time::Duration::from_millis(ms as u64));
+    }
+}
+
+type Dev = Device<'static, HubBridge>;
+
+// ---------------------------------------------------------------------------
+// Module
+// ---------------------------------------------------------------------------
+
+struct ModDefMeter {
+    /// Leaked so the borrowed `Device<'static, _>` can outlive `on_ready`. The
+    /// module runs for the process lifetime, so this is a one-time leak.
+    doc: &'static ModDefDocument,
+    device_index: usize,
+    unit_id: i64,
+    interval_ms: u64,
+    errors_threshold: usize,
+    /// Command ids resolved once at startup (None ⇒ NOT_SUPPORTED).
+    start_cmd: Option<String>,
+    stop_cmd: Option<String>,
+    /// Set in `on_ready`, once the hub publisher is available.
+    device: OnceLock<Arc<Mutex<Dev>>>,
+}
+
+impl generated::OnReadySubscriber for ModDefMeter {
+    fn on_ready(&self, publishers: &generated::ModulePublisher) {
+        let bridge = HubBridge {
+            hub: publishers.serial_comm_hub.clone(),
+            unit_id: self.unit_id,
+        };
+        let device = Device::from_profile(&self.doc.devices[self.device_index], bridge);
+        let device = Arc::new(Mutex::new(device));
+        if self.device.set(device.clone()).is_err() {
+            log::warn!("on_ready called twice; ignoring");
+            return;
+        }
+
+        // Best-effort: publish the OCMF public key if the profile exposes one.
+        if let Some(pk) = read_public_key(&device) {
+            if let Err(e) = publishers.meter.public_key_ocmf(pk) {
+                log::warn!("failed to publish public_key_ocmf: {e:?}");
+            }
+        }
+
+        // Fixed-rate metering loop.
+        let meter_pub = publishers.meter.clone();
+        let interval = std::time::Duration::from_millis(self.interval_ms);
+        let threshold = self.errors_threshold;
+        std::thread::spawn(move || {
+            let mut consecutive_failures = 0usize;
+            loop {
+                let start = std::time::Instant::now();
+                let result = {
+                    let mut dev = device.lock().expect("device mutex poisoned");
+                    read_powermeter(&mut dev)
+                };
+                match result {
+                    Ok(meter) => {
+                        if let Err(e) = meter_pub.powermeter(meter) {
+                            log::error!("failed to publish powermeter: {e:?}");
+                        }
+                        if consecutive_failures >= threshold {
+                            meter_pub.clear_error(Error::Powermeter(
+                                PowermeterError::CommunicationFault,
+                            ));
+                        }
+                        consecutive_failures = 0;
+                    }
+                    Err(e) => {
+                        consecutive_failures += 1;
+                        log::warn!("meter read failed ({consecutive_failures}/{threshold}): {e:?}");
+                        if consecutive_failures == threshold {
+                            meter_pub.raise_error(
+                                Error::Powermeter(PowermeterError::CommunicationFault).into(),
+                            );
+                        }
+                    }
+                }
+                let took = start.elapsed();
+                if took < interval {
+                    std::thread::sleep(interval - took);
+                }
+            }
+        });
+    }
+}
+
+impl generated::SerialCommunicationHubClientSubscriber for ModDefMeter {}
+
+impl generated::PowermeterServiceSubscriber for ModDefMeter {
+    fn start_transaction(
+        &self,
+        _context: &generated::Context,
+        value: TransactionReq,
+    ) -> ::everestrs::Result<TransactionStartResponse> {
+        let Some(cmd) = self.start_cmd.as_deref() else {
+            return Ok(start_not_supported());
+        };
+        let Some(device) = self.device.get() else {
+            return Err(::everestrs::Error::HandlerException(
+                "not initialized".into(),
+            ));
+        };
+        let mut dev = device
+            .lock()
+            .map_err(|_| ::everestrs::Error::HandlerException("device mutex poisoned".into()))?;
+        match run_start(&mut dev, cmd, &value, self.doc) {
+            Ok(resp) => Ok(resp),
+            Err(e) => {
+                log::error!("start_transaction failed: {e:?}");
+                Ok(start_err(&e))
+            }
+        }
+    }
+
+    fn stop_transaction(
+        &self,
+        _context: &generated::Context,
+        _transaction_id: String,
+    ) -> ::everestrs::Result<TransactionStopResponse> {
+        let Some(cmd) = self.stop_cmd.as_deref() else {
+            return Ok(stop_not_supported());
+        };
+        let Some(device) = self.device.get() else {
+            return Err(::everestrs::Error::HandlerException(
+                "not initialized".into(),
+            ));
+        };
+        let mut dev = device
+            .lock()
+            .map_err(|_| ::everestrs::Error::HandlerException("device mutex poisoned".into()))?;
+        match run_stop(&mut dev, cmd) {
+            Ok(resp) => Ok(resp),
+            Err(e) => {
+                log::error!("stop_transaction failed: {e:?}");
+                Ok(stop_err(&e))
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Metering: measurand-tagged points → Powermeter
+// ---------------------------------------------------------------------------
+
+/// A physical quantity we read from the profile, with the unit the EVerest
+/// Powermeter field expects (so we can rescale from the point's own unit).
+#[derive(Clone, Copy)]
+enum Kind {
+    Energy, // Wh
+    Power,  // W
+    Var,    // var
+    Volt,   // V
+    Amp,    // A
+    Hertz,  // Hz
+}
+
+/// Find the value for a measurand query, rescaled to `kind`'s canonical EVerest
+/// unit. Returns Ok(None) when the profile has no matching point (field stays
+/// absent); Err only on a real read/transport failure.
+fn read_field(dev: &mut Dev, q: &MeasurandQuery, kind: Kind) -> anyhow::Result<Option<f64>> {
+    // Collect matching (point_id, unit) first — `points()` borrows the device
+    // immutably, so finish before the mutable `read_point`.
+    let mut matches: Vec<(String, String)> = dev
+        .points()
+        .filter(|p| measurand_matches(p.measurand.as_ref(), q))
+        .map(|p| (p.point_id.clone(), p.unit.clone()))
+        .collect();
+    if matches.is_empty() {
+        return Ok(None);
+    }
+    if matches.len() > 1 {
+        // Ambiguous tuple (e.g. a live value and its signed-snapshot twin).
+        // Prefer the point whose unit already matches the target, else the first.
+        matches.sort_by_key(|(_, unit)| {
+            if unit_scale(unit, kind).is_some() {
+                0
+            } else {
+                1
+            }
+        });
+        log::debug!(
+            "measurand {} matched {} points; using {}",
+            q.base_quantity,
+            matches.len(),
+            matches[0].0
+        );
+    }
+    let (id, unit) = &matches[0];
+    let decoded =
+        pollster::block_on(dev.read_point(id)).map_err(|e| anyhow::anyhow!("read {id}: {e}"))?;
+    let Some(raw) = decoded.as_f64() else {
+        return Ok(None);
+    };
+    let scale = unit_scale(unit, kind).unwrap_or(1.0);
+    Ok(Some(raw * scale))
+}
+
+/// Multiplier taking a value in `unit` to `kind`'s canonical EVerest unit
+/// (Wh / W / var / V / A / Hz). `None` if the unit isn't recognised for `kind`.
+fn unit_scale(unit: &str, kind: Kind) -> Option<f64> {
+    match kind {
+        Kind::Energy => match unit {
+            "Wh" => Some(1.0),
+            "kWh" => Some(1_000.0),
+            "MWh" => Some(1_000_000.0),
+            _ => None,
+        },
+        Kind::Power => match unit {
+            "W" => Some(1.0),
+            "kW" => Some(1_000.0),
+            _ => None,
+        },
+        Kind::Var => match unit {
+            "var" => Some(1.0),
+            "kvar" => Some(1_000.0),
+            _ => None,
+        },
+        Kind::Volt => match unit {
+            "V" => Some(1.0),
+            "kV" => Some(1_000.0),
+            "mV" => Some(0.001),
+            _ => None,
+        },
+        Kind::Amp => match unit {
+            "A" => Some(1.0),
+            "mA" => Some(0.001),
+            _ => None,
+        },
+        Kind::Hertz => match unit {
+            "Hz" => Some(1.0),
+            _ => None,
+        },
+    }
+}
+
+fn energy(dev: &mut Dev, dir: Direction) -> anyhow::Result<Option<Energy>> {
+    let q = MeasurandQuery::base("energy_active")
+        .direction(dir)
+        .accumulation(Accumulation::Register)
+        .aggregation(Aggregation::Total);
+    Ok(read_field(dev, &q, Kind::Energy)?.map(|total| Energy {
+        total,
+        l_1: None,
+        l_2: None,
+        l_3: None,
+    }))
+}
+
+fn read_powermeter(dev: &mut Dev) -> anyhow::Result<Powermeter> {
+    // Per-phase + total active power.
+    let p = |dev: &mut Dev, phase: Option<PhaseRef>| -> anyhow::Result<Option<f64>> {
+        let mut q = MeasurandQuery::base("active_power");
+        q = match phase {
+            Some(ph) => q.phase(ph),
+            None => q.aggregation(Aggregation::Total),
+        };
+        read_field(dev, &q, Kind::Power)
+    };
+    let power = Power {
+        total: p(dev, None)?.unwrap_or(0.0),
+        l_1: p(dev, Some(PhaseRef::L1))?,
+        l_2: p(dev, Some(PhaseRef::L2))?,
+        l_3: p(dev, Some(PhaseRef::L3))?,
+    };
+
+    let v = |dev: &mut Dev, phase: PhaseRef| {
+        read_field(
+            dev,
+            &MeasurandQuery::base("voltage").phase(phase),
+            Kind::Volt,
+        )
+    };
+    let voltage = Voltage {
+        dc: None,
+        l_1: v(dev, PhaseRef::L1N)?,
+        l_2: v(dev, PhaseRef::L2N)?,
+        l_3: v(dev, PhaseRef::L3N)?,
+    };
+
+    let c = |dev: &mut Dev, phase: PhaseRef| {
+        read_field(
+            dev,
+            &MeasurandQuery::base("current").phase(phase),
+            Kind::Amp,
+        )
+    };
+    let current = Current {
+        dc: None,
+        l_1: c(dev, PhaseRef::L1)?,
+        l_2: c(dev, PhaseRef::L2)?,
+        l_3: c(dev, PhaseRef::L3)?,
+        n: None,
+    };
+
+    let r = |dev: &mut Dev, phase: Option<PhaseRef>| -> anyhow::Result<Option<f64>> {
+        let mut q = MeasurandQuery::base("reactive_power");
+        q = match phase {
+            Some(ph) => q.phase(ph),
+            None => q.aggregation(Aggregation::Total),
+        };
+        read_field(dev, &q, Kind::Var)
+    };
+    let var = match r(dev, None)? {
+        Some(total) => {
+            let l_1 = r(dev, Some(PhaseRef::L1))?;
+            let l_2 = r(dev, Some(PhaseRef::L2))?;
+            let l_3 = r(dev, Some(PhaseRef::L3))?;
+            Some(ReactivePower {
+                total,
+                l_1,
+                l_2,
+                l_3,
+            })
+        }
+        None => None,
+    };
+
+    let frequency =
+        read_field(dev, &MeasurandQuery::base("frequency"), Kind::Hertz)?.map(|l_1| Frequency {
+            l_1,
+            l_2: None,
+            l_3: None,
+        });
+
+    let energy_wh_import = energy(dev, Direction::Import)?.unwrap_or(Energy {
+        total: 0.0,
+        l_1: None,
+        l_2: None,
+        l_3: None,
+    });
+    let energy_wh_export = energy(dev, Direction::Export)?;
+
+    Ok(Powermeter {
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        energy_wh_import,
+        energy_wh_export,
+        power_w: Some(power),
+        voltage_v: Some(voltage),
+        current_a: Some(current),
+        frequency_hz: frequency,
+        var,
+        meter_id: None,
+        phase_seq_error: None,
+        // Signed / extension fields are populated by the transaction flow, not
+        // the live metering loop.
+        energy_wh_import_signed: None,
+        energy_wh_export_signed: None,
+        power_w_signed: None,
+        voltage_v_signed: None,
+        current_a_signed: None,
+        frequency_hz_signed: None,
+        var_signed: None,
+        signed_meter_value: None,
+        temperatures: None,
+    })
+}
+
+fn read_public_key(device: &Arc<Mutex<Dev>>) -> Option<String> {
+    let mut dev = device.lock().ok()?;
+    let id = dev
+        .points()
+        .find(|p| p.point_id.contains("public_key"))
+        .map(|p| p.point_id.clone())?;
+    match pollster::block_on(dev.read_point(&id)) {
+        Ok(DecodedValue::Bytes(b)) => Some(hex(&b)),
+        Ok(DecodedValue::Str(s)) => Some(s),
+        _ => None,
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02X}"));
+    }
+    s
+}
+
+// ---------------------------------------------------------------------------
+// Transactions
+// ---------------------------------------------------------------------------
+
+/// Build the command params from a TransactionReq and run the start command.
+fn run_start(
+    dev: &mut Dev,
+    cmd_id: &str,
+    req: &TransactionReq,
+    doc: &'static ModDefDocument,
+) -> anyhow::Result<TransactionStartResponse> {
+    // The command's declared params tell us which OCMF fields this meter exposes
+    // as registers and which enum each maps to. Unset/absent params are skipped
+    // by the executor (the meter's defaults are valid).
+    let cmd = dev
+        .profile()
+        .commands
+        .iter()
+        .find(|c| c.command_id == cmd_id)
+        .ok_or_else(|| anyhow::anyhow!("command {cmd_id} not found"))?;
+
+    let has = |field: &str| cmd.params.iter().any(|p| p.field == field);
+
+    let mut params: Vec<(&str, ParamValue<'_>)> = Vec::new();
+
+    // String / free-text fields.
+    if has("transaction_id") && !req.transaction_id.is_empty() {
+        params.push(("transaction_id", ParamValue::Str(&req.transaction_id)));
+    }
+    if has("evse_id") && !req.evse_id.is_empty() {
+        params.push(("evse_id", ParamValue::Str(&req.evse_id)));
+    }
+    if let Some(ref data) = req.identification_data {
+        if has("identification_data") {
+            params.push(("identification_data", ParamValue::Str(data)));
+        }
+    }
+    if let Some(ref tt) = req.tariff_text {
+        if has("tariff_text") {
+            params.push(("tariff_text", ParamValue::Str(tt)));
+        }
+    }
+
+    // Enum fields: resolve the EVerest enum variant NAME against the profile's
+    // enum (value names match OCMF) to get the numeric register value. Kept as
+    // flat statements (no closure over `enum_vals`) to avoid borrow conflicts.
+    let mut enum_vals: Vec<(&'static str, i64)> = Vec::new();
+
+    let status_name = enum_name(&req.identification_status);
+    if let Some(v) = resolve_param(cmd, doc, "identification_status", &status_name) {
+        enum_vals.push(("identification_status", v));
+    }
+    if let Some(ref lvl) = req.identification_level {
+        let name = enum_name(lvl);
+        if let Some(v) = resolve_param(cmd, doc, "identification_level", &name) {
+            enum_vals.push(("identification_level", v));
+        }
+    }
+    let type_name = enum_name(&req.identification_type);
+    if let Some(v) = resolve_param(cmd, doc, "identification_type", &type_name) {
+        enum_vals.push(("identification_type", v));
+    }
+
+    // Flags: route each flag to its group param (by name prefix) and resolve.
+    for flag in &req.identification_flags {
+        let name = enum_name(flag);
+        if let Some(field) = flag_group_field(&name) {
+            if let Some(v) = resolve_param(cmd, doc, field, &name) {
+                enum_vals.push((field, v));
+            }
+        }
+    }
+    for (field, v) in &enum_vals {
+        params.push((field, ParamValue::Value(Value::I64(*v))));
+    }
+
+    let mut delay = BlockingDelay;
+    let out = pollster::block_on(dev.run_command(cmd_id, &params, &mut delay))
+        .map_err(|e| anyhow::anyhow!("run_command {cmd_id}: {e}"))?;
+    let _ = out; // start typically only signals status; success ⇒ OK below.
+
+    Ok(TransactionStartResponse {
+        status: TransactionRequestStatus::OK,
+        error: None,
+        transaction_min_stop_time: None,
+        transaction_max_stop_time: None,
+        signed_meter_value: None,
+    })
+}
+
+fn run_stop(dev: &mut Dev, cmd_id: &str) -> anyhow::Result<TransactionStopResponse> {
+    let mut delay = BlockingDelay;
+    let out = pollster::block_on(dev.run_command(cmd_id, &[], &mut delay))
+        .map_err(|e| anyhow::anyhow!("run_command {cmd_id}: {e}"))?;
+
+    let smv = signed_meter_value_from(&out);
+    Ok(TransactionStopResponse {
+        status: TransactionRequestStatus::OK,
+        error: None,
+        start_signed_meter_value: None,
+        signed_meter_value: smv,
+    })
+}
+
+/// Assemble a SignedMeterValue from a stop command's results. Looks for an OCMF
+/// payload result field (`ocmf` or `signed_meter_value`) and an optional
+/// `public_key`.
+fn signed_meter_value_from(out: &BTreeMap<&str, DecodedValue>) -> Option<SignedMeterValue> {
+    let payload = out
+        .get("ocmf")
+        .or_else(|| out.get("signed_meter_value"))
+        .or_else(|| out.get("message"))?;
+    let signed_meter_data = match payload {
+        DecodedValue::Str(s) => s.clone(),
+        DecodedValue::Bytes(b) => String::from_utf8_lossy(b).into_owned(),
+        _ => return None,
+    };
+    let public_key = out.get("public_key").and_then(|v| match v {
+        DecodedValue::Str(s) => Some(s.clone()),
+        DecodedValue::Bytes(b) => Some(hex(b)),
+        _ => None,
+    });
+    Some(SignedMeterValue {
+        signed_meter_data,
+        signing_method: String::new(),
+        encoding_method: "OCMF".to_string(),
+        public_key,
+        timestamp: None,
+    })
+}
+
+/// The enum `type_id` a command param references, if it is an enum-typed param.
+/// `ValueType` carries the reference inside its `kind` oneof.
+fn param_enum_type_id<'a>(cmd: &'a moddef_core::schema::Command, field: &str) -> Option<&'a str> {
+    use moddef_core::schema::value_type::Kind;
+    let p = cmd.params.iter().find(|p| p.field == field)?;
+    match p.value_type.as_ref()?.kind.as_ref()? {
+        Kind::EnumRef(er) => Some(er.type_id.as_str()),
+        _ => None,
+    }
+}
+
+/// Resolve an EVerest enum value `name` to the numeric value the profile's
+/// enum (referenced by the command param `field`) assigns it.
+fn resolve_param(
+    cmd: &moddef_core::schema::Command,
+    doc: &ModDefDocument,
+    field: &str,
+    name: &str,
+) -> Option<i64> {
+    let type_id = param_enum_type_id(cmd, field)?;
+    resolve_enum(doc, type_id, name)
+}
+
+/// Resolve an enum value name to its numeric value within `doc`'s enum table.
+fn resolve_enum(doc: &ModDefDocument, type_id: &str, name: &str) -> Option<i64> {
+    doc.enums
+        .iter()
+        .find(|e| e.type_id == type_id)?
+        .values
+        .iter()
+        .find(|v| v.name == name)
+        .map(|v| v.value)
+}
+
+/// Group param a given OCMF IF flag belongs to (EM580 splits IF into four
+/// registers, one per group).
+fn flag_group_field(flag_name: &str) -> Option<&'static str> {
+    if flag_name.starts_with("RFID_") {
+        Some("identification_flags_rfid")
+    } else if flag_name.starts_with("OCPP_") {
+        Some("identification_flags_ocpp")
+    } else if flag_name.starts_with("ISO15118_") {
+        Some("identification_flags_iso15118")
+    } else if flag_name.starts_with("PLMN_") {
+        Some("identification_flags_plmn")
+    } else {
+        None
+    }
+}
+
+/// The EVerest OCMF enums are fieldless, so their Debug repr is exactly the
+/// enum value name (e.g. `ISO14443`, `RFID_PLAIN`) — which matches the profile
+/// enum value names. This avoids a ~50-arm hand-written mapping.
+fn enum_name<T: std::fmt::Debug>(v: &T) -> String {
+    format!("{v:?}")
+}
+
+// ---------------------------------------------------------------------------
+// Response constructors
+// ---------------------------------------------------------------------------
+
+fn start_not_supported() -> TransactionStartResponse {
+    TransactionStartResponse {
+        status: TransactionRequestStatus::NOT_SUPPORTED,
+        error: Some("profile declares no start_transaction command".into()),
+        transaction_min_stop_time: None,
+        transaction_max_stop_time: None,
+        signed_meter_value: None,
+    }
+}
+fn start_err<E: std::fmt::Debug>(e: &E) -> TransactionStartResponse {
+    TransactionStartResponse {
+        status: TransactionRequestStatus::UNEXPECTED_ERROR,
+        error: Some(format!("{e:?}")),
+        transaction_min_stop_time: None,
+        transaction_max_stop_time: None,
+        signed_meter_value: None,
+    }
+}
+fn stop_not_supported() -> TransactionStopResponse {
+    TransactionStopResponse {
+        status: TransactionRequestStatus::NOT_SUPPORTED,
+        error: Some("profile declares no stop_transaction command".into()),
+        start_signed_meter_value: None,
+        signed_meter_value: None,
+    }
+}
+fn stop_err<E: std::fmt::Debug>(e: &E) -> TransactionStopResponse {
+    TransactionStopResponse {
+        status: TransactionRequestStatus::UNEXPECTED_ERROR,
+        error: Some(format!("{e:?}")),
+        start_signed_meter_value: None,
+        signed_meter_value: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Startup
+// ---------------------------------------------------------------------------
+
+/// Resolve the command implementing a role: prefer a `command_ref` match, then
+/// fall back to a well-known `command_id`.
+fn find_command(
+    profile: &moddef_core::schema::DeviceProfile,
+    role: &str,
+    id: &str,
+) -> Option<String> {
+    profile
+        .commands
+        .iter()
+        .find(|c| c.command_ref == role)
+        .or_else(|| profile.commands.iter().find(|c| c.command_id == id))
+        .map(|c| c.command_id.clone())
+}
+
+#[everestrs::main]
+fn main(module: &Module) {
+    let config = module.get_config();
+
+    let doc = moddef_core::load(&config.profile)
+        .unwrap_or_else(|e| panic!("failed to load ModDef profile {}: {e}", config.profile));
+    let doc: &'static ModDefDocument = Box::leak(Box::new(doc));
+
+    if doc.devices.is_empty() {
+        panic!("profile {} declares no devices", config.profile);
+    }
+    let device_index = if config.device_id.is_empty() {
+        0
+    } else {
+        doc.devices
+            .iter()
+            .position(|d| d.device_id == config.device_id)
+            .unwrap_or_else(|| panic!("device_id {} not found in profile", config.device_id))
+    };
+    let profile = &doc.devices[device_index];
+
+    let start_cmd = find_command(profile, ROLE_START, ID_START);
+    let stop_cmd = find_command(profile, ROLE_STOP, ID_STOP);
+    log::info!(
+        "RsModDefMeter driving {} (transactions: start={}, stop={})",
+        profile.device_id,
+        start_cmd.is_some(),
+        stop_cmd.is_some(),
+    );
+
+    let class = Arc::new(ModDefMeter {
+        doc,
+        device_index,
+        unit_id: config.powermeter_device_id,
+        interval_ms: config.read_meter_values_interval_ms as u64,
+        errors_threshold: config.communication_errors_threshold as usize,
+        start_cmd,
+        stop_cmd,
+        device: OnceLock::new(),
+    });
+
+    let _publishers = module.start(class.clone(), class.clone(), class.clone());
+
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}

--- a/modules/HardwareDrivers/PowerMeters/RsModDefMeter/src/main.rs
+++ b/modules/HardwareDrivers/PowerMeters/RsModDefMeter/src/main.rs
@@ -845,3 +845,262 @@ fn main(module: &Module) {
         std::thread::sleep(std::time::Duration::from_secs(1));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use generated::types::powermeter::{
+        OCMFIdentificationFlags, OCMFIdentificationType, OCMFUserIdentificationStatus,
+    };
+    use generated::types::serial_comm_hub_requests::Result as HubResult;
+    use mockall::predicate::eq;
+
+    const UNIT: i64 = 1;
+
+    fn leak_doc(yaml: &str) -> &'static ModDefDocument {
+        let doc = moddef_core::parse_document(yaml.as_bytes(), moddef_core::DocumentFormat::Yaml)
+            .expect("parse test profile");
+        Box::leak(Box::new(doc))
+    }
+
+    fn make_dev(doc: &'static ModDefDocument, hub: SerialCommunicationHubClientPublisher) -> Dev {
+        Device::from_profile(&doc.devices[0], HubBridge { hub, unit_id: UNIT })
+    }
+
+    fn ok_read(words: Vec<i64>) -> ::everestrs::Result<HubResult> {
+        Ok(HubResult {
+            status_code: StatusCodeEnum::Success,
+            value: Some(words),
+        })
+    }
+
+    // A meter with a voltage (V) and an import-energy (kWh) point.
+    const METER_YAML: &str = r#"
+doc_id: test.meter
+name: Test Meter
+version: 1.0.0
+devices:
+  - device_id: test
+    vendor: Test
+    model: M
+    supported_transports: [MODBUS_RTU]
+    blocks:
+      - block_id: m
+        space: INPUT_REGISTER
+        length_words: 4
+        points:
+          - point_id: v_l1
+            access: READ_ONLY
+            storage_type: S32
+            value_type: { primitive: DECIMAL }
+            mapping: { space: INPUT_REGISTER, offset: 0, length_words: 2, byte_order: BIG_ENDIAN, word_order: WORD_LITTLE_ENDIAN }
+            transform: { scale: { numerator: 1, denominator: 10 } }
+            unit: V
+            measurand: { base_quantity: voltage, phase_ref: L1_N }
+          - point_id: e_imp
+            access: READ_ONLY
+            storage_type: S32
+            value_type: { primitive: DECIMAL }
+            mapping: { space: INPUT_REGISTER, offset: 2, length_words: 2, byte_order: BIG_ENDIAN, word_order: WORD_LITTLE_ENDIAN }
+            transform: { scale: { numerator: 1, denominator: 10 } }
+            unit: kWh
+            measurand: { base_quantity: energy_active, direction: IMPORT, accumulation: REGISTER, aggregation: TOTAL }
+"#;
+
+    // A meter that declares a typed-register start_transaction command.
+    const TXN_YAML: &str = r#"
+doc_id: test.txn
+name: Test Txn
+version: 1.0.0
+enums:
+  - type_id: id_type
+    name: ID Type
+    values:
+      - { value: 0, name: NONE }
+      - { value: 10, name: ISO14443 }
+devices:
+  - device_id: test
+    vendor: Test
+    model: M
+    supported_transports: [MODBUS_RTU]
+    blocks:
+      - block_id: ctrl
+        space: HOLDING_REGISTER
+        start_offset: 30
+        length_words: 2
+        points:
+          - point_id: cmd
+            access: WRITE_ONLY
+            storage_type: U16
+            value_type: { primitive: UINT32 }
+            mapping: { space: HOLDING_REGISTER, offset: 30, length_words: 1, byte_order: BIG_ENDIAN }
+            write: { behavior: COMMAND_TRIGGER }
+          - point_id: st
+            access: READ_ONLY
+            storage_type: U16
+            value_type: { primitive: UINT32 }
+            mapping: { space: HOLDING_REGISTER, offset: 31, length_words: 1, byte_order: BIG_ENDIAN }
+    commands:
+      - command_id: start_transaction
+        command_ref: "ocmf:start_transaction"
+        params:
+          - field: identification_type
+            storage_type: U16
+            value_type: { enum_ref: { type_id: id_type } }
+            mapping: { space: HOLDING_REGISTER, offset: 10, length_words: 1, byte_order: BIG_ENDIAN }
+        steps:
+          - name: w_type
+            write: { param: identification_type }
+          - name: begin
+            write: { trigger: { point_id: cmd, value: 66 } }
+        results:
+          - field: status
+            from: st
+            value_type: { primitive: UINT32 }
+"#;
+
+    // ----- pure helpers -----
+
+    #[test]
+    fn unit_scale_rescales_to_everest_units() {
+        assert_eq!(unit_scale("kWh", Kind::Energy), Some(1000.0));
+        assert_eq!(unit_scale("Wh", Kind::Energy), Some(1.0));
+        assert_eq!(unit_scale("kW", Kind::Power), Some(1000.0));
+        assert_eq!(unit_scale("mA", Kind::Amp), Some(0.001));
+        assert_eq!(unit_scale("V", Kind::Volt), Some(1.0));
+        assert_eq!(unit_scale("Hz", Kind::Hertz), Some(1.0));
+        // Unit that doesn't belong to the requested kind is rejected.
+        assert_eq!(unit_scale("kWh", Kind::Power), None);
+    }
+
+    #[test]
+    fn flag_group_routing() {
+        assert_eq!(
+            flag_group_field("RFID_PLAIN"),
+            Some("identification_flags_rfid")
+        );
+        assert_eq!(
+            flag_group_field("OCPP_RS"),
+            Some("identification_flags_ocpp")
+        );
+        assert_eq!(
+            flag_group_field("ISO15118_PNC"),
+            Some("identification_flags_iso15118")
+        );
+        assert_eq!(
+            flag_group_field("PLMN_SMS"),
+            Some("identification_flags_plmn")
+        );
+        assert_eq!(flag_group_field("NONSENSE"), None);
+    }
+
+    #[test]
+    fn everest_enum_debug_equals_ocmf_value_name() {
+        // The enum mapping relies on Debug producing the exact OCMF value name.
+        assert_eq!(enum_name(&OCMFIdentificationType::ISO14443), "ISO14443");
+        assert_eq!(
+            enum_name(&OCMFUserIdentificationStatus::ASSIGNED),
+            "ASSIGNED"
+        );
+        assert_eq!(
+            enum_name(&OCMFIdentificationFlags::RFID_PLAIN),
+            "RFID_PLAIN"
+        );
+    }
+
+    #[test]
+    fn resolve_enum_by_value_name() {
+        let doc = leak_doc(TXN_YAML);
+        assert_eq!(resolve_enum(doc, "id_type", "ISO14443"), Some(10));
+        assert_eq!(resolve_enum(doc, "id_type", "NONE"), Some(0));
+        assert_eq!(resolve_enum(doc, "id_type", "MISSING"), None);
+        assert_eq!(resolve_enum(doc, "no_such_enum", "ISO14443"), None);
+    }
+
+    #[test]
+    fn capability_detection_via_command_ref() {
+        let with = leak_doc(TXN_YAML);
+        assert_eq!(
+            find_command(&with.devices[0], ROLE_START, ID_START),
+            Some("start_transaction".to_string())
+        );
+        // A metering-only profile advertises no transaction command.
+        let without = leak_doc(METER_YAML);
+        assert_eq!(
+            find_command(&without.devices[0], ROLE_START, ID_START),
+            None
+        );
+    }
+
+    // ----- metering (mock hub) -----
+
+    #[test]
+    fn metering_maps_measurands_and_rescales_units() {
+        let mut hub = SerialCommunicationHubClientPublisher::default();
+        // voltage L1-N: S32, LSW-first, 2300 -> 230.0 V (kept in V).
+        hub.expect_modbus_read_input_registers()
+            .with(eq(0i64), eq(2i64), eq(UNIT))
+            .times(1)
+            .returning(|_, _, _| ok_read(vec![0x08FC, 0x0000]));
+        // import energy: 5000 -> 500.0 kWh -> rescaled to 500000 Wh.
+        hub.expect_modbus_read_input_registers()
+            .with(eq(2i64), eq(2i64), eq(UNIT))
+            .times(1)
+            .returning(|_, _, _| ok_read(vec![0x1388, 0x0000]));
+
+        let doc = leak_doc(METER_YAML);
+        let mut dev = make_dev(doc, hub);
+        let pm = read_powermeter(&mut dev).expect("read_powermeter");
+
+        assert_eq!(pm.voltage_v.expect("voltage").l_1, Some(230.0));
+        assert_eq!(pm.energy_wh_import.total, 500_000.0);
+        // No active-power point in the profile -> total defaults to 0.0.
+        assert_eq!(pm.power_w.expect("power").total, 0.0);
+        // No export-energy point -> field absent.
+        assert!(pm.energy_wh_export.is_none());
+    }
+
+    // ----- transactions (mock hub) -----
+
+    #[test]
+    fn start_transaction_resolves_enum_and_triggers() {
+        let mut hub = SerialCommunicationHubClientPublisher::default();
+        // identification_type ISO14443 -> value 10 written to holding reg 10.
+        hub.expect_modbus_write_multiple_registers()
+            .withf(|data, addr, unit| data.data == vec![10i64] && *addr == 10 && *unit == UNIT)
+            .times(1)
+            .returning(|_, _, _| Ok(StatusCodeEnum::Success));
+        // begin command 'B' (0x42 = 66) written to the trigger register.
+        hub.expect_modbus_write_multiple_registers()
+            .withf(|data, addr, _| data.data == vec![66i64] && *addr == 30)
+            .times(1)
+            .returning(|_, _, _| Ok(StatusCodeEnum::Success));
+        // result read of the status register.
+        hub.expect_modbus_read_holding_registers()
+            .with(eq(31i64), eq(1i64), eq(UNIT))
+            .returning(|_, _, _| ok_read(vec![7]));
+
+        let doc = leak_doc(TXN_YAML);
+        let mut dev = make_dev(doc, hub);
+        let req = TransactionReq {
+            evse_id: String::new(),
+            transaction_id: String::new(),
+            identification_status: OCMFUserIdentificationStatus::ASSIGNED,
+            identification_type: OCMFIdentificationType::ISO14443,
+            identification_flags: Vec::new(),
+            identification_data: None,
+            identification_level: None,
+            tariff_text: None,
+        };
+        let resp = run_start(&mut dev, "start_transaction", &req, doc).expect("run_start");
+        assert!(matches!(resp.status, TransactionRequestStatus::OK));
+    }
+
+    #[test]
+    fn start_transaction_not_supported_response() {
+        let r = start_not_supported();
+        assert!(matches!(r.status, TransactionRequestStatus::NOT_SUPPORTED));
+        let s = stop_not_supported();
+        assert!(matches!(s.status, TransactionRequestStatus::NOT_SUPPORTED));
+    }
+}


### PR DESCRIPTION
## Describe your changes

`RsModDefMeter` is a new EVerest `powermeter` driver that is configured by a [ModDef](https://moddef.org/) device profile rather than written per meter model. One binary drives any conforming meter: the register map, framing, scaling, polling and — where the meter supports it — the signed-transaction procedure all come from a declarative profile instead of from code. It is the profile-driven counterpart to `GenericPowermeter`, extended to cover signed metering.

**Metering (any profile).** The `powermeter` variable is published by querying the profile's measurand-tagged points (`base_quantity` plus phase / direction / aggregation) and rescaling each value into the unit the EVerest field expects (Wh, W, var, V, A, Hz). Fields the profile does not provide are left absent. Where a measurand tuple matches more than one point (a live value and its signed-snapshot twin, say), the point whose unit already matches the target is preferred.

**Signed transactions (typed-register OCMF meters).** When the profile declares a start/stop command — matched by the `command_ref` role tag `ocmf:start_transaction` / `ocmf:stop_transaction`, otherwise by command id — the module maps the EVerest `TransactionReq` onto that command's typed parameters and executes it through ModDef's multi-step command construct (write / poll / read). Identification enums are resolved against the profile's own enum table (OCMF value names match), the OCMF identification flags are routed to their per-group registers, and the stop command's OCMF result is returned as a `SignedMeterValue`.

**Capability discovery.** A profile that declares no transaction commands advertises plain metering and returns `NOT_SUPPORTED` from `start_transaction` / `stop_transaction`, so metering-only and signing meters are served by the same module.

**Implementation.** Modbus RTU goes through the required `serial_communication_hub`: a small `HubBridge` implements ModDef's `Transport` trait on top of the hub commands. everestrs handlers are synchronous while ModDef's `Device` is async and `&mut`, so the device is driven with `pollster::block_on` behind a `Mutex<Device>`, which also serialises access to the shared RS485 bus. No async runtime is introduced — the hub calls and the poll delay are blocking, so every await completes without a reactor. `moddef-core` is consumed as a git dependency, and the module is registered with both `ev_add_module` (under `EVEREST_ENABLE_RS_SUPPORT`) and the `MODULE.bazel` crate index plus `modules/Cargo.lock`.

Configuration keys — `profile` (path to a `.moddef`, `.moddef.yaml` or `.moddef.json`), `device_id`, `powermeter_device_id`, `read_meter_values_interval_ms`, `communication_errors_threshold` — are documented in the module README.

**Scope and known limitations**

- Transactions require a *typed-register* OCMF meter, where each OCMF field is its own register and the meter composes the signed document itself; the reference profile is the Carlo Gavazzi EM580. Meters that expose a single opaque OCMF blob assembled by the caller (for example the Bauer BSM or Iskra WM3M4C) need payload composition that cannot be expressed declaratively — they keep their dedicated drivers and this module reports `NOT_SUPPORTED` for them.
- Modbus RTU via `serial_communication_hub` only. A config-selected Modbus TCP transport is a natural follow-up, since ModDef's `Transport` trait already has a tokio-modbus backend.
- Discrete-input reads are not offered by the hub interface, and `COMPOSED` (multi-register mantissa/exponent) measurand points are not yet readable through the ModDef facade; such fields publish as absent.
- **Not hardware-verified.** The register-level behaviour has so far been exercised against mocks only.

**Tests.** Eight unit tests run against a mocked `serial_communication_hub` publisher, following the approach used by `RsIskraMeter`: metering (measurand lookup, decode, and the kWh → Wh rescale); `start_transaction` (an identification enum resolved against the profile's enum table to its register value, the `'B'` trigger written, the result register read); capability discovery via the `command_ref` role tag and the `NOT_SUPPORTED` paths; and the helpers, including a test pinning the assumption that the EVerest OCMF enums' `Debug` representation equals the OCMF value name, which the enum mapping relies on. Run in the `everest-ci` build-kit container: 8 passed, 0 failed, with `cargo fmt` and `cargo clippy` clean.

**Bazel.** `bazelisk build --config=ci` on this target completes the crate-universe repin (the `moddef-core` git dependency resolves) and the analysis phase — `66 packages loaded, 8 targets configured` — but I was not able to run the execution phase to completion locally for want of disk space, so a full Bazel build on CI is the outstanding confirmation. I would welcome a maintainer's view on whether the crate index needs anything further for a git-sourced dependency.

## Issue ticket number and link

Closes #2504 — *Profile-driven powermeter module: describe Modbus meters (incl. OCMF signing) as data instead of per-model drivers*.

Background from the ModDef project, which motivated the design (context only):

- `ModDefOrg/moddef#2` — the multi-step command construct (`commands` / `poll` / `length_ref`) that this module drives.
- `ModDefOrg/moddef#3` — why declarative payload composition was rejected for opaque-blob meters, and why typed-register meters such as the EM580 are the ones this module can serve.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

All commits are DCO signed off, new files carry SPDX and copyright headers, tests and documentation are included, and the change is limited to a single logical addition. The repository's `clang-format` lint covers C++ only, so the Rust sources are kept `rustfmt`- and `clippy`-clean instead. For transparency: the branch was rebased once *before* this PR was opened, solely to add the DCO sign-offs; there will be no further force-pushes during review.
