### PR TITLE
fix(EvseManager): do not raise cable check fault on requested transaction stop

### DIFF
--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -2072,6 +2072,28 @@ void Charger::dlink_error() {
 
     shared_context.hlc_allow_close_contactor = false;
 
+    // If the session is being stopped for good (e.g. the transaction was stopped on request
+    // during cable check) or is already over, the D-LINK_ERROR is a consequence of the HLC
+    // session shutting down, not a communication error to recover from. Do not restart matching
+    // in this case as the session can not continue anyway; stop PWM and power instead so the
+    // StoppingCharging state can proceed to Finished once the contactors are open.
+    const bool stopping_for_good = shared_context.current_state == EvseState::StoppingCharging and
+                                   (not shared_context.flag_transaction_active or not shared_context.flag_authorized or
+                                    shared_context.flag_disable_requested);
+    if (stopping_for_good or shared_context.current_state == EvseState::Finished) {
+        session_log.evse(false, "D-LINK_ERROR while the session is stopping or finished: not restarting matching");
+        if (shared_context.pwm_running) {
+            cp_state_X1();
+        }
+
+        if (config_context.charge_mode == ChargeMode::DC) {
+            signal_dc_supply_off();
+        }
+
+        bsp->allow_power_on(false, types::evse_board_support::Reason::PowerOff);
+        return;
+    }
+
     // Is PWM on at the moment?
     if (not shared_context.pwm_running) {
         // [V2G3-M07-04]: With receiving a D-LINK_ERROR.request from HLE in X1 state, the EVSE's

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -503,6 +503,9 @@ protected:
     constexpr auto& get_shared_context() {
         return shared_context;
     }
+    auto& get_hlc_use_5percent_current_session() {
+        return hlc_use_5percent_current_session;
+    }
     constexpr const auto& get_enable_disable_source_table() const {
         return enable_disable_source_table;
     }

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -2539,17 +2539,26 @@ void EvseManager::fail_cable_check(const std::string& reason) {
         r_hlc[0]->call_cable_check_finished(false);
     }
     // Raising a cable check fault should not happen if:
-    // - a cancel_transaction (DeAuthorized) is triggered during cable check
+    // - the transaction was stopped on request (DeAuthorized, or a regular local/remote stop)
+    //   during cable check: this is a regular termination, not a fault
     // - the car has already been unplugged (Idle/Finished), which prevents a race condition
     //   where the detached cable check thread raises an error after clear_errors_on_unplug()
     //   has already run, leaving the charger permanently inoperative (see GitHub issue #1392)
     const auto current_state = charger->get_current_state();
     const auto last_stop_transaction_reason = charger->get_last_stop_transaction_reason();
+    const bool stop_requested =
+        last_stop_transaction_reason.has_value() and
+        (last_stop_transaction_reason.value() == types::evse_manager::StopTransactionReason::DeAuthorized or
+         last_stop_transaction_reason.value() == types::evse_manager::StopTransactionReason::Local or
+         last_stop_transaction_reason.value() == types::evse_manager::StopTransactionReason::Remote or
+         last_stop_transaction_reason.value() == types::evse_manager::StopTransactionReason::EVSEDisabled);
     if (current_state == Charger::EvseState::Idle || current_state == Charger::EvseState::Finished) {
         EVLOG_info << "Cable check failed due to: " << reason
                    << ", but session already ended (car unplugged). Not raising cable check fault error.";
-    } else if (not last_stop_transaction_reason.has_value() or
-               last_stop_transaction_reason.value() != types::evse_manager::StopTransactionReason::DeAuthorized) {
+    } else if (stop_requested) {
+        EVLOG_info << "Cable check failed due to: " << reason
+                   << ", but transaction was stopped on request. Not raising cable check fault error.";
+    } else {
         // Raising the cable check error also causes the HLC stack to get notified
         this->error_handling->raise_cable_check_fault(reason);
     }

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -19,6 +19,7 @@ using namespace types::evse_manager;
 struct ChargerDerived : public Charger {
     using Charger::Charger;
     using Charger::get_enable_disable_source_table;
+    using Charger::get_hlc_use_5percent_current_session;
     using Charger::get_shared_context;
     using Charger::run_state_machine;
 
@@ -759,6 +760,120 @@ TEST_F(ChargerTest, DisableDuringIdle) {
     // Must immediately transition to Disabled
     EXPECT_EQ(ctx.current_state, Charger::EvseState::Disabled);
     EXPECT_EQ(last_event, SessionEventEnum::Disabled);
+}
+
+// ----------------------------------------------------------------------------
+// tests for dlink_error()
+// A D-LINK_ERROR normally restarts SLAC matching via T_step_X1/T_step_EF
+// ([V2G3-M07-05] error recovery). When the session is being stopped for good or
+// is already finished, the D-LINK_ERROR is just the consequence of the HLC
+// session shutting down and matching must NOT be restarted, so the session can
+// end in StoppingCharging -> Finished.
+
+struct ChargerDlinkErrorTest : public ChargerTest {
+    // never dereferenced: the IECStateMachine used here is the no-op stub below
+    std::unique_ptr<evse_board_supportIntf> bsp_if;
+
+    void SetUp() override {
+        charger_bsp = std::make_unique<IECStateMachine>(bsp_if, true, false);
+        ChargerTest::SetUp();
+    }
+
+    void setup_hlc_session_in(Charger::EvseState state) {
+        auto& ctx = charger->get_shared_context();
+        ctx.current_state = state;
+        ctx.pwm_running = true;
+        ctx.hlc_charging_active = true;
+        ctx.flag_transaction_active = true;
+        ctx.flag_authorized = true;
+        charger->get_hlc_use_5percent_current_session() = true;
+    }
+};
+
+TEST_F(ChargerDlinkErrorTest, NoMatchingRestartWhenStoppingDeauthorized) {
+    // Transaction stopped on request during cable check: auth is withdrawn and the
+    // charger is in StoppingCharging when the dying HLC session reports D-LINK_ERROR
+    setup_hlc_session_in(Charger::EvseState::StoppingCharging);
+    auto& ctx = charger->get_shared_context();
+    ctx.flag_authorized = false;
+
+    charger->dlink_error();
+
+    // Matching must not be restarted; PWM is switched off so the state machine can
+    // proceed to Finished
+    EXPECT_EQ(charger->current_state(), Charger::EvseState::StoppingCharging);
+    EXPECT_FALSE(ctx.pwm_running);
+}
+
+TEST_F(ChargerDlinkErrorTest, NoMatchingRestartWhenStoppingWithoutTransaction) {
+    setup_hlc_session_in(Charger::EvseState::StoppingCharging);
+    auto& ctx = charger->get_shared_context();
+    ctx.flag_transaction_active = false;
+
+    charger->dlink_error();
+
+    EXPECT_EQ(charger->current_state(), Charger::EvseState::StoppingCharging);
+    EXPECT_FALSE(ctx.pwm_running);
+}
+
+TEST_F(ChargerDlinkErrorTest, NoMatchingRestartWhenStoppingForDisable) {
+    setup_hlc_session_in(Charger::EvseState::StoppingCharging);
+    auto& ctx = charger->get_shared_context();
+    ctx.flag_disable_requested = true;
+
+    charger->dlink_error();
+
+    EXPECT_EQ(charger->current_state(), Charger::EvseState::StoppingCharging);
+    EXPECT_FALSE(ctx.pwm_running);
+}
+
+TEST_F(ChargerDlinkErrorTest, NoMatchingRestartWhenFinished) {
+    // The EV may drop to state B quickly after a requested stop, in which case the
+    // charger reaches Finished (with PWM still running) before the dying HLC session
+    // reports D-LINK_ERROR. This must not resurrect the finished session.
+    setup_hlc_session_in(Charger::EvseState::Finished);
+    auto& ctx = charger->get_shared_context();
+    ctx.flag_transaction_active = false;
+    ctx.flag_authorized = false;
+
+    charger->dlink_error();
+
+    EXPECT_EQ(charger->current_state(), Charger::EvseState::Finished);
+    EXPECT_FALSE(ctx.pwm_running);
+}
+
+TEST_F(ChargerDlinkErrorTest, MatchingRestartDuringActiveSession) {
+    // A D-LINK_ERROR during an active session (e.g. HLC communication error during
+    // cable check with the transaction still running) must keep the ISO 15118-3
+    // error recovery: restart matching via T_step_X1 -> T_step_EF
+    setup_hlc_session_in(Charger::EvseState::PrepareCharging);
+
+    charger->dlink_error();
+
+    EXPECT_EQ(charger->current_state(), Charger::EvseState::T_step_X1);
+}
+
+TEST_F(ChargerDlinkErrorTest, MatchingRestartWhenStoppingToPause) {
+    // StoppingCharging is also a transit state for EVSE-initiated pause: the session
+    // continues afterwards, so the error recovery must still restart matching
+    setup_hlc_session_in(Charger::EvseState::StoppingCharging);
+    auto& ctx = charger->get_shared_context();
+    ctx.flag_paused_by_evse = true;
+
+    charger->dlink_error();
+
+    EXPECT_EQ(charger->current_state(), Charger::EvseState::T_step_X1);
+}
+
+TEST_F(ChargerDlinkErrorTest, NoMatchingRestartWithNominalPwm) {
+    // [V2G3-M07-12]: in nominal PWM mode (AC with HLC on nominal duty cycle), basic
+    // charging continues and matching is not restarted on a D-LINK_ERROR
+    setup_hlc_session_in(Charger::EvseState::Charging);
+    charger->get_hlc_use_5percent_current_session() = false;
+
+    charger->dlink_error();
+
+    EXPECT_EQ(charger->current_state(), Charger::EvseState::Charging);
 }
 
 } // namespace

--- a/tests/core_tests/smoke_tests.py
+++ b/tests/core_tests/smoke_tests.py
@@ -52,13 +52,14 @@ class DcConfigAdjustmentStrategy(EverestConfigAdjustmentStrategy):
     Adjustment strategy to disable DIN SPEC 70121 module
     """
 
-    def __init__(self, zero_power_ignore_pause: bool = False, hlc_charge_loop_without_energy_timeout_s: int = 300, ev_d20_only = False, payment_enable_contract = True, force_payment_option = False, fail_cable_check=False):
+    def __init__(self, zero_power_ignore_pause: bool = False, hlc_charge_loop_without_energy_timeout_s: int = 300, ev_d20_only = False, payment_enable_contract = True, force_payment_option = False, fail_cable_check=False, cable_check_measurements: int = 1):
         self.zero_power_ignore_pause = zero_power_ignore_pause
         self.hlc_charge_loop_without_energy_timeout_s = hlc_charge_loop_without_energy_timeout_s
         self.ev_d20_only = ev_d20_only
         self.payment_enable_contract = payment_enable_contract
         self.force_payment_option = force_payment_option
         self.fail_cable_check = fail_cable_check
+        self.cable_check_measurements = cable_check_measurements
 
     def adjust_everest_configuration(self, everest_config: Dict):
         adjusted_config = deepcopy(everest_config)
@@ -72,6 +73,7 @@ class DcConfigAdjustmentStrategy(EverestConfigAdjustmentStrategy):
         adjusted_config["active_modules"]["evse_manager"]["config_module"]["payment_enable_contract"] = self.payment_enable_contract
         adjusted_config["active_modules"]["ev_manager"]["config_module"]["force_payment_option"] = self.force_payment_option
         adjusted_config["active_modules"]["imd"]["config_implementation"]["main"]["resistance_F_Ohm"] = 0 if self.fail_cable_check else 900000
+        adjusted_config["active_modules"]["evse_manager"]["config_module"]["cable_check_wait_number_of_imd_measurements"] = self.cable_check_measurements
         return adjusted_config
 
 
@@ -1379,16 +1381,100 @@ async def test_iso15118_dc_cable_check_failed(
     test_controller: TestController, everest_core: EverestCore
 ):
     """
-    Test that a DC EVSE fails the cable check resulting in EnergyTransferSetupFailed.
+    Test that a DC EVSE fails the cable check resulting in EnergyTransferSetupFailed
+    and a raised MREC11CableCheckFault error.
     """
-    _, _, _, hlc_session_failed_mock = await setup_session_mocks(
+    probe_module, _, _, hlc_session_failed_mock = await setup_session_mocks(
         test_controller, everest_core
     )
+    error_raised_mock, _ = setup_error_monitoring(probe_module, "evse_manager")
 
     # Simulate an EV that enforces PnC (contract) payment against an EIM-only charger.
     # iso_start_v2g_session with 2 args: energy_mode + payment_option.
     test_controller.plug_in_dc_iso()
 
     await wait_for_hlc_session_failed_with_reason(hlc_session_failed_mock, "EnergyTransferSetupFailed")
+
+    # A genuine cable check failure must raise the cable check fault error
+    await wait_for_error(error_raised_mock, timeout=10)
+    raised_error_types = [call[0][0].type for call in error_raised_mock.call_args_list]
+    assert "evse_manager/MREC11CableCheckFault" in raised_error_types, (
+        f"Expected MREC11CableCheckFault to be raised on a failed cable check, got: {raised_error_types}"
+    )
+
     test_controller.plug_out()
+
+
+@pytest.mark.asyncio
+@pytest.mark.probe_module(
+    connections={
+        "evse_manager": [Requirement("evse_manager", "evse")],
+        "imd": [Requirement("imd", "main")],
+    }
+)
+@pytest.mark.everest_core_config("config-sil-dc.yaml")
+@pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy(cable_check_measurements=10))
+async def test_iso15118_dc_stop_transaction_during_cable_check(
+    test_controller: TestController, everest_core: EverestCore
+):
+    """
+    Test that stopping the transaction on request (regular Local/Remote stop) while the
+    cable check is still running does not raise a cable check fault: the cable check is
+    aborted because of the requested stop, which is a regular termination and must not
+    surface as MREC11CableCheckFault/Inoperative to the user. The session must still wind
+    down cleanly with a TransactionFinished event (StoppingCharging -> Finished), without
+    the D-LINK_ERROR of the dying HLC session restarting SLAC matching.
+    """
+    probe_module, session_event_mock, powermeter_mock, _ = await setup_session_mocks(
+        test_controller, everest_core
+    )
+    error_raised_mock, _ = setup_error_monitoring(probe_module, "evse_manager")
+    imd_measurement_mock = Mock()
+    probe_module.subscribe_variable("imd", "isolation_measurement", imd_measurement_mock)
+
+    # Run a complete charging session first: the state machine only arms the HLC stop
+    # handling (hlc_charging_active) when the Idle state is re-entered, so only from the
+    # second session on does a stop during cable check take the HLC stop path that must
+    # end in StoppingCharging -> Finished (and not in a SLAC matching restart).
+    await run_basic_session(test_controller, session_event_mock, powermeter_mock, "plug_in_dc_iso")
+    await asyncio.sleep(3)
+    imd_measurement_mock.reset_mock()
+
+    test_controller.plug_in_dc_iso()
+
+    # Wait until the EVSE starts preparing for charging (DC: CableCheck, PreCharge, PowerDelivery)
+    await wait_for_session_events(session_event_mock, NO_ENERGY_SESSION_START_SEQUENCE)
+
+    # The IMD is first started during the cable check measurement phase, so the first
+    # isolation measurement means the cable check is running right now. The config asks
+    # for 10 measurement samples (10s at the simulator's 1Hz), so the stop request below
+    # reliably lands within the cable check.
+    await wait_for_ready(imd_measurement_mock, timeout=30)
+    await probe_module.call_command(
+        "evse_manager",
+        "stop_transaction",
+        {
+            "request": {
+                "reason": "Local"
+            }
+        },
+    )
+
+    # The stop must land during the cable check, i.e. charging must never start
+    await assert_no_events(session_event_mock, ["ChargingStarted"], wait_time=2, reset_after_check=False)
+    await wait_for_session_events(session_event_mock, ["TransactionFinished"])
+
+    # Give the detached cable check thread time to wind down before checking for errors
+    await asyncio.sleep(3)
+    raised_error_types = [call[0][0].type for call in error_raised_mock.call_args_list]
+    assert "evse_manager/MREC11CableCheckFault" not in raised_error_types, (
+        f"A requested stop during cable check must not raise a cable check fault, got: {raised_error_types}"
+    )
+    assert "evse_manager/Inoperative" not in raised_error_types, (
+        f"A requested stop during cable check must not make the EVSE inoperative, got: {raised_error_types}"
+    )
+
+    # Follow the session to its end to verify it winds down cleanly after the unplug
+    test_controller.plug_out()
+    await wait_for_session_events(session_event_mock, ["SessionFinished"])
 


### PR DESCRIPTION
## Describe your changes

Stopping a charging session on request (e.g. a Local or Remote `stop_transaction`) while the DC cable check is still running raised `evse_manager/MREC11CableCheckFault` (sub_type "Self test failed" is hardcoded for all cable check faults, which is misleading in the logs), which in turn cascaded into `evse_manager/Inoperative` — so the user saw an error for a perfectly regular stop.

`fail_cable_check()` already had a guard that skips raising the fault when the stop reason is `DeAuthorized` or when the session has already ended (Idle/Finished, #1392). This PR extends that guard to also cover `Local` and `Remote` stop reasons: a requested stop during cable check is a regular termination, not a fault. Genuine cable check failures (failed self test, isolation resistance out of range, timeouts) still raise the fault as before.

### Tests

- New SIL smoke test `test_iso15118_dc_stop_transaction_during_cable_check`: stops the transaction (reason `Local`) while the cable check is running and asserts no `MREC11CableCheckFault`/`Inoperative` is raised and the session winds down cleanly through `TransactionFinished`/`SessionFinished`. The stop is anchored on the first `isolation_measurement` published by the IMDSimulator (the IMD is first started inside the cable check measurement phase), and the measurement phase is stretched to 10 samples via a new `cable_check_measurements` knob on `DcConfigAdjustmentStrategy`, so the stop deterministically lands within the cable check. An `assert_no_events(["ChargingStarted"])` check guards against the test passing vacuously if timing ever drifts.
- Extended `test_iso15118_dc_cable_check_failed` to assert that a genuine cable check failure still raises `MREC11CableCheckFault` (protects against over-suppression).

Both tests pass locally against config-sil-dc.

### Note

With the error no longer raised, nothing actively fails the V2G session towards the EV anymore (`cable_check_finished(false)` leaves `EVSEProcessing = Ongoing`; previously the raised error made the stack answer FAILED). The EV is expected to terminate via its own cable check timeout or the IEC-level shutdown (PWM off). If a crisper termination towards the EV is wanted for requested stops, that would be a follow-up change in EvseManager/EvseV2G.

## Issue ticket number and link

-

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)