### PR TITLE
refactor(EvseManager): centralize HLC session setup and Charger config

### DIFF
--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -1544,38 +1544,31 @@ bool Charger::switch_three_phases_while_charging(bool n) {
     return true;
 }
 
-void Charger::setup(bool has_ventilation, const ChargeMode _charge_mode, bool _ac_hlc_enabled,
-                    bool _ac_hlc_use_5percent, bool _ac_enforce_hlc, bool _ac_with_soc_timeout,
-                    float _soft_over_current_tolerance_percent, float _soft_over_current_measurement_noise_A,
-                    const int _switch_3ph1ph_delay_s, const std::string _switch_3ph1ph_cp_state,
-                    const int _soft_over_current_timeout_ms, const int _state_F_after_fault_ms,
-                    const bool fail_on_powermeter_errors, const bool raise_mrec9,
-                    const int sleep_before_enabling_pwm_hlc_mode_ms, const utils::SessionIdType session_id_type,
-                    const int hlc_charge_loop_without_energy_timeout_s) {
+void Charger::setup(const SetupConfig& config) {
     // set up board support package
-    bsp->setup(has_ventilation);
+    bsp->setup(config.has_ventilation);
 
     Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_setup);
     // cache our config variables
-    config_context.charge_mode = _charge_mode;
-    ac_hlc_enabled_current_session = config_context.ac_hlc_enabled = _ac_hlc_enabled;
-    config_context.ac_hlc_use_5percent = _ac_hlc_use_5percent;
-    config_context.ac_enforce_hlc = _ac_enforce_hlc;
-    config_context.soft_over_current_timeout_ms = _soft_over_current_timeout_ms;
-    shared_context.ac_with_soc_timeout = _ac_with_soc_timeout;
+    config_context.charge_mode = config.charge_mode;
+    ac_hlc_enabled_current_session = config_context.ac_hlc_enabled = config.ac_hlc_enabled;
+    config_context.ac_hlc_use_5percent = config.ac_hlc_use_5percent;
+    config_context.ac_enforce_hlc = config.ac_enforce_hlc;
+    config_context.soft_over_current_timeout_ms = config.soft_over_current_timeout_ms;
+    shared_context.ac_with_soc_timeout = config.ac_with_soc_timeout;
     shared_context.ac_with_soc_timer = 3600000;
-    soft_over_current_tolerance_percent = _soft_over_current_tolerance_percent;
-    soft_over_current_measurement_noise_A = _soft_over_current_measurement_noise_A;
+    soft_over_current_tolerance_percent = config.soft_over_current_tolerance_percent;
+    soft_over_current_measurement_noise_A = config.soft_over_current_measurement_noise_A;
 
-    config_context.switch_3ph1ph_delay_s = _switch_3ph1ph_delay_s;
-    config_context.switch_3ph1ph_cp_state_F = _switch_3ph1ph_cp_state == "F";
+    config_context.switch_3ph1ph_delay_s = config.switch_3ph1ph_delay_s;
+    config_context.switch_3ph1ph_cp_state_F = config.switch_3ph1ph_cp_state == "F";
 
-    config_context.state_F_after_fault_ms = _state_F_after_fault_ms;
-    config_context.fail_on_powermeter_errors = fail_on_powermeter_errors;
-    config_context.raise_mrec9 = raise_mrec9;
-    config_context.sleep_before_enabling_pwm_hlc_mode_ms = sleep_before_enabling_pwm_hlc_mode_ms;
-    config_context.session_id_type = session_id_type;
-    config_context.hlc_charge_loop_without_energy_timeout_s = hlc_charge_loop_without_energy_timeout_s;
+    config_context.state_F_after_fault_ms = config.state_F_after_fault_ms;
+    config_context.fail_on_powermeter_errors = config.fail_on_powermeter_errors;
+    config_context.raise_mrec9 = config.raise_mrec9;
+    config_context.sleep_before_enabling_pwm_hlc_mode_ms = config.sleep_before_enabling_pwm_hlc_mode_ms;
+    config_context.session_id_type = config.session_id_type;
+    config_context.hlc_charge_loop_without_energy_timeout_s = config.hlc_charge_loop_without_energy_timeout_s;
 
     if (config_context.charge_mode == ChargeMode::AC and config_context.ac_hlc_enabled)
         EVLOG_info << "AC HLC mode enabled.";

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -1551,38 +1551,31 @@ bool Charger::switch_three_phases_while_charging(bool n) {
     return true;
 }
 
-void Charger::setup(bool has_ventilation, const ChargeMode _charge_mode, bool _ac_hlc_enabled,
-                    bool _ac_hlc_use_5percent, bool _ac_enforce_hlc, bool _ac_with_soc_timeout,
-                    float _soft_over_current_tolerance_percent, float _soft_over_current_measurement_noise_A,
-                    const int _switch_3ph1ph_delay_s, const std::string _switch_3ph1ph_cp_state,
-                    const int _soft_over_current_timeout_ms, const int _state_F_after_fault_ms,
-                    const bool fail_on_powermeter_errors, const bool raise_mrec9,
-                    const int sleep_before_enabling_pwm_hlc_mode_ms, const utils::SessionIdType session_id_type,
-                    const int hlc_charge_loop_without_energy_timeout_s) {
+void Charger::setup(const SetupConfig& config) {
     // set up board support package
-    bsp->setup(has_ventilation);
+    bsp->setup(config.has_ventilation);
 
     Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_setup);
     // cache our config variables
-    config_context.charge_mode = _charge_mode;
-    ac_hlc_enabled_current_session = config_context.ac_hlc_enabled = _ac_hlc_enabled;
-    config_context.ac_hlc_use_5percent = _ac_hlc_use_5percent;
-    config_context.ac_enforce_hlc = _ac_enforce_hlc;
-    config_context.soft_over_current_timeout_ms = _soft_over_current_timeout_ms;
-    shared_context.ac_with_soc_timeout = _ac_with_soc_timeout;
+    config_context.charge_mode = config.charge_mode;
+    ac_hlc_enabled_current_session = config_context.ac_hlc_enabled = config.ac_hlc_enabled;
+    config_context.ac_hlc_use_5percent = config.ac_hlc_use_5percent;
+    config_context.ac_enforce_hlc = config.ac_enforce_hlc;
+    config_context.soft_over_current_timeout_ms = config.soft_over_current_timeout_ms;
+    shared_context.ac_with_soc_timeout = config.ac_with_soc_timeout;
     shared_context.ac_with_soc_timer = 3600000;
-    soft_over_current_tolerance_percent = _soft_over_current_tolerance_percent;
-    soft_over_current_measurement_noise_A = _soft_over_current_measurement_noise_A;
+    soft_over_current_tolerance_percent = config.soft_over_current_tolerance_percent;
+    soft_over_current_measurement_noise_A = config.soft_over_current_measurement_noise_A;
 
-    config_context.switch_3ph1ph_delay_s = _switch_3ph1ph_delay_s;
-    config_context.switch_3ph1ph_cp_state_F = _switch_3ph1ph_cp_state == "F";
+    config_context.switch_3ph1ph_delay_s = config.switch_3ph1ph_delay_s;
+    config_context.switch_3ph1ph_cp_state_F = config.switch_3ph1ph_cp_state == "F";
 
-    config_context.state_F_after_fault_ms = _state_F_after_fault_ms;
-    config_context.fail_on_powermeter_errors = fail_on_powermeter_errors;
-    config_context.raise_mrec9 = raise_mrec9;
-    config_context.sleep_before_enabling_pwm_hlc_mode_ms = sleep_before_enabling_pwm_hlc_mode_ms;
-    config_context.session_id_type = session_id_type;
-    config_context.hlc_charge_loop_without_energy_timeout_s = hlc_charge_loop_without_energy_timeout_s;
+    config_context.state_F_after_fault_ms = config.state_F_after_fault_ms;
+    config_context.fail_on_powermeter_errors = config.fail_on_powermeter_errors;
+    config_context.raise_mrec9 = config.raise_mrec9;
+    config_context.sleep_before_enabling_pwm_hlc_mode_ms = config.sleep_before_enabling_pwm_hlc_mode_ms;
+    config_context.session_id_type = config.session_id_type;
+    config_context.hlc_charge_loop_without_energy_timeout_s = config.hlc_charge_loop_without_energy_timeout_s;
 
     if (config_context.charge_mode == ChargeMode::AC and config_context.ac_hlc_enabled)
         EVLOG_info << "AC HLC mode enabled.";

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -1509,38 +1509,31 @@ bool Charger::switch_three_phases_while_charging(bool n) {
     return true;
 }
 
-void Charger::setup(bool has_ventilation, const ChargeMode _charge_mode, bool _ac_hlc_enabled,
-                    bool _ac_hlc_use_5percent, bool _ac_enforce_hlc, bool _ac_with_soc_timeout,
-                    float _soft_over_current_tolerance_percent, float _soft_over_current_measurement_noise_A,
-                    const int _switch_3ph1ph_delay_s, const std::string _switch_3ph1ph_cp_state,
-                    const int _soft_over_current_timeout_ms, const int _state_F_after_fault_ms,
-                    const bool fail_on_powermeter_errors, const bool raise_mrec9,
-                    const int sleep_before_enabling_pwm_hlc_mode_ms, const utils::SessionIdType session_id_type,
-                    const int hlc_charge_loop_without_energy_timeout_s) {
+void Charger::setup(const SetupConfig& config) {
     // set up board support package
-    bsp->setup(has_ventilation);
+    bsp->setup(config.has_ventilation);
 
     Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_setup);
     // cache our config variables
-    config_context.charge_mode = _charge_mode;
-    ac_hlc_enabled_current_session = config_context.ac_hlc_enabled = _ac_hlc_enabled;
-    config_context.ac_hlc_use_5percent = _ac_hlc_use_5percent;
-    config_context.ac_enforce_hlc = _ac_enforce_hlc;
-    config_context.soft_over_current_timeout_ms = _soft_over_current_timeout_ms;
-    shared_context.ac_with_soc_timeout = _ac_with_soc_timeout;
+    config_context.charge_mode = config.charge_mode;
+    ac_hlc_enabled_current_session = config_context.ac_hlc_enabled = config.ac_hlc_enabled;
+    config_context.ac_hlc_use_5percent = config.ac_hlc_use_5percent;
+    config_context.ac_enforce_hlc = config.ac_enforce_hlc;
+    config_context.soft_over_current_timeout_ms = config.soft_over_current_timeout_ms;
+    shared_context.ac_with_soc_timeout = config.ac_with_soc_timeout;
     shared_context.ac_with_soc_timer = 3600000;
-    soft_over_current_tolerance_percent = _soft_over_current_tolerance_percent;
-    soft_over_current_measurement_noise_A = _soft_over_current_measurement_noise_A;
+    soft_over_current_tolerance_percent = config.soft_over_current_tolerance_percent;
+    soft_over_current_measurement_noise_A = config.soft_over_current_measurement_noise_A;
 
-    config_context.switch_3ph1ph_delay_s = _switch_3ph1ph_delay_s;
-    config_context.switch_3ph1ph_cp_state_F = _switch_3ph1ph_cp_state == "F";
+    config_context.switch_3ph1ph_delay_s = config.switch_3ph1ph_delay_s;
+    config_context.switch_3ph1ph_cp_state_F = config.switch_3ph1ph_cp_state == "F";
 
-    config_context.state_F_after_fault_ms = _state_F_after_fault_ms;
-    config_context.fail_on_powermeter_errors = fail_on_powermeter_errors;
-    config_context.raise_mrec9 = raise_mrec9;
-    config_context.sleep_before_enabling_pwm_hlc_mode_ms = sleep_before_enabling_pwm_hlc_mode_ms;
-    config_context.session_id_type = session_id_type;
-    config_context.hlc_charge_loop_without_energy_timeout_s = hlc_charge_loop_without_energy_timeout_s;
+    config_context.state_F_after_fault_ms = config.state_F_after_fault_ms;
+    config_context.fail_on_powermeter_errors = config.fail_on_powermeter_errors;
+    config_context.raise_mrec9 = config.raise_mrec9;
+    config_context.sleep_before_enabling_pwm_hlc_mode_ms = config.sleep_before_enabling_pwm_hlc_mode_ms;
+    config_context.session_id_type = config.session_id_type;
+    config_context.hlc_charge_loop_without_energy_timeout_s = config.hlc_charge_loop_without_energy_timeout_s;
 
     if (config_context.charge_mode == ChargeMode::AC and config_context.ac_hlc_enabled)
         EVLOG_info << "AC HLC mode enabled.";

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -67,6 +67,26 @@ public:
         DC
     };
 
+    struct SetupConfig {
+        bool has_ventilation;
+        ChargeMode charge_mode;
+        bool ac_hlc_enabled;
+        bool ac_hlc_use_5percent;
+        bool ac_enforce_hlc;
+        bool ac_with_soc_timeout;
+        float soft_over_current_tolerance_percent;
+        float soft_over_current_measurement_noise_A;
+        int switch_3ph1ph_delay_s;
+        std::string switch_3ph1ph_cp_state;
+        int soft_over_current_timeout_ms;
+        int state_F_after_fault_ms;
+        bool fail_on_powermeter_errors;
+        bool raise_mrec9;
+        int sleep_before_enabling_pwm_hlc_mode_ms;
+        utils::SessionIdType session_id_type;
+        int hlc_charge_loop_without_energy_timeout_s;
+    };
+
     enum class EvseState {
         Disabled,
         Idle,
@@ -100,13 +120,7 @@ public:
 
     sigslot::signal<float> signal_max_current;
 
-    void setup(bool has_ventilation, const ChargeMode charge_mode, bool ac_hlc_enabled, bool ac_hlc_use_5percent,
-               bool ac_enforce_hlc, bool ac_with_soc_timeout, float soft_over_current_tolerance_percent,
-               float soft_over_current_measurement_noise_A, const int switch_3ph1ph_delay_s,
-               const std::string switch_3ph1ph_cp_state, const int soft_over_current_timeout_ms,
-               const int _state_F_after_fault_ms, const bool fail_on_powermeter_errors, const bool raise_mrec9,
-               const int sleep_before_enabling_pwm_hlc_mode_ms, const utils::SessionIdType session_id_type,
-               const int hlc_charge_loop_without_energy_timeout_s);
+    void setup(const SetupConfig& config);
 
     void enable_disable_initial_state_publish();
     bool enable_disable(int connector_id, const types::evse_manager::EnableDisableSource& source);

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -342,25 +342,13 @@ void EvseManager::ready() {
         // Set up EVSE ID
         types::iso15118::EVSEID evseid = {config.evse_id, config.evse_id_din};
 
-        // Set up auth options for HLC
-        std::vector<types::iso15118::PaymentOption> payment_options;
-        // if pnc is disabled, disable contract installation and central contract validation
-        bool _contract_certificate_installation_enabled =
-            pnc_enabled ? contract_certificate_installation_enabled.load() : false;
-        bool _central_contract_validation_allowed = pnc_enabled ? central_contract_validation_allowed.load() : false;
-
-        if (config.payment_enable_eim) {
-            payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
-        }
-        if (pnc_enabled) {
-            payment_options.push_back(types::iso15118::PaymentOption::Contract);
-        }
-        if (!config.payment_enable_eim and !pnc_enabled) {
-            EVLOG_warning << "Both payment options are disabled! ExternalPayment is nevertheless enabled in this case.";
-            payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
-        }
-        r_hlc[0]->call_session_setup(payment_options, _contract_certificate_installation_enabled,
-                                     _central_contract_validation_allowed);
+        const bool include_contract_payment = true;
+        const bool pnc_is_enabled = pnc_enabled;
+        const bool supported_certificate_service = pnc_is_enabled and contract_certificate_installation_enabled;
+        const bool central_contract_validation = pnc_is_enabled and central_contract_validation_allowed;
+        const bool force_external_payment = false;
+        update_hlc_session_setup(include_contract_payment, supported_certificate_service, central_contract_validation,
+                                 force_external_payment);
 
         r_hlc[0]->subscribe_hlc_session_failed([this](types::evse_manager::HlcSessionFailedReasonEnum reason) {
             types::evse_manager::HlcSessionFailedEvent ev;
@@ -1266,8 +1254,8 @@ void EvseManager::ready() {
         }
     });
 
-    charger->signal_simple_event.connect([this](types::evse_manager::SessionEventEnum s) {
-        if (s == types::evse_manager::SessionEventEnum::SessionFinished) {
+    charger->signal_simple_event.connect([this](types::evse_manager::SessionEventEnum session_event) {
+        if (session_event == types::evse_manager::SessionEventEnum::SessionFinished) {
             // Reset EV information on Session start and end
             ev_info = types::evse_manager::EVInfo();
             p_evse->publish_ev_info(ev_info);
@@ -1277,35 +1265,22 @@ void EvseManager::ready() {
             return;
         }
 
-        if (s != types::evse_manager::SessionEventEnum::Authorized and
-            s != types::evse_manager::SessionEventEnum::SessionFinished) {
+        // Only Authorized and SessionFinished require an HLC payment option update.
+        if (session_event != types::evse_manager::SessionEventEnum::Authorized and
+            session_event != types::evse_manager::SessionEventEnum::SessionFinished) {
             return;
         }
 
-        std::vector<types::iso15118::PaymentOption> payment_options;
-        // if pnc is disabled, disable contract installation and central contract validation
-        bool _contract_certificate_installation_enabled =
-            pnc_enabled ? contract_certificate_installation_enabled.load() : false;
-        bool _central_contract_validation_allowed = pnc_enabled ? central_contract_validation_allowed.load() : false;
-
-        if (config.payment_enable_eim) {
-            payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
-        }
-        if (pnc_enabled and s == types::evse_manager::SessionEventEnum::SessionFinished) {
-            // PnC is enabled and this is a SessionFinished event -> enable Contract payment option
-            payment_options.push_back(types::iso15118::PaymentOption::Contract);
-        } else {
-            // We dont add contract if this is an Authorized event, as in this case the ISO15118 stack
-            // should not offer the contract option and certifiate installation service.
-            _contract_certificate_installation_enabled = false;
-        }
-
-        if (config.payment_enable_eim == false and pnc_enabled == false) {
-            EVLOG_warning << "Both payment options are disabled! ExternalPayment is nevertheless enabled in this case.";
-            payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
-        }
-        r_hlc[0]->call_session_setup(payment_options, _contract_certificate_installation_enabled,
-                                     _central_contract_validation_allowed);
+        // Offer Contract payment only when PnC is enabled and this is a SessionFinished event.
+        // For an Authorized event, do not offer Contract payment or the certificate installation service.
+        const bool include_contract_payment = session_event == types::evse_manager::SessionEventEnum::SessionFinished;
+        const bool pnc_is_enabled = pnc_enabled;
+        const bool supported_certificate_service =
+            include_contract_payment and pnc_is_enabled and contract_certificate_installation_enabled;
+        const bool central_contract_validation = pnc_is_enabled and central_contract_validation_allowed;
+        const bool force_external_payment = false;
+        update_hlc_session_setup(include_contract_payment, supported_certificate_service, central_contract_validation,
+                                 force_external_payment);
     });
 
     charger->signal_session_started_event.connect(
@@ -1319,29 +1294,24 @@ void EvseManager::ready() {
                 return;
             }
 
-            std::vector<types::iso15118::PaymentOption> payment_options;
-            // if pnc is disabled, disable contract installation and central contract validation
-            bool _contract_certificate_installation_enabled =
-                pnc_enabled ? contract_certificate_installation_enabled.load() : false;
-            bool _central_contract_validation_allowed =
-                pnc_enabled ? central_contract_validation_allowed.load() : false;
-
             if (start_reason == types::evse_manager::StartSessionReason::Authorized) {
                 // Session is already authorized, only use ExternalPayment in PaymentOptions
-                payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
-                _contract_certificate_installation_enabled = false;
-                _central_contract_validation_allowed = false;
+                const bool include_contract_payment = false;
+                const bool supported_certificate_service = false;
+                const bool central_contract_validation = false;
+                const bool force_external_payment = true;
+                update_hlc_session_setup(include_contract_payment, supported_certificate_service,
+                                         central_contract_validation, force_external_payment);
             } else {
                 // Set payment options according to configuration
-                if (config.payment_enable_eim) {
-                    payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
-                }
-                if (pnc_enabled) {
-                    payment_options.push_back(types::iso15118::PaymentOption::Contract);
-                }
+                const bool include_contract_payment = true;
+                const bool pnc_is_enabled = pnc_enabled;
+                const bool supported_certificate_service = pnc_is_enabled and contract_certificate_installation_enabled;
+                const bool central_contract_validation = pnc_is_enabled and central_contract_validation_allowed;
+                const bool force_external_payment = false;
+                update_hlc_session_setup(include_contract_payment, supported_certificate_service,
+                                         central_contract_validation, force_external_payment);
             }
-            r_hlc[0]->call_session_setup(payment_options, _contract_certificate_installation_enabled,
-                                         _central_contract_validation_allowed);
         });
 
     invoke_ready(*p_evse);
@@ -1538,6 +1508,31 @@ void EvseManager::switch_DC_mode() {
 
 void EvseManager::switch_AC_mode() {
     setup_AC_mode();
+}
+
+void EvseManager::update_hlc_session_setup(bool include_contract_payment, bool supported_certificate_service,
+                                           bool central_contract_validation, bool force_external_payment) {
+    // Callers must disable the certificate service and central contract validation when PnC is disabled.
+    if (not hlc_enabled or r_hlc.empty()) {
+        return;
+    }
+
+    std::vector<types::iso15118::PaymentOption> payment_options;
+
+    if (force_external_payment or config.payment_enable_eim) {
+        payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
+    }
+
+    if (include_contract_payment and pnc_enabled) {
+        payment_options.push_back(types::iso15118::PaymentOption::Contract);
+    }
+
+    if (not force_external_payment and not config.payment_enable_eim and not pnc_enabled) {
+        EVLOG_warning << "Both payment options are disabled! ExternalPayment is nevertheless enabled in this case.";
+        payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
+    }
+
+    r_hlc[0]->call_session_setup(payment_options, supported_certificate_service, central_contract_validation);
 }
 
 // This sets up a fake DC mode that is just supposed to work until we get the SoC.

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -1322,15 +1322,8 @@ void EvseManager::ready() {
     if (config.ac_with_soc) {
         setup_fake_DC_mode();
     } else {
-        charger->setup(config.has_ventilation,
-                       (config.charge_mode == "DC" ? Charger::ChargeMode::DC : Charger::ChargeMode::AC), hlc_enabled,
-                       config.ac_hlc_use_5percent, config.ac_enforce_hlc, false,
-                       config.soft_over_current_tolerance_percent, config.soft_over_current_measurement_noise_A,
-                       config.switch_3ph1ph_delay_s, config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms,
-                       config.state_F_after_fault_ms, config.fail_on_powermeter_errors, config.raise_mrec9,
-                       config.sleep_before_enabling_pwm_hlc_mode_ms,
-                       utils::get_session_id_type_from_string(config.session_id_type),
-                       config.hlc_charge_loop_without_energy_timeout_s);
+        const auto charge_mode = config.charge_mode == "DC" ? Charger::ChargeMode::DC : Charger::ChargeMode::AC;
+        charger->setup(get_charger_setup_config(charge_mode, false));
     }
 
     telemetryThreadHandle = std::thread([this]() {
@@ -1535,16 +1528,31 @@ void EvseManager::update_hlc_session_setup(bool include_contract_payment, bool s
     r_hlc[0]->call_session_setup(payment_options, supported_certificate_service, central_contract_validation);
 }
 
+Charger::SetupConfig EvseManager::get_charger_setup_config(Charger::ChargeMode charge_mode,
+                                                           bool ac_with_soc_timeout) const {
+    return {config.has_ventilation,
+            charge_mode,
+            hlc_enabled,
+            config.ac_hlc_use_5percent,
+            config.ac_enforce_hlc,
+            ac_with_soc_timeout,
+            config.soft_over_current_tolerance_percent,
+            config.soft_over_current_measurement_noise_A,
+            config.switch_3ph1ph_delay_s,
+            config.switch_3ph1ph_cp_state,
+            config.soft_over_current_timeout_ms,
+            config.state_F_after_fault_ms,
+            config.fail_on_powermeter_errors,
+            config.raise_mrec9,
+            config.sleep_before_enabling_pwm_hlc_mode_ms,
+            utils::get_session_id_type_from_string(config.session_id_type),
+            config.hlc_charge_loop_without_energy_timeout_s};
+}
+
 // This sets up a fake DC mode that is just supposed to work until we get the SoC.
 // It is only used for AC<>DC<>AC<>DC mode to get AC charging with SoC.
 void EvseManager::setup_fake_DC_mode() {
-    charger->setup(config.has_ventilation, Charger::ChargeMode::DC, hlc_enabled, config.ac_hlc_use_5percent,
-                   config.ac_enforce_hlc, false, config.soft_over_current_tolerance_percent,
-                   config.soft_over_current_measurement_noise_A, config.switch_3ph1ph_delay_s,
-                   config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms, config.state_F_after_fault_ms,
-                   config.fail_on_powermeter_errors, config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
-                   utils::get_session_id_type_from_string(config.session_id_type),
-                   config.hlc_charge_loop_without_energy_timeout_s);
+    charger->setup(get_charger_setup_config(Charger::ChargeMode::DC, false));
 
     types::iso15118::EVSEID evseid = {config.evse_id, config.evse_id_din};
 
@@ -1581,13 +1589,7 @@ void EvseManager::setup_fake_DC_mode() {
 }
 
 void EvseManager::setup_AC_mode() {
-    charger->setup(config.has_ventilation, Charger::ChargeMode::AC, hlc_enabled, config.ac_hlc_use_5percent,
-                   config.ac_enforce_hlc, true, config.soft_over_current_tolerance_percent,
-                   config.soft_over_current_measurement_noise_A, config.switch_3ph1ph_delay_s,
-                   config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms, config.state_F_after_fault_ms,
-                   config.fail_on_powermeter_errors, config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
-                   utils::get_session_id_type_from_string(config.session_id_type),
-                   config.hlc_charge_loop_without_energy_timeout_s);
+    charger->setup(get_charger_setup_config(Charger::ChargeMode::AC, true));
 
     types::iso15118::EVSEID evseid = {config.evse_id, config.evse_id_din};
 

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -351,25 +351,13 @@ void EvseManager::ready() {
         // Set up EVSE ID
         types::iso15118::EVSEID evseid = {config.evse_id, config.evse_id_din};
 
-        // Set up auth options for HLC
-        std::vector<types::iso15118::PaymentOption> payment_options;
-        // if pnc is disabled, disable contract installation and central contract validation
-        bool _contract_certificate_installation_enabled =
-            pnc_enabled ? contract_certificate_installation_enabled.load() : false;
-        bool _central_contract_validation_allowed = pnc_enabled ? central_contract_validation_allowed.load() : false;
-
-        if (config.payment_enable_eim) {
-            payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
-        }
-        if (pnc_enabled) {
-            payment_options.push_back(types::iso15118::PaymentOption::Contract);
-        }
-        if (!config.payment_enable_eim and !pnc_enabled) {
-            EVLOG_warning << "Both payment options are disabled! ExternalPayment is nevertheless enabled in this case.";
-            payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
-        }
-        r_hlc[0]->call_session_setup(payment_options, _contract_certificate_installation_enabled,
-                                     _central_contract_validation_allowed);
+        const bool include_contract_payment = true;
+        const bool pnc_is_enabled = pnc_enabled;
+        const bool supported_certificate_service = pnc_is_enabled and contract_certificate_installation_enabled;
+        const bool central_contract_validation = pnc_is_enabled and central_contract_validation_allowed;
+        const bool force_external_payment = false;
+        update_hlc_session_setup(include_contract_payment, supported_certificate_service, central_contract_validation,
+                                 force_external_payment);
 
         r_hlc[0]->subscribe_hlc_session_failed([this](types::evse_manager::HlcSessionFailedReasonEnum reason) {
             types::evse_manager::HlcSessionFailedEvent ev;
@@ -1280,8 +1268,8 @@ void EvseManager::ready() {
         }
     });
 
-    charger->signal_simple_event.connect([this](types::evse_manager::SessionEventEnum s) {
-        if (s == types::evse_manager::SessionEventEnum::SessionFinished) {
+    charger->signal_simple_event.connect([this](types::evse_manager::SessionEventEnum session_event) {
+        if (session_event == types::evse_manager::SessionEventEnum::SessionFinished) {
             // Reset EV information on Session start and end
             ev_info = types::evse_manager::EVInfo();
             p_evse->publish_ev_info(ev_info);
@@ -1291,35 +1279,22 @@ void EvseManager::ready() {
             return;
         }
 
-        if (s != types::evse_manager::SessionEventEnum::Authorized and
-            s != types::evse_manager::SessionEventEnum::SessionFinished) {
+        // Only Authorized and SessionFinished require an HLC payment option update.
+        if (session_event != types::evse_manager::SessionEventEnum::Authorized and
+            session_event != types::evse_manager::SessionEventEnum::SessionFinished) {
             return;
         }
 
-        std::vector<types::iso15118::PaymentOption> payment_options;
-        // if pnc is disabled, disable contract installation and central contract validation
-        bool _contract_certificate_installation_enabled =
-            pnc_enabled ? contract_certificate_installation_enabled.load() : false;
-        bool _central_contract_validation_allowed = pnc_enabled ? central_contract_validation_allowed.load() : false;
-
-        if (config.payment_enable_eim) {
-            payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
-        }
-        if (pnc_enabled and s == types::evse_manager::SessionEventEnum::SessionFinished) {
-            // PnC is enabled and this is a SessionFinished event -> enable Contract payment option
-            payment_options.push_back(types::iso15118::PaymentOption::Contract);
-        } else {
-            // We dont add contract if this is an Authorized event, as in this case the ISO15118 stack
-            // should not offer the contract option and certifiate installation service.
-            _contract_certificate_installation_enabled = false;
-        }
-
-        if (config.payment_enable_eim == false and pnc_enabled == false) {
-            EVLOG_warning << "Both payment options are disabled! ExternalPayment is nevertheless enabled in this case.";
-            payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
-        }
-        r_hlc[0]->call_session_setup(payment_options, _contract_certificate_installation_enabled,
-                                     _central_contract_validation_allowed);
+        // Offer Contract payment only when PnC is enabled and this is a SessionFinished event.
+        // For an Authorized event, do not offer Contract payment or the certificate installation service.
+        const bool include_contract_payment = session_event == types::evse_manager::SessionEventEnum::SessionFinished;
+        const bool pnc_is_enabled = pnc_enabled;
+        const bool supported_certificate_service =
+            include_contract_payment and pnc_is_enabled and contract_certificate_installation_enabled;
+        const bool central_contract_validation = pnc_is_enabled and central_contract_validation_allowed;
+        const bool force_external_payment = false;
+        update_hlc_session_setup(include_contract_payment, supported_certificate_service, central_contract_validation,
+                                 force_external_payment);
     });
 
     charger->signal_session_started_event.connect(
@@ -1333,29 +1308,24 @@ void EvseManager::ready() {
                 return;
             }
 
-            std::vector<types::iso15118::PaymentOption> payment_options;
-            // if pnc is disabled, disable contract installation and central contract validation
-            bool _contract_certificate_installation_enabled =
-                pnc_enabled ? contract_certificate_installation_enabled.load() : false;
-            bool _central_contract_validation_allowed =
-                pnc_enabled ? central_contract_validation_allowed.load() : false;
-
             if (start_reason == types::evse_manager::StartSessionReason::Authorized) {
                 // Session is already authorized, only use ExternalPayment in PaymentOptions
-                payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
-                _contract_certificate_installation_enabled = false;
-                _central_contract_validation_allowed = false;
+                const bool include_contract_payment = false;
+                const bool supported_certificate_service = false;
+                const bool central_contract_validation = false;
+                const bool force_external_payment = true;
+                update_hlc_session_setup(include_contract_payment, supported_certificate_service,
+                                         central_contract_validation, force_external_payment);
             } else {
                 // Set payment options according to configuration
-                if (config.payment_enable_eim) {
-                    payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
-                }
-                if (pnc_enabled) {
-                    payment_options.push_back(types::iso15118::PaymentOption::Contract);
-                }
+                const bool include_contract_payment = true;
+                const bool pnc_is_enabled = pnc_enabled;
+                const bool supported_certificate_service = pnc_is_enabled and contract_certificate_installation_enabled;
+                const bool central_contract_validation = pnc_is_enabled and central_contract_validation_allowed;
+                const bool force_external_payment = false;
+                update_hlc_session_setup(include_contract_payment, supported_certificate_service,
+                                         central_contract_validation, force_external_payment);
             }
-            r_hlc[0]->call_session_setup(payment_options, _contract_certificate_installation_enabled,
-                                         _central_contract_validation_allowed);
         });
 
     invoke_ready(*p_evse);
@@ -1552,6 +1522,31 @@ void EvseManager::switch_DC_mode() {
 
 void EvseManager::switch_AC_mode() {
     setup_AC_mode();
+}
+
+void EvseManager::update_hlc_session_setup(bool include_contract_payment, bool supported_certificate_service,
+                                           bool central_contract_validation, bool force_external_payment) {
+    // Callers must disable the certificate service and central contract validation when PnC is disabled.
+    if (not hlc_enabled or r_hlc.empty()) {
+        return;
+    }
+
+    std::vector<types::iso15118::PaymentOption> payment_options;
+
+    if (force_external_payment or config.payment_enable_eim) {
+        payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
+    }
+
+    if (include_contract_payment and pnc_enabled) {
+        payment_options.push_back(types::iso15118::PaymentOption::Contract);
+    }
+
+    if (not force_external_payment and not config.payment_enable_eim and not pnc_enabled) {
+        EVLOG_warning << "Both payment options are disabled! ExternalPayment is nevertheless enabled in this case.";
+        payment_options.push_back(types::iso15118::PaymentOption::ExternalPayment);
+    }
+
+    r_hlc[0]->call_session_setup(payment_options, supported_certificate_service, central_contract_validation);
 }
 
 // This sets up a fake DC mode that is just supposed to work until we get the SoC.

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -1336,15 +1336,8 @@ void EvseManager::ready() {
     if (config.ac_with_soc) {
         setup_fake_DC_mode();
     } else {
-        charger->setup(config.has_ventilation,
-                       (config.charge_mode == "DC" ? Charger::ChargeMode::DC : Charger::ChargeMode::AC), hlc_enabled,
-                       config.ac_hlc_use_5percent, config.ac_enforce_hlc, false,
-                       config.soft_over_current_tolerance_percent, config.soft_over_current_measurement_noise_A,
-                       config.switch_3ph1ph_delay_s, config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms,
-                       config.state_F_after_fault_ms, config.fail_on_powermeter_errors, config.raise_mrec9,
-                       config.sleep_before_enabling_pwm_hlc_mode_ms,
-                       utils::get_session_id_type_from_string(config.session_id_type),
-                       config.hlc_charge_loop_without_energy_timeout_s);
+        const auto charge_mode = config.charge_mode == "DC" ? Charger::ChargeMode::DC : Charger::ChargeMode::AC;
+        charger->setup(get_charger_setup_config(charge_mode, false));
     }
 
     telemetryThreadHandle = std::thread([this]() {
@@ -1549,16 +1542,31 @@ void EvseManager::update_hlc_session_setup(bool include_contract_payment, bool s
     r_hlc[0]->call_session_setup(payment_options, supported_certificate_service, central_contract_validation);
 }
 
+Charger::SetupConfig EvseManager::get_charger_setup_config(Charger::ChargeMode charge_mode,
+                                                           bool ac_with_soc_timeout) const {
+    return {config.has_ventilation,
+            charge_mode,
+            hlc_enabled,
+            config.ac_hlc_use_5percent,
+            config.ac_enforce_hlc,
+            ac_with_soc_timeout,
+            config.soft_over_current_tolerance_percent,
+            config.soft_over_current_measurement_noise_A,
+            config.switch_3ph1ph_delay_s,
+            config.switch_3ph1ph_cp_state,
+            config.soft_over_current_timeout_ms,
+            config.state_F_after_fault_ms,
+            config.fail_on_powermeter_errors,
+            config.raise_mrec9,
+            config.sleep_before_enabling_pwm_hlc_mode_ms,
+            utils::get_session_id_type_from_string(config.session_id_type),
+            config.hlc_charge_loop_without_energy_timeout_s};
+}
+
 // This sets up a fake DC mode that is just supposed to work until we get the SoC.
 // It is only used for AC<>DC<>AC<>DC mode to get AC charging with SoC.
 void EvseManager::setup_fake_DC_mode() {
-    charger->setup(config.has_ventilation, Charger::ChargeMode::DC, hlc_enabled, config.ac_hlc_use_5percent,
-                   config.ac_enforce_hlc, false, config.soft_over_current_tolerance_percent,
-                   config.soft_over_current_measurement_noise_A, config.switch_3ph1ph_delay_s,
-                   config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms, config.state_F_after_fault_ms,
-                   config.fail_on_powermeter_errors, config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
-                   utils::get_session_id_type_from_string(config.session_id_type),
-                   config.hlc_charge_loop_without_energy_timeout_s);
+    charger->setup(get_charger_setup_config(Charger::ChargeMode::DC, false));
 
     types::iso15118::EVSEID evseid = {config.evse_id, config.evse_id_din};
 
@@ -1595,13 +1603,7 @@ void EvseManager::setup_fake_DC_mode() {
 }
 
 void EvseManager::setup_AC_mode() {
-    charger->setup(config.has_ventilation, Charger::ChargeMode::AC, hlc_enabled, config.ac_hlc_use_5percent,
-                   config.ac_enforce_hlc, true, config.soft_over_current_tolerance_percent,
-                   config.soft_over_current_measurement_noise_A, config.switch_3ph1ph_delay_s,
-                   config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms, config.state_F_after_fault_ms,
-                   config.fail_on_powermeter_errors, config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
-                   utils::get_session_id_type_from_string(config.session_id_type),
-                   config.hlc_charge_loop_without_energy_timeout_s);
+    charger->setup(get_charger_setup_config(Charger::ChargeMode::AC, true));
 
     types::iso15118::EVSEID evseid = {config.evse_id, config.evse_id_din};
 

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -372,6 +372,8 @@ private:
 
     void setup_AC_mode();
     void setup_fake_DC_mode();
+    void update_hlc_session_setup(bool include_contract_payment, bool supported_certificate_service,
+                                  bool central_contract_validation, bool force_external_payment);
 
     // special funtion to switch mode while session is active
     void switch_AC_mode();

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -372,6 +372,7 @@ private:
 
     void setup_AC_mode();
     void setup_fake_DC_mode();
+    Charger::SetupConfig get_charger_setup_config(Charger::ChargeMode charge_mode, bool ac_with_soc_timeout) const;
     void update_hlc_session_setup(bool include_contract_payment, bool supported_certificate_service,
                                   bool central_contract_validation, bool force_external_payment);
 

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -376,6 +376,8 @@ private:
 
     void setup_AC_mode();
     void setup_fake_DC_mode();
+    void update_hlc_session_setup(bool include_contract_payment, bool supported_certificate_service,
+                                  bool central_contract_validation, bool force_external_payment);
 
     // special funtion to switch mode while session is active
     void switch_AC_mode();

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -376,6 +376,7 @@ private:
 
     void setup_AC_mode();
     void setup_fake_DC_mode();
+    Charger::SetupConfig get_charger_setup_config(Charger::ChargeMode charge_mode, bool ac_with_soc_timeout) const;
     void update_hlc_session_setup(bool include_contract_payment, bool supported_certificate_service,
                                   bool central_contract_validation, bool force_external_payment);
 


### PR DESCRIPTION
## Describe your changes

- Centralize HLC session setup across initialization, authorization, and session-start paths.
- Replace the positional `Charger::setup()` argument list with a named `SetupConfig`.
- Consolidate construction of the Charger configuration.

No functional behavior is intended to change.

## Issue ticket number and link

N/A — internal refactoring without an issue.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

