### PR TITLE
fix(LemDCBM400600): enforce maximum length for tariff text in transaction start request

### DIFF
--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
@@ -339,12 +339,20 @@ LemDCBM400600Controller::transaction_start_request_to_dcbm_payload(const types::
     std::string client_id = request.identification_data.value_or("") + ',' + request.transaction_id;
     const int max_length_client_id = 37; // as defined by LEM documentation
     client_id = (client_id.length() > max_length_client_id) ? client_id.substr(0, max_length_client_id) : client_id;
+    std::string tariff_text = request.tariff_text.value_or("");
+    const int max_length_tariff_text = 20; // as defined by LEM documentation
+    tariff_text = (tariff_text.length() > max_length_tariff_text) ? tariff_text.substr(0, max_length_tariff_text) : tariff_text;
+    // the device cannot handle multi-line text, so truncate at the first newline even if the result is shorter than the max length checked above
+    const auto newline_pos = tariff_text.find('\n');
+    if (newline_pos != std::string::npos) {
+        tariff_text = tariff_text.substr(0, newline_pos);
+    }
     if (this->v2_capable) {
         return nlohmann::ordered_json{{"evseId", request.evse_id},
                                       {"transactionId", request.transaction_id},
                                       {"clientId", client_id},
                                       {"tariffId", this->config.tariff_id},
-                                      {"TT", request.tariff_text.value_or("")},
+                                      {"TT", tariff_text},
                                       {"UV", this->config.UV},
                                       {"UD", this->config.UD},
                                       {"cableId", this->config.cable_id},

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
@@ -3,6 +3,8 @@
 
 #include "lem_dcbm_400600_controller.hpp"
 #include <stdexcept>
+#include <algorithm>
+#include <string>
 namespace module::main {
 
 void LemDCBM400600Controller::init() {
@@ -342,11 +344,9 @@ LemDCBM400600Controller::transaction_start_request_to_dcbm_payload(const types::
     std::string tariff_text = request.tariff_text.value_or("");
     const int max_length_tariff_text = 20; // as defined by LEM documentation
     tariff_text = (tariff_text.length() > max_length_tariff_text) ? tariff_text.substr(0, max_length_tariff_text) : tariff_text;
-    // the device cannot handle multi-line text, so truncate at the first newline even if the result is shorter than the max length checked above
-    const auto newline_pos = tariff_text.find('\n');
-    if (newline_pos != std::string::npos) {
-        tariff_text = tariff_text.substr(0, newline_pos);
-    }
+    // the device cannot handle multi-line text, so replace newlines and carriage returns with spaces instead of truncating the text
+    std::replace(tariff_text.begin(), tariff_text.end(), '\n', ' ');
+    std::replace(tariff_text.begin(), tariff_text.end(), '\r', ' ');
     if (this->v2_capable) {
         return nlohmann::ordered_json{{"evseId", request.evse_id},
                                       {"transactionId", request.transaction_id},


### PR DESCRIPTION
- truncate tariff text at newline, because device cannot handle multiple lines

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements