### PR TITLE
feat(EvManager): allow the simulated EV's EVCCID to be set at runtime

### DIFF
--- a/config/nodered/config-sil-dc-bpt-flow.json
+++ b/config/nodered/config-sil-dc-bpt-flow.json
@@ -1810,7 +1810,7 @@
         "type": "function",
         "z": "ed603c51db9dcbb9",
         "name": "Buffer sim commands",
-        "func": "if (msg.topic.indexOf('sim_commands') > -1) {\n    const s = msg.payload.split('#');\n    flow.set('sim_commands_start', s[0]);\n    flow.set('sim_commands_stop', s[1]);\n    flow.set('sim_commands_pause', s[2]);\n    flow.set('sim_commands_resume', s[3]);\n} else if (msg.payload == 'start') {\n    msg.payload = flow.get('sim_commands_start');\n    return msg;\n} else if (msg.payload == 'stop') {\n    msg.payload = flow.get('sim_commands_stop');\n    return msg;\n} else if (msg.payload == 'pause') {\n    msg.payload = flow.get('sim_commands_pause');\n    return msg;\n} else if (msg.payload == 'resume') {\n    msg.payload = flow.get('sim_commands_resume');\n    return msg;\n} else {\n    msg.payload = 'NONE';\n    return msg;\n}\n",
+        "func": "// The \"Vehicle MAC (VID)\" input arrives here with the topic 'evcc_id'. The value is kept in flow context and\n// prepended to the session start commands rather than sent on its own, because execute_charging_session and\n// modify_charging_session replace the whole command queue - sending it separately would abort a running\n// session. Prepending also means the EV picks it up for the session that is starting, since the EVCCID is\n// fixed at SessionSetupReq.\nif (msg.topic === 'evcc_id') {\n    const typed = String(msg.payload || '').trim();\n    const mac = typed.replace(/^vid:/i, '').replace(/[:\\-. ]/g, '');\n    if (typed === '') {\n        // Blank restores the MAC address of the EV's network interface.\n        flow.set('evcc_id_command', 'set_evcc_id;');\n    } else if (/^[0-9a-f]{12}$/i.test(mac)) {\n        flow.set('evcc_id_command', 'set_evcc_id ' + mac.toUpperCase() + ';');\n    } else {\n        node.warn('Ignoring vehicle MAC \"' + typed + '\": not a MAC address');\n    }\n    return null;\n}\n\nif (msg.topic.indexOf('sim_commands') > -1) {\n    const s = msg.payload.split('#');\n    flow.set('sim_commands_start', s[0]);\n    flow.set('sim_commands_stop', s[1]);\n    flow.set('sim_commands_pause', s[2]);\n    flow.set('sim_commands_resume', s[3]);\n} else if (msg.payload == 'start') {\n    msg.payload = (flow.get('evcc_id_command') || '') + flow.get('sim_commands_start');\n    return msg;\n} else if (msg.payload == 'stop') {\n    msg.payload = flow.get('sim_commands_stop');\n    return msg;\n} else if (msg.payload == 'pause') {\n    msg.payload = flow.get('sim_commands_pause');\n    return msg;\n} else if (msg.payload == 'resume') {\n    msg.payload = flow.get('sim_commands_resume');\n    return msg;\n} else {\n    msg.payload = 'NONE';\n    return msg;\n}\n",
         "outputs": 1,
         "noerr": 0,
         "initialize": "",
@@ -1972,6 +1972,98 @@
         "color": "#000000",
         "x": 820,
         "y": 640,
+        "wires": []
+    },
+    {
+        "id": "b1d0ae5efa11ce00",
+        "type": "comment",
+        "z": "ed603c51db9dcbb9",
+        "name": "Simulated vehicle identity (Autocharge)",
+        "info": "The EV announces its MAC address as the EVCCID in SessionSetupReq. EvseManager turns that into the Autocharge token \"VID:<mac>\" and sends it to the CSMS as the Authorize idTag.\n\nWithout an override the MAC comes from the container's network interface, so every simulated session looks like the same car. Setting a value here makes a different vehicle turn up on the next plug-in.\n\nThe value is prepended to the \"Car Plugin\" command string as \"set_evcc_id <mac>\", so it takes effect for the session it starts.\n\nAccepts VID:0242AC110099, 02:42:AC:11:00:99 or 0242AC110099. Leave blank to go back to the interface MAC address.",
+        "x": 240,
+        "y": 1240,
+        "wires": []
+    },
+    {
+        "id": "b1d0ae5efa11ce01",
+        "type": "ui_text_input",
+        "z": "ed603c51db9dcbb9",
+        "name": "Vehicle MAC (VID)",
+        "label": "Vehicle MAC (VID)",
+        "tooltip": "Applied when the next session starts. Blank restores the network interface MAC address.",
+        "group": "b364f7eb4621082b",
+        "order": 16,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "mode": "text",
+        "delay": "0",
+        "topic": "evcc_id",
+        "sendOnBlur": true,
+        "className": "",
+        "topicType": "str",
+        "x": 200,
+        "y": 1300,
+        "wires": [
+            [
+                "620b0d248a89ece0"
+            ]
+        ]
+    },
+    {
+        "id": "b1d0ae5efa11ce02",
+        "type": "mqtt in",
+        "z": "ed603c51db9dcbb9",
+        "name": "",
+        "topic": "everest_external/nodered/+/carsim/state/evcc_id",
+        "qos": "2",
+        "datatype": "auto",
+        "broker": "fc8686af.48d178",
+        "nl": false,
+        "rap": true,
+        "rh": 0,
+        "inputs": 0,
+        "x": 290,
+        "y": 1360,
+        "wires": [
+            [
+                "b1d0ae5efa11ce03"
+            ]
+        ]
+    },
+    {
+        "id": "b1d0ae5efa11ce03",
+        "type": "function",
+        "z": "ed603c51db9dcbb9",
+        "name": "Filter connector number",
+        "func": "// The retained EVCCID is delivered the instant the broker connects, which can beat the inject node that\n// seeds connector_number, so fall back to this tab's connector rather than dropping the value silently.\nconst connector = flow.get('connector_number') || '1';\nif (msg.topic.indexOf(String(connector)) > -1) return msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 710,
+        "y": 1360,
+        "wires": [
+            [
+                "b1d0ae5efa11ce04"
+            ]
+        ]
+    },
+    {
+        "id": "b1d0ae5efa11ce04",
+        "type": "ui_text",
+        "z": "ed603c51db9dcbb9",
+        "group": "b364f7eb4621082b",
+        "order": 17,
+        "width": 0,
+        "height": 0,
+        "name": "",
+        "label": "Announced VID",
+        "format": "{{msg.payload}}",
+        "layout": "row-spread",
+        "x": 1000,
+        "y": 1360,
         "wires": []
     }
 ]

--- a/config/nodered/config-sil-dc-flow.json
+++ b/config/nodered/config-sil-dc-flow.json
@@ -1924,5 +1924,97 @@
                 "620b0d248a89ece0"
             ]
         ]
+    },
+    {
+        "id": "b1d0ae5efa11ce00",
+        "type": "comment",
+        "z": "ed603c51db9dcbb9",
+        "name": "Simulated vehicle identity (Autocharge)",
+        "info": "The EV announces its MAC address as the EVCCID in SessionSetupReq. EvseManager turns that into the Autocharge token \"VID:<mac>\" and sends it to the CSMS as the Authorize idTag.\n\nWithout an override the MAC comes from the container's network interface, so every simulated session looks like the same car. Setting a value here makes a different vehicle turn up on the next plug-in.\n\nAccepts VID:0242AC110099, 02:42:AC:11:00:99 or 0242AC110099. Leave blank to go back to the interface MAC address.",
+        "x": 240,
+        "y": 1240,
+        "wires": []
+    },
+    {
+        "id": "b1d0ae5efa11ce01",
+        "type": "ui_text_input",
+        "z": "ed603c51db9dcbb9",
+        "name": "Vehicle MAC (VID)",
+        "label": "Vehicle MAC (VID)",
+        "tooltip": "Applied on the next plug-in. Blank restores the network interface MAC address.",
+        "group": "b364f7eb4621082b",
+        "order": 14,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "mode": "text",
+        "delay": "0",
+        "topic": "everest_external/nodered/#/carsim/cmd/set_evcc_id",
+        "sendOnBlur": true,
+        "className": "",
+        "topicType": "str",
+        "x": 200,
+        "y": 1300,
+        "wires": [
+            [
+                "361b3d846c4e6673"
+            ]
+        ]
+    },
+    {
+        "id": "b1d0ae5efa11ce02",
+        "type": "mqtt in",
+        "z": "ed603c51db9dcbb9",
+        "name": "",
+        "topic": "everest_external/nodered/+/carsim/state/evcc_id",
+        "qos": "2",
+        "datatype": "auto",
+        "broker": "fc8686af.48d178",
+        "nl": false,
+        "rap": true,
+        "rh": 0,
+        "inputs": 0,
+        "x": 290,
+        "y": 620,
+        "wires": [
+            [
+                "b1d0ae5efa11ce03"
+            ]
+        ]
+    },
+    {
+        "id": "b1d0ae5efa11ce03",
+        "type": "function",
+        "z": "ed603c51db9dcbb9",
+        "name": "Filter connector number",
+        "func": "// The retained EVCCID is delivered the instant the broker connects, which can beat the inject node that\n// seeds connector_number, so fall back to this tab's connector rather than dropping the value silently.\nconst connector = flow.get('connector_number') || '1';\nif (msg.topic.indexOf(String(connector)) > -1) return msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 710,
+        "y": 620,
+        "wires": [
+            [
+                "b1d0ae5efa11ce04"
+            ]
+        ]
+    },
+    {
+        "id": "b1d0ae5efa11ce04",
+        "type": "ui_text",
+        "z": "ed603c51db9dcbb9",
+        "group": "b364f7eb4621082b",
+        "order": 15,
+        "width": 0,
+        "height": 0,
+        "name": "",
+        "label": "Announced VID",
+        "format": "{{msg.payload}}",
+        "layout": "row-spread",
+        "x": 1000,
+        "y": 620,
+        "wires": []
     }
 ]

--- a/config/nodered/config-sil-dc-flow.json
+++ b/config/nodered/config-sil-dc-flow.json
@@ -1810,7 +1810,7 @@
         "type": "function",
         "z": "ed603c51db9dcbb9",
         "name": "Buffer sim commands",
-        "func": "if (msg.topic.indexOf('sim_commands') > -1) {\n    const s = msg.payload.split('#');\n    flow.set('sim_commands_start', s[0]);\n    flow.set('sim_commands_stop', s[1]);\n    flow.set('sim_commands_pause', s[2]);\n    flow.set('sim_commands_resume', s[3]);\n} else if (msg.payload == 'start') {\n    msg.payload = flow.get('sim_commands_start');\n    return msg;\n} else if (msg.payload == 'stop') {\n    msg.payload = flow.get('sim_commands_stop');\n    return msg;\n} else if (msg.payload == 'pause') {\n    msg.payload = flow.get('sim_commands_pause');\n    return msg;\n} else if (msg.payload == 'resume') {\n    msg.payload = flow.get('sim_commands_resume');\n    return msg;\n} else {\n    msg.payload = 'NONE';\n    return msg;\n}\n",
+        "func": "// The \"Vehicle MAC (VID)\" input arrives here with the topic 'evcc_id'. The value is kept in flow context and\n// prepended to the session start commands rather than sent on its own, because execute_charging_session and\n// modify_charging_session replace the whole command queue - sending it separately would abort a running\n// session. Prepending also means the EV picks it up for the session that is starting, since the EVCCID is\n// fixed at SessionSetupReq.\nif (msg.topic === 'evcc_id') {\n    const typed = String(msg.payload || '').trim();\n    const mac = typed.replace(/^vid:/i, '').replace(/[:\\-. ]/g, '');\n    if (typed === '') {\n        // Blank restores the MAC address of the EV's network interface.\n        flow.set('evcc_id_command', 'set_evcc_id;');\n    } else if (/^[0-9a-f]{12}$/i.test(mac)) {\n        flow.set('evcc_id_command', 'set_evcc_id ' + mac.toUpperCase() + ';');\n    } else {\n        node.warn('Ignoring vehicle MAC \"' + typed + '\": not a MAC address');\n    }\n    return null;\n}\n\nif (msg.topic.indexOf('sim_commands') > -1) {\n    const s = msg.payload.split('#');\n    flow.set('sim_commands_start', s[0]);\n    flow.set('sim_commands_stop', s[1]);\n    flow.set('sim_commands_pause', s[2]);\n    flow.set('sim_commands_resume', s[3]);\n} else if (msg.payload == 'start') {\n    msg.payload = (flow.get('evcc_id_command') || '') + flow.get('sim_commands_start');\n    return msg;\n} else if (msg.payload == 'stop') {\n    msg.payload = flow.get('sim_commands_stop');\n    return msg;\n} else if (msg.payload == 'pause') {\n    msg.payload = flow.get('sim_commands_pause');\n    return msg;\n} else if (msg.payload == 'resume') {\n    msg.payload = flow.get('sim_commands_resume');\n    return msg;\n} else {\n    msg.payload = 'NONE';\n    return msg;\n}\n",
         "outputs": 1,
         "noerr": 0,
         "initialize": "",
@@ -1930,7 +1930,7 @@
         "type": "comment",
         "z": "ed603c51db9dcbb9",
         "name": "Simulated vehicle identity (Autocharge)",
-        "info": "The EV announces its MAC address as the EVCCID in SessionSetupReq. EvseManager turns that into the Autocharge token \"VID:<mac>\" and sends it to the CSMS as the Authorize idTag.\n\nWithout an override the MAC comes from the container's network interface, so every simulated session looks like the same car. Setting a value here makes a different vehicle turn up on the next plug-in.\n\nAccepts VID:0242AC110099, 02:42:AC:11:00:99 or 0242AC110099. Leave blank to go back to the interface MAC address.",
+        "info": "The EV announces its MAC address as the EVCCID in SessionSetupReq. EvseManager turns that into the Autocharge token \"VID:<mac>\" and sends it to the CSMS as the Authorize idTag.\n\nWithout an override the MAC comes from the container's network interface, so every simulated session looks like the same car. Setting a value here makes a different vehicle turn up on the next plug-in.\n\nThe value is prepended to the \"Car Plugin\" command string as \"set_evcc_id <mac>\", so it takes effect for the session it starts.\n\nAccepts VID:0242AC110099, 02:42:AC:11:00:99 or 0242AC110099. Leave blank to go back to the interface MAC address.",
         "x": 240,
         "y": 1240,
         "wires": []
@@ -1941,7 +1941,7 @@
         "z": "ed603c51db9dcbb9",
         "name": "Vehicle MAC (VID)",
         "label": "Vehicle MAC (VID)",
-        "tooltip": "Applied on the next plug-in. Blank restores the network interface MAC address.",
+        "tooltip": "Applied when the next session starts. Blank restores the network interface MAC address.",
         "group": "b364f7eb4621082b",
         "order": 14,
         "width": 0,
@@ -1949,7 +1949,7 @@
         "passthru": false,
         "mode": "text",
         "delay": "0",
-        "topic": "everest_external/nodered/#/carsim/cmd/set_evcc_id",
+        "topic": "evcc_id",
         "sendOnBlur": true,
         "className": "",
         "topicType": "str",
@@ -1957,7 +1957,7 @@
         "y": 1300,
         "wires": [
             [
-                "361b3d846c4e6673"
+                "620b0d248a89ece0"
             ]
         ]
     },
@@ -1975,7 +1975,7 @@
         "rh": 0,
         "inputs": 0,
         "x": 290,
-        "y": 620,
+        "y": 1360,
         "wires": [
             [
                 "b1d0ae5efa11ce03"
@@ -1994,7 +1994,7 @@
         "finalize": "",
         "libs": [],
         "x": 710,
-        "y": 620,
+        "y": 1360,
         "wires": [
             [
                 "b1d0ae5efa11ce04"
@@ -2014,7 +2014,7 @@
         "format": "{{msg.payload}}",
         "layout": "row-spread",
         "x": 1000,
-        "y": 620,
+        "y": 1360,
         "wires": []
     }
 ]

--- a/config/nodered/config-sil-energy-management-flow.json
+++ b/config/nodered/config-sil-energy-management-flow.json
@@ -1817,7 +1817,7 @@
         "type": "function",
         "z": "ed603c51db9dcbb9",
         "name": "Buffer sim commands",
-        "func": "if (msg.topic.indexOf('sim_commands') > -1) {\n    const s = msg.payload.split('#');\n    flow.set('sim_commands_start', s[0]);\n    flow.set('sim_commands_stop', s[1]);\n} else if (msg.payload == 'start') {\n    msg.payload = flow.get('sim_commands_start');\n    return msg;\n} else if (msg.payload == 'stop') {\n    msg.payload = flow.get('sim_commands_stop');\n    return msg;\n} else {\n    msg.payload = 'NONE';\n    return msg;\n}\n",
+        "func": "// The \"Vehicle MAC (VID)\" input arrives here with the topic 'evcc_id'. The value is kept in flow context and\n// prepended to the session start commands rather than sent on its own, because execute_charging_session and\n// modify_charging_session replace the whole command queue - sending it separately would abort a running\n// session. Prepending also means the EV picks it up for the session that is starting, since the EVCCID is\n// fixed at SessionSetupReq.\nif (msg.topic === 'evcc_id') {\n    const typed = String(msg.payload || '').trim();\n    const mac = typed.replace(/^vid:/i, '').replace(/[:\\-. ]/g, '');\n    if (typed === '') {\n        // Blank restores the MAC address of the EV's network interface.\n        flow.set('evcc_id_command', 'set_evcc_id;');\n    } else if (/^[0-9a-f]{12}$/i.test(mac)) {\n        flow.set('evcc_id_command', 'set_evcc_id ' + mac.toUpperCase() + ';');\n    } else {\n        node.warn('Ignoring vehicle MAC \"' + typed + '\": not a MAC address');\n    }\n    return null;\n}\n\nif (msg.topic.indexOf('sim_commands') > -1) {\n    const s = msg.payload.split('#');\n    flow.set('sim_commands_start', s[0]);\n    flow.set('sim_commands_stop', s[1]);\n} else if (msg.payload == 'start') {\n    msg.payload = (flow.get('evcc_id_command') || '') + flow.get('sim_commands_start');\n    return msg;\n} else if (msg.payload == 'stop') {\n    msg.payload = flow.get('sim_commands_stop');\n    return msg;\n} else {\n    msg.payload = 'NONE';\n    return msg;\n}\n",
         "outputs": 1,
         "noerr": 0,
         "initialize": "",
@@ -2952,6 +2952,98 @@
         "className": "",
         "x": 750,
         "y": 680,
+        "wires": []
+    },
+    {
+        "id": "b1d0ae5efa11ce00",
+        "type": "comment",
+        "z": "ed603c51db9dcbb9",
+        "name": "Simulated vehicle identity (Autocharge)",
+        "info": "The EV announces its MAC address as the EVCCID in SessionSetupReq. EvseManager turns that into the Autocharge token \"VID:<mac>\" and sends it to the CSMS as the Authorize idTag.\n\nWithout an override the MAC comes from the container's network interface, so every simulated session looks like the same car. Setting a value here makes a different vehicle turn up on the next plug-in.\n\nThe value is prepended to the \"Car Plugin\" command string as \"set_evcc_id <mac>\", so it takes effect for the session it starts.\n\nAccepts VID:0242AC110099, 02:42:AC:11:00:99 or 0242AC110099. Leave blank to go back to the interface MAC address.",
+        "x": 240,
+        "y": 1160,
+        "wires": []
+    },
+    {
+        "id": "b1d0ae5efa11ce01",
+        "type": "ui_text_input",
+        "z": "ed603c51db9dcbb9",
+        "name": "Vehicle MAC (VID)",
+        "label": "Vehicle MAC (VID)",
+        "tooltip": "Applied when the next session starts. Blank restores the network interface MAC address.",
+        "group": "b364f7eb4621082b",
+        "order": 16,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "mode": "text",
+        "delay": "0",
+        "topic": "evcc_id",
+        "sendOnBlur": true,
+        "className": "",
+        "topicType": "str",
+        "x": 200,
+        "y": 1220,
+        "wires": [
+            [
+                "620b0d248a89ece0"
+            ]
+        ]
+    },
+    {
+        "id": "b1d0ae5efa11ce02",
+        "type": "mqtt in",
+        "z": "ed603c51db9dcbb9",
+        "name": "",
+        "topic": "everest_external/nodered/+/carsim/state/evcc_id",
+        "qos": "2",
+        "datatype": "auto",
+        "broker": "fc8686af.48d178",
+        "nl": false,
+        "rap": true,
+        "rh": 0,
+        "inputs": 0,
+        "x": 290,
+        "y": 1280,
+        "wires": [
+            [
+                "b1d0ae5efa11ce03"
+            ]
+        ]
+    },
+    {
+        "id": "b1d0ae5efa11ce03",
+        "type": "function",
+        "z": "ed603c51db9dcbb9",
+        "name": "Filter connector number",
+        "func": "// The retained EVCCID is delivered the instant the broker connects, which can beat the inject node that\n// seeds connector_number, so fall back to this tab's connector rather than dropping the value silently.\nconst connector = flow.get('connector_number') || '1';\nif (msg.topic.indexOf(String(connector)) > -1) return msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 710,
+        "y": 1280,
+        "wires": [
+            [
+                "b1d0ae5efa11ce04"
+            ]
+        ]
+    },
+    {
+        "id": "b1d0ae5efa11ce04",
+        "type": "ui_text",
+        "z": "ed603c51db9dcbb9",
+        "group": "b364f7eb4621082b",
+        "order": 17,
+        "width": 0,
+        "height": 0,
+        "name": "",
+        "label": "Announced VID",
+        "format": "{{msg.payload}}",
+        "layout": "row-spread",
+        "x": 1000,
+        "y": 1280,
         "wires": []
     }
 ]

--- a/config/nodered/config-sil-flow.json
+++ b/config/nodered/config-sil-flow.json
@@ -1888,7 +1888,7 @@
         "type": "function",
         "z": "ed603c51db9dcbb9",
         "name": "Buffer sim commands",
-        "func": "if (msg.topic.indexOf('sim_commands') > -1) {\n    const s = msg.payload.split('#');\n    flow.set('sim_commands_start', s[0]);\n    flow.set('sim_commands_stop', s[1]);\n    flow.set('sim_commands_pause', s[2]);\n    flow.set('sim_commands_resume', s[3]);\n} else if (msg.payload == 'start') {\n    msg.payload = flow.get('sim_commands_start');\n    return msg;\n} else if (msg.payload == 'stop') {\n    msg.payload = flow.get('sim_commands_stop');\n    return msg;\n} else if (msg.payload == 'pause') {\n    msg.payload = flow.get('sim_commands_pause');\n    return msg;\n} else if (msg.payload == 'resume') {\n    msg.payload = flow.get('sim_commands_resume');\n    return msg;\n} else {\n    msg.payload = 'NONE';\n    return msg;\n}\n",
+        "func": "// The \"Vehicle MAC (VID)\" input arrives here with the topic 'evcc_id'. The value is kept in flow context and\n// prepended to the session start commands rather than sent on its own, because execute_charging_session and\n// modify_charging_session replace the whole command queue - sending it separately would abort a running\n// session. Prepending also means the EV picks it up for the session that is starting, since the EVCCID is\n// fixed at SessionSetupReq.\nif (msg.topic === 'evcc_id') {\n    const typed = String(msg.payload || '').trim();\n    const mac = typed.replace(/^vid:/i, '').replace(/[:\\-. ]/g, '');\n    if (typed === '') {\n        // Blank restores the MAC address of the EV's network interface.\n        flow.set('evcc_id_command', 'set_evcc_id;');\n    } else if (/^[0-9a-f]{12}$/i.test(mac)) {\n        flow.set('evcc_id_command', 'set_evcc_id ' + mac.toUpperCase() + ';');\n    } else {\n        node.warn('Ignoring vehicle MAC \"' + typed + '\": not a MAC address');\n    }\n    return null;\n}\n\nif (msg.topic.indexOf('sim_commands') > -1) {\n    const s = msg.payload.split('#');\n    flow.set('sim_commands_start', s[0]);\n    flow.set('sim_commands_stop', s[1]);\n    flow.set('sim_commands_pause', s[2]);\n    flow.set('sim_commands_resume', s[3]);\n} else if (msg.payload == 'start') {\n    msg.payload = (flow.get('evcc_id_command') || '') + flow.get('sim_commands_start');\n    return msg;\n} else if (msg.payload == 'stop') {\n    msg.payload = flow.get('sim_commands_stop');\n    return msg;\n} else if (msg.payload == 'pause') {\n    msg.payload = flow.get('sim_commands_pause');\n    return msg;\n} else if (msg.payload == 'resume') {\n    msg.payload = flow.get('sim_commands_resume');\n    return msg;\n} else {\n    msg.payload = 'NONE';\n    return msg;\n}\n",
         "outputs": 1,
         "noerr": 0,
         "initialize": "",
@@ -3419,5 +3419,97 @@
                 "e17f0c84ed298eab"
             ]
         ]
+    },
+    {
+        "id": "b1d0ae5efa11ce00",
+        "type": "comment",
+        "z": "ed603c51db9dcbb9",
+        "name": "Simulated vehicle identity (Autocharge)",
+        "info": "The EV announces its MAC address as the EVCCID in SessionSetupReq. EvseManager turns that into the Autocharge token \"VID:<mac>\" and sends it to the CSMS as the Authorize idTag.\n\nWithout an override the MAC comes from the container's network interface, so every simulated session looks like the same car. Setting a value here makes a different vehicle turn up on the next plug-in.\n\nThe value is prepended to the \"Car Plugin\" command string as \"set_evcc_id <mac>\", so it takes effect for the session it starts.\n\nAccepts VID:0242AC110099, 02:42:AC:11:00:99 or 0242AC110099. Leave blank to go back to the interface MAC address.",
+        "x": 240,
+        "y": 1240,
+        "wires": []
+    },
+    {
+        "id": "b1d0ae5efa11ce01",
+        "type": "ui_text_input",
+        "z": "ed603c51db9dcbb9",
+        "name": "Vehicle MAC (VID)",
+        "label": "Vehicle MAC (VID)",
+        "tooltip": "Applied when the next session starts. Blank restores the network interface MAC address.",
+        "group": "b364f7eb4621082b",
+        "order": 16,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "mode": "text",
+        "delay": "0",
+        "topic": "evcc_id",
+        "sendOnBlur": true,
+        "className": "",
+        "topicType": "str",
+        "x": 200,
+        "y": 1300,
+        "wires": [
+            [
+                "620b0d248a89ece0"
+            ]
+        ]
+    },
+    {
+        "id": "b1d0ae5efa11ce02",
+        "type": "mqtt in",
+        "z": "ed603c51db9dcbb9",
+        "name": "",
+        "topic": "everest_external/nodered/+/carsim/state/evcc_id",
+        "qos": "2",
+        "datatype": "auto",
+        "broker": "fc8686af.48d178",
+        "nl": false,
+        "rap": true,
+        "rh": 0,
+        "inputs": 0,
+        "x": 290,
+        "y": 1360,
+        "wires": [
+            [
+                "b1d0ae5efa11ce03"
+            ]
+        ]
+    },
+    {
+        "id": "b1d0ae5efa11ce03",
+        "type": "function",
+        "z": "ed603c51db9dcbb9",
+        "name": "Filter connector number",
+        "func": "// The retained EVCCID is delivered the instant the broker connects, which can beat the inject node that\n// seeds connector_number, so fall back to this tab's connector rather than dropping the value silently.\nconst connector = flow.get('connector_number') || '1';\nif (msg.topic.indexOf(String(connector)) > -1) return msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 710,
+        "y": 1360,
+        "wires": [
+            [
+                "b1d0ae5efa11ce04"
+            ]
+        ]
+    },
+    {
+        "id": "b1d0ae5efa11ce04",
+        "type": "ui_text",
+        "z": "ed603c51db9dcbb9",
+        "group": "b364f7eb4621082b",
+        "order": 17,
+        "width": 0,
+        "height": 0,
+        "name": "",
+        "label": "Announced VID",
+        "format": "{{msg.payload}}",
+        "layout": "row-spread",
+        "x": 1000,
+        "y": 1360,
+        "wires": []
     }
 ]

--- a/config/nodered/config-sil-two-evse-flow.json
+++ b/config/nodered/config-sil-two-evse-flow.json
@@ -2161,7 +2161,7 @@
         "type": "function",
         "z": "ed603c51db9dcbb9",
         "name": "Buffer sim commands",
-        "func": "if (msg.topic.indexOf('sim_commands') > -1) {\n    const s = msg.payload.split('#');\n    flow.set('sim_commands_start', s[0]);\n    flow.set('sim_commands_stop', s[1]);\n    flow.set('sim_commands_pause', s[2]);\n    flow.set('sim_commands_resume', s[3]);\n} else if (msg.payload == 'start') {\n    msg.payload = flow.get('sim_commands_start');\n    return msg;\n} else if (msg.payload == 'stop') {\n    msg.payload = flow.get('sim_commands_stop');\n    return msg;\n} else if (msg.payload == 'pause') {\n    msg.payload = flow.get('sim_commands_pause');\n    return msg;\n} else if (msg.payload == 'resume') {\n    msg.payload = flow.get('sim_commands_resume');\n    return msg;\n} else {\n    msg.payload = 'NONE';\n    return msg;\n}\n",
+        "func": "// The \"Vehicle MAC (VID)\" input arrives here with the topic 'evcc_id'. The value is kept in flow context and\n// prepended to the session start commands rather than sent on its own, because execute_charging_session and\n// modify_charging_session replace the whole command queue - sending it separately would abort a running\n// session. Prepending also means the EV picks it up for the session that is starting, since the EVCCID is\n// fixed at SessionSetupReq.\nif (msg.topic === 'evcc_id') {\n    const typed = String(msg.payload || '').trim();\n    const mac = typed.replace(/^vid:/i, '').replace(/[:\\-. ]/g, '');\n    if (typed === '') {\n        // Blank restores the MAC address of the EV's network interface.\n        flow.set('evcc_id_command', 'set_evcc_id;');\n    } else if (/^[0-9a-f]{12}$/i.test(mac)) {\n        flow.set('evcc_id_command', 'set_evcc_id ' + mac.toUpperCase() + ';');\n    } else {\n        node.warn('Ignoring vehicle MAC \"' + typed + '\": not a MAC address');\n    }\n    return null;\n}\n\nif (msg.topic.indexOf('sim_commands') > -1) {\n    const s = msg.payload.split('#');\n    flow.set('sim_commands_start', s[0]);\n    flow.set('sim_commands_stop', s[1]);\n    flow.set('sim_commands_pause', s[2]);\n    flow.set('sim_commands_resume', s[3]);\n} else if (msg.payload == 'start') {\n    msg.payload = (flow.get('evcc_id_command') || '') + flow.get('sim_commands_start');\n    return msg;\n} else if (msg.payload == 'stop') {\n    msg.payload = flow.get('sim_commands_stop');\n    return msg;\n} else if (msg.payload == 'pause') {\n    msg.payload = flow.get('sim_commands_pause');\n    return msg;\n} else if (msg.payload == 'resume') {\n    msg.payload = flow.get('sim_commands_resume');\n    return msg;\n} else {\n    msg.payload = 'NONE';\n    return msg;\n}\n",
         "outputs": 1,
         "noerr": 0,
         "initialize": "",
@@ -3052,5 +3052,97 @@
                 "3ce436b7f3df46a5"
             ]
         ]
+    },
+    {
+        "id": "b1d0ae5efa11ce00",
+        "type": "comment",
+        "z": "ed603c51db9dcbb9",
+        "name": "Simulated vehicle identity (Autocharge)",
+        "info": "The EV announces its MAC address as the EVCCID in SessionSetupReq. EvseManager turns that into the Autocharge token \"VID:<mac>\" and sends it to the CSMS as the Authorize idTag.\n\nWithout an override the MAC comes from the container's network interface, so every simulated session looks like the same car. Setting a value here makes a different vehicle turn up on the next plug-in.\n\nThe value is prepended to the \"Car Plugin\" command string as \"set_evcc_id <mac>\", so it takes effect for the session it starts.\n\nAccepts VID:0242AC110099, 02:42:AC:11:00:99 or 0242AC110099. Leave blank to go back to the interface MAC address.",
+        "x": 240,
+        "y": 1240,
+        "wires": []
+    },
+    {
+        "id": "b1d0ae5efa11ce01",
+        "type": "ui_text_input",
+        "z": "ed603c51db9dcbb9",
+        "name": "Vehicle MAC (VID)",
+        "label": "Vehicle MAC (VID)",
+        "tooltip": "Applied when the next session starts. Blank restores the network interface MAC address.",
+        "group": "b364f7eb4621082b",
+        "order": 11,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "mode": "text",
+        "delay": "0",
+        "topic": "evcc_id",
+        "sendOnBlur": true,
+        "className": "",
+        "topicType": "str",
+        "x": 200,
+        "y": 1300,
+        "wires": [
+            [
+                "620b0d248a89ece0"
+            ]
+        ]
+    },
+    {
+        "id": "b1d0ae5efa11ce02",
+        "type": "mqtt in",
+        "z": "ed603c51db9dcbb9",
+        "name": "",
+        "topic": "everest_external/nodered/+/carsim/state/evcc_id",
+        "qos": "2",
+        "datatype": "auto",
+        "broker": "fc8686af.48d178",
+        "nl": false,
+        "rap": true,
+        "rh": 0,
+        "inputs": 0,
+        "x": 290,
+        "y": 1360,
+        "wires": [
+            [
+                "b1d0ae5efa11ce03"
+            ]
+        ]
+    },
+    {
+        "id": "b1d0ae5efa11ce03",
+        "type": "function",
+        "z": "ed603c51db9dcbb9",
+        "name": "Filter connector number",
+        "func": "// The retained EVCCID is delivered the instant the broker connects, which can beat the inject node that\n// seeds connector_number, so fall back to this tab's connector rather than dropping the value silently.\nconst connector = flow.get('connector_number') || '1';\nif (msg.topic.indexOf(String(connector)) > -1) return msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 710,
+        "y": 1360,
+        "wires": [
+            [
+                "b1d0ae5efa11ce04"
+            ]
+        ]
+    },
+    {
+        "id": "b1d0ae5efa11ce04",
+        "type": "ui_text",
+        "z": "ed603c51db9dcbb9",
+        "group": "b364f7eb4621082b",
+        "order": 12,
+        "width": 0,
+        "height": 0,
+        "name": "",
+        "label": "Announced VID",
+        "format": "{{msg.payload}}",
+        "layout": "row-spread",
+        "x": 1000,
+        "y": 1360,
+        "wires": []
     }
 ]

--- a/interfaces/ISO15118_ev.yaml
+++ b/interfaces/ISO15118_ev.yaml
@@ -55,6 +55,24 @@ cmds:
         description: The actual State of Charge from the EV
         type: number
         minimum: 0
+  set_evcc_id:
+    description: >-
+      Override the EVCCID that the EV announces in SessionSetupReq. Implementations normally derive it from the
+      MAC address of the HLC network interface, which is fixed for the lifetime of the process. Overriding it
+      lets a single simulator present itself as a series of different vehicles, which is what Autocharge keys
+      off. Takes effect on the next V2G session, so call it before plugging in.
+    arguments:
+      EvccId:
+        description: >-
+          MAC address to announce, with an optional "VID:" prefix and with or without separators, e.g.
+          "VID:0242AC110099", "02:42:AC:11:00:99" or "0242ac110099". An empty string clears the override and
+          restores the MAC address of the network interface.
+        type: string
+    result:
+      description: >-
+        The EVCCID that will be announced on the next session, as 12 uppercase hex digits, or an empty string if
+        the argument was not a MAC address - in which case the previous EVCCID stays in use.
+      type: string
 vars:
   v2g_session_finished:
     description: The v2g session between the charger and the car is finished

--- a/interfaces/ISO15118_ev.yaml
+++ b/interfaces/ISO15118_ev.yaml
@@ -60,7 +60,8 @@ cmds:
       Override the EVCCID that the EV announces in SessionSetupReq. Implementations normally derive it from the
       MAC address of the HLC network interface, which is fixed for the lifetime of the process. Overriding it
       lets a single simulator present itself as a series of different vehicles, which is what Autocharge keys
-      off. Takes effect on the next V2G session, so call it before plugging in.
+      off. The EVCCID is fixed at SessionSetupReq, so this has to be called before the V2G session starts and
+      applies from that session onwards.
     arguments:
       EvccId:
         description: >-
@@ -70,8 +71,8 @@ cmds:
         type: string
     result:
       description: >-
-        The EVCCID that will be announced on the next session, as 12 uppercase hex digits, or an empty string if
-        the argument was not a MAC address - in which case the previous EVCCID stays in use.
+        The EVCCID that will be announced, as 12 uppercase hex digits, or an empty string if the argument was
+        not a MAC address - in which case the previous EVCCID stays in use.
       type: string
 vars:
   v2g_session_finished:

--- a/modules/EV/EvManager/docs/index.rst
+++ b/modules/EV/EvManager/docs/index.rst
@@ -38,6 +38,25 @@ The module listens to the following MQTT topics:
     | Used to modify the current charging session.
     | Follows the same format as ``execute_charging_session``.
 
+``everest_external/nodered/{connector_id}/carsim/cmd/set_evcc_id``
+    | Used to override the EVCCID that the simulated EV announces in ``SessionSetupReq``,
+      so that one simulator can present itself as a series of different vehicles.
+    | Accepts an optional ``VID:`` prefix and any of the usual separators. An empty payload
+      restores the MAC address of the network interface.
+    | Takes effect on the next V2G session, so set it before plugging in.
+    | Example values:
+
+    - ``VID:0242AC110099``
+    - ``02:42:AC:11:00:99``
+    - ``0242ac110099``
+
+The module publishes to the following MQTT topics:
+
+``everest_external/nodered/{connector_id}/carsim/state/evcc_id``
+    | The EVCCID that will be announced, in the ``VID:`` form the charging station uses as the
+      Autocharge token, or ``rejected`` if the requested value was not a MAC address.
+    | Published retained, so a dashboard connecting later still sees the vehicle being simulated.
+
 .. _everest_modules_handwritten_EvManager_simulator_commands:
 
 Simulator Commands
@@ -46,5 +65,10 @@ Simulator Commands
 ``sleep {time in seconds}``
     | Sleeps for the specified time.
     | Example: ``sleep 10``
+
+``set_evcc_id {mac address}``
+    | Overrides the EVCCID announced by the simulated EV from the next V2G session onwards.
+    | Only available when an ``ISO15118_ev`` implementation is connected.
+    | Example: ``set_evcc_id 0242AC110099``
 
 ``test``

--- a/modules/EV/EvManager/docs/index.rst
+++ b/modules/EV/EvManager/docs/index.rst
@@ -38,23 +38,12 @@ The module listens to the following MQTT topics:
     | Used to modify the current charging session.
     | Follows the same format as ``execute_charging_session``.
 
-``everest_external/nodered/{connector_id}/carsim/cmd/set_evcc_id``
-    | Used to override the EVCCID that the simulated EV announces in ``SessionSetupReq``,
-      so that one simulator can present itself as a series of different vehicles.
-    | Accepts an optional ``VID:`` prefix and any of the usual separators. An empty payload
-      restores the MAC address of the network interface.
-    | Takes effect on the next V2G session, so set it before plugging in.
-    | Example values:
-
-    - ``VID:0242AC110099``
-    - ``02:42:AC:11:00:99``
-    - ``0242ac110099``
-
 The module publishes to the following MQTT topics:
 
 ``everest_external/nodered/{connector_id}/carsim/state/evcc_id``
-    | The EVCCID that will be announced, in the ``VID:`` form the charging station uses as the
-      Autocharge token, or ``rejected`` if the requested value was not a MAC address.
+    | Published whenever a ``set_evcc_id`` simulator command runs. Carries the EVCCID that the EV
+      will announce, in the ``VID:`` form the charging station uses as the Autocharge token, or
+      ``rejected`` if the requested value was not a MAC address.
     | Published retained, so a dashboard connecting later still sees the vehicle being simulated.
 
 .. _everest_modules_handwritten_EvManager_simulator_commands:
@@ -66,9 +55,22 @@ Simulator Commands
     | Sleeps for the specified time.
     | Example: ``sleep 10``
 
-``set_evcc_id {mac address}``
-    | Overrides the EVCCID announced by the simulated EV from the next V2G session onwards.
+``set_evcc_id [{mac address}]``
+    | Overrides the EVCCID announced by the simulated EV, so that one simulator can present itself
+      as a series of different vehicles. ``EvseManager`` turns the EVCCID into the Autocharge token
+      ``VID:{mac address}`` and sends it to the CSMS as the ``Authorize`` idTag.
+    | Accepts an optional ``VID:`` prefix and any of the usual separators. Called without an
+      argument it drops the override and goes back to the MAC address of the network interface.
+    | The EVCCID is fixed at ``SessionSetupReq``, so put this in front of the command that starts
+      the V2G session for it to apply to that session.
     | Only available when an ``ISO15118_ev`` implementation is connected.
-    | Example: ``set_evcc_id 0242AC110099``
+    | Examples:
+
+    ::
+
+        "set_evcc_id 0242AC110099;iso_wait_slac_matched;iso_start_v2g_session DC 86400 0"
+        "set_evcc_id VID:0242AC110099"
+        "set_evcc_id 02:42:AC:11:00:99"
+        "set_evcc_id"
 
 ``test``

--- a/modules/EV/EvManager/main/car_simulation.cpp
+++ b/modules/EV/EvManager/main/car_simulation.cpp
@@ -369,6 +369,21 @@ bool CarSimulation::iso_draw_power_regulated(const CmdArguments& arguments) {
     return true;
 }
 
+std::string CarSimulation::set_evcc_id(const std::string& evcc_id) {
+    if (r_ev.empty()) {
+        EVLOG_error << "set_evcc_id requires an ISO15118_ev connection, none is configured";
+        return {};
+    }
+
+    const auto accepted = r_ev[0]->call_set_evcc_id(evcc_id);
+    if (accepted.empty()) {
+        EVLOG_error << "EV rejected EVCCID \"" << evcc_id << "\", the previous one is still in use";
+    } else {
+        EVLOG_info << "EV will announce EVCCID " << accepted << " on the next session";
+    }
+    return accepted;
+}
+
 bool CarSimulation::iso_stop_charging(const CmdArguments& arguments) {
     r_ev[0]->call_stop_charging();
     r_ev_board_support->call_allow_power_on(false);

--- a/modules/EV/EvManager/main/car_simulation.hpp
+++ b/modules/EV/EvManager/main/car_simulation.hpp
@@ -54,6 +54,11 @@ public:
         sim_data.modify_charging_session_cmds.emplace(cmds);
     }
 
+    /// Ask the EV to announce a different EVCCID (its MAC address) from the next V2G session onwards, so that a
+    /// single simulator can play the part of several vehicles. Returns the EVCCID that will actually be
+    /// announced, or an empty string if the EV rejected the value or there is no EV connected.
+    std::string set_evcc_id(const std::string& evcc_id);
+
     void set_state(SimState state) {
         sim_data.state = state;
     }

--- a/modules/EV/EvManager/main/car_simulatorImpl.cpp
+++ b/modules/EV/EvManager/main/car_simulatorImpl.cpp
@@ -271,6 +271,12 @@ void car_simulatorImpl::register_all_commands() {
         command_registry->register_command("iso_start_bcb_toggle", 1, [this](const CmdArguments& arguments) {
             return this->car_simulation->iso_start_bcb_toggle(arguments);
         });
+        command_registry->register_command("set_evcc_id", 1, [this](const CmdArguments& arguments) {
+            // The command parser lower-cases the whole simulation string, which is harmless here because the EV
+            // normalises the MAC address to upper case anyway.
+            publish_evcc_id(this->car_simulation->set_evcc_id(arguments.at(0)));
+            return true;
+        });
     }
 }
 
@@ -415,6 +421,18 @@ void car_simulatorImpl::subscribe_to_external_mqtt() {
                        auto data_copy = data;
                        handle_modify_charging_session(data_copy);
                    });
+    mqtt.subscribe("everest_external/nodered/" + std::to_string(mod->config.connector_id) + "/carsim/cmd/set_evcc_id",
+                   [this](const std::string& data) { publish_evcc_id(car_simulation->set_evcc_id(data)); });
+}
+
+void car_simulatorImpl::publish_evcc_id(const std::string& evcc_id) {
+    // Echo back what the EV will actually announce so a dashboard can confirm the value was taken. It is
+    // published in the "VID:" form because that is what the charging station turns it into for Autocharge, and
+    // therefore what has to be registered with the CSMS. Retained, so a dashboard that connects later still
+    // sees which vehicle is currently being simulated.
+    const auto payload = evcc_id.empty() ? std::string{"rejected"} : "VID:" + evcc_id;
+    mod->mqtt.publish("everest_external/nodered/" + std::to_string(mod->config.connector_id) + "/carsim/state/evcc_id",
+                      payload, true);
 }
 
 void car_simulatorImpl::reset_car_simulation_defaults() {

--- a/modules/EV/EvManager/main/car_simulatorImpl.cpp
+++ b/modules/EV/EvManager/main/car_simulatorImpl.cpp
@@ -271,10 +271,16 @@ void car_simulatorImpl::register_all_commands() {
         command_registry->register_command("iso_start_bcb_toggle", 1, [this](const CmdArguments& arguments) {
             return this->car_simulation->iso_start_bcb_toggle(arguments);
         });
+        // Two arities: "set_evcc_id <mac>" announces that MAC address, "set_evcc_id" on its own drops the
+        // override and goes back to the MAC address of the EV's network interface. The command parser
+        // lower-cases the whole simulation string, which is harmless here because the EV normalises the MAC
+        // address to upper case anyway.
         command_registry->register_command("set_evcc_id", 1, [this](const CmdArguments& arguments) {
-            // The command parser lower-cases the whole simulation string, which is harmless here because the EV
-            // normalises the MAC address to upper case anyway.
             publish_evcc_id(this->car_simulation->set_evcc_id(arguments.at(0)));
+            return true;
+        });
+        command_registry->register_command("set_evcc_id", 0, [this](const CmdArguments& /*arguments*/) {
+            publish_evcc_id(this->car_simulation->set_evcc_id(""));
             return true;
         });
     }
@@ -421,8 +427,6 @@ void car_simulatorImpl::subscribe_to_external_mqtt() {
                        auto data_copy = data;
                        handle_modify_charging_session(data_copy);
                    });
-    mqtt.subscribe("everest_external/nodered/" + std::to_string(mod->config.connector_id) + "/carsim/cmd/set_evcc_id",
-                   [this](const std::string& data) { publish_evcc_id(car_simulation->set_evcc_id(data)); });
 }
 
 void car_simulatorImpl::publish_evcc_id(const std::string& evcc_id) {

--- a/modules/EV/EvManager/main/car_simulatorImpl.hpp
+++ b/modules/EV/EvManager/main/car_simulatorImpl.hpp
@@ -61,6 +61,7 @@ private:
     void setup_ev_parameters();
     void call_ev_board_support_functions();
     void subscribe_to_external_mqtt();
+    void publish_evcc_id(const std::string& evcc_id);
     void reset_car_simulation_defaults();
     void update_command_queue(std::string& value);
     void set_execution_active(bool value);

--- a/modules/EV/EvManager/tests/SimCommandTest.cpp
+++ b/modules/EV/EvManager/tests/SimCommandTest.cpp
@@ -116,3 +116,52 @@ SCENARIO("SimCommands can be parsed", "[SimCommand]") {
         }
     }
 }
+
+SCENARIO("Overloaded SimCommands are parsed by their argument count", "[SimCommand]") {
+    GIVEN("A command registered with both 0 and 1 arguments, as set_evcc_id is") {
+        auto command_registry = CommandRegistry();
+        const auto command_name = std::string{"set_evcc_id"};
+
+        auto called_without_argument = false;
+        auto called_with_argument = std::string{};
+
+        command_registry.register_command(command_name, 0,
+                                          [&called_without_argument](const std::vector<std::string>& /*arguments*/) {
+                                              called_without_argument = true;
+                                              return true;
+                                          });
+        command_registry.register_command(command_name, 1,
+                                          [&called_with_argument](const std::vector<std::string>& arguments) {
+                                              called_with_argument = arguments.at(0);
+                                              return true;
+                                          });
+
+        WHEN("Both forms appear in the same command string") {
+            // Note that parsing lower-cases the whole string, which is why the argument comes back lower-cased.
+            const auto command_string = "set_evcc_id 0242AC110099;set_evcc_id";
+            auto parsed_commands = SimulationCommand::parse_sim_commands(command_string, command_registry);
+
+            THEN("Each one resolves to the overload with the matching argument count") {
+                CHECK(parsed_commands.front().execute());
+                CHECK(called_with_argument == "0242ac110099");
+                CHECK_FALSE(called_without_argument);
+                parsed_commands.pop();
+
+                CHECK(parsed_commands.front().execute());
+                CHECK(called_without_argument);
+                parsed_commands.pop();
+
+                CHECK(parsed_commands.empty());
+            }
+        }
+
+        WHEN("The command is given too many arguments") {
+            const auto command_string = "set_evcc_id 0242ac110099 extra";
+
+            THEN("Parsing should fail") {
+                CHECK_THROWS_WITH(SimulationCommand::parse_sim_commands(command_string, command_registry),
+                                  "Command not found: set_evcc_id");
+            }
+        }
+    }
+}

--- a/modules/EV/PyEvJosev/manifest.yaml
+++ b/modules/EV/PyEvJosev/manifest.yaml
@@ -52,6 +52,15 @@ config:
     description: If true, the ev will select all offered services
     type: boolean
     default: false
+  evcc_id:
+    description: >-
+      EVCCID announced in SessionSetupReq, overriding the MAC address of the HLC network interface. Accepts an
+      optional "VID:" prefix and any of the usual separators, e.g. "VID:0242AC110099", "02:42:AC:11:00:99" or
+      "0242ac110099". Leave empty to use the interface MAC address. Can be changed at runtime with the
+      set_evcc_id command. Only applies to DIN 70121 and ISO 15118-2; ISO 15118-20 announces a manufacturer
+      string rather than a MAC address, so the override is ignored there.
+    type: string
+    default: ""
   supported_d20_energy_services:
     description: >-
       The supported ISO15118-20 energy services (DC, DC_BPT, AC, AC_BPT) the EV supports,

--- a/modules/EV/PyEvJosev/module.py
+++ b/modules/EV/PyEvJosev/module.py
@@ -16,12 +16,16 @@ from iso15118.evcc import EVCCHandler
 from iso15118.evcc.controller.simulator import SimEVController
 from iso15118.evcc.evcc_config import EVCCConfig
 from iso15118.evcc.everest import context as JOSEV_CONTEXT
+from iso15118.shared.exceptions import MACAddressNotFound
 from iso15118.shared.exificient_exi_codec import ExificientEXICodec
+from iso15118.shared.messages.enums import Protocol
+from iso15118.shared.network import get_nic_mac_address
 from iso15118.shared.settings import set_PKI_PATH, enable_tls_1_3
 
 from utilities import (
     setup_everest_logging,
     determine_network_interface,
+    normalize_evcc_id,
     patch_josev_config
 )
 
@@ -29,7 +33,37 @@ setup_everest_logging()
 
 EVEREST_CERTS_SUB_DIR = 'certs'
 
-async def evcc_handler_main_loop(module_config: dict, exi_codec: ExificientEXICodec):
+# The EVCCID is a MAC address only for these two protocols. ISO 15118-20 announces a manufacturer string
+# instead, so an override expressed as a MAC address is meaningless there and is left alone.
+MAC_ADDRESS_PROTOCOLS = (Protocol.ISO_15118_2, Protocol.DIN_SPEC_70121)
+
+
+class SimEVControllerWithEvccIdOverride(SimEVController):
+    """
+    A SimEVController that can announce an EVCCID other than the MAC address of the HLC network interface.
+
+    josev derives the EVCCID from the NIC, which is fixed for the lifetime of the process - in a container it is
+    fixed for the lifetime of the container. That makes it impossible to simulate a second vehicle arriving,
+    which matters because Autocharge identifies a vehicle purely by this address. The override is read fresh on
+    every session, so changing it between sessions is enough to impersonate a different car.
+    """
+
+    def __init__(self, evcc_config: EVCCConfig, evcc_id_source):
+        super().__init__(evcc_config)
+        self._evcc_id_source = evcc_id_source
+
+    async def get_evcc_id(self, protocol: Protocol, iface: str) -> str:
+        """Overrides SimEVController.get_evcc_id()."""
+
+        override = self._evcc_id_source()
+        if override and protocol in MAC_ADDRESS_PROTOCOLS:
+            log.info(f"Announcing EVCCID {override} instead of the {iface} MAC address")
+            return override
+
+        return await super().get_evcc_id(protocol, iface)
+
+
+async def evcc_handler_main_loop(module_config: dict, exi_codec: ExificientEXICodec, evcc_id_source):
     """
     Entrypoint function that starts the ISO 15118 code running on
     the EVCC (EV Communication Controller)
@@ -43,7 +77,7 @@ async def evcc_handler_main_loop(module_config: dict, exi_codec: ExificientEXICo
         evcc_config=evcc_config,
         iface=iface,
         exi_codec=exi_codec,
-        ev_controller=SimEVController(evcc_config),
+        ev_controller=SimEVControllerWithEvccIdOverride(evcc_config, evcc_id_source),
     ).start()
 
 class PyEVJosevModule():
@@ -65,6 +99,13 @@ class PyEVJosevModule():
         self._es.internet_service_needed = self._setup.configs.module['is_internet_service_needed']
         self._es.all_service_details = self._setup.configs.module['request_all_service_details']
         self._es.all_vas_services = self._setup.configs.module['select_all_vas_services']
+
+        # Read by the EV controller on every session, and written by _handler_set_evcc_id from the framework
+        # thread. A plain string assignment is atomic under the GIL, so no lock is needed.
+        configured_evcc_id = self._setup.configs.module['evcc_id']
+        self._evcc_id_override = normalize_evcc_id(configured_evcc_id)
+        if configured_evcc_id and not self._evcc_id_override:
+            log.error(f'Ignoring evcc_id config "{configured_evcc_id}": not a MAC address')
 
         # setup publishing callback
         def publish_callback(variable_name: str, value: any):
@@ -90,7 +131,8 @@ class PyEVJosevModule():
             while True:
                 self._ready_event.wait()
                 try:
-                    asyncio.run(evcc_handler_main_loop(self._setup.configs.module, exi_codec))
+                    asyncio.run(evcc_handler_main_loop(self._setup.configs.module, exi_codec,
+                                                       lambda: self._evcc_id_override))
                     self._mod.publish_variable('ev', 'v2g_session_finished', None)
                 except KeyboardInterrupt:
                     log.debug("SECC program terminated manually")
@@ -150,6 +192,31 @@ class PyEVJosevModule():
 
     def _handler_update_soc(self, args):
         self._es.actual_soc = math.floor(args['SoC'])
+
+    def _handler_set_evcc_id(self, args) -> str:
+        requested = args['EvccId']
+
+        if not requested.strip():
+            self._evcc_id_override = ''
+            log.info('EVCCID override cleared, falling back to the network interface MAC address')
+            return self._interface_mac_address()
+
+        normalized = normalize_evcc_id(requested)
+        if not normalized:
+            log.error(f'Ignoring set_evcc_id "{requested}": not a MAC address. Keeping the current EVCCID')
+            return ''
+
+        self._evcc_id_override = normalized
+        log.info(f'EVCCID set to {normalized}, it will be announced on the next V2G session')
+        return normalized
+
+    def _interface_mac_address(self) -> str:
+        iface = determine_network_interface(self._setup.configs.module['device'])
+        try:
+            return get_nic_mac_address(iface).replace(':', '').upper()
+        except MACAddressNotFound as exc:
+            log.warning(f"Couldn't determine the MAC address of {iface}: {exc}")
+            return ''
 
 py_ev_josev = PyEVJosevModule()
 py_ev_josev.start_evcc_handler()

--- a/modules/EV/PyEvJosev/utilities.py
+++ b/modules/EV/PyEvJosev/utilities.py
@@ -63,6 +63,40 @@ def determine_network_interface(preferred_interface: str) -> str:
     return preferred_interface
 
 
+MAC_ADDRESS_HEX_DIGITS = 12
+EVCC_ID_SEPARATORS = (':', '-', '.', ' ')
+VID_PREFIX = 'VID:'
+
+
+def normalize_evcc_id(value: str) -> str:
+    """
+    Turn a MAC address written in any of the forms a user is likely to type into the 12 uppercase hex digits
+    that DIN 70121 and ISO 15118-2 expect in SessionSetupReq. Accepts "VID:0242AC110099", "02:42:AC:11:00:99",
+    "02-42-ac-11-00-99" and "0242ac110099" alike, and returns an empty string for anything that is not a MAC
+    address.
+
+    The "VID:" prefix belongs to the OCPP token, not to the EVCCID - EvseManager prepends it again on the
+    charging station side - so it is accepted for convenience and then stripped.
+    """
+    candidate = value.strip()
+
+    if candidate.upper().startswith(VID_PREFIX):
+        candidate = candidate[len(VID_PREFIX):]
+
+    for separator in EVCC_ID_SEPARATORS:
+        candidate = candidate.replace(separator, '')
+
+    if len(candidate) != MAC_ADDRESS_HEX_DIGITS:
+        return ''
+
+    try:
+        int(candidate, 16)
+    except ValueError:
+        return ''
+
+    return candidate.upper()
+
+
 def patch_josev_config(josev_config: EVCCConfig, everest_config: dict) -> None:
 
     josev_config.use_tls = everest_config['tls_active']


### PR DESCRIPTION
## Describe your changes

Lets the simulated EV announce an EVCCID other than the MAC address of its network interface, so one SIL setup
can simulate a series of different vehicles arriving.

**Why.** josev derives the EVCCID from the NIC (`get_nic_mac_address`), which is fixed for the lifetime of the
process - in a container, for the lifetime of the container. Autocharge identifies a vehicle solely by that
address: `EvseManager` turns the EVCCID into the token `VID:<mac>` and sends it to the CSMS as the `Authorize`
idTag. So today a SIL deployment can only ever present one vehicle, and testing anything fleet-shaped means
recreating the container with a different MAC.

<img width="367" height="383" alt="image" src="https://github.com/user-attachments/assets/12f821a4-6ced-47f5-8775-d3a7899fbd2a" />

**What changed**

- `interfaces/ISO15118_ev.yaml` - new `set_evcc_id` command, returning the EVCCID that will actually be
  announced (12 uppercase hex digits) or an empty string if the argument was not a MAC address.
- `PyEvJosev` - new `evcc_id` config key, plus the runtime command. Implemented by subclassing josev's
  `SimEVController` and overriding `get_evcc_id`, so nothing in the fetched josev dependency is patched. The
  override is read fresh per session.
- `EvManager` - a `set_evcc_id` simulation command and an
  `everest_external/nodered/<n>/carsim/cmd/set_evcc_id` MQTT topic, echoing the accepted value back retained on
  `.../carsim/state/evcc_id` as `VID:...`, or `rejected`.
- `config/nodered/config-sil-dc-flow.json` - a "Vehicle MAC (VID)" input and an "Announced VID" readout on the
  Connector 1 card.

Input is accepted as `VID:0242AC110099`, `02:42:AC:11:00:99` or `0242ac110099`; blank restores the interface
MAC address.

**Notes for reviewers**

- This adds a command to a shared interface. `PyEvJosev` is the only implementer of `ISO15118_ev` today, so
  nothing else needs updating, but flagging it as an API change.
- The override applies from the **next** V2G session, since the EVCCID is fixed at `SessionSetupReq`.
- ISO 15118-20 is deliberately unaffected - it announces a manufacturer string rather than a MAC, so a MAC
  override is meaningless there and is skipped.
- Only the DC SIL flow gained the dashboard widget. Happy to add it to the other flows in `config/nodered/` if
  you would like that in the same PR.
- No automated tests added. `EvManager/tests/` would be the natural home for coverage of the command
  registration and the MAC normalisation - happy to add it if you want that before merge.

## Issue ticket number and link

None - happy to open one first if that is preferred.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

Verified end to end against a live CSMS: setting `VID:AABBCCDDEE01` produced
`EVCCID: AA:BB:CC:DD:EE:01` in `SessionSetupReq` and `"idTag": "VID:AABBCCDDEE01"` in the OCPP transcript,
where the container's own MAC would otherwise have been used. Blank input restored the interface MAC, and a
non-MAC input was rejected with the previous value left in place.
