### PR TITLE
feat(YetiSimulator): make simulated AC nominal frequency configurable

### DIFF
--- a/modules/Simulation/YetiSimulator/YetiSimulator.hpp
+++ b/modules/Simulation/YetiSimulator/YetiSimulator.hpp
@@ -32,6 +32,7 @@ struct Conf {
     std::string dummy_meter_value_blob_start;
     std::string dummy_meter_value_blob_stop;
     double ac_nominal_voltage;
+    double ac_nominal_frequency;
 };
 
 class YetiSimulator : public Everest::ModuleBase {
@@ -79,6 +80,16 @@ public:
         new_state->powermeter_data.vrmsL1 = nominal_voltage;
         new_state->powermeter_data.vrmsL2 = nominal_voltage;
         new_state->powermeter_data.vrmsL3 = nominal_voltage;
+        const auto nominal_frequency = config.ac_nominal_frequency;
+        new_state->simdata_setting.frequencies.L1 = nominal_frequency;
+        new_state->simdata_setting.frequencies.L2 = nominal_frequency;
+        new_state->simdata_setting.frequencies.L3 = nominal_frequency;
+        new_state->simulation_data.frequencies.L1 = nominal_frequency;
+        new_state->simulation_data.frequencies.L2 = nominal_frequency;
+        new_state->simulation_data.frequencies.L3 = nominal_frequency;
+        new_state->powermeter_data.freqL1 = nominal_frequency;
+        new_state->powermeter_data.freqL2 = nominal_frequency;
+        new_state->powermeter_data.freqL3 = nominal_frequency;
         module_state = std::move(new_state);
     }
 

--- a/modules/Simulation/YetiSimulator/YetiSimulator.hpp
+++ b/modules/Simulation/YetiSimulator/YetiSimulator.hpp
@@ -31,6 +31,7 @@ struct Conf {
     bool dummy_meter_value_send_on_transaction_start;
     std::string dummy_meter_value_blob_start;
     std::string dummy_meter_value_blob_stop;
+    double ac_nominal_voltage;
 };
 
 class YetiSimulator : public Everest::ModuleBase {
@@ -67,7 +68,18 @@ public:
     std::unique_ptr<state::ModuleState> module_state;
 
     void reset_module_state() {
-        module_state = std::make_unique<state::ModuleState>();
+        auto new_state = std::make_unique<state::ModuleState>();
+        const auto nominal_voltage = config.ac_nominal_voltage;
+        new_state->simdata_setting.voltages.L1 = nominal_voltage;
+        new_state->simdata_setting.voltages.L2 = nominal_voltage;
+        new_state->simdata_setting.voltages.L3 = nominal_voltage;
+        new_state->simulation_data.voltages.L1 = nominal_voltage;
+        new_state->simulation_data.voltages.L2 = nominal_voltage;
+        new_state->simulation_data.voltages.L3 = nominal_voltage;
+        new_state->powermeter_data.vrmsL1 = nominal_voltage;
+        new_state->powermeter_data.vrmsL2 = nominal_voltage;
+        new_state->powermeter_data.vrmsL3 = nominal_voltage;
+        module_state = std::move(new_state);
     }
 
     void pwm_on(const double dutycycle);

--- a/modules/Simulation/YetiSimulator/manifest.yaml
+++ b/modules/Simulation/YetiSimulator/manifest.yaml
@@ -24,6 +24,12 @@ config:
     type: number
     default: 230.0
     minimum: 99.0
+  ac_nominal_frequency:
+    description: Nominal AC grid frequency in Hertz, reported per phase by the simulated power meter
+    type: number
+    default: 50.0
+    minimum: 50.0
+    maximum: 60.0
 provides:
   powermeter:
     interface: powermeter

--- a/modules/Simulation/YetiSimulator/manifest.yaml
+++ b/modules/Simulation/YetiSimulator/manifest.yaml
@@ -19,6 +19,11 @@ config:
     description: Dummy meter value blob sent on transaction stop to be used for testing
     type: string
     default: "test stop value"
+  ac_nominal_voltage:
+    description: Nominal AC voltage between phase and neutral in Volt, reported per phase by the simulated power meter
+    type: number
+    default: 230.0
+    minimum: 99.0
 provides:
   powermeter:
     interface: powermeter


### PR DESCRIPTION
## Describe your changes

### Motivation

Follow-up to #2523, as suggested by @SebaLukas in [this comment](https://github.com/EVerest/EVerest/pull/2523#issuecomment-5117484919): the YetiSimulator hardcodes the simulated AC grid frequency to 50 Hz (struct defaults in `util/state.hpp`), while several regions of the world run 60 Hz grids (most of the Americas, parts of Asia).

Japan — the motivating region for #2523 — is actually the strongest example: it is one of the very few countries with **both** nominal frequencies in domestic service (50 Hz in East Japan, 60 Hz in West Japan). A SIL setup modeling Japanese charging stations therefore needs this to be configurable even within a single country.

### What changed

Mirrors the approach of #2523 (`ac_nominal_voltage`):

- `modules/Simulation/YetiSimulator/manifest.yaml`: new config option `ac_nominal_frequency` (type `number`, default `50.0`, minimum `50.0`, maximum `60.0`). All public grids worldwide are nominally 50 or 60 Hz, hence the bounds; frequency excursions around the nominal value are already simulated at runtime by `add_noise()` and are not constrained by them.
- `modules/Simulation/YetiSimulator/YetiSimulator.hpp`:
  - `Conf` struct extended with `double ac_nominal_frequency;` (matching the generated code from `ev-cli` for the updated manifest).
  - `reset_module_state()` now applies the configured value to `simdata_setting.frequencies`, `simulation_data.frequencies` and `powermeter_data.freqL1/L2/L3`, so the configured frequency is reported both while the simulation loop is stepping and while it is idle, and survives the runtime module state reset triggered via `ev_board_supportImpl::handle_enable()` — same reasoning as in #2523.

### Depends on #2523

This branch is stacked on `feature/yetisim-configurable-nominal-voltage`, since both PRs touch the same config block and `reset_module_state()`. Until #2523 merges, the diff here also shows its commits — only the last commit is new. I will rebase onto `main` as soon as #2523 lands.

### Backward compatibility

The default remains 50 Hz and the struct defaults in `util/state.hpp` are unchanged, so existing configurations behave exactly as before.

## Issue ticket number and link

None — follow-up to review discussion on #2523.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (config option description in the manifest; no further docs reference the simulated frequency)
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
