### PR TITLE
feat(libiso15118): Adding skipping sap negotiation when using an already open fd

### DIFF
--- a/lib/everest/iso15118/include/iso15118/d20/state/session_setup.hpp
+++ b/lib/everest/iso15118/include/iso15118/d20/state/session_setup.hpp
@@ -8,7 +8,8 @@
 namespace iso15118::d20::state {
 
 struct SessionSetup : public StateBase {
-    SessionSetup(Context& ctx) : StateBase(ctx, StateID::SessionSetup) {
+    SessionSetup(Context& ctx, bool skip_app_protocol_negotiation_) :
+        StateBase(ctx, StateID::SessionSetup), skip_app_protocol_negotiation(skip_app_protocol_negotiation_) {
     }
 
     void enter() final;
@@ -17,6 +18,7 @@ struct SessionSetup : public StateBase {
 
 private:
     std::string evse_id;
+    bool skip_app_protocol_negotiation;
 };
 
 } // namespace iso15118::d20::state

--- a/lib/everest/iso15118/include/iso15118/session/iso.hpp
+++ b/lib/everest/iso15118/include/iso15118/session/iso.hpp
@@ -34,6 +34,8 @@ class Session {
 public:
     Session(std::unique_ptr<io::IConnection>, d20::SessionConfig, const session::feedback::Callbacks&,
             std::optional<d20::PauseContext>&);
+    Session(std::unique_ptr<io::IConnection>, d20::SessionConfig, const session::feedback::Callbacks&,
+            std::optional<d20::PauseContext>&, bool skip_app_protocol_negotiation);
     ~Session();
 
     TimePoint const& poll();

--- a/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
+++ b/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
@@ -32,6 +32,11 @@ enum class StartSessionResult : std::uint8_t {
     SessionComplete,
 };
 
+struct StartSessionOptions {
+    std::optional<io::sha512_hash_t> vehicle_cert_hash{std::nullopt};
+    bool skip_app_protocol_negotiation{false};
+};
+
 struct TbdConfig {
     config::SSLConfig ssl{};
     std::string interface_name;
@@ -57,8 +62,7 @@ public:
     void loop();
     // Mutually exclusive with the other driver; see the class note. Refuses (logs and returns false) if the other
     // driver is already running.
-    StartSessionResult start_session(int connected_fd);
-    StartSessionResult start_session(int connected_fd, const std::optional<io::sha512_hash_t>& vehicle_cert_hash);
+    StartSessionResult start_session(int connected_fd, const StartSessionOptions& start_options);
     void tick();
 
     bool has_active_session() const {

--- a/lib/everest/iso15118/src/iso15118/d20/state/session_setup.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/session_setup.cpp
@@ -91,8 +91,12 @@ Result SessionSetup::feed(Event ev) {
         logf_info("Received session setup with evccid: %s", req->evccid.c_str());
         m_ctx.feedback.evcc_id(req->evccid);
         m_ctx.ev_info.evcc_id = req->evccid;
-        m_ctx.feedback.ev_information(m_ctx.ev_info);
 
+        // Only emit ev_information feedback when the sap negotiation is handled here. When SAP is skipped the
+        // application already has the information.
+        if (not skip_app_protocol_negotiation) {
+            m_ctx.feedback.ev_information(m_ctx.ev_info);
+        }
         bool new_session{false};
 
         const auto vehicle_cert_hash = m_ctx.get_new_vehicle_cert_hash();

--- a/lib/everest/iso15118/src/iso15118/d20/state/supported_app_protocol.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/supported_app_protocol.cpp
@@ -131,7 +131,7 @@ Result SupportedAppProtocol::feed(Event ev) {
                 }
             }
         }
-        return m_ctx.create_state<SessionSetup>();
+        return m_ctx.create_state<SessionSetup>(false);
     }
     logf_warning("Expected SupportedAppProtocolReq! But code type id: %d", variant->get_type());
 

--- a/lib/everest/iso15118/src/iso15118/message/session_setup.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/session_setup.cpp
@@ -21,6 +21,7 @@ template <> void convert(const struct iso20_SessionSetupReqType& in, SessionSetu
 
 template <> void convert(const struct iso20_SessionSetupResType& in, SessionSetupResponse& out) {
     convert(in.Header, out.header);
+    cb_convert_enum(in.ResponseCode, out.response_code);
     out.evseid = CB2CPP_STRING(in.EVSEID);
 }
 

--- a/lib/everest/iso15118/src/iso15118/session/iso.cpp
+++ b/lib/everest/iso15118/src/iso15118/session/iso.cpp
@@ -9,6 +9,7 @@
 
 #include <arpa/inet.h>
 
+#include <iso15118/d20/state/session_setup.hpp>
 #include <iso15118/d20/state/supported_app_protocol.hpp>
 
 #include <iso15118/detail/helper.hpp>
@@ -18,7 +19,9 @@ namespace iso15118 {
 static constexpr auto SESSION_IDLE_TIMEOUT_MS = 5000;
 static constexpr auto MIN_RESPONSE_INTERVAL_MS = 100; // minimum time between two response messages
 
-static void log_sdp_packet(const iso15118::io::SdpPacket& sdp) {
+namespace {
+
+void log_sdp_packet(const iso15118::io::SdpPacket& sdp) {
     static constexpr auto ESCAPED_BYTE_CHAR_COUNT = 4;
     auto payload_string_buffer = std::make_unique<char[]>(sdp.get_payload_length() * ESCAPED_BYTE_CHAR_COUNT + 1);
     for (std::size_t i = 0; i < sdp.get_payload_length(); ++i) {
@@ -30,7 +33,7 @@ static void log_sdp_packet(const iso15118::io::SdpPacket& sdp) {
                         payload_string_buffer.get());
 }
 
-static std::unique_ptr<message_20::Variant> make_variant_from_packet(const iso15118::io::SdpPacket& packet) {
+std::unique_ptr<message_20::Variant> make_variant_from_packet(const iso15118::io::SdpPacket& packet) {
     return std::make_unique<message_20::Variant>(
         packet.get_payload_type(), io::StreamInputView{packet.get_payload_buffer(), packet.get_payload_length()});
 }
@@ -119,7 +122,7 @@ V2GTPReadResult read_single_v2gtp_packet(io::IConnection& connection, io::SdpPac
     return V2GTPReadResult::complete;
 }
 
-static size_t setup_response_header(uint8_t* buffer, iso15118::io::v2gtp::PayloadType payload_type, size_t size) {
+size_t setup_response_header(uint8_t* buffer, iso15118::io::v2gtp::PayloadType payload_type, size_t size) {
     buffer[0] = iso15118::io::SDP_PROTOCOL_VERSION;
     buffer[1] = iso15118::io::SDP_INVERSE_PROTOCOL_VERSION;
 
@@ -134,12 +137,20 @@ static size_t setup_response_header(uint8_t* buffer, iso15118::io::v2gtp::Payloa
 
     return size + iso15118::io::SdpPacket::V2GTP_HEADER_SIZE;
 }
+} // namespace
 
 Session::Session(std::unique_ptr<io::IConnection> connection_, d20::SessionConfig session_config,
                  const session::feedback::Callbacks& callbacks, std::optional<d20::PauseContext>& pause_ctx) :
+    Session(std::move(connection_), std::move(session_config), callbacks, pause_ctx, false) {
+}
+
+Session::Session(std::unique_ptr<io::IConnection> connection_, d20::SessionConfig session_config,
+                 const session::feedback::Callbacks& callbacks, std::optional<d20::PauseContext>& pause_ctx,
+                 bool skip_app_protocol_negotiation) :
     connection(std::move(connection_)),
     ctx(callbacks, std::move(session_config), pause_ctx, active_control_event, message_exchange, timeouts),
-    fsm(ctx.create_state<d20::state::SupportedAppProtocol>()) {
+    fsm(skip_app_protocol_negotiation ? ctx.create_state<d20::state::SessionSetup>(true)
+                                      : ctx.create_state<d20::state::SupportedAppProtocol>()) {
 
     next_session_event = offset_time_point_by_ms(get_current_time_point(), SESSION_IDLE_TIMEOUT_MS);
     connection->set_event_callback([this](io::ConnectionEvent event) { this->handle_connection_event(event); });

--- a/lib/everest/iso15118/src/iso15118/tbd_controller.cpp
+++ b/lib/everest/iso15118/src/iso15118/tbd_controller.cpp
@@ -141,12 +141,7 @@ void TbdController::loop() {
 
 // The caller of this function needs to provide a non-blocking, keepalive fd.
 // ConnectionPlain::read() depends on the socket being non-blocking
-StartSessionResult TbdController::start_session(int connected_fd) {
-    return start_session(connected_fd, std::nullopt);
-}
-
-StartSessionResult TbdController::start_session(int connected_fd,
-                                                const std::optional<io::sha512_hash_t>& vehicle_cert_hash) {
+StartSessionResult TbdController::start_session(int connected_fd, const StartSessionOptions& start_options) {
     if (driver_running.exchange(true)) {
         logf_error("Another driver (loop/start_session) is already running; refusing concurrent entry");
         return StartSessionResult::KeepFdOpen;
@@ -172,9 +167,10 @@ StartSessionResult TbdController::start_session(int connected_fd,
     // Reseting because this could cancel service_active_session.
     terminate_session_requested.store(false);
 
-    auto connection = std::make_unique<io::ConnectionPlain>(poll_manager, connected_fd, vehicle_cert_hash);
+    auto connection =
+        std::make_unique<io::ConnectionPlain>(poll_manager, connected_fd, start_options.vehicle_cert_hash);
     session = std::make_unique<Session>(std::move(connection), d20::SessionConfig(*evse_setup.handle()), callbacks,
-                                        pause_ctx);
+                                        pause_ctx, start_options.skip_app_protocol_negotiation);
     shutdown_active.store(false);
     shutdown_signaled = false;
 

--- a/lib/everest/iso15118/test/exi/cb/iso20/session_setup.cpp
+++ b/lib/everest/iso15118/test/exi/cb/iso20/session_setup.cpp
@@ -71,6 +71,29 @@ SCENARIO("Se/Deserialize session setup messages") {
         }
     }
 
+    GIVEN("Deserialize session_setup_res") {
+        uint8_t doc_raw[] = {0x80, 0x90, 0x04, 0x3b, 0x18, 0x22, 0x6f, 0x13, 0xd8, 0x8a,
+                             0xe0, 0x8f, 0xdd, 0x3b, 0x1d, 0x30, 0x62, 0x04, 0x00, 0x80};
+
+        const io::StreamInputView stream_view{doc_raw, sizeof(doc_raw)};
+
+        message_20::Variant variant(io::v2gtp::PayloadType::Part20Main, stream_view);
+
+        THEN("It should be deserialized successfully") {
+            REQUIRE(variant.get_type() == message_20::Type::SessionSetupRes);
+
+            const auto& msg = variant.get<message_20::SessionSetupResponse>();
+            const auto& header = msg.header;
+
+            REQUIRE(header.session_id == std::array<uint8_t, 8>{0x76, 0x30, 0x44, 0xDE, 0x27, 0xB1, 0x15, 0xC1});
+            REQUIRE(header.timestamp == 1785489917);
+
+            REQUIRE(msg.response_code == message_20::datatypes::ResponseCode::OK_NewSessionEstablished);
+
+            REQUIRE(msg.evseid == "");
+        }
+    }
+
     GIVEN("Serialize session_setup_req") {
 
         const auto header = message_20::Header{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, 1739635913};

--- a/lib/everest/iso15118/test/iso15118/fsm/session_setup.cpp
+++ b/lib/everest/iso15118/test/iso15118/fsm/session_setup.cpp
@@ -43,9 +43,13 @@ SCENARIO("ISO15118-20 session setup state transitions") {
                                           std::nullopt,
                                           powersupply_limits};
 
+    const bool skip_app_protocol_negotiation{false};
+    bool ev_information_called{false};
+
     std::optional<d20::PauseContext> pause_ctx{std::nullopt};
 
-    const session::feedback::Callbacks callbacks{};
+    session::feedback::Callbacks callbacks{};
+    callbacks.ev_information = [&ev_information_called](const d20::EVInformation&) { ev_information_called = true; };
 
     auto state_helper = FsmStateHelper(d20::SessionConfig(evse_setup), pause_ctx, callbacks);
     auto ctx = state_helper.get_context();
@@ -65,7 +69,7 @@ SCENARIO("ISO15118-20 session setup state transitions") {
 
     GIVEN("Good case - New session") {
 
-        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SessionSetup>()};
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SessionSetup>(skip_app_protocol_negotiation)};
 
         const auto header_req = message_20::Header{{0, 0, 0, 0, 0, 0, 0, 0}, 1691411798};
         const auto req = message_20::SessionSetupRequest{header_req, "WMIV1234567890ABCDEX"};
@@ -87,8 +91,44 @@ SCENARIO("ISO15118-20 session setup state transitions") {
         }
     }
 
+    GIVEN("Good case - New session, app protocol negotiation not skipped: ev_information is emitted") {
+        ev_information_called = false; // reset
+
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SessionSetup>(false)};
+
+        const auto header_req = message_20::Header{{0, 0, 0, 0, 0, 0, 0, 0}, 1691411798};
+        const auto req = message_20::SessionSetupRequest{header_req, "WMIV1234567890ABCDEX"};
+
+        state_helper.handle_request(req);
+        const auto result = fsm.feed(d20::Event::V2GTP_MESSAGE);
+
+        THEN("Check state transition and that ev_information feedback is called") {
+            REQUIRE(result.transitioned() == true);
+            REQUIRE(fsm.get_current_state_id() == d20::StateID::AuthorizationSetup);
+            REQUIRE(ev_information_called == true);
+        }
+    }
+
+    GIVEN("Good case - New session, app protocol negotiation skipped: ev_information is not emitted") {
+        ev_information_called = false; // reset
+
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SessionSetup>(true)};
+
+        const auto header_req = message_20::Header{{0, 0, 0, 0, 0, 0, 0, 0}, 1691411798};
+        const auto req = message_20::SessionSetupRequest{header_req, "WMIV1234567890ABCDEX"};
+
+        state_helper.handle_request(req);
+        const auto result = fsm.feed(d20::Event::V2GTP_MESSAGE);
+
+        THEN("Check state transition and that ev_information feedback is not called") {
+            REQUIRE(result.transitioned() == true);
+            REQUIRE(fsm.get_current_state_id() == d20::StateID::AuthorizationSetup);
+            REQUIRE(ev_information_called == false);
+        }
+    }
+
     GIVEN("Good case - resume old session") {
-        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SessionSetup>()};
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SessionSetup>(skip_app_protocol_negotiation)};
 
         ctx.set_new_vehicle_cert_hash(io::sha512_hash_t{
             0x3F, 0x66, 0xE4, 0x5F, 0x3A, 0x30, 0x3B, 0x8F, 0x47, 0xCD, 0xD6, 0x86, 0xAD, 0x75, 0x13, 0x6F,
@@ -119,7 +159,7 @@ SCENARIO("ISO15118-20 session setup state transitions") {
     }
 
     GIVEN("Try to resume old session with another session id") {
-        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SessionSetup>()};
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SessionSetup>(skip_app_protocol_negotiation)};
 
         ctx.set_new_vehicle_cert_hash(io::sha512_hash_t{
             0x3F, 0x66, 0xE4, 0x5F, 0x3A, 0x30, 0x3B, 0x8F, 0x47, 0xCD, 0xD6, 0x86, 0xAD, 0x75, 0x13, 0x6F,
@@ -151,7 +191,7 @@ SCENARIO("ISO15118-20 session setup state transitions") {
     }
 
     GIVEN("Try to resume old session with no vehicle cert hash") {
-        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SessionSetup>()};
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SessionSetup>(skip_app_protocol_negotiation)};
 
         const auto header_req = message_20::Header{session_id, 1691411798};
         const auto req = message_20::SessionSetupRequest{header_req, "WMIV1234567890ABCDEX"};
@@ -177,7 +217,7 @@ SCENARIO("ISO15118-20 session setup state transitions") {
     }
 
     GIVEN("Try to resume old session with different vehicle cert hash") {
-        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SessionSetup>()};
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SessionSetup>(skip_app_protocol_negotiation)};
 
         ctx.set_new_vehicle_cert_hash(io::sha512_hash_t{
             0x3F, 0x66, 0xE4, 0x5F, 0x3A, 0x30, 0x3B, 0x8F, 0x47, 0xCD, 0xD6, 0x86, 0xAD, 0x75, 0x13, 0x6F,
@@ -209,7 +249,7 @@ SCENARIO("ISO15118-20 session setup state transitions") {
     }
 
     GIVEN("Sequence Error") {
-        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SessionSetup>()};
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SessionSetup>(skip_app_protocol_negotiation)};
 
         const auto header_req = message_20::Header{d20::Session().get_id(), 1691411798};
         const auto req =

--- a/lib/everest/iso15118/test/iso15118/session/tbd_controller_start_session.cpp
+++ b/lib/everest/iso15118/test/iso15118/session/tbd_controller_start_session.cpp
@@ -20,9 +20,11 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <iso15118/d20/config.hpp>
+#include <iso15118/io/logging.hpp>
 #include <iso15118/io/sdp.hpp>
 #include <iso15118/io/sdp_packet.hpp>
 #include <iso15118/io/stream_view.hpp>
+#include <iso15118/message/session_setup.hpp>
 #include <iso15118/message/supported_app_protocol.hpp>
 #include <iso15118/message/variant.hpp>
 #include <iso15118/session/feedback.hpp>
@@ -56,6 +58,11 @@ bool fd_is_open(int fd) {
 constexpr uint8_t sap_req[] = {0x80, 0x00, 0xf3, 0xab, 0x93, 0x71, 0xd3, 0x4b, 0x9b, 0x79, 0xd3, 0x9b, 0xa3,
                                0x21, 0xd3, 0x4b, 0x9b, 0x79, 0xd1, 0x89, 0xa9, 0x89, 0x89, 0xc1, 0xd1, 0x69,
                                0x91, 0x81, 0xd2, 0x0a, 0x18, 0x01, 0x00, 0x00, 0x04, 0x00, 0x40};
+
+// Captured SessionSetupReq with a zeroed session id (starts a new session).
+constexpr uint8_t session_setup_req[] = {0x80, 0x8c, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0c, 0x9f,
+                                         0x9c, 0x2b, 0xd0, 0x62, 0x0b, 0x2b, 0xa6, 0xa4, 0xab, 0x18, 0x99, 0x19, 0x9a,
+                                         0x1a, 0x9b, 0x1b, 0x9c, 0x1c, 0x98, 0x20, 0xa1, 0x21, 0xa2, 0x22, 0xac, 0x00};
 
 // Wraps an EXI payload in a V2GTP frame (8-byte header + payload), mirroring the framing in
 // MockConnection::queue_v2gtp_packet.
@@ -119,6 +126,101 @@ std::optional<std::vector<uint8_t>> read_v2gtp_frame(int fd, std::chrono::millis
     return buffer;
 }
 
+class SessionWatchdog {
+public:
+    SessionWatchdog(iso15118::TbdController& controller, std::chrono::seconds timeout) {
+        thread = std::thread([this, &controller, timeout] {
+            std::unique_lock<std::mutex> lock(mutex);
+            if (not cv.wait_for(lock, timeout, [this] { return done; })) {
+                timed_out_flag.store(true);
+                controller.shutdown();
+            }
+        });
+    }
+
+    ~SessionWatchdog() {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            done = true;
+        }
+        cv.notify_all();
+        thread.join();
+    }
+
+    SessionWatchdog(const SessionWatchdog&) = delete;
+    SessionWatchdog& operator=(const SessionWatchdog&) = delete;
+
+    bool timed_out() const {
+        return timed_out_flag.load();
+    }
+
+private:
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool done{false};
+    std::atomic_bool timed_out_flag{false};
+    std::thread thread;
+};
+
+struct RoundTripResult {
+    iso15118::StartSessionResult ok{};
+    ssize_t written{0};
+    std::optional<std::vector<uint8_t>> response;
+    bool timed_out{false};
+};
+
+RoundTripResult run_start_session_round_trip(iso15118::TbdController& controller, std::array<int, 2>& fds,
+                                             iso15118::io::v2gtp::PayloadType payload_type, const uint8_t* req,
+                                             std::size_t req_len, bool skip_app_protocol_negotiation) {
+    RoundTripResult result;
+    auto start_options = iso15118::StartSessionOptions{};
+
+    std::thread start_session_thread([&] {
+        if (skip_app_protocol_negotiation) {
+            start_options.skip_app_protocol_negotiation = true;
+        }
+        result.ok = controller.start_session(fds.at(0), start_options);
+    });
+
+    SessionWatchdog watchdog(controller, std::chrono::seconds(20));
+
+    const auto request_frame = make_v2gtp_frame(payload_type, req, req_len);
+    result.written = ::write(fds.at(1), request_frame.data(), request_frame.size());
+
+    result.response = read_v2gtp_frame(fds.at(1), std::chrono::seconds(5));
+
+    close(fds.at(1));
+    controller.shutdown();
+    start_session_thread.join();
+
+    result.timed_out = watchdog.timed_out();
+    return result;
+}
+
+template <typename Response>
+Response require_response(const std::optional<std::vector<uint8_t>>& response,
+                          iso15118::io::v2gtp::PayloadType payload_type) {
+    constexpr std::size_t header_size = iso15118::io::SdpPacket::V2GTP_HEADER_SIZE;
+
+    REQUIRE(response.has_value());
+    REQUIRE(response->size() > header_size);
+    REQUIRE(response->at(0) == iso15118::io::SDP_PROTOCOL_VERSION);
+    REQUIRE(response->at(1) == iso15118::io::SDP_INVERSE_PROTOCOL_VERSION);
+
+    uint16_t response_type{};
+    std::memcpy(&response_type, response->data() + 2, sizeof(response_type));
+    REQUIRE(ntohs(response_type) == static_cast<uint16_t>(payload_type));
+
+    const uint8_t* payload = response->data() + header_size;
+    const std::size_t payload_len = response->size() - header_size;
+
+    const iso15118::io::StreamInputView view{payload, payload_len};
+    const iso15118::message_20::Variant variant(payload_type, view);
+    REQUIRE(variant.get_type() == iso15118::message_20::TypeTrait<Response>::type);
+
+    return variant.get<Response>();
+}
+
 } // namespace
 
 SCENARIO("session_start guard check - invalid/closed fd") {
@@ -126,9 +228,10 @@ SCENARIO("session_start guard check - invalid/closed fd") {
     callbacks.signal = [](auto) {};
 
     auto controller = make_controller(false, callbacks);
+    const auto start_options = iso15118::StartSessionOptions{};
 
     WHEN("start_session gets an invalid/closed fd") {
-        const auto ok = controller.start_session(-1);
+        const auto ok = controller.start_session(-1, start_options);
 
         THEN("Session not started") {
             REQUIRE(ok == iso15118::StartSessionResult::FdNotValid);
@@ -144,9 +247,10 @@ SCENARIO("session_start guard check - enable_sdp_server: true") {
     auto controller = make_controller(true, callbacks);
 
     const auto fds = make_nonblocking_socketpair();
+    const auto start_options = iso15118::StartSessionOptions{};
 
     WHEN("start_session - sdp_server is enabled") {
-        const auto ok = controller.start_session(fds.at(0));
+        const auto ok = controller.start_session(fds.at(0), start_options);
 
         THEN("Session not started") {
             REQUIRE(ok == iso15118::StartSessionResult::KeepFdOpen);
@@ -170,9 +274,10 @@ SCENARIO("session_start guard check - session already started") {
     REQUIRE(controller.has_active_session());
 
     const auto fds = make_nonblocking_socketpair();
+    const auto start_options = iso15118::StartSessionOptions{};
 
     WHEN("start_session - session already started") {
-        const auto ok = controller.start_session(fds.at(0));
+        const auto ok = controller.start_session(fds.at(0), start_options);
 
         THEN("Start session does not end already started session") {
             REQUIRE(ok == iso15118::StartSessionResult::KeepFdOpen);
@@ -191,79 +296,58 @@ SCENARIO("session_start functionality") {
 
     auto controller = make_controller(false, callbacks);
 
-    const auto fds = make_nonblocking_socketpair();
-
-    iso15118::StartSessionResult ok{iso15118::StartSessionResult::KeepFdOpen};
+    auto fds = make_nonblocking_socketpair();
 
     WHEN("start_session") {
-        std::thread start_session_thread([&] { ok = controller.start_session(fds.at(0)); });
-
-        // Watchdog: if start_session() never returns (e.g. the session fails to finish), force it out
-        // with shutdown() so the test cannot hang forever. Stays armed across the join below.
-        std::mutex watchdog_mutex;
-        std::condition_variable watchdog_cv;
-        bool watchdog_done{false};
-        std::atomic_bool timed_out{false};
-        std::thread watchdog_thread([&] {
-            std::unique_lock<std::mutex> lock(watchdog_mutex);
-            if (not watchdog_cv.wait_for(lock, std::chrono::seconds(20), [&] { return watchdog_done; })) {
-                timed_out.store(true);
-                controller.shutdown();
-            }
-        });
-
-        // Create a V2GTP message (8-byte header + SupportedAppProtocolReq EXI payload) and send it
-        // through the client end of the socketpair.
-        const auto request_frame = make_v2gtp_frame(iso15118::io::v2gtp::PayloadType::SAP, sap_req, sizeof(sap_req));
-        const auto written = ::write(fds.at(1), request_frame.data(), request_frame.size());
-
-        // Wait for the SupportedAppProtocolRes the server writes back.
-        const auto response = read_v2gtp_frame(fds.at(1), std::chrono::seconds(5));
-
-        // Tear down before asserting: closing the client end signals EOF to the server, so its session
-        // finishes and start_session() returns. shutdown() is a belt-and-suspenders unblock. Both
-        // worker threads are joined here so no assertion below can throw with a thread still running.
-        close(fds.at(1));
-        controller.shutdown();
-        start_session_thread.join();
-
-        {
-            std::lock_guard<std::mutex> lock(watchdog_mutex);
-            watchdog_done = true;
-        }
-        watchdog_cv.notify_all();
-        watchdog_thread.join();
+        // Drive one full round-trip: send a SupportedAppProtocolReq and read the response.
+        const auto result = run_start_session_round_trip(controller, fds, iso15118::io::v2gtp::PayloadType::SAP,
+                                                         sap_req, sizeof(sap_req), false);
 
         THEN("the server answers with a valid SupportedAppProtocolRes and the session ends cleanly") {
-            REQUIRE_FALSE(timed_out.load());
-            REQUIRE(written == static_cast<ssize_t>(request_frame.size()));
+            REQUIRE_FALSE(result.timed_out);
+            REQUIRE(result.written ==
+                    static_cast<ssize_t>(iso15118::io::SdpPacket::V2GTP_HEADER_SIZE + sizeof(sap_req)));
 
-            // The response is a well-formed V2GTP SAP frame.
-            constexpr std::size_t header_size = iso15118::io::SdpPacket::V2GTP_HEADER_SIZE;
-            REQUIRE(response.has_value());
-            REQUIRE(response->size() > header_size);
-            REQUIRE(response->at(0) == iso15118::io::SDP_PROTOCOL_VERSION);
-            REQUIRE(response->at(1) == iso15118::io::SDP_INVERSE_PROTOCOL_VERSION);
-
-            uint16_t response_type{};
-            std::memcpy(&response_type, response->data() + 2, sizeof(response_type));
-            REQUIRE(ntohs(response_type) == static_cast<uint16_t>(iso15118::io::v2gtp::PayloadType::SAP));
-
-            // Decode the payload to a SupportedAppProtocolResponse via the library Variant.
-            const uint8_t* payload = response->data() + header_size;
-            const std::size_t payload_len = response->size() - header_size;
-
-            const iso15118::io::StreamInputView view{payload, payload_len};
-            const iso15118::message_20::Variant variant(iso15118::io::v2gtp::PayloadType::SAP, view);
-            REQUIRE(variant.get_type() == iso15118::message_20::Type::SupportedAppProtocolRes);
-
-            const auto& sap_res = variant.get<iso15118::message_20::SupportedAppProtocolResponse>();
+            const auto sap_res = require_response<iso15118::message_20::SupportedAppProtocolResponse>(
+                result.response, iso15118::io::v2gtp::PayloadType::SAP);
             REQUIRE(sap_res.response_code ==
                     iso15118::message_20::SupportedAppProtocolResponse::ResponseCode::OK_SuccessfulNegotiation);
             REQUIRE(sap_res.schema_id.has_value());
 
             // start_session() returned true and reaped the session; ConnectionPlain::close() closed the fd.
-            REQUIRE(ok == iso15118::StartSessionResult::SessionComplete);
+            REQUIRE(result.ok == iso15118::StartSessionResult::SessionComplete);
+            REQUIRE_FALSE(controller.has_active_session());
+            REQUIRE_FALSE(fd_is_open(fds.at(0)));
+        }
+    }
+}
+
+SCENARIO("session_start functionality - skip sap") {
+    iso15118::session::feedback::Callbacks callbacks;
+    callbacks.signal = [](auto) {};
+
+    auto controller = make_controller(false, callbacks);
+
+    auto fds = make_nonblocking_socketpair();
+
+    WHEN("start_session - skip sap") {
+        // Drive one full round-trip with app-protocol negotiation skipped: send a SessionSetupReq
+        // straight away and read the response.
+        const auto result = run_start_session_round_trip(controller, fds, iso15118::io::v2gtp::PayloadType::Part20Main,
+                                                         session_setup_req, sizeof(session_setup_req), true);
+
+        THEN("the server answers with a valid SessionSetupRes and the session ends cleanly") {
+            REQUIRE_FALSE(result.timed_out);
+            REQUIRE(result.written ==
+                    static_cast<ssize_t>(iso15118::io::SdpPacket::V2GTP_HEADER_SIZE + sizeof(session_setup_req)));
+
+            const auto session_setup_res = require_response<iso15118::message_20::SessionSetupResponse>(
+                result.response, iso15118::io::v2gtp::PayloadType::Part20Main);
+            REQUIRE(session_setup_res.response_code ==
+                    iso15118::message_20::datatypes::ResponseCode::OK_NewSessionEstablished);
+
+            // start_session() returned true and reaped the session; ConnectionPlain::close() closed the fd.
+            REQUIRE(result.ok == iso15118::StartSessionResult::SessionComplete);
             REQUIRE_FALSE(controller.has_active_session());
             REQUIRE_FALSE(fd_is_open(fds.at(0)));
         }


### PR DESCRIPTION
## Describe your changes
See title.
The application that links against libiso15118 can also start_session directly in session_setup. If another application handles the sdp+tcp/tls+sap handshakes.

## Issue ticket number and link
Sometimes outside of libiso15118 the caller handles the sap negotiation already. Before the changes that was not possible.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

