### PR TITLE
feat(YetiSimulator): make reported hardware capabilities configurable

### DIFF
--- a/modules/Simulation/YetiSimulator/YetiSimulator.hpp
+++ b/modules/Simulation/YetiSimulator/YetiSimulator.hpp
@@ -31,6 +31,8 @@ struct Conf {
     bool dummy_meter_value_send_on_transaction_start;
     std::string dummy_meter_value_blob_start;
     std::string dummy_meter_value_blob_stop;
+    int caps_min_current_A;
+    int caps_max_current_A;
 };
 
 class YetiSimulator : public Everest::ModuleBase {

--- a/modules/Simulation/YetiSimulator/board_support/evse_board_supportImpl.cpp
+++ b/modules/Simulation/YetiSimulator/board_support/evse_board_supportImpl.cpp
@@ -27,8 +27,16 @@ void evse_board_supportImpl::init() {
 }
 
 void evse_board_supportImpl::ready() {
-    const auto default_capabilities = set_default_capabilities();
-    publish_capabilities(default_capabilities);
+    auto capabilities = set_default_capabilities();
+    if (mod->config.caps_min_current_A >= 0) {
+        capabilities.min_current_A_import = mod->config.caps_min_current_A;
+        capabilities.min_current_A_export = mod->config.caps_min_current_A;
+    }
+    if (mod->config.caps_max_current_A >= 0) {
+        capabilities.max_current_A_import = mod->config.caps_max_current_A;
+        capabilities.max_current_A_export = mod->config.caps_max_current_A;
+    }
+    publish_capabilities(capabilities);
 }
 
 void evse_board_supportImpl::handle_enable(bool& value) {

--- a/modules/Simulation/YetiSimulator/manifest.yaml
+++ b/modules/Simulation/YetiSimulator/manifest.yaml
@@ -19,6 +19,14 @@ config:
     description: Dummy meter value blob sent on transaction stop to be used for testing
     type: string
     default: "test stop value"
+  caps_min_current_A:
+    description: Minimal current on AC side reported in hardware capabilities. -1 means use the built-in default of the simulated hardware (6 A import / 0 A export).
+    type: integer
+    default: -1
+  caps_max_current_A:
+    description: Maximum current on AC side reported in hardware capabilities. -1 means use the built-in default of the simulated hardware (32 A import / 16 A export).
+    type: integer
+    default: -1
 provides:
   powermeter:
     interface: powermeter


### PR DESCRIPTION
## Describe your changes

### Motivation

The YetiSimulator BSP hardcodes the `HardwareCapabilities` it publishes
(`set_default_capabilities()` in `board_support/evse_board_supportImpl.cpp`:
32 A / 6 A import, 16 A / 0 A export). Since EvseManager clamps all energy-management
and charging-profile limits to the reported hardware capabilities, every SIL EVSE is
capped at 32 A (~22 kW at 3ph/230 V) no matter what a CSMS requests via
SetChargingProfile.

The real-hardware `YetiDriver` module already solves this: it exposes
`caps_min_current_A` / `caps_max_current_A` config options that override the
capabilities reported by the firmware (`-1` = use the hardware-reported values).
This PR brings the same mechanism to the simulator, so SIL setups can model EVSEs
larger than the 22 kW Yeti reference board (up to 80 A, the IEC 61851 PWM encoding
limit) without patching the source. Other BSP modules (`PhyVersoBSP`, `TIDA010939`)
also expose their capability currents as config options.

### What changed

- `modules/Simulation/YetiSimulator/manifest.yaml`: new config options
  `caps_min_current_A` / `caps_max_current_A` (type `integer`, default `-1`), named
  and behaving identically to the existing `YetiDriver` options.
- `modules/Simulation/YetiSimulator/YetiSimulator.hpp`: `Conf` struct extended
  accordingly (matching the generated code from `ev-cli` for the updated manifest).
- `modules/Simulation/YetiSimulator/board_support/evse_board_supportImpl.cpp`:
  `ready()` applies the overrides on top of the built-in defaults before publishing.
  As in `YetiDriver`, a value `>= 0` overrides both the import and export side;
  `-1` keeps the built-in default for that bound.

### Backward compatibility

Defaults are `-1` (keep built-in 32/6 A import, 16/0 A export), so existing
configurations behave exactly as before.

### Testing

Built in the devcontainer (`ninja YetiSimulator`) and ran `config-sil.yaml` twice
while subscribing to the capability topics on MQTT:

- without the new options (defaults): `board_support/var/capabilities` and
  EvseManager's `evse/var/hw_capabilities` report `32.0/6.0` A import,
  `16.0/0.0` A export — identical to current behavior;
- with `caps_max_current_A: 80` / `caps_min_current_A: 10`: both topics report
  `80.0/10.0` A for import and export, confirming the override propagates
  through EvseManager.

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
