### PR TITLE
feat(Huawei_V100R023C10): make Modbus communication timeout configurable

### DIFF
--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/Huawei_V100R023C10.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/Huawei_V100R023C10.cpp
@@ -126,6 +126,7 @@ void Huawei_V100R023C10::init() {
     dispenser_config.verify_secure_goose_hmac = config.verify_secure_goose;
     dispenser_config.module_placeholder_allocation_timeout =
         std::chrono::seconds(config.module_placeholder_allocation_timeout_s);
+    dispenser_config.modbus_timeout_ms = std::chrono::seconds(config.modbus_timeout_s);
 
     dispenser_config.telemetry_publisher = this->telemetry_publisher;
 

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/Huawei_V100R023C10.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/Huawei_V100R023C10.hpp
@@ -38,6 +38,7 @@ struct Conf {
     std::string client_cert;
     std::string client_key;
     int module_placeholder_allocation_timeout_s;
+    int modbus_timeout_s;
     std::string esn;
     bool HACK_publish_requested_voltage_current;
     bool HACK_use_ovm_while_cable_check;

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/include/configuration.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/include/configuration.hpp
@@ -27,7 +27,7 @@ struct DispenserConfig {
     std::uint16_t charging_connector_count;
     std::string esn;
 
-    std::chrono::milliseconds modbus_timeout_ms = std::chrono::seconds(60);
+    std::chrono::milliseconds modbus_timeout_ms = std::chrono::seconds(10);
 
     bool send_secure_goose = true;        // if set to true send secured goose frames,
                                           // if false only send unsecured frames

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/manifest.yaml
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/manifest.yaml
@@ -43,6 +43,15 @@ config:
       Timeout in seconds for the allocation of a module placeholder.
     type: integer
     default: 5
+  modbus_timeout_s:
+    description: |
+      Timeout in seconds for the Modbus communication with the power supply.
+      If no Modbus data is received from the power supply for this duration,
+      the communication is considered lost and a CommunicationFault is raised.
+    type: integer
+    default: 60
+    minimum: 1
+    maximum: 120
   esn:
     description: |
       Electronic Serial Number of the dispenser.

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/manifest.yaml
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/manifest.yaml
@@ -43,6 +43,15 @@ config:
       Timeout in seconds for the allocation of a module placeholder.
     type: integer
     default: 5
+  modbus_timeout_s:
+    description: |
+      Timeout in seconds for the Modbus communication with the power supply.
+      If no Modbus data is received from the power supply for this duration,
+      the communication is considered lost and a CommunicationFault is raised.
+    type: integer
+    default: 10
+    minimum: 1
+    maximum: 120
   esn:
     description: |
       Electronic Serial Number of the dispenser.


### PR DESCRIPTION
## Describe your changes

The timeout after which lost Modbus communication with the Huawei power unit raises a `power_supply_DC/CommunicationFault` was hardcoded to 60 s in the fusion-charger dispenser library (`DispenserConfig::modbus_timeout_ms`) and could not be changed via the module configuration. 60 s is a long time to keep charging after the PU has gone silent before declaring the link dead.

This change:

- Adds a new manifest config parameter `modbus_timeout_s` (integer, default **10**, range **1–120**) to the `Huawei_V100R023C10` module and wires it into `DispenserConfig::modbus_timeout_ms` in `init()`.
- Lowers the library's built-in default from 60 s to 10 s so direct library users get the same default.

Note on choosing values: the poll-thread timer resets on *any* Modbus PDU received from the PU (which is the Modbus master), so the practical lower bound depends on the PU's natural register-write cadence; very low values may false-positive.

## Issue ticket number and link

n/a

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)