### PR TITLE
feat(YetiSimulator): make reported import current limits configurable

### DIFF
--- a/modules/Simulation/YetiSimulator/YetiSimulator.hpp
+++ b/modules/Simulation/YetiSimulator/YetiSimulator.hpp
@@ -30,6 +30,8 @@ struct Conf {
     bool dummy_meter_value_send_on_transaction_start;
     std::string dummy_meter_value_blob_start;
     std::string dummy_meter_value_blob_stop;
+    double max_current_A_import;
+    double min_current_A_import;
 };
 
 class YetiSimulator : public Everest::ModuleBase {

--- a/modules/Simulation/YetiSimulator/YetiSimulator.hpp
+++ b/modules/Simulation/YetiSimulator/YetiSimulator.hpp
@@ -33,6 +33,8 @@ struct Conf {
     std::string dummy_meter_value_blob_stop;
     double ac_nominal_voltage;
     double ac_nominal_frequency;
+    double max_current_A_import;
+    double min_current_A_import;
 };
 
 class YetiSimulator : public Everest::ModuleBase {

--- a/modules/Simulation/YetiSimulator/board_support/evse_board_supportImpl.cpp
+++ b/modules/Simulation/YetiSimulator/board_support/evse_board_supportImpl.cpp
@@ -7,9 +7,10 @@
 namespace module::board_support {
 
 namespace {
-types::evse_board_support::HardwareCapabilities set_default_capabilities() {
-    return {32.0,                                                          // max_current_A_import
-            6.0,                                                           // min_current_A_import
+types::evse_board_support::HardwareCapabilities set_default_capabilities(double max_current_A_import,
+                                                                         double min_current_A_import) {
+    return {max_current_A_import,                                          // max_current_A_import
+            min_current_A_import,                                          // min_current_A_import
             3,                                                             // max_phase_count_import
             1,                                                             // min_phase_count_import
             16.0,                                                          // max_current_A_export
@@ -27,7 +28,8 @@ void evse_board_supportImpl::init() {
 }
 
 void evse_board_supportImpl::ready() {
-    const auto default_capabilities = set_default_capabilities();
+    const auto default_capabilities =
+        set_default_capabilities(mod->config.max_current_A_import, mod->config.min_current_A_import);
     publish_capabilities(default_capabilities);
 }
 

--- a/modules/Simulation/YetiSimulator/manifest.yaml
+++ b/modules/Simulation/YetiSimulator/manifest.yaml
@@ -19,6 +19,20 @@ config:
     description: Dummy meter value blob sent on transaction stop to be used for testing
     type: string
     default: "test stop value"
+  max_current_A_import:
+    description: >-
+      Maximum import current in amps reported as a hardware capability. The default matches a 32 A AC wallbox. DC
+      configurations must raise this, since the energy manager derives the available power from
+      max_current_A_import * max_phase_count_import * nominal_voltage_V and would otherwise cap a high-power DC
+      supply at the AC-side figure.
+    type: number
+    minimum: 0
+    default: 32.0
+  min_current_A_import:
+    description: Minimum import current in amps reported as a hardware capability
+    type: number
+    minimum: 0
+    default: 6.0
 provides:
   powermeter:
     interface: powermeter

--- a/modules/Simulation/YetiSimulator/manifest.yaml
+++ b/modules/Simulation/YetiSimulator/manifest.yaml
@@ -30,6 +30,20 @@ config:
     default: 50.0
     minimum: 50.0
     maximum: 60.0
+  max_current_A_import:
+    description: >-
+      Maximum import current in amps reported as a hardware capability. The default matches a 32 A AC wallbox. DC
+      configurations must raise this, since the energy manager derives the available power from
+      max_current_A_import * max_phase_count_import * nominal_voltage_V and would otherwise cap a high-power DC
+      supply at the AC-side figure.
+    type: number
+    minimum: 0
+    default: 32.0
+  min_current_A_import:
+    description: Minimum import current in amps reported as a hardware capability
+    type: number
+    minimum: 0
+    default: 6.0
 provides:
   powermeter:
     interface: powermeter


### PR DESCRIPTION
## Describe your changes

`YetiSimulator` reported a hard-coded 32 A / 6 A as its import current capability. Those two values are now
config keys, `max_current_A_import` and `min_current_A_import`, with the defaults left at 32.0 and 6.0 so every
shipped config behaves exactly as before.

**Why this matters beyond AC.** The energy manager derives the power available to an EVSE from

```
power = max_current_A_import * max_phase_count_import * nominal_voltage_V
```

so the board support figure caps a DC configuration at the AC-side number regardless of what the DC supply can
deliver. Using `YetiSimulator` in a high-power DC SIL setup silently limits the session to roughly 22 kW, with
no error and nothing in the logs pointing at the cause - the only way I found it was enabling
`energy_manager: debug` and reading which limit was binding each trading round.

Note for reviewers: `struct Conf` in `YetiSimulator.hpp` is checked in rather than generated, so it is edited by
hand here to match the manifest. Without that the build fails in the generated `ld-ev.cpp`.

## Issue ticket number and link

None - happy to open one first if that is preferred.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

Verified by taking a simulated CCS session from ~22 kW to 240 kW at 800 V / 300 A against a live CSMS, and by
confirming the shipped configs are unaffected because the defaults are unchanged.
