### PR TITLE
feat(OCPP1.6): support multi-slot network configuration via device model

### DIFF
--- a/applications/utils/everest-testing/src/everest/testing/core_utils/_configuration/everest_environment_setup.py
+++ b/applications/utils/everest-testing/src/everest/testing/core_utils/_configuration/everest_environment_setup.py
@@ -25,7 +25,8 @@ from .everest_configuration_strategies.persistent_store_configuration_strategy i
 from .everest_configuration_strategies.probe_module_configuration_strategy import \
     ProbeModuleConfigurationStrategy
 from .libocpp_configuration_helper import \
-    LibOCPP2XConfigurationHelper, LibOCPP16ConfigurationHelper
+    LibOCPP2XConfigurationHelper, LibOCPP16ConfigurationHelper, \
+    OCPPConfigAdjustmentStrategy, _OCPP16ComponentConfigCsmsUrlAdjustment
 
 
 @dataclass
@@ -39,6 +40,9 @@ class EverestEnvironmentOCPPConfiguration:
     device_model_component_config_path: Optional[
         Path] = None  # Path of the OCPP device model json schemas.
     configuration_strategies: list[OCPPModuleConfigurationStrategy] | None = None
+    # OCPP1.6 device-model (component config) adjustment strategies; applied to the copied
+    # NetworkConfiguration/OCPPCommCtrlr component config JSONs before the DB is migrated.
+    ocpp16_component_config_strategies: list[OCPPConfigAdjustmentStrategy] | None = None
 
 
 @dataclass
@@ -317,4 +321,51 @@ class EverestTestEnvironmentSetup:
         shutil.copytree(source_migration_dir,
                         temporary_paths.ocpp_device_model_migration_path,
                         dirs_exist_ok=True)
+
+        self._adjust_ocpp16_component_config(temporary_paths)
+
+    def _adjust_ocpp16_component_config(self, temporary_paths: _EverestEnvironmentTemporaryPaths):
+        """Applies component config adjustment strategies to the copied OCPP1.6 device-model config.
+
+        Loads the copied component config JSONs (standardized/ and custom/ subdirs, keyed by file
+        stem - same shape as LibOCPP2XConfigurationHelper._get_config), applies any user strategies
+        from the ``ocpp16_component_config_adaptions`` marker, then a default strategy that rewrites
+        every configured NetworkConfiguration_N OcppCsmsUrl to the test CSMS URL, and writes the
+        JSONs back to their original locations.
+        """
+        component_config_dir = temporary_paths.ocpp_device_model_config_path
+
+        config_files: Dict[str, Path] = {}
+        component_config: Dict[str, dict] = {}
+        for subdir in ("standardized", "custom"):
+            subdir_path = component_config_dir / subdir
+            if not subdir_path.is_dir():
+                continue
+            for config_file in sorted(subdir_path.glob("*.json")):
+                stem = config_file.stem
+                config_files[stem] = config_file
+                component_config[stem] = json.loads(config_file.read_text())
+
+        strategies: List[OCPPConfigAdjustmentStrategy] = list(
+            self._ocpp_config.ocpp16_component_config_strategies or [])
+        # Default strategy runs last so it also normalizes URLs set by user strategies (e.g. a
+        # placeholder OcppCsmsUrl) to the mock CSMS.
+        strategies.append(_OCPP16ComponentConfigCsmsUrlAdjustment(
+            central_system_host=self._ocpp_config.central_system_host,
+            central_system_port=self._ocpp_config.central_system_port,
+            charge_point_id=self._determine_ocpp16_charge_point_id()))
+
+        for strategy in strategies:
+            component_config = strategy.adjust_ocpp_configuration(component_config)
+
+        for stem, data in component_config.items():
+            config_files[stem].write_text(json.dumps(data))
+
+    def _determine_ocpp16_charge_point_id(self) -> str:
+        """Reads the ChargePointId from the legacy OCPP1.6 config (same source LibOCPP16ConfigurationHelper uses)."""
+        if self._ocpp_config.template_ocpp_config:
+            source_ocpp_config = self._ocpp_config.template_ocpp_config
+        else:
+            source_ocpp_config = self._determine_configured_charge_point_config_path_from_everest_config()
+        return json.loads(source_ocpp_config.read_text())["Internal"]["ChargePointId"]
 

--- a/applications/utils/everest-testing/src/everest/testing/core_utils/_configuration/libocpp_configuration_helper.py
+++ b/applications/utils/everest-testing/src/everest/testing/core_utils/_configuration/libocpp_configuration_helper.py
@@ -128,6 +128,49 @@ class _OCPP2XNetworkConnectionProfileAdjustment(OCPPConfigAdjustmentStrategy):
         return config
 
 
+class _OCPP16ComponentConfigCsmsUrlAdjustment(OCPPConfigAdjustmentStrategy):
+    """ Rewrites the ``OcppCsmsUrl`` of every ``NetworkConfiguration_N`` component (device-model
+    backed OCPP1.6 configuration) that carries a non-empty value or non-empty default to the test
+    CSMS URL.
+
+    The URL is written as an explicit ``Actual`` attribute value (which the device-model DB init
+    treats as operator-set), using the exact same scheme-less ``{host}:{port}/{charge_point_id}``
+    format ``LibOCPP16ConfigurationHelper`` writes to ``Internal/CentralSystemURI``. This keeps
+    multi-slot 1.6 tests pointed at the mock CSMS.
+
+    The component config is the ``{file_stem: component_json}`` dict (same shape as
+    ``LibOCPP2XConfigurationHelper._get_config``).
+    """
+
+    def __init__(self, central_system_host: str, central_system_port: int | str, charge_point_id: str):
+        self._central_system_host = central_system_host
+        self._central_system_port = central_system_port
+        self._charge_point_id = charge_point_id
+
+    def adjust_ocpp_configuration(self, config: dict) -> dict:
+        config = deepcopy(config)
+        url = f"{self._central_system_host}:{self._central_system_port}/{self._charge_point_id}"
+        for component_name, component in config.items():
+            if not component_name.startswith("NetworkConfiguration"):
+                continue
+            ocpp_csms_url = component.get("properties", {}).get("OcppCsmsUrl")
+            if not ocpp_csms_url:
+                continue
+            attributes = ocpp_csms_url.get("attributes", [])
+            current_value = None
+            for attribute in attributes:
+                if attribute.get("type") == "Actual" and "value" in attribute:
+                    current_value = attribute["value"]
+            if current_value is None:
+                current_value = ocpp_csms_url.get("default")
+            if current_value in (None, ""):
+                continue
+            for attribute in attributes:
+                if attribute.get("type") == "Actual":
+                    attribute["value"] = url
+        return config
+
+
 class LibOCPPConfigurationHelperBase(ABC):
     """ Helper for parsing / adapting the LibOCPP configuration and dumping it a database file. """
 

--- a/applications/utils/everest-testing/src/everest/testing/ocpp_utils/fixtures.py
+++ b/applications/utils/everest-testing/src/everest/testing/ocpp_utils/fixtures.py
@@ -49,6 +49,15 @@ def ocpp_config(request, central_system: CentralSystem, test_config: OcppTestCon
                            "adjust_ocpp_configuration"), "Arguments to 'ocpp_config_adaptions' must all provide interface of OCPPConfigAdjustmentStrategy"
             ocpp_configuration_strategies.append(v)
 
+    ocpp16_component_config_strategies_marker = request.node.get_closest_marker(
+        "ocpp16_component_config_adaptions")
+    ocpp16_component_config_strategies = []
+    if ocpp16_component_config_strategies_marker:
+        for v in ocpp16_component_config_strategies_marker.args:
+            assert hasattr(v,
+                           "adjust_ocpp_configuration"), "Arguments to 'ocpp16_component_config_adaptions' must all provide interface of OCPPConfigAdjustmentStrategy"
+            ocpp16_component_config_strategies.append(v)
+
     return EverestEnvironmentOCPPConfiguration(
         central_system_port=central_system.port,
         central_system_host="127.0.0.1",
@@ -56,7 +65,8 @@ def ocpp_config(request, central_system: CentralSystem, test_config: OcppTestCon
         template_ocpp_config=Path(
             ocpp_config_marker.args[0]) if ocpp_config_marker else None,
         device_model_component_config_path=Path(f"{request.config.getoption('--everest-prefix')}/share/everest/modules/OCPP201/component_config"),
-        configuration_strategies=ocpp_configuration_strategies
+        configuration_strategies=ocpp_configuration_strategies,
+        ocpp16_component_config_strategies=ocpp16_component_config_strategies
     )
 
 

--- a/config/config-sil-ocpp-multi.yaml
+++ b/config/config-sil-ocpp-multi.yaml
@@ -1,4 +1,15 @@
 active_modules:
+  ocpp_api:
+    module: ocpp_consumer_API
+    config_module:
+      cfg_communication_check_to_s: 0
+    connections:
+      ocpp:
+        - module_id: ocpp
+          implementation_id: ocpp_generic
+      data_transfer:
+        - module_id: ocpp
+          implementation_id: data_transfer
   iso15118_charger:
     module: EvseV2G
     config_module:

--- a/docs/source/how-to-guides/ocpp-storage-migration.rst
+++ b/docs/source/how-to-guides/ocpp-storage-migration.rst
@@ -158,8 +158,21 @@ module configuration parameters:
   ``NetworkConfiguration`` slot that network connection details
   (``CentralSystemURI``, ``SecurityProfile``, ``AuthorizationKey``,
   ``HostName``, ``ChargePointId``) are written to during migration. Any
-  existing attribute values in the target slot are overwritten. Set to ``0``
-  to skip migration of network connection details entirely.
+  existing attribute values in the target slot are overwritten, the slot's
+  ``OcppInterface`` is pinned to ``Any`` unless the component config sets an
+  explicit attribute ``value`` (a ``default`` does not count), and
+  ``OCPPCommCtrlr/ActiveNetworkProfile`` is pointed at the
+  slot. Set to ``0`` to skip migration of network connection details entirely.
+
+  The target slot must be defined in the component configuration at
+  ``DeviceModelConfigPath``: a ``NetworkConfiguration_<N>`` component config
+  must exist for it; a missing component config skips the network connection
+  migration with an error log. Two independent gates apply afterwards: a slot
+  missing from the ``OCPPCommCtrlr/NetworkConfigurationPriority`` *value* is
+  migrated but not used for connecting, and a slot missing from that
+  variable's ``valuesList`` cannot be added to the priority at runtime
+  (each is logged as a warning). With the shipped example configs,
+  the default slot ``1`` satisfies all of this out of the box.
 
 These parameters define the source configuration, the target database, and the
 structural baseline that receives the migrated values.
@@ -307,6 +320,9 @@ so existing connections carry over:
   ``OCPP`` module required it).
 * ``charger_information`` is supported (0..1 connections, as in ``OCPP``; the
   old ``OCPP201`` module did not have it).
+* ``grid_support`` is new in OCPPmulti (optional, 0..128 connections);
+  neither old module had it, so no wiring change is needed unless you want
+  to use it.
 * All other requirements (``auth``, ``data_transfer``, ``display_message``,
   ``evse_energy_sink``, ``evse_manager``, ``extensions_15118``, ``security``,
   ``system``) are identical to both old modules.

--- a/docs/source/tutorials/ocpp-combined.rst
+++ b/docs/source/tutorials/ocpp-combined.rst
@@ -69,7 +69,10 @@ configuration parameter (see :ref:`tutorial-ocpp-combined-version`). The
 example configuration ships with ``Mode: Only1.6``; switch it to
 ``Mode: Only2`` to run OCPP 2.x:
 
-- With OCPP 1.6, the example configuration connects to SteVe. You have to add
+- With OCPP 1.6, the example configuration connects to SteVe: the SteVe URL
+  lives in the legacy 1.6 JSON config (``ChargePointConfigPath``), which
+  enters the device model via the one-time migration enabled by
+  ``EnableLegacyConfigMigration`` in the example configuration. You have to add
   the chargepoint id *cp001* in SteVe's webinterface to allow the charging
   station to connect. If you want to simulate charging sessions, you also need
   to add OCPP tags for the authorization in SteVe.
@@ -274,8 +277,11 @@ device model, so there are two ways to configure OCPP 1.6:
    into the device model database once. Network connection details
    (``CentralSystemURI``, ``SecurityProfile``, ``AuthorizationKey``, ...) are
    migrated to the NetworkConfiguration slot given by
-   ``Ocpp16NetworkConfigSlot``. Once the database is initialized, the
-   migration is skipped and the legacy JSON is no longer read.
+   ``Ocpp16NetworkConfigSlot``. The ``NetworkConfiguration_<N>`` component
+   config for that slot must exist and the slot must be listed in
+   ``NetworkConfigurationPriority`` (the shipped example configs cover the
+   default slot ``1``). Once the database is initialized, the migration is
+   skipped and the legacy JSON is no longer read.
 
 For a detailed walkthrough of migrating an existing OCPP 1.6 deployment,
 please see the
@@ -298,9 +304,10 @@ Connect to a different CSMS
 ---------------------------
 
 Each connection profile is defined in its own JSON file under the device model
-configuration directory. At least two slots must be configured; you may add as
-many additional slots as you need (see
-:ref:`tutorial-ocpp-combined-adding-slots`). The default profiles are:
+configuration directory. The number of slots is defined by your component
+configuration - one JSON file per slot, as many as you need (see
+:ref:`tutorial-ocpp-combined-adding-slots`). The shipped configuration
+provides two slots as an example:
 
 - ``component_config/standardized/NetworkConfiguration_1.json`` (slot 1)
 - ``component_config/standardized/NetworkConfiguration_2.json`` (slot 2)
@@ -320,6 +327,13 @@ appropriate slot's JSON file:
   - ``3``: TLS with mutual authentication (client + server certificates) over ``wss://``
 
 - ``MessageTimeout``: Message timeout in seconds (minimum 1)
+- ``OcppInterface``: The network interface to use for this profile (e.g.
+  ``Wired0``, ``Wireless0``, or ``Any``)
+- ``OcppTransport``: The OCPP transport encoding; use ``JSON``
+
+Together with ``OcppCsmsUrl`` and ``SecurityProfile``, the last three are
+mandatory for a usable profile; a slot missing any of them is silently
+skipped by the failover.
 
 Each slot can optionally override the charging station's identity and
 authentication credentials:
@@ -336,7 +350,12 @@ The **connection priority** is controlled by the ``NetworkConfigurationPriority`
 variable in ``OCPPCommCtrlr``. This is a comma-separated list of slot numbers
 that determines the order in which profiles are tried. For example, ``"1,2"``
 means slot 1 is tried first; if it fails, slot 2 is tried, then back to slot 1
-(round-robin failover).
+(round-robin failover). Only slots listed in the priority are used: the shipped
+configuration lists only slot 1 (value ``"1"``) and deliberately keeps slot 2 as
+an unlisted spare, because a slot listed in the priority (or currently active)
+is write-protected at runtime; the runtime reconfiguration workflow relies on
+populating a spare slot first (see the
+:ref:`OCPPmulti module documentation <everest_modules_OCPPmulti>`).
 
 .. note::
 
@@ -350,7 +369,8 @@ means slot 1 is tried first; if it fails, slot 2 is tried, then back to slot 1
 Adding more network configuration slots
 ---------------------------------------
 
-By default, two NetworkConfiguration slots are shipped. To add more:
+The component configuration defines which slots exist; the shipped
+configuration contains two as an example. To add more:
 
 1. **Create the JSON file.** Copy an existing slot file (e.g. ``NetworkConfiguration_1.json``)
    to a new file named ``NetworkConfiguration_N.json`` where ``N`` is your slot number.
@@ -366,15 +386,25 @@ By default, two NetworkConfiguration slots are shipped. To add more:
        ...
      }
 
-3. **Configure the slot's variables.** Set ``OcppCsmsUrl``, ``SecurityProfile``,
-   and other variables as needed for this connection profile.
+3. **Configure the slot's variables.** ``OcppCsmsUrl``, ``SecurityProfile``,
+   ``OcppInterface``, ``OcppTransport`` and ``MessageTimeout`` are all mandatory
+   for a usable profile; a slot missing any of them is silently skipped by the
+   failover. Note that ``NetworkConfiguration_2.json`` carries no defaults for
+   these fields, so when copying it every one must be set explicitly;
+   ``NetworkConfiguration_1.json`` carries defaults for everything except the URL.
 
 4. **Add the slot to the priority list.** In ``OCPPCommCtrlr.json``, append the new
-   slot number to the ``NetworkConfigurationPriority`` value. For example, change
-   ``"1,2"`` to ``"1,2,3"``.
+   slot number to the ``NetworkConfigurationPriority`` value (for example, change
+   ``"1"`` to ``"1,3"``) - or leave it out to keep the slot as a runtime-writable
+   spare. Also append it to the variable's characteristics
+   ``valuesList``; runtime writes of the priority are validated against it, so a
+   slot missing there cannot be added to the priority at runtime.
 
-5. **Rebuild and restart.** The device model database will be re-initialized with the
-   new slot on next startup.
+5. **Rebuild and restart.** The device model database is updated with the
+   new slot on next startup. Values that were already changed at runtime (by the
+   CSMS or via the consumer API) are protected from being overwritten by
+   component-config values; editing an already-changed value in the JSON has no
+   effect on a deployed station (see :ref:`howto-ocpp-storage-migration`).
 
 .. _tutorial-ocpp-combined-enable-pnc:
 

--- a/docs/source/tutorials/ocpp2.rst
+++ b/docs/source/tutorials/ocpp2.rst
@@ -300,12 +300,9 @@ in functional requirements of the specification. Please have
 a look at the OCPP 2.x specifications for more information about each of the
 standardized components and variables.
 For this reason, it is recommended to use the
-`device device model definitions of libocpp <https://github.com/EVerest/EVerest/tree/main/lib/everest/ocpp/config/v2/component_config>`_
-as a starting point. This is an examplary device model configuration for two
+`device model definitions of libocpp <https://github.com/EVerest/EVerest/tree/main/lib/everest/ocpp/config/common/component_config>`_
+as a starting point. This is an exemplary device model configuration for two
 EVSEs.
-
-The `device model setup from libocpp <https://github.com/EVerest/EVerest/tree/main/lib/everest/ocpp/config/v2/component_config>`_
-serves as a good example. 
 
 The split between the two directories only has semantic reasons.
 The **standardized** directory usually does not need to be modified since it
@@ -333,9 +330,10 @@ Connect to a different CSMS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Each connection profile is defined in its own JSON file under the device model
-configuration directory. At least two slots must be configured; you may add as
-many additional slots as you need (see :ref:`tutorial-ocpp2-adding-slots`).
-The default profiles are:
+configuration directory. The number of slots is defined by your component
+configuration - one JSON file per slot, as many as you need (see
+:ref:`tutorial-ocpp2-adding-slots`). The shipped configuration provides two
+slots as an example:
 
 - ``component_config/standardized/NetworkConfiguration_1.json`` (slot 1)
 - ``component_config/standardized/NetworkConfiguration_2.json`` (slot 2)
@@ -373,7 +371,12 @@ The **connection priority** is controlled by the ``NetworkConfigurationPriority`
 variable in ``OCPPCommCtrlr``. This is a comma-separated list of slot numbers
 that determines the order in which profiles are tried. For example, ``"1,2"``
 means slot 1 is tried first; if it fails, slot 2 is tried, then back to slot 1
-(round-robin failover).
+(round-robin failover). Only slots listed in the priority are used: the shipped
+configuration lists only slot 1 (value ``"1"``) and deliberately keeps slot 2 as
+an unlisted spare, because a slot listed in the priority (or currently active)
+is write-protected at runtime; the runtime reconfiguration workflow relies on
+populating a spare slot first (see the
+:ref:`OCPPmulti module documentation <everest_modules_OCPPmulti>`).
 
 .. note::
 
@@ -387,7 +390,8 @@ means slot 1 is tried first; if it fails, slot 2 is tried, then back to slot 1
 Adding more network configuration slots
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default, libocpp ships with two NetworkConfiguration slots. To add more:
+The component configuration defines which slots exist; the shipped
+configuration contains two as an example. To add more:
 
 1. **Create the JSON file.** Copy an existing slot file (e.g. ``NetworkConfiguration_1.json``)
    to a new file named ``NetworkConfiguration_N.json`` where ``N`` is your slot number.
@@ -395,7 +399,7 @@ By default, libocpp ships with two NetworkConfiguration slots. To add more:
 2. **Update the instance number.** In the new file, change the ``"instance"`` field
    at the top level to match your slot number:
 
-   .. code-block:: json
+   .. code-block:: text
 
      {
        "name": "NetworkConfiguration",
@@ -403,15 +407,25 @@ By default, libocpp ships with two NetworkConfiguration slots. To add more:
        ...
      }
 
-3. **Configure the slot's variables.** Set ``OcppCsmsUrl``, ``SecurityProfile``,
-   and other variables as needed for this connection profile.
+3. **Configure the slot's variables.** ``OcppCsmsUrl``, ``SecurityProfile``,
+   ``OcppInterface``, ``OcppTransport`` and ``MessageTimeout`` are all mandatory
+   for a usable profile; a slot missing any of them is silently skipped by the
+   failover. Note that ``NetworkConfiguration_2.json`` carries no defaults for
+   these fields, so when copying it every one must be set explicitly;
+   ``NetworkConfiguration_1.json`` carries defaults for everything except the URL.
 
 4. **Add the slot to the priority list.** In ``OCPPCommCtrlr.json``, append the new
-   slot number to the ``NetworkConfigurationPriority`` value. For example, change
-   ``"1,2"`` to ``"1,2,3"``.
+   slot number to the ``NetworkConfigurationPriority`` value (for example, change
+   ``"1"`` to ``"1,3"``) - or leave it out to keep the slot as a runtime-writable
+   spare. Also append it to the variable's characteristics
+   ``valuesList``; runtime writes of the priority are validated against it, so a
+   slot missing there cannot be added to the priority at runtime.
 
-5. **Rebuild and restart.** The device model database will be re-initialized with the
-   new slot on next startup.
+5. **Rebuild and restart.** The device model database is updated with the
+   new slot on next startup. Values that were already changed at runtime (by the
+   CSMS or via the consumer API) are protected from being overwritten by
+   component-config values; editing an already-changed value in the JSON has no
+   effect on a deployed station (see :ref:`howto-ocpp-storage-migration`).
 
 .. _tutorial-ocpp2-migration:
 

--- a/docs/source/tutorials/ocpp2.rst
+++ b/docs/source/tutorials/ocpp2.rst
@@ -300,12 +300,9 @@ in functional requirements of the specification. Please have
 a look at the OCPP 2.x specifications for more information about each of the
 standardized components and variables.
 For this reason, it is recommended to use the
-`device device model definitions of libocpp <https://github.com/EVerest/EVerest/tree/main/lib/everest/ocpp/config/v2/component_config>`_
-as a starting point. This is an examplary device model configuration for two
+`device model definitions of libocpp <https://github.com/EVerest/everest-core/tree/main/lib/everest/ocpp/config/common/component_config>`_
+as a starting point. This is an exemplary device model configuration for two
 EVSEs.
-
-The `device model setup from libocpp <https://github.com/EVerest/EVerest/tree/main/lib/everest/ocpp/config/v2/component_config>`_
-serves as a good example. 
 
 The split between the two directories only has semantic reasons.
 The **standardized** directory usually does not need to be modified since it
@@ -333,9 +330,10 @@ Connect to a different CSMS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Each connection profile is defined in its own JSON file under the device model
-configuration directory. At least two slots must be configured; you may add as
-many additional slots as you need (see :ref:`tutorial-ocpp2-adding-slots`).
-The default profiles are:
+configuration directory. The number of slots is defined by your component
+configuration - one JSON file per slot, as many as you need (see
+:ref:`tutorial-ocpp2-adding-slots`). The shipped configuration provides two
+slots as an example:
 
 - ``component_config/standardized/NetworkConfiguration_1.json`` (slot 1)
 - ``component_config/standardized/NetworkConfiguration_2.json`` (slot 2)
@@ -373,7 +371,12 @@ The **connection priority** is controlled by the ``NetworkConfigurationPriority`
 variable in ``OCPPCommCtrlr``. This is a comma-separated list of slot numbers
 that determines the order in which profiles are tried. For example, ``"1,2"``
 means slot 1 is tried first; if it fails, slot 2 is tried, then back to slot 1
-(round-robin failover).
+(round-robin failover). Only slots listed in the priority are used: the shipped
+configuration lists only slot 1 (value ``"1"``) and deliberately keeps slot 2 as
+an unlisted spare, because a slot listed in the priority (or currently active)
+is write-protected at runtime; the runtime reconfiguration workflow relies on
+populating a spare slot first (see the
+:ref:`OCPPmulti module documentation <everest_modules_OCPPmulti>`).
 
 .. note::
 
@@ -387,7 +390,8 @@ means slot 1 is tried first; if it fails, slot 2 is tried, then back to slot 1
 Adding more network configuration slots
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default, libocpp ships with two NetworkConfiguration slots. To add more:
+The component configuration defines which slots exist; the shipped
+configuration contains two as an example. To add more:
 
 1. **Create the JSON file.** Copy an existing slot file (e.g. ``NetworkConfiguration_1.json``)
    to a new file named ``NetworkConfiguration_N.json`` where ``N`` is your slot number.
@@ -395,7 +399,7 @@ By default, libocpp ships with two NetworkConfiguration slots. To add more:
 2. **Update the instance number.** In the new file, change the ``"instance"`` field
    at the top level to match your slot number:
 
-   .. code-block:: json
+   .. code-block:: text
 
      {
        "name": "NetworkConfiguration",
@@ -403,15 +407,25 @@ By default, libocpp ships with two NetworkConfiguration slots. To add more:
        ...
      }
 
-3. **Configure the slot's variables.** Set ``OcppCsmsUrl``, ``SecurityProfile``,
-   and other variables as needed for this connection profile.
+3. **Configure the slot's variables.** ``OcppCsmsUrl``, ``SecurityProfile``,
+   ``OcppInterface``, ``OcppTransport`` and ``MessageTimeout`` are all mandatory
+   for a usable profile; a slot missing any of them is silently skipped by the
+   failover. Note that ``NetworkConfiguration_2.json`` carries no defaults for
+   these fields, so when copying it every one must be set explicitly;
+   ``NetworkConfiguration_1.json`` carries defaults for everything except the URL.
 
 4. **Add the slot to the priority list.** In ``OCPPCommCtrlr.json``, append the new
-   slot number to the ``NetworkConfigurationPriority`` value. For example, change
-   ``"1,2"`` to ``"1,2,3"``.
+   slot number to the ``NetworkConfigurationPriority`` value (for example, change
+   ``"1"`` to ``"1,3"``) - or leave it out to keep the slot as a runtime-writable
+   spare. Also append it to the variable's characteristics
+   ``valuesList``; runtime writes of the priority are validated against it, so a
+   slot missing there cannot be added to the priority at runtime.
 
-5. **Rebuild and restart.** The device model database will be re-initialized with the
-   new slot on next startup.
+5. **Rebuild and restart.** The device model database is updated with the
+   new slot on next startup. Values that were already changed at runtime (by the
+   CSMS or via the consumer API) are protected from being overwritten by
+   component-config values; editing an already-changed value in the JSON has no
+   effect on a deployed station (see :ref:`howto-ocpp-storage-migration`).
 
 .. _tutorial-ocpp2-migration:
 

--- a/lib/everest/ocpp/config/common/component_config/standardized/NetworkConfiguration_2.json
+++ b/lib/everest/ocpp/config/common/component_config/standardized/NetworkConfiguration_2.json
@@ -365,7 +365,7 @@
       "characteristics": {
         "supportsMonitoring": false,
         "dataType": "OptionList",
-        "valuesList": "OCPP20,OCPP201,OCPP21"
+        "valuesList": "OCPP16,OCPP20,OCPP201,OCPP21"
       },
       "attributes": [
         {

--- a/lib/everest/ocpp/config/common/component_config/standardized/SecurityCtrlr.json
+++ b/lib/everest/ocpp/config/common/component_config/standardized/SecurityCtrlr.json
@@ -160,7 +160,7 @@
     "SecurityProfile": {
       "variable_name": "SecurityProfile",
       "characteristics": {
-        "minLimit": 1,
+        "minLimit": 0,
         "maxLimit": 3,
         "supportsMonitoring": true,
         "dataType": "integer"
@@ -173,7 +173,7 @@
         }
       ],
       "description": "The security profile used by the Charging Station.",
-      "minimum": 1,
+      "minimum": 0,
       "maximum": 3,
       "default": "1",
       "type": "integer"

--- a/lib/everest/ocpp/include/ocpp/common/connectivity_manager.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/connectivity_manager.hpp
@@ -93,6 +93,14 @@ public:
     virtual std::optional<std::int32_t>
     get_priority_from_configuration_slot(const std::int32_t configuration_slot) const = 0;
 
+    /// \brief Get the active network configuration slot in use.
+    /// \return The active slot (or pending slot override) if one is available, std::nullopt if the slot
+    ///         list is empty or the current priority index would be out of range.
+    ///
+    virtual std::optional<int> get_active_network_configuration_slot() const {
+        return std::nullopt;
+    }
+
     /// @brief Get a snapshot of the network connection slots sorted by priority.
     /// Each item in the vector contains the configured configuration slots, where the slot with index 0 has the highest
     /// priority. A copy is returned so callers do not observe mid-mutation state through a reference.
@@ -234,6 +242,13 @@ public:
     /// connected security profile
     void check_cache_for_invalid_security_profiles();
 
+    ///
+    /// \brief Get the active network configuration slot in use.
+    /// \return The active slot (or pending slot override) if one is available, std::nullopt if the slot
+    ///         list is empty or the current priority index would be out of range.
+    ///
+    std::optional<int> get_active_network_configuration_slot() const override;
+
 private:
     std::atomic<std::chrono::time_point<std::chrono::steady_clock>> time_disconnected{};
 
@@ -277,13 +292,6 @@ private:
     ///        and does not re-attempt to connect again
     ///
     void on_websocket_stopped_connecting(ocpp::WebsocketCloseReason reason);
-
-    ///
-    /// \brief Get the active network configuration slot in use.
-    /// \return The active slot (or pending slot override) if one is available, std::nullopt if the slot
-    ///         list is empty or the current priority index would be out of range.
-    ///
-    std::optional<int> get_active_network_configuration_slot() const;
 
     ///
     /// \brief Get the network configuration slot of the given priority.

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point.hpp
@@ -168,6 +168,12 @@ public:
     /// \brief Disconnects the the websocket connection to the CSMS if it is connected
     void disconnect_websocket();
 
+    /// \brief Rebuilds the cached network connection profiles and slot priority list from the configuration.
+    /// Call after network-related configuration (NetworkConfiguration components, NetworkConfigurationPriority)
+    /// was changed externally, e.g. via the EVerest ocpp interface. Does not affect an active connection; the
+    /// updated profiles take effect on the next (re)connect attempt.
+    void reload_network_profiles();
+
     /// \brief Notifies the charge point that the websocket is connected. This allows an external owner of an injected
     /// ConnectivityManager to drive the charge point's websocket lifecycle (mirroring ocpp::v2::ChargePointInterface).
     void on_websocket_connected(const int configuration_slot,
@@ -546,6 +552,14 @@ public:
     /// the CSMS.
     /// \param callback
     void register_set_connection_timeout_callback(const std::function<void(std::int32_t connection_timeout)>& callback);
+
+    /// \brief registers a \p callback that is called before each websocket connection attempt so the host can
+    /// configure (e.g. bring up) the network interface for the network connection profile. OCPP 1.6 has a single
+    /// implicit profile (configuration slot 1, ocppInterface Any) synthesized from CentralSystemURI/SecurityProfile.
+    /// The returned future is awaited (60 s default timeout) before connecting; an unsuccessful result skips the
+    /// connection attempt and schedules a retry. Must be called before start().
+    /// \param callback
+    void register_configure_network_connection_profile_callback(ConfigureNetworkConnectionProfileCallback callback);
 
     /// \brief registers a \p callback function that can be used to check if a reset is allowed . The
     /// is_reset_allowed_callback is called when a Reset.req is received.

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_connectivity.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_connectivity.hpp
@@ -30,6 +30,13 @@ public:
     void set_per_slot_ocpp_version(int32_t slot, const std::string& version, const std::string& source) override;
     void set_security_ctrl_security_profile(int32_t security_profile, const std::string& source) override;
     void set_security_ctrl_identity(const std::string& identity, const std::string& source) override;
+
+protected:
+    /// \brief Legacy single-profile synthesis from the global v1.6 getters (slot-agnostic): CentralSystemURI,
+    /// SecurityProfile, ChargePointId and AuthorizationKey with ocppInterface Any. Kept as a protected helper so
+    /// device-model-backed configurations can fall back to it for slots without a configured NetworkConfiguration
+    /// component.
+    ocpp::v2::NetworkConnectionProfile synthesize_legacy_network_connection_profile();
 };
 
 } // namespace ocpp::v16

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
@@ -521,7 +521,35 @@ public:
 
     std::optional<ConfigurationStatus> set(const CiString<50>& key, const CiString<500>& value) override;
 
+    // Connectivity: device-model-backed multi-slot network profiles.
+    //
+    // Unlike the JSON backend (single slot-1 profile), these overrides source per-slot connection details from the
+    // v2 device-model NetworkConfiguration[N] components (the same data 2.x uses)
+    // Slots without a configured NetworkConfiguration component fall back to the legacy single-profile behavior
+    // synthesized from the global v1.6 getters.
+    std::string get_network_configuration_priority() override;
+    std::optional<ocpp::v2::NetworkConnectionProfile> read_network_connection_profile(int32_t slot) override;
+    std::optional<WebsocketConnectionOptions> get_websocket_connection_options(int32_t slot) override;
+    void set_active_network_profile_slot(int32_t slot, const std::string& source) override;
+    std::optional<int32_t> get_network_config_timeout() override;
+
+    // Returns the confirmed security profile (SecurityCtrlr.SecurityProfile, set on successful connect),
+    // not the attempt-time value served by getSecurityProfile().
+    int32_t get_security_profile() override;
+    // Writes NetworkConfiguration[slot].SecurityProfile, unlike setSecurityProfile() which targets the
+    // active slot at call time.
+    void set_security_profile_for_slot(std::int32_t slot, std::int32_t security_profile) override;
+    void set_active_security_profile(int32_t security_profile, const std::string& source) override;
+    void set_security_ctrl_security_profile(int32_t security_profile, const std::string& source) override;
+
 private:
+    /// \brief A slot is usable for OCPP 1.6 when its NetworkConfiguration[slot].OcppVersion is unset/empty or
+    /// names "OCPP16"; slots pinned to any other version are filtered out of priority and profile lookups.
+    bool is_slot_usable_for_ocpp16(int32_t slot);
+    /// \brief OCPPCommCtrlr/NetworkProfileConnectionAttempts, or 3 (the shipped component-config default) when
+    /// absent. A finite value is what lets the ConnectivityManager fail over to the next priority slot instead of
+    /// retrying forever.
+    std::int32_t getNetworkProfileConnectionAttempts();
     bool shouldExposeKey(keys::valid_keys key) const;
     std::optional<KeyValue> getCustomKeyValue(const std::string& key);
     void appendDefaultPriceTextKeyValues(std::vector<KeyValue>& all);

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_interface.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_interface.hpp
@@ -343,6 +343,12 @@ public:
     virtual void setCpoName(const std::string& cpo_name) = 0;
     virtual void setDisableSecurityEventNotifications(bool disable_security_event_notifications) = 0;
     virtual void setSecurityProfile(std::int32_t security_profile) = 0;
+    /// \brief Set the SecurityProfile of a specific network profile slot. Used by the security-profile
+    ///        switch so the revert targets the slot captured at switch time even if the active slot moved
+    ///        (multi-slot failover). Backends without per-slot profiles ignore the slot.
+    virtual void set_security_profile_for_slot(std::int32_t /*slot*/, std::int32_t security_profile) {
+        setSecurityProfile(security_profile);
+    }
 
     // Local Auth List Management Profile
     virtual bool getLocalAuthListEnabled() = 0;

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
@@ -522,6 +522,10 @@ public:
     /// \brief Disconnects the the websocket connection to the CSMS if it is connected
     void disconnect_websocket();
 
+    /// \brief Rebuilds the ConnectivityManager's cached network connection profiles and slot priority list.
+    /// \see ocpp::v16::ChargePoint::reload_network_profiles
+    void reload_network_profiles();
+
     /// \brief Calls the set_connection_timeout_callback that can be registered. This function is used to notify an
     /// Authorization mechanism about a changed ConnectionTimeout configuration key.
     void call_set_connection_timeout();
@@ -865,6 +869,12 @@ public:
     /// the CSMS.
     /// \param callback
     void register_set_connection_timeout_callback(const std::function<void(std::int32_t connection_timeout)>& callback);
+
+    /// \brief registers a \p callback on the connectivity manager that is called before each websocket connection
+    /// attempt so the host can configure the network interface for the network connection profile. Must be called
+    /// before start(). \see ocpp::v16::ChargePoint::register_configure_network_connection_profile_callback
+    /// \param callback
+    void register_configure_network_connection_profile_callback(ConfigureNetworkConnectionProfileCallback callback);
 
     /// \brief registers a \p callback function that can be used to check if a reset is allowed . The
     /// is_reset_allowed_callback is called when a Reset.req is received.

--- a/lib/everest/ocpp/include/ocpp/v16/variable_resolver.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/variable_resolver.hpp
@@ -32,6 +32,15 @@ enum class CVClass {
     Free,
 };
 
+/// \brief Whether the CV belongs to the connection/network-profile configuration managed by the
+///        1.6 stack (see CVClass::ConnectionConfig): NetworkConfiguration/<slot>, the OCPPCommCtrlr
+///        profile selectors and the SecurityCtrlr connection fallbacks.
+///
+/// Custom config mappings must not target these CVs: the key path writes the device model without
+/// the RebootRequired/reconnect semantics the standardized keys and canonical CVs carry.
+/// load_ocpp16_custom_config_mappings_from_yaml rejects such mappings.
+bool is_connection_config_cv(const ocpp::v2::Component& component, const ocpp::v2::Variable& variable);
+
 /// \brief Result of a reverse (CV -> 1.6 key) lookup.
 struct ReverseResult {
     std::optional<std::string> key;

--- a/lib/everest/ocpp/include/ocpp/v2/ocpp16_custom_config_mappings.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/ocpp16_custom_config_mappings.hpp
@@ -28,7 +28,9 @@ nlohmann::json get_ocpp16_custom_mapping_schema();
 /// \brief Load OCPP 1.6 custom mappings from YAML file, validate against schema and convert to mapping map.
 /// \param mapping_file_path Path to YAML mapping file.
 /// \returns Parsed mappings for use with patch_component_config_with_ocpp16.
-/// \throws Ocpp16CustomConfigMappingsError on file parsing, schema validation or conversion errors.
+/// \throws Ocpp16CustomConfigMappingsError on file parsing, schema validation or conversion errors, on
+///         duplicate keys, and on mappings targeting connection-config CVs (see
+///         ocpp::v16::is_connection_config_cv), which are managed via the standardized OCPP 1.6 keys.
 Ocpp16CustomConfigMappings load_ocpp16_custom_config_mappings_from_yaml(const std::filesystem::path& mapping_file_path);
 
 } // namespace ocpp::v2

--- a/lib/everest/ocpp/lib/ocpp/common/connectivity_manager.cpp
+++ b/lib/everest/ocpp/lib/ocpp/common/connectivity_manager.cpp
@@ -531,6 +531,20 @@ void ConnectivityManager::append_slot_to_network_configuration_priority_if_absen
 
 void ConnectivityManager::cache_network_connection_profiles() {
     auto state = this->m_state.handle();
+
+    // Capture the slot currently in use (pending attempt, else the active one) so the rebuild can re-derive
+    // its index: a reordered or extended priority list shifts indices, and keeping the raw active_priority
+    // would silently name a different slot (wrong confirms and disconnect/connected slot reporting).
+    std::optional<std::int32_t> before_slot;
+    if (state->pending_configuration_slot.has_value()) {
+        before_slot = state->pending_configuration_slot;
+    } else if (!state->slots.empty()) {
+        const auto idx = static_cast<std::size_t>(std::max<std::int32_t>(state->active_priority, 0));
+        if (idx < state->slots.size()) {
+            before_slot = state->slots[idx];
+        }
+    }
+
     state->cached_profiles.clear();
     state->slots.clear();
 
@@ -552,12 +566,27 @@ void ConnectivityManager::cache_network_connection_profiles() {
         }
     }
 
-    // Re-clamp active_priority to remain a valid index after rebuild
+    // Remap active_priority to the slot captured above; clamp when that slot is gone from the list.
+    // The recursive mutex allows get_priority_from_configuration_slot to re-acquire the same handle.
     if (state->slots.empty()) {
         state->active_priority = 0;
-    } else if (static_cast<std::size_t>(state->active_priority) >= state->slots.size()) {
-        state->active_priority = static_cast<std::int32_t>(state->slots.size() - 1);
+    } else {
+        std::optional<std::int32_t> remapped_priority;
+        if (before_slot.has_value()) {
+            remapped_priority = this->get_priority_from_configuration_slot(before_slot.value());
+        }
+        if (remapped_priority.has_value()) {
+            state->active_priority = remapped_priority.value();
+        } else if (static_cast<std::size_t>(state->active_priority) >= state->slots.size()) {
+            state->active_priority = static_cast<std::int32_t>(state->slots.size() - 1);
+        }
     }
+
+    // The rebuild resurrects every slot listed in the priority string, including ones previously pruned for an
+    // insufficient security profile. Force the next check_cache_for_invalid_security_profiles() (always run before
+    // an attempt, see try_connect_websocket) to re-prune instead of early-returning on an unchanged level;
+    // otherwise a reload could let a lower-security-profile slot connect and downgrade the confirmed profile.
+    state->last_known_security_level = -1;
 
     this->warn_if_all_security_level_zero_locked(*state);
 }

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point.cpp
@@ -76,6 +76,10 @@ void ChargePoint::disconnect_websocket() {
     this->charge_point->disconnect_websocket();
 }
 
+void ChargePoint::reload_network_profiles() {
+    this->charge_point->reload_network_profiles();
+}
+
 void ChargePoint::on_websocket_connected(const int configuration_slot,
                                          const ocpp::v2::NetworkConnectionProfile& network_connection_profile,
                                          const ocpp::OcppProtocolVersion ocpp_version) {
@@ -314,6 +318,11 @@ void ChargePoint::register_upload_logs_callback(const std::function<GetLogRespon
 void ChargePoint::register_set_connection_timeout_callback(
     const std::function<void(std::int32_t connection_timeout)>& callback) {
     this->charge_point->register_set_connection_timeout_callback(callback);
+}
+
+void ChargePoint::register_configure_network_connection_profile_callback(
+    ConfigureNetworkConnectionProfileCallback callback) {
+    this->charge_point->register_configure_network_connection_profile_callback(std::move(callback));
 }
 
 void ChargePoint::register_is_reset_allowed_callback(const std::function<bool(const ResetType& reset_type)>& callback) {

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_connectivity.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_connectivity.cpp
@@ -27,10 +27,15 @@ ChargePointConfigurationConnectivity::read_network_connection_profile(int32_t sl
     if (slot != 1) {
         return std::nullopt;
     }
+    return synthesize_legacy_network_connection_profile();
+}
+
+ocpp::v2::NetworkConnectionProfile
+ChargePointConfigurationConnectivity::synthesize_legacy_network_connection_profile() {
     ocpp::v2::NetworkConnectionProfile profile;
     profile.ocppCsmsUrl = getCentralSystemURI();
     profile.securityProfile = getSecurityProfile();
-    profile.ocppInterface = ocpp::v2::OCPPInterfaceEnum::Any; // not used for OCPP1.6
+    profile.ocppInterface = ocpp::v2::OCPPInterfaceEnum::Any; // no interface notion in the legacy 1.6 config
     profile.ocppTransport = ocpp::v2::OCPPTransportEnum::JSON;
     profile.messageTimeout = 10;
     profile.identity = getChargePointId();
@@ -100,6 +105,9 @@ ChargePointConfigurationConnectivity::get_websocket_connection_options(int32_t /
         EVLOG_error << "Could not configure v1.6 connection options, device model error: " << e.what();
         return std::nullopt;
     } catch (const std::invalid_argument& e) {
+        EVLOG_error << "Could not configure v1.6 connection options, invalid argument: " << e.what();
+        return std::nullopt;
+    } catch (const std::exception& e) {
         EVLOG_error << "Could not configure v1.6 connection options: " << e.what();
         return std::nullopt;
     }

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
@@ -45,6 +45,9 @@ constexpr const std::string_view cost_and_price_feature{"CostAndPrice"};
 constexpr const std::string_view custom_feature{"Custom"};
 constexpr const std::string_view pnc_feature{"PnC"};
 
+// Matches the shipped OCPPCommCtrlr.NetworkProfileConnectionAttempts component-config default.
+constexpr std::int32_t default_network_profile_connection_attempts{3};
+
 constexpr v16::ConfigurationStatus convert(SetResult res) {
     switch (res) {
     case SetResult::Accepted:
@@ -1596,6 +1599,201 @@ std::string ChargePointConfigurationDeviceModel::getCentralSystemURI() {
     return get_value<std::string>(*storage, cv, v2::AttributeEnum::Actual);
 }
 
+// ----------------------------------------------------------------------------
+// Connectivity: device-model-backed multi-slot network profiles
+
+bool ChargePointConfigurationDeviceModel::is_slot_usable_for_ocpp16(int32_t slot) {
+    namespace NC = ocpp::v2::NetworkConfigurationComponentVariables;
+    const auto ocpp_version = get_optional<std::string>(*storage, NC::get_component_variable(slot, NC::OcppVersion),
+                                                        v2::AttributeEnum::Actual);
+    // Unset/empty means no protocol restriction; a slot pinned to any other version is not usable for 1.6.
+    return !ocpp_version.has_value() || ocpp_version->empty() || *ocpp_version == "OCPP16";
+}
+
+std::int32_t ChargePointConfigurationDeviceModel::getNetworkProfileConnectionAttempts() {
+    const auto attempts = get_optional<std::int32_t>(*storage, "OCPPCommCtrlr", "NetworkProfileConnectionAttempts",
+                                                     v2::AttributeEnum::Actual);
+    if (!attempts.has_value()) {
+        // -1 (retry forever) would silently disable websocket-failure-driven slot failover.
+        EVLOG_warning << "OCPPCommCtrlr.NetworkProfileConnectionAttempts is not set in the device model; defaulting "
+                      << "to " << default_network_profile_connection_attempts << " attempts per slot";
+        return default_network_profile_connection_attempts;
+    }
+    return attempts.value();
+}
+
+std::optional<int32_t> ChargePointConfigurationDeviceModel::get_network_config_timeout() {
+    return get_optional<std::int32_t>(*storage, "InternalCtrlr", "NetworkConfigTimeout", v2::AttributeEnum::Actual);
+}
+
+std::string ChargePointConfigurationDeviceModel::get_network_configuration_priority() {
+    const auto priority =
+        get_optional<std::string>(*storage, "OCPPCommCtrlr", "NetworkConfigurationPriority", v2::AttributeEnum::Actual);
+    std::vector<std::string> usable_slots;
+    if (priority.has_value()) {
+        for (const auto& token : utils::split_string(',', *priority)) {
+            try {
+                const auto slot = std::stoi(token);
+                if (is_slot_usable_for_ocpp16(slot)) {
+                    usable_slots.push_back(std::to_string(slot));
+                }
+            } catch (const std::exception& e) {
+                EVLOG_warning << "Ignoring non-integer NetworkConfigurationPriority token '" << token
+                              << "': " << e.what();
+            }
+        }
+    }
+    if (usable_slots.empty()) {
+        // No usable slot configured: fall back to the single active slot (legacy single-profile behavior).
+        return std::to_string(get_active_network_slot(*storage));
+    }
+    return utils::to_csl(usable_slots);
+}
+
+std::optional<ocpp::v2::NetworkConnectionProfile>
+ChargePointConfigurationDeviceModel::read_network_connection_profile(int32_t slot) {
+    namespace NC = ocpp::v2::NetworkConfigurationComponentVariables;
+    const bool usable_for_ocpp16 = is_slot_usable_for_ocpp16(slot);
+    if (usable_for_ocpp16) {
+        if (auto profile = NC::read_profile_from_device_model(*storage, slot); profile.has_value()) {
+            return profile;
+        }
+    }
+
+    if (slot == get_active_network_slot(*storage)) {
+        if (!usable_for_ocpp16) {
+            EVLOG_warning << "NetworkConfiguration slot " << slot
+                          << " is pinned to a non-OCPP16 OcppVersion but is the active slot; using the legacy "
+                             "single-profile synthesis for OCPP 1.6";
+        }
+        try {
+            return synthesize_legacy_network_connection_profile();
+        } catch (const std::exception& e) {
+            EVLOG_error << "Could not synthesize legacy network connection profile for slot " << slot << ": "
+                        << e.what();
+            return std::nullopt;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<WebsocketConnectionOptions>
+ChargePointConfigurationDeviceModel::get_websocket_connection_options(int32_t slot) {
+    namespace NC = ocpp::v2::NetworkConfigurationComponentVariables;
+    namespace CC = ocpp::v2::ControllerComponentVariables;
+
+    const auto profile =
+        is_slot_usable_for_ocpp16(slot) ? NC::read_profile_from_device_model(*storage, slot) : std::nullopt;
+    if (!profile.has_value()) {
+        // Unconfigured (or version-filtered) slot -> legacy single-profile connection options.
+        auto fallback = ChargePointConfigurationConnectivity::get_websocket_connection_options(slot);
+        if (fallback.has_value()) {
+            // The legacy options retry forever (-1), which would pin the connection to this slot and
+            // disable websocket-failure-driven failover to the other configured slots.
+            fallback->max_connection_attempts = getNetworkProfileConnectionAttempts();
+        }
+        return fallback;
+    }
+
+    try {
+        // Identity: per-slot value, else the global SecurityCtrlr.Identity. ':' is invalid in the basic-auth user.
+        std::string identity = profile->identity.has_value() ? profile->identity->get() : std::string{};
+        if (identity.empty()) {
+            identity =
+                get_optional<std::string>(*storage, CC::SecurityCtrlrIdentity, v2::AttributeEnum::Actual).value_or("");
+        }
+        if (identity.find(':') != std::string::npos) {
+            // Returning std::nullopt lets the caller fall back to another profile instead.
+            EVLOG_error << "ChargePointId must not contain ':'";
+            return std::nullopt;
+        }
+
+        // Password: per-slot value, else the global SecurityCtrlr.BasicAuthPassword. Kept optional.
+        std::optional<std::string> basic_auth_password;
+        if (profile->basicAuthPassword.has_value()) {
+            basic_auth_password = profile->basicAuthPassword->get();
+        } else {
+            basic_auth_password =
+                get_optional<std::string>(*storage, CC::BasicAuthPassword, v2::AttributeEnum::Actual, true);
+        }
+
+        const auto hostname = get_optional<std::string>(*storage, NC::get_component_variable(slot, NC::HostName),
+                                                        v2::AttributeEnum::Actual);
+
+        auto uri = Uri::parse_and_validate(profile->ocppCsmsUrl.get(), identity, profile->securityProfile);
+
+        WebsocketConnectionOptions opts{{OcppProtocolVersion::v16},
+                                        uri,
+                                        profile->securityProfile,
+                                        basic_auth_password,
+                                        // Per-slot NetworkConfiguration[N].MessageTimeout, as in the 2.x path.
+                                        std::chrono::seconds(std::max(profile->messageTimeout, 1)),
+                                        getRetryBackoffRandomRange(),
+                                        getRetryBackoffRepeatTimes(),
+                                        getRetryBackoffWaitMinimum(),
+                                        getNetworkProfileConnectionAttempts(),
+                                        getSupportedCiphers12(),
+                                        getSupportedCiphers13(),
+                                        getWebsocketPingInterval().value_or(0),
+                                        getWebsocketPingPayload(),
+                                        getWebsocketPongTimeout(),
+                                        getUseSslDefaultVerifyPaths(),
+                                        getAdditionalRootCertificateCheck().value_or(false),
+                                        hostname,
+                                        getVerifyCsmsCommonName(),
+                                        getUseTPM(),
+                                        getVerifyCsmsAllowWildcards(),
+                                        getIFace(),
+                                        getEnableTLSKeylog(),
+                                        getTLSKeylogFile()};
+        return opts;
+    } catch (const ocpp::v2::DeviceModelError& e) {
+        EVLOG_error << "Could not configure v1.6 connection options, device model error: " << e.what();
+        return std::nullopt;
+    } catch (const std::invalid_argument& e) {
+        EVLOG_error << "Could not configure v1.6 connection options, invalid argument: " << e.what();
+        return std::nullopt;
+    } catch (const std::exception& e) {
+        EVLOG_error << "Could not configure v1.6 connection options: " << e.what();
+        return std::nullopt;
+    }
+}
+
+void ChargePointConfigurationDeviceModel::set_active_network_profile_slot(int32_t slot, const std::string& source) {
+    const auto& cv = ocpp::v2::ControllerComponentVariables::ActiveNetworkProfile;
+    if (cv.variable.has_value()) {
+        storage->set_read_only_value(cv.component, cv.variable.value(), v2::AttributeEnum::Actual, std::to_string(slot),
+                                     source);
+    }
+}
+
+int32_t ChargePointConfigurationDeviceModel::get_security_profile() {
+    const auto& cv = ocpp::v2::ControllerComponentVariables::SecurityProfile;
+    const auto confirmed = get_optional<std::int32_t>(*storage, cv, v2::AttributeEnum::Actual);
+    if (!confirmed.has_value()) {
+        // 0 = "nothing confirmed yet": never prunes, so all configured slots stay attemptable.
+        EVLOG_warning << "SecurityCtrlr.SecurityProfile is not set in the device model; "
+                         "treating the confirmed security profile as 0";
+        return 0;
+    }
+    return confirmed.value();
+}
+
+void ChargePointConfigurationDeviceModel::set_active_security_profile(int32_t security_profile,
+                                                                      const std::string& source) {
+    const auto& cv = ocpp::v2::ControllerComponentVariables::SecurityProfile;
+    if (cv.variable.has_value()) {
+        storage->set_read_only_value(cv.component, cv.variable.value(), v2::AttributeEnum::Actual,
+                                     std::to_string(security_profile), source);
+    }
+}
+
+void ChargePointConfigurationDeviceModel::set_security_ctrl_security_profile(int32_t security_profile,
+                                                                             const std::string& source) {
+    // Same cell as set_active_security_profile, mirroring the 2.x device model.
+    set_active_security_profile(security_profile, source);
+}
+
 std::string ChargePointConfigurationDeviceModel::getChargePointId() {
     namespace NC = ocpp::v2::NetworkConfigurationComponentVariables;
     namespace CC = ocpp::v2::ControllerComponentVariables;
@@ -2852,6 +3050,13 @@ void ChargePointConfigurationDeviceModel::setDisableSecurityEventNotifications(
 
 void ChargePointConfigurationDeviceModel::setSecurityProfile(std::int32_t security_profile) {
     setInternalSecurityProfile(std::to_string(security_profile));
+}
+
+void ChargePointConfigurationDeviceModel::set_security_profile_for_slot(std::int32_t slot,
+                                                                        std::int32_t security_profile) {
+    namespace NC = ocpp::v2::NetworkConfigurationComponentVariables;
+    const auto cv = NC::get_component_variable(slot, NC::SecurityProfile);
+    set_value(*storage, cv.component, cv.variable.value(), std::to_string(security_profile));
 }
 
 // ----------------------------------------------------------------------------

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -432,6 +432,10 @@ void ChargePointImpl::disconnect_websocket() {
     }
 }
 
+void ChargePointImpl::reload_network_profiles() {
+    this->connectivity_manager->reload_network_profiles();
+}
+
 void ChargePointImpl::call_set_connection_timeout() {
     if (this->set_connection_timeout_callback != nullptr) {
         this->set_connection_timeout_callback(this->configuration.getConnectionTimeOut());
@@ -2034,7 +2038,17 @@ void ChargePointImpl::handleChangeConfigurationRequest(ocpp::Call<ChangeConfigur
 void ChargePointImpl::switchSecurityProfile(std::int32_t new_security_profile, std::int32_t fallback_security_profile) {
     EVLOG_info << "Switching security profile from " << this->configuration.getSecurityProfile() << " to "
                << new_security_profile;
-    this->configuration.setSecurityProfile(new_security_profile);
+    // Pin the slot at switch time: the connection attempts below can move the active slot (multi-slot
+    // failover), and both the switch and a later revert must write the slot the switch targeted.
+    const auto switch_slot = this->connectivity_manager->get_active_network_configuration_slot();
+    const auto set_profile = [this, switch_slot](std::int32_t security_profile) {
+        if (switch_slot.has_value()) {
+            this->configuration.set_security_profile_for_slot(switch_slot.value(), security_profile);
+        } else {
+            this->configuration.setSecurityProfile(security_profile);
+        }
+    };
+    set_profile(new_security_profile);
     this->connectivity_manager->reload_network_profiles();
     this->connectivity_manager->connect();
 
@@ -2046,7 +2060,7 @@ void ChargePointImpl::switchSecurityProfile(std::int32_t new_security_profile, s
     // Arm a revert timer: if the new security profile does not result in a successful connection within the timeout,
     // revert to the fallback security profile. A successful connection cancels this timer via connected_callback().
     this->security_profile_revert_timer.timeout(
-        [this, fallback_security_profile]() {
+        [this, fallback_security_profile, set_profile]() {
             std::lock_guard<std::mutex> lock(this->security_profile_switch_mutex);
             if (this->connectivity_manager->is_websocket_connected()) {
                 EVLOG_info << "Security profile switch connected within the revert timeout window; not reverting.";
@@ -2055,7 +2069,7 @@ void ChargePointImpl::switchSecurityProfile(std::int32_t new_security_profile, s
             EVLOG_warning << "Security profile switch did not connect within timeout; reverting.";
             this->connectivity_manager
                 ->disconnect(); // ensures that connectivity_manager does not initiate a reconnect on its own
-            this->configuration.setSecurityProfile(fallback_security_profile);
+            set_profile(fallback_security_profile);
             this->connectivity_manager->reload_network_profiles();
             this->connectivity_manager->connect();
         },
@@ -4864,6 +4878,11 @@ void ChargePointImpl::register_upload_logs_callback(const std::function<GetLogRe
 void ChargePointImpl::register_set_connection_timeout_callback(
     const std::function<void(std::int32_t connection_timeout)>& callback) {
     this->set_connection_timeout_callback = callback;
+}
+
+void ChargePointImpl::register_configure_network_connection_profile_callback(
+    ConfigureNetworkConnectionProfileCallback callback) {
+    this->connectivity_manager->set_configure_network_connection_profile_callback(std::move(callback));
 }
 
 void ChargePointImpl::register_connection_state_changed_callback(

--- a/lib/everest/ocpp/lib/ocpp/v16/variable_resolver.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/variable_resolver.cpp
@@ -14,20 +14,6 @@ bool matches(const ocpp::v2::ComponentVariable& cv, const ocpp::v2::Component& c
     return cv.variable.has_value() && (cv.component == component) && (cv.variable.value() == variable);
 }
 
-bool is_connection_config(const ocpp::v2::Component& component, const ocpp::v2::Variable& variable) {
-    using namespace ocpp::v2;
-    if (component.name == "NetworkConfiguration") {
-        return true; // any slot instance
-    }
-    if (matches(ControllerComponentVariables::NetworkConfigurationPriority, component, variable) ||
-        matches(ControllerComponentVariables::ActiveNetworkProfile, component, variable)) {
-        return true;
-    }
-    // SecurityCtrlr fallback CVs used by make_nc_kv_with_fallback for ChargePointId / AuthorizationKey
-    return matches(ControllerComponentVariables::SecurityCtrlrIdentity, component, variable) ||
-           matches(ControllerComponentVariables::BasicAuthPassword, component, variable);
-}
-
 bool is_read_only_derived(const ocpp::v2::Component& component, const ocpp::v2::Variable& variable) {
     if (matches(ocpp::v2::ControllerComponentVariables::SupportedFeatureProfiles, component, variable)) {
         return true;
@@ -43,6 +29,20 @@ bool is_read_only_derived(const ocpp::v2::Component& component, const ocpp::v2::
 } // namespace
 
 namespace ocpp::v16 {
+
+bool is_connection_config_cv(const ocpp::v2::Component& component, const ocpp::v2::Variable& variable) {
+    using namespace ocpp::v2;
+    if (component.name == "NetworkConfiguration") {
+        return true; // any slot instance
+    }
+    if (matches(ControllerComponentVariables::NetworkConfigurationPriority, component, variable) ||
+        matches(ControllerComponentVariables::ActiveNetworkProfile, component, variable)) {
+        return true;
+    }
+    // SecurityCtrlr fallback CVs used by make_nc_kv_with_fallback for ChargePointId / AuthorizationKey
+    return matches(ControllerComponentVariables::SecurityCtrlrIdentity, component, variable) ||
+           matches(ControllerComponentVariables::BasicAuthPassword, component, variable);
+}
 
 VariableResolver::VariableResolver(ocpp::v2::Ocpp16CustomConfigMappings custom_mappings) :
     custom_mappings(std::move(custom_mappings)) {
@@ -87,7 +87,7 @@ ReverseResult VariableResolver::cv_to_key(const ocpp::v2::Component& component,
 }
 
 CVClass VariableResolver::classify(const ocpp::v2::Component& component, const ocpp::v2::Variable& variable) const {
-    if (is_connection_config(component, variable)) {
+    if (is_connection_config_cv(component, variable)) {
         return CVClass::ConnectionConfig;
     }
     if (is_read_only_derived(component, variable)) {

--- a/lib/everest/ocpp/lib/ocpp/v2/ocpp16_component_config_patcher.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/ocpp16_component_config_patcher.cpp
@@ -14,7 +14,6 @@
 #include <ocpp/v16/utils.hpp>
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/init_device_model_db.hpp>
-#include <ocpp/v2/network_configuration_default_schema.hpp>
 
 namespace ocpp::v2 {
 
@@ -240,6 +239,113 @@ void patch_supported_measurands(std::map<ComponentKey, std::vector<DeviceModelVa
     }
 }
 
+// Warn when the migrated slot is not reachable through OCPPCommCtrlr.NetworkConfigurationPriority: the
+// priority value selects the slots in use, and its valuesList gates runtime priority writes.
+void warn_when_migrated_slot_not_in_priority(
+    std::map<ComponentKey, std::vector<DeviceModelVariable>>& component_configs, const int32_t network_config_slot) {
+    const auto priority_dm_cv = component_variable_to_dm_cv(ControllerComponentVariables::NetworkConfigurationPriority);
+    const auto priority_var = get_variable_to_patch(component_configs, priority_dm_cv);
+    if (!priority_var.has_value()) {
+        return; // get_variable_to_patch already warned
+    }
+    const auto& dm_variable = priority_var->get();
+    const auto slot_str = std::to_string(network_config_slot);
+
+    const auto attribute_it =
+        std::find_if(dm_variable.attributes.begin(), dm_variable.attributes.end(), [](const DbVariableAttribute& attr) {
+            return attr.variable_attribute.type.has_value() and
+                   attr.variable_attribute.type.value() == AttributeEnum::Actual;
+        });
+    std::string current_priority;
+    if (attribute_it != dm_variable.attributes.end() and attribute_it->variable_attribute.value.has_value()) {
+        current_priority = attribute_it->variable_attribute.value.value().get();
+    } else if (dm_variable.default_actual_value.has_value()) {
+        current_priority = dm_variable.default_actual_value.value();
+    }
+
+    const auto priority_slots = ocpp::v16::utils::from_csl(current_priority);
+    if (std::find(priority_slots.begin(), priority_slots.end(), slot_str) == priority_slots.end()) {
+        EVLOG_warning << "Migrated NetworkConfiguration slot " << network_config_slot
+                      << " is not listed in OCPPCommCtrlr/NetworkConfigurationPriority (\"" << current_priority
+                      << "\"); the migrated connection profile will not be used until the priority lists slot "
+                      << network_config_slot << " in the component config.";
+    }
+
+    if (dm_variable.characteristics.valuesList.has_value()) {
+        const auto values_list = ocpp::v16::utils::from_csl(dm_variable.characteristics.valuesList.value().get());
+        if (std::find(values_list.begin(), values_list.end(), slot_str) == values_list.end()) {
+            EVLOG_warning << "Migrated NetworkConfiguration slot " << network_config_slot
+                          << " is not part of OCPPCommCtrlr/NetworkConfigurationPriority's valuesList (\""
+                          << dm_variable.characteristics.valuesList.value().get()
+                          << "\"); runtime priority writes containing slot " << network_config_slot
+                          << " will be Rejected until the component config's valuesList includes it.";
+        }
+    }
+}
+
+// Migrate the OCPP 1.6 connection settings (CentralSystemURI, SecurityProfile, AuthorizationKey, HostName,
+// ChargePointId) into NetworkConfiguration[network_config_slot] and point OCPPCommCtrlr.ActiveNetworkProfile
+// at that slot. The slot's component config and its listing in NetworkConfigurationPriority come from the
+// component configuration; when they are missing, this is reported and the slot is left as configured.
+void patch_network_connection_profile(std::map<ComponentKey, std::vector<DeviceModelVariable>>& component_configs,
+                                      ocpp::v16::ChargePointConfiguration& ocpp16_config,
+                                      const int32_t network_config_slot) {
+    namespace NC = ocpp::v2::NetworkConfigurationComponentVariables;
+
+    ComponentKey nc_component_key;
+    nc_component_key.name = "NetworkConfiguration";
+    nc_component_key.instance = std::to_string(network_config_slot);
+    if (component_configs.find(nc_component_key) == component_configs.end()) {
+        EVLOG_error << "NetworkConfiguration[" << network_config_slot
+                    << "] not found in the component configs - skipping migration of the network connection "
+                       "settings. Provide a NetworkConfiguration_"
+                    << network_config_slot
+                    << " component config or point Ocpp16NetworkConfigSlot at a configured slot.";
+        return;
+    }
+
+    // CentralSystemURI -> NetworkConfiguration[N].OcppCsmsUrl
+    {
+        const auto uri = ocpp16_config.getCentralSystemURI();
+        if (!uri.empty()) {
+            patch_variable_value(component_configs, NC::get_component_variable(network_config_slot, NC::OcppCsmsUrl),
+                                 uri);
+        }
+    }
+    // SecurityProfile -> NetworkConfiguration[N].SecurityProfile
+    patch_variable_value(component_configs, NC::get_component_variable(network_config_slot, NC::SecurityProfile),
+                         std::to_string(ocpp16_config.getSecurityProfile()), true);
+    // OcppInterface -> NetworkConfiguration[N].OcppInterface (pinned to "Any")
+    // Legacy 1.6 configs have no interface notion; pinning "Any" keeps post-migration behavior identical to
+    // the pre-device-model single-profile synthesis. An explicit attribute value set by the integrator wins.
+    patch_variable_value(component_configs, NC::get_component_variable(network_config_slot, NC::OcppInterface), "Any",
+                         /*allow_override=*/false);
+    // AuthorizationKey -> NetworkConfiguration[N].BasicAuthPassword
+    if (const auto ak = ocpp16_config.getAuthorizationKey(); ak.has_value()) {
+        patch_variable_value(component_configs, NC::get_component_variable(network_config_slot, NC::BasicAuthPassword),
+                             ak.value());
+    }
+    // HostName -> NetworkConfiguration[N].HostName
+    if (const auto hn = ocpp16_config.getHostName(); hn.has_value()) {
+        patch_variable_value(component_configs,
+                             NC::get_component_variable(network_config_slot, ocpp::v2::Variable{"HostName"}),
+                             hn.value());
+    }
+    // ChargePointId -> NetworkConfiguration[N].Identity
+    {
+        const auto id = ocpp16_config.getChargePointId();
+        if (!id.empty()) {
+            patch_variable_value(component_configs, NC::get_component_variable(network_config_slot, NC::Identity), id);
+        }
+    }
+    // ActiveNetworkProfile -> the migrated slot, so the OCPP 1.6 key surface (CentralSystemURI,
+    // SecurityProfile, AuthorizationKey, ...) targets it already before the first successful connect.
+    patch_variable_value(component_configs, ControllerComponentVariables::ActiveNetworkProfile,
+                         std::to_string(network_config_slot));
+
+    warn_when_migrated_slot_not_in_priority(component_configs, network_config_slot);
+}
+
 } // namespace
 
 void patch_component_config_with_ocpp16(std::map<ComponentKey, std::vector<DeviceModelVariable>>& component_configs,
@@ -288,59 +394,11 @@ void patch_component_config_with_ocpp16(std::map<ComponentKey, std::vector<Devic
 
     // Handling for special cases that cannot be covered by the generic mapping above:
 
-    if (network_config_slot > 0) {
-        namespace NC = ocpp::v2::NetworkConfigurationComponentVariables;
+    patch_variable_value(component_configs, ControllerComponentVariables::SecurityProfile,
+                         std::to_string(ocpp16_config.getSecurityProfile()));
 
-        ComponentKey nc_component_key;
-        nc_component_key.name = "NetworkConfiguration";
-        nc_component_key.instance = std::to_string(network_config_slot);
-        if (component_configs.find(nc_component_key) == component_configs.end()) {
-            EVLOG_info << "NetworkConfiguration[" << network_config_slot
-                       << "] not found in component configs, injecting from embedded default schema.";
-            try {
-                auto [key, vars] = parse_component_config_from_string(get_default_network_configuration_schema());
-                key.instance = std::to_string(network_config_slot);
-                component_configs[key] = std::move(vars);
-            } catch (const std::exception& e) {
-                EVLOG_error << "Failed to inject NetworkConfiguration[" << network_config_slot
-                            << "] from embedded default schema: " << e.what()
-                            << " — skipping network connection migration.";
-            }
-        }
-        if (component_configs.find(nc_component_key) != component_configs.end()) {
-            // CentralSystemURI -> NetworkConfiguration[N].OcppCsmsUrl
-            {
-                const auto uri = ocpp16_config.getCentralSystemURI();
-                if (!uri.empty()) {
-                    patch_variable_value(component_configs,
-                                         NC::get_component_variable(network_config_slot, NC::OcppCsmsUrl), uri);
-                }
-            }
-            // SecurityProfile -> NetworkConfiguration[N].SecurityProfile
-            patch_variable_value(component_configs,
-                                 NC::get_component_variable(network_config_slot, NC::SecurityProfile),
-                                 std::to_string(ocpp16_config.getSecurityProfile()), true);
-            // AuthorizationKey -> NetworkConfiguration[N].BasicAuthPassword
-            if (const auto ak = ocpp16_config.getAuthorizationKey(); ak.has_value()) {
-                patch_variable_value(component_configs,
-                                     NC::get_component_variable(network_config_slot, NC::BasicAuthPassword),
-                                     ak.value());
-            }
-            // HostName -> NetworkConfiguration[N].HostName
-            if (const auto hn = ocpp16_config.getHostName(); hn.has_value()) {
-                patch_variable_value(component_configs,
-                                     NC::get_component_variable(network_config_slot, ocpp::v2::Variable{"HostName"}),
-                                     hn.value());
-            }
-            // ChargePointId -> NetworkConfiguration[N].Identity
-            {
-                const auto id = ocpp16_config.getChargePointId();
-                if (!id.empty()) {
-                    patch_variable_value(component_configs,
-                                         NC::get_component_variable(network_config_slot, NC::Identity), id);
-                }
-            }
-        }
+    if (network_config_slot > 0) {
+        patch_network_connection_profile(component_configs, ocpp16_config, network_config_slot);
     }
 
     // MeterPublicKeys -> MeterPublicKey[0], MeterPublicKey[1], ...

--- a/lib/everest/ocpp/lib/ocpp/v2/ocpp16_custom_config_mappings.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/ocpp16_custom_config_mappings.cpp
@@ -10,6 +10,8 @@
 #include <ryml.hpp>
 #include <ryml_std.hpp>
 
+#include <ocpp/v16/variable_resolver.hpp>
+
 namespace ocpp::v2 {
 
 namespace {
@@ -209,6 +211,16 @@ load_ocpp16_custom_config_mappings_from_yaml(const std::filesystem::path& mappin
         variable.name = entry.at("variable").at("name").get<std::string>();
         if (entry.at("variable").contains("instance")) {
             variable.instance = entry.at("variable").at("instance").get<std::string>();
+        }
+
+        // Connection config is managed by the standardized OCPP 1.6 keys (with their reboot/reconnect
+        // semantics) or direct canonical CV access; a custom key would write it without either.
+        if (v16::is_connection_config_cv(component, variable)) {
+            throw Ocpp16CustomConfigMappingsError(
+                "Invalid custom mapping in '" + mapping_file_path.string() + "': key '" + ocpp16_key +
+                "' targets connection configuration " + component.name.get() + "/" + variable.name.get() +
+                "; connection configuration is managed via the standardized OCPP 1.6 keys and must not be "
+                "custom-mapped");
         }
 
         if (!mappings.emplace(ocpp16_key, std::make_pair(component, variable)).second) {

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(libocpp_unit_tests PRIVATE
         test_charge_point_state_machine.cpp
         test_composite_schedule.cpp
         test_charge_point_connectivity.cpp
+        test_devicemodel_connectivity.cpp
         test_config_validation.cpp
         utils_tests.cpp
         test_configuration.cpp

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/test_charge_point_connectivity.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/test_charge_point_connectivity.cpp
@@ -104,6 +104,7 @@ TEST_F(ChargePointConnectivityTest, InjectedManagerNotAutoWiredForLifecycle) {
     EXPECT_CALL(*this->connectivity_manager, set_websocket_disconnected_callback(_)).Times(0);
     EXPECT_CALL(*this->connectivity_manager, set_websocket_connection_failed_callback(_)).Times(0);
     EXPECT_CALL(*this->connectivity_manager, set_message_callback(_)).Times(0);
+    EXPECT_CALL(*this->connectivity_manager, set_configure_network_connection_profile_callback(_)).Times(0);
 
     auto charge_point = make_charge_point();
 

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/test_devicemodel_connectivity.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/test_devicemodel_connectivity.cpp
@@ -1,0 +1,951 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+/// \file test_devicemodel_connectivity.cpp
+/// \brief Unit tests for the device-model-backed v16 connectivity overrides on
+/// ocpp::v16::ChargePointConfigurationDeviceModel.
+///
+/// Unlike the JSON backend (single slot-1 profile, hardcoded ocppInterface Any, slot-ignoring websocket options),
+/// the device-model adapter sources per-slot connection details from the v2 device-model NetworkConfiguration[N]
+/// components; the same data 2.x uses.
+/// These tests exercise the four overrides against a real sqlite-backed ocpp::v2::DeviceModel seeded with the shipped
+/// example component config (which carries NetworkConfiguration_1 / _2 slots):
+///   * get_network_configuration_priority() - DM CSL, 2.x-version filtering, empty->active-slot fallback,
+///   * read_network_connection_profile(slot) - configured slot, legacy-synthesis fallback, version filter, nullopt,
+///   * get_websocket_connection_options(slot) - per-slot fields + identity/password fallbacks + base equivalence
+///     + nullopt rejections (':' in identity, URL scheme vs security profile),
+///   * set_active_network_profile_slot(slot) - persistence + getter redirection,
+///   * a ConnectivityManager smoke test built over the adapter, and
+///   * the ocpp16 component-config patcher pinning NetworkConfiguration[slot].OcppInterface to "Any".
+
+#include <chrono>
+#include <filesystem>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include <ocpp/common/connectivity_manager.hpp>
+#include <ocpp/common/websocket/websocket_uri.hpp>
+#include <ocpp/v16/charge_point_configuration.hpp>
+#include <ocpp/v16/charge_point_configuration_devicemodel.hpp>
+#include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v2/device_model.hpp>
+#include <ocpp/v2/device_model_interface.hpp>
+#include <ocpp/v2/init_device_model_db.hpp>
+#include <ocpp/v2/ocpp16_component_config_patcher.hpp>
+#include <ocpp/v2/ocpp_enums.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
+
+#include "evse_security_mock.hpp"
+#include "ocpp16_test_config.hpp"
+#include "v2/device_model_test_helper.hpp"
+
+using ::testing::NiceMock;
+
+namespace ocpp {
+namespace v16 {
+namespace {
+
+namespace NC = ocpp::v2::NetworkConfigurationComponentVariables;
+namespace CC = ocpp::v2::ControllerComponentVariables;
+
+using ocpp::v2::AttributeEnum;
+using ocpp::v2::OCPPInterfaceEnum;
+using ocpp::v2::OCPPTransportEnum;
+using ocpp::v2::SetVariableStatusEnum;
+
+/// \brief Non-owning forwarding proxy for a v2::DeviceModelInterface. The ChargePointConfigurationDeviceModel
+/// constructor takes ownership of a unique_ptr<DeviceModelInterface>, but the tests need to keep a raw handle to
+/// the underlying DeviceModel to seed per-slot NetworkConfiguration values. The proxy is handed to the config
+/// (single owner) while the test retains the real DeviceModel* owned by DeviceModelTestHelper.
+class DeviceModelProxy : public ocpp::v2::DeviceModelInterface {
+public:
+    using VariableAttribute = ocpp::v2::VariableAttribute;
+    using Component = ocpp::v2::Component;
+    using ComponentVariable = ocpp::v2::ComponentVariable;
+    using ComponentCriterionEnum = ocpp::v2::ComponentCriterionEnum;
+    using Variable = ocpp::v2::Variable;
+    using GetVariableStatusEnum = ocpp::v2::GetVariableStatusEnum;
+    using VariableMonitoringMeta = ocpp::v2::VariableMonitoringMeta;
+    using SetMonitoringData = ocpp::v2::SetMonitoringData;
+    using SetMonitoringResult = ocpp::v2::SetMonitoringResult;
+    using VariableMonitorType = ocpp::v2::VariableMonitorType;
+    using VariableMonitoringPeriodic = ocpp::v2::VariableMonitoringPeriodic;
+    using MonitoringCriterionEnum = ocpp::v2::MonitoringCriterionEnum;
+    using MonitoringData = ocpp::v2::MonitoringData;
+    using ClearMonitoringResult = ocpp::v2::ClearMonitoringResult;
+    using MutabilityEnum = ocpp::v2::MutabilityEnum;
+    using VariableCharacteristics = ocpp::v2::VariableCharacteristics;
+    using VariableMetaData = ocpp::v2::VariableMetaData;
+    using ReportData = ocpp::v2::ReportData;
+    using ReportBaseEnum = ocpp::v2::ReportBaseEnum;
+
+    explicit DeviceModelProxy(ocpp::v2::DeviceModelInterface& storage) : storage(storage) {
+    }
+
+    GetVariableStatusEnum get_variable(const Component& component_id, const Variable& variable_id,
+                                       const AttributeEnum& attribute_enum, std::string& value,
+                                       bool allow_write_only) const override {
+        return storage.get_variable(component_id, variable_id, attribute_enum, value, allow_write_only);
+    }
+
+    SetVariableStatusEnum set_value(const Component& component_id, const Variable& variable_id,
+                                    const AttributeEnum& attribute_enum, const std::string& value,
+                                    const std::string& source, bool allow_read_only) override {
+        return storage.set_value(component_id, variable_id, attribute_enum, value, source, allow_read_only);
+    }
+
+    SetVariableStatusEnum set_read_only_value(const Component& component_id, const Variable& variable_id,
+                                              const AttributeEnum& attribute_enum, const std::string& value,
+                                              const std::string& source) override {
+        return storage.set_read_only_value(component_id, variable_id, attribute_enum, value, source);
+    }
+
+    SetVariableStatusEnum clear_value(const Component& component_id, const Variable& variable_id,
+                                      const AttributeEnum& attribute_enum, const std::string& source) override {
+        return storage.clear_value(component_id, variable_id, attribute_enum, source);
+    }
+
+    std::optional<MutabilityEnum> get_mutability(const Component& component_id, const Variable& variable_id,
+                                                 const AttributeEnum& attribute_enum) override {
+        return storage.get_mutability(component_id, variable_id, attribute_enum);
+    }
+
+    std::optional<VariableMetaData> get_variable_meta_data(const Component& component_id,
+                                                           const Variable& variable_id) override {
+        return storage.get_variable_meta_data(component_id, variable_id);
+    }
+
+    std::vector<ReportData> get_base_report_data(const ReportBaseEnum& report_base) override {
+        return storage.get_base_report_data(report_base);
+    }
+
+    std::vector<ReportData>
+    get_custom_report_data(const std::optional<std::vector<ComponentVariable>>& component_variables,
+                           const std::optional<std::vector<ComponentCriterionEnum>>& component_criteria) override {
+        return storage.get_custom_report_data(component_variables, component_criteria);
+    }
+
+    std::vector<SetMonitoringResult>
+    set_monitors(const std::vector<SetMonitoringData>& requests,
+                 const VariableMonitorType type = VariableMonitorType::CustomMonitor) override {
+        return storage.set_monitors(requests, type);
+    }
+
+    bool update_monitor_reference(std::int32_t monitor_id, const std::string& reference_value) override {
+        return storage.update_monitor_reference(monitor_id, reference_value);
+    }
+
+    std::vector<VariableMonitoringPeriodic> get_periodic_monitors() override {
+        return storage.get_periodic_monitors();
+    }
+
+    std::vector<MonitoringData> get_monitors(const std::vector<MonitoringCriterionEnum>& criteria,
+                                             const std::vector<ComponentVariable>& component_variables) override {
+        return storage.get_monitors(criteria, component_variables);
+    }
+
+    std::vector<ClearMonitoringResult> clear_monitors(const std::vector<int>& request_ids,
+                                                      bool allow_protected) override {
+        return storage.clear_monitors(request_ids, allow_protected);
+    }
+
+    std::int32_t clear_custom_monitors() override {
+        return storage.clear_custom_monitors();
+    }
+
+    void register_variable_listener(
+        std::function<void(const std::unordered_map<std::int64_t, VariableMonitoringMeta>& monitors,
+                           const Component& component, const Variable& variable,
+                           const VariableCharacteristics& characteristics, const VariableAttribute& attribute,
+                           const std::string& value_previous, const std::string& value_current)>&& listener) override {
+        return storage.register_variable_listener(std::move(listener));
+    }
+
+    void register_monitor_listener(
+        std::function<void(const VariableMonitoringMeta& updated_monitor, const Component& component,
+                           const Variable& variable, const VariableCharacteristics& characteristics,
+                           const VariableAttribute& attribute, const std::string& current_value)>&& listener) override {
+        return storage.register_monitor_listener(std::move(listener));
+    }
+
+    void check_integrity(const std::map<std::int32_t, std::int32_t>& evse_connector_structure) override {
+        return storage.check_integrity(evse_connector_structure);
+    }
+
+private:
+    ocpp::v2::DeviceModelInterface& storage;
+};
+
+/// \brief Build a fully-specified NetworkConnectionProfile for a slot (URL + security profile + interface).
+ocpp::v2::NetworkConnectionProfile make_slot_profile(const std::string& url, int security_profile,
+                                                     OCPPInterfaceEnum iface) {
+    ocpp::v2::NetworkConnectionProfile p;
+    p.ocppCsmsUrl = url;
+    p.securityProfile = security_profile;
+    p.ocppInterface = iface;
+    p.ocppTransport = OCPPTransportEnum::JSON;
+    p.messageTimeout = 30;
+    return p;
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: real in-memory sqlite v2 DeviceModel over the shipped example
+// component config (InternalCtrlr, OCPPCommCtrlr, SecurityCtrlr,
+// NetworkConfiguration_1 / _2). The ChargePointConfigurationDeviceModel under
+// test owns a forwarding proxy; the fixture keeps the raw DeviceModel* to seed
+// per-slot values.
+// ---------------------------------------------------------------------------
+class DeviceModelConnectivityTest : public ::testing::Test {
+protected:
+    ocpp::v2::DeviceModelTestHelper dm_helper;
+    ocpp::v2::DeviceModel* dm{nullptr};
+    std::unique_ptr<ChargePointConfigurationDeviceModel> config;
+
+    DeviceModelConnectivityTest() : dm_helper() {
+        dm = dm_helper.get_device_model();
+        config = std::make_unique<ChargePointConfigurationDeviceModel>(CONFIG_DIR_V16,
+                                                                       std::make_unique<DeviceModelProxy>(*dm));
+    }
+
+    void write_slot_profile(int slot, const ocpp::v2::NetworkConnectionProfile& profile) {
+        ASSERT_TRUE(NC::write_profile_to_device_model(*dm, slot, profile, "test"))
+            << "seeding NetworkConfiguration[" << slot << "] failed";
+    }
+
+    void set_priority(const std::string& csl) {
+        ASSERT_TRUE(CC::NetworkConfigurationPriority.variable.has_value());
+        ASSERT_EQ(dm->set_value(CC::NetworkConfigurationPriority.component,
+                                CC::NetworkConfigurationPriority.variable.value(), AttributeEnum::Actual, csl, "test"),
+                  SetVariableStatusEnum::Accepted)
+            << "setting NetworkConfigurationPriority to '" << csl << "' was rejected";
+    }
+
+    void set_slot_ocpp_version(int slot, const std::string& version) {
+        ASSERT_EQ(dm->set_value(NC::get_component_variable(slot, NC::OcppVersion).component,
+                                NC::get_component_variable(slot, NC::OcppVersion).variable.value(),
+                                AttributeEnum::Actual, version, "test"),
+                  SetVariableStatusEnum::Accepted)
+            << "setting NetworkConfiguration[" << slot << "].OcppVersion to '" << version << "' was rejected";
+    }
+
+    void set_slot_identity(int slot, const std::string& identity) {
+        ASSERT_EQ(dm->set_value(NC::get_component_variable(slot, NC::Identity).component,
+                                NC::get_component_variable(slot, NC::Identity).variable.value(), AttributeEnum::Actual,
+                                identity, "test"),
+                  SetVariableStatusEnum::Accepted);
+    }
+
+    void set_slot_hostname(int slot, const std::string& hostname) {
+        const auto cv = NC::get_component_variable(slot, ocpp::v2::Variable{"HostName"});
+        ASSERT_TRUE(cv.variable.has_value());
+        // HostName is ReadOnly in the component config; seed it the way write_profile_to_device_model writes
+        // profile fields (forced set_value).
+        ASSERT_EQ(dm->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, hostname, "test", true),
+                  SetVariableStatusEnum::Accepted);
+    }
+};
+
+// Compare two WebsocketConnectionOptions field-by-field. Uri::string() is non-const, so parameters are taken by
+// value.
+void expect_ws_options_equal(WebsocketConnectionOptions a, WebsocketConnectionOptions b) {
+    EXPECT_EQ(a.ocpp_versions, b.ocpp_versions);
+    EXPECT_EQ(a.csms_uri.string(), b.csms_uri.string());
+    EXPECT_EQ(a.security_profile, b.security_profile);
+    EXPECT_EQ(a.authorization_key, b.authorization_key);
+    EXPECT_EQ(a.message_timeout, b.message_timeout);
+    EXPECT_EQ(a.retry_backoff_random_range_s, b.retry_backoff_random_range_s);
+    EXPECT_EQ(a.retry_backoff_repeat_times, b.retry_backoff_repeat_times);
+    EXPECT_EQ(a.retry_backoff_wait_minimum_s, b.retry_backoff_wait_minimum_s);
+    EXPECT_EQ(a.max_connection_attempts, b.max_connection_attempts);
+    EXPECT_EQ(a.supported_ciphers_12, b.supported_ciphers_12);
+    EXPECT_EQ(a.supported_ciphers_13, b.supported_ciphers_13);
+    EXPECT_EQ(a.ping_interval_s, b.ping_interval_s);
+    EXPECT_EQ(a.ping_payload, b.ping_payload);
+    EXPECT_EQ(a.pong_timeout_s, b.pong_timeout_s);
+    EXPECT_EQ(a.use_ssl_default_verify_paths, b.use_ssl_default_verify_paths);
+    EXPECT_EQ(a.additional_root_certificate_check, b.additional_root_certificate_check);
+    EXPECT_EQ(a.hostName, b.hostName);
+    EXPECT_EQ(a.verify_csms_common_name, b.verify_csms_common_name);
+    EXPECT_EQ(a.use_tpm_tls, b.use_tpm_tls);
+    EXPECT_EQ(a.verify_csms_allow_wildcards, b.verify_csms_allow_wildcards);
+    EXPECT_EQ(a.iface, b.iface);
+    EXPECT_EQ(a.enable_tls_keylog, b.enable_tls_keylog);
+    EXPECT_EQ(a.keylog_file, b.keylog_file);
+    EXPECT_EQ(a.everest_version, b.everest_version);
+}
+
+// ---------------------------------------------------------------------------
+// get_network_configuration_priority()
+// ---------------------------------------------------------------------------
+
+// An empty NetworkConfigurationPriority yields no usable slots, so the priority falls back to the active slot as a
+// single-element list.
+TEST_F(DeviceModelConnectivityTest, PriorityDefaultsToActiveSlotWhenDmEmpty) {
+    config->set_active_network_profile_slot(2, "test");
+    set_priority("");
+
+    EXPECT_EQ(config->get_network_configuration_priority(), "2");
+}
+
+// The device-model CSL is exposed verbatim when every listed slot is usable for OCPP 1.6 (OcppVersion unset).
+TEST_F(DeviceModelConnectivityTest, PriorityExposesDeviceModelCsl) {
+    set_priority("1,2");
+
+    EXPECT_EQ(config->get_network_configuration_priority(), "1,2");
+}
+
+// Slots pinned to a 2.x-only OcppVersion are filtered out of the priority list; when all listed slots are filtered
+// the result falls back to the active slot.
+TEST_F(DeviceModelConnectivityTest, PriorityFiltersTwoXOnlySlots) {
+    // Slot 2 is pinned to a 2.x-only version and must be dropped, leaving slot 1.
+    set_priority("1,2");
+    set_slot_ocpp_version(2, "OCPP201");
+    EXPECT_EQ(config->get_network_configuration_priority(), "1");
+
+    // All listed slots filtered -> fall back to the active slot (1).
+    config->set_active_network_profile_slot(1, "test");
+    set_priority("2");
+    EXPECT_EQ(config->get_network_configuration_priority(), "1");
+}
+
+// ---------------------------------------------------------------------------
+// read_network_connection_profile(slot)
+// ---------------------------------------------------------------------------
+
+// An unconfigured ACTIVE slot (default slot 1 has an empty OcppCsmsUrl) falls back to the legacy single-profile
+// synthesis: byte-equivalent to the base ChargePointConfigurationConnectivity behavior (Any / JSON / 10 s + global
+// URL/identity/password getters).
+TEST_F(DeviceModelConnectivityTest, ReadProfileFallsBackToLegacySynthesisWhenUnconfigured) {
+    // Active slot defaults to 1; do not seed slot 1 so read_profile_from_device_model returns nullopt.
+    const auto fallback = config->read_network_connection_profile(1);
+    ASSERT_TRUE(fallback.has_value()) << "Unconfigured active slot must fall back to legacy synthesis";
+
+    // Constant parts of the legacy synthesis.
+    EXPECT_EQ(fallback->ocppInterface, OCPPInterfaceEnum::Any);
+    EXPECT_EQ(fallback->ocppTransport, OCPPTransportEnum::JSON);
+    EXPECT_EQ(fallback->messageTimeout, 10);
+
+    // Byte-equivalence with the global getters.
+    EXPECT_EQ(fallback->ocppCsmsUrl.get(), config->getCentralSystemURI());
+    EXPECT_EQ(fallback->securityProfile, config->getSecurityProfile());
+    if (const auto id = config->getChargePointId(); !id.empty()) {
+        ASSERT_TRUE(fallback->identity.has_value());
+        EXPECT_EQ(fallback->identity->get(), id);
+    }
+
+    // The override result must be identical to the base-class synthesis, field for field.
+    const auto base = config->ChargePointConfigurationConnectivity::read_network_connection_profile(1);
+    ASSERT_TRUE(base.has_value());
+    EXPECT_EQ(fallback->ocppCsmsUrl.get(), base->ocppCsmsUrl.get());
+    EXPECT_EQ(fallback->securityProfile, base->securityProfile);
+    EXPECT_EQ(fallback->ocppInterface, base->ocppInterface);
+    EXPECT_EQ(fallback->ocppTransport, base->ocppTransport);
+    EXPECT_EQ(fallback->messageTimeout, base->messageTimeout);
+    EXPECT_EQ(fallback->identity.has_value(), base->identity.has_value());
+    if (fallback->identity.has_value() && base->identity.has_value()) {
+        EXPECT_EQ(fallback->identity->get(), base->identity->get());
+    }
+    EXPECT_EQ(fallback->basicAuthPassword.has_value(), base->basicAuthPassword.has_value());
+    if (fallback->basicAuthPassword.has_value() && base->basicAuthPassword.has_value()) {
+        EXPECT_EQ(fallback->basicAuthPassword->get(), base->basicAuthPassword->get());
+    }
+}
+
+// A configured (non-active) slot is returned verbatim, including the interface selection and APN sub-fields.
+TEST_F(DeviceModelConnectivityTest, ReadProfileReturnsConfiguredSlot) {
+    auto profile = make_slot_profile("wss://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0);
+    ocpp::v2::APN apn;
+    apn.apn = "internet";
+    apn.apnAuthentication = ocpp::v2::APNAuthenticationEnum::AUTO;
+    apn.apnUserName = "user";
+    apn.apnPassword = "pass";
+    profile.apn = apn;
+    write_slot_profile(2, profile);
+
+    const auto result = config->read_network_connection_profile(2);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->ocppCsmsUrl.get(), "wss://slot2.example.com/ocpp");
+    EXPECT_EQ(result->ocppInterface, OCPPInterfaceEnum::Wireless0);
+    ASSERT_TRUE(result->apn.has_value());
+    EXPECT_EQ(result->apn->apn, "internet");
+    EXPECT_EQ(result->apn->apnUserName, "user");
+    EXPECT_EQ(result->apn->apnPassword, "pass");
+}
+
+// A configured slot pinned to a 2.x-only OcppVersion is filtered out and reads as nullopt.
+TEST_F(DeviceModelConnectivityTest, ReadProfileFiltersOcppVersion) {
+    write_slot_profile(2, make_slot_profile("wss://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+    set_slot_ocpp_version(2, "OCPP201");
+
+    EXPECT_FALSE(config->read_network_connection_profile(2).has_value())
+        << "A 2.x-pinned slot must not be usable for OCPP 1.6";
+}
+
+// Regression: a 2.x-only OcppVersion pin on the active slot must not dead-end the charge point; the read falls
+// back to the legacy synthesis rather than returning nullopt.
+TEST_F(DeviceModelConnectivityTest, ReadProfilePinnedActiveSlotFallsBackToLegacySynthesis) {
+    write_slot_profile(1, make_slot_profile("wss://active.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+    config->set_active_network_profile_slot(1, "test");
+    set_slot_ocpp_version(1, "OCPP201");
+
+    const auto result = config->read_network_connection_profile(1);
+    ASSERT_TRUE(result.has_value()) << "Pinned active slot must fall back to legacy synthesis, not dead-end";
+
+    // Synthesis (Any / JSON / 10 s), not the stored per-slot profile (which was Wireless0).
+    EXPECT_EQ(result->ocppInterface, OCPPInterfaceEnum::Any);
+    EXPECT_EQ(result->ocppTransport, OCPPTransportEnum::JSON);
+    EXPECT_EQ(result->messageTimeout, 10);
+
+    const auto base = config->ChargePointConfigurationConnectivity::read_network_connection_profile(1);
+    ASSERT_TRUE(base.has_value());
+    EXPECT_EQ(result->ocppCsmsUrl.get(), base->ocppCsmsUrl.get());
+    EXPECT_EQ(result->securityProfile, base->securityProfile);
+}
+
+// An unconfigured NON-active slot reads as nullopt (no legacy fallback - that only applies to the active slot).
+TEST_F(DeviceModelConnectivityTest, ReadProfileNullForUnconfiguredNonActiveSlot) {
+    // Active slot is 1 by default; slot 2 has no configured URL.
+    EXPECT_FALSE(config->read_network_connection_profile(2).has_value());
+}
+
+// ---------------------------------------------------------------------------
+// get_websocket_connection_options(slot)
+// ---------------------------------------------------------------------------
+
+// A configured slot yields per-slot uri/securityProfile/identity/password/hostname; remaining fields come from the
+// global getters, including iface == getIFace().
+TEST_F(DeviceModelConnectivityTest, WsOptionsPerSlotFields) {
+    auto profile = make_slot_profile("ws://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0);
+    profile.identity = "slot2id";
+    profile.basicAuthPassword = ocpp::CiString<64>("Slot2PasswordSlot2Pw");
+    write_slot_profile(2, profile);
+    set_slot_hostname(2, "slot2.host");
+
+    auto opts = config->get_websocket_connection_options(2); // non-const: Uri accessors are non-const
+    ASSERT_TRUE(opts.has_value());
+    EXPECT_EQ(opts->security_profile, 1);
+    EXPECT_EQ(opts->csms_uri.get_chargepoint_id(), "slot2id") << "per-slot Identity must drive the websocket URI";
+    EXPECT_EQ(opts->csms_uri.get_hostname(), "slot2.example.com");
+    ASSERT_TRUE(opts->authorization_key.has_value());
+    EXPECT_EQ(opts->authorization_key.value(), "Slot2PasswordSlot2Pw");
+    ASSERT_TRUE(opts->hostName.has_value());
+    EXPECT_EQ(opts->hostName.value(), "slot2.host");
+    EXPECT_EQ(opts->message_timeout, std::chrono::seconds(30))
+        << "per-slot NetworkConfiguration[N].MessageTimeout must drive the message timeout";
+    EXPECT_EQ(opts->iface, config->getIFace()) << "static iface default must come from Internal/IFace (getIFace())";
+}
+
+// Per-slot options honor OCPPCommCtrlr/NetworkProfileConnectionAttempts so the websocket gives up on an
+// unreachable CSMS and the ConnectivityManager can advance to the next priority slot (multi-slot failover).
+TEST_F(DeviceModelConnectivityTest, WsOptionsUseNetworkProfileConnectionAttempts) {
+    write_slot_profile(2, make_slot_profile("ws://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+
+    ASSERT_TRUE(CC::NetworkProfileConnectionAttempts.variable.has_value());
+    ASSERT_EQ(dm->set_value(CC::NetworkProfileConnectionAttempts.component,
+                            CC::NetworkProfileConnectionAttempts.variable.value(), AttributeEnum::Actual, "5", "test"),
+              SetVariableStatusEnum::Accepted);
+
+    auto opts = config->get_websocket_connection_options(2); // non-const: Uri accessors are non-const
+    ASSERT_TRUE(opts.has_value());
+    EXPECT_EQ(opts->max_connection_attempts, 5)
+        << "device-model slots must use a finite attempt count, not the legacy unlimited (-1)";
+}
+
+// A stripped component config without OCPPCommCtrlr/NetworkProfileConnectionAttempts falls back to a finite
+// default (3, the shipped config value) instead of -1 (retry forever), which would silently disable
+// websocket-failure-driven failover.
+TEST_F(DeviceModelConnectivityTest, WsOptionsDefaultNetworkProfileConnectionAttemptsWhenAbsent) {
+    write_slot_profile(2, make_slot_profile("ws://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+
+    ASSERT_TRUE(CC::NetworkProfileConnectionAttempts.variable.has_value());
+    ASSERT_EQ(dm->clear_value(CC::NetworkProfileConnectionAttempts.component,
+                              CC::NetworkProfileConnectionAttempts.variable.value(), AttributeEnum::Actual, "test"),
+              SetVariableStatusEnum::Accepted)
+        << "fixture precondition: clearing NetworkProfileConnectionAttempts must succeed";
+
+    auto opts = config->get_websocket_connection_options(2); // non-const: Uri accessors are non-const
+    ASSERT_TRUE(opts.has_value());
+    EXPECT_EQ(opts->max_connection_attempts, 3);
+}
+
+// When a configured slot has no per-slot Identity, the websocket identity falls back to SecurityCtrlr/Identity.
+TEST_F(DeviceModelConnectivityTest, WsOptionsPerSlotFallsBackToSecurityCtrlrIdentity) {
+    // Configure slot 2 with a URL but leave the per-slot Identity empty (default).
+    write_slot_profile(2, make_slot_profile("ws://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+
+    const auto expected_identity = dm->get_value<std::string>(CC::SecurityCtrlrIdentity);
+    ASSERT_FALSE(expected_identity.empty()) << "fixture precondition: SecurityCtrlr/Identity must be set";
+
+    auto opts = config->get_websocket_connection_options(2); // non-const: Uri accessors are non-const
+    ASSERT_TRUE(opts.has_value());
+    EXPECT_EQ(opts->csms_uri.get_chargepoint_id(), expected_identity);
+}
+
+// An unconfigured slot delegates to the base ChargePointConfigurationConnectivity implementation, producing options
+// identical to the base (which ignores the slot and uses the global getters of the active slot) - except for
+// max_connection_attempts, where the base's -1 (retry forever) would disable failover to the other slots.
+TEST_F(DeviceModelConnectivityTest, WsOptionsFallbackEqualsBaseExceptFiniteAttempts) {
+    // Make the active slot (1) configured with a valid URL + identity so the base impl produces a real result.
+    auto active = make_slot_profile("ws://active.example.com/ocpp", 1, OCPPInterfaceEnum::Any);
+    active.identity = "cp001";
+    write_slot_profile(1, active);
+
+    // Slot 3 is unconfigured -> override delegates to base.
+    const auto via_override = config->get_websocket_connection_options(3);
+    auto via_base = config->ChargePointConfigurationConnectivity::get_websocket_connection_options(3);
+    ASSERT_EQ(via_override.has_value(), via_base.has_value());
+    ASSERT_TRUE(via_override.has_value()) << "base synthesis over a configured active slot must yield options";
+    EXPECT_EQ(via_base->max_connection_attempts, -1) << "precondition: the base still retries forever";
+    EXPECT_EQ(via_override->max_connection_attempts, 3)
+        << "fallback options must use OCPPCommCtrlr/NetworkProfileConnectionAttempts (shipped default 3), not -1";
+    via_base->max_connection_attempts = via_override->max_connection_attempts;
+    expect_ws_options_equal(via_override.value(), via_base.value());
+}
+
+// A ':' in the resolved identity is invalid in the basic-auth user; the options read must yield nullopt so the
+// ConnectivityManager falls back to another profile instead of attempting a doomed connect.
+TEST_F(DeviceModelConnectivityTest, WsOptionsNulloptForIdentityWithColon) {
+    auto profile = make_slot_profile("ws://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0);
+    profile.identity = "cp:001";
+    write_slot_profile(2, profile);
+
+    EXPECT_FALSE(config->get_websocket_connection_options(2).has_value())
+        << "an identity containing ':' must not produce connection options";
+}
+
+// A per-slot URL whose scheme contradicts the slot's security profile (insecure ws:// with a TLS profile) fails
+// Uri::parse_and_validate; the options read must yield nullopt instead of letting the exception escape.
+TEST_F(DeviceModelConnectivityTest, WsOptionsNulloptForSchemeSecurityProfileMismatch) {
+    write_slot_profile(2, make_slot_profile("ws://slot2.example.com/ocpp", 2, OCPPInterfaceEnum::Wireless0));
+
+    EXPECT_FALSE(config->get_websocket_connection_options(2).has_value())
+        << "an insecure ws:// URL with a TLS security profile must not produce connection options";
+}
+
+// ---------------------------------------------------------------------------
+// set_active_network_profile_slot(slot)
+// ---------------------------------------------------------------------------
+
+// Persisting the active slot must redirect the active-slot getters (getCentralSystemURI) to that slot's URL.
+TEST_F(DeviceModelConnectivityTest, SetActiveNetworkProfileSlotPersistsAndRedirectsGetters) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 1, OCPPInterfaceEnum::Wired0));
+    write_slot_profile(2, make_slot_profile("wss://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+
+    config->set_active_network_profile_slot(2, "test");
+
+    // The persisted ActiveNetworkProfile is observable and drives the active-slot getters.
+    EXPECT_EQ(dm->get_value<int>(CC::ActiveNetworkProfile), 2);
+    EXPECT_EQ(config->getCentralSystemURI(), "wss://slot2.example.com/ocpp");
+
+    config->set_active_network_profile_slot(1, "test");
+    EXPECT_EQ(dm->get_value<int>(CC::ActiveNetworkProfile), 1);
+    EXPECT_EQ(config->getCentralSystemURI(), "wss://slot1.example.com/ocpp");
+}
+
+// ---------------------------------------------------------------------------
+// ConnectivityManager smoke test over the adapter
+// ---------------------------------------------------------------------------
+
+// The shared ConnectivityManager, built over the v16 device-model adapter with two configured slots and priority
+// "1,2", must cache both slots with their respective interfaces - proving the adapter feeds the failover machinery.
+TEST_F(DeviceModelConnectivityTest, ConnectivityManagerCachesBothConfiguredSlots) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 1, OCPPInterfaceEnum::Wired0));
+    write_slot_profile(2, make_slot_profile("wss://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+    set_priority("1,2");
+
+    auto evse_security = std::make_shared<NiceMock<ocpp::EvseSecurityMock>>();
+    ocpp::ConnectivityManager cm(*config, evse_security, "");
+
+    const auto slots = cm.get_network_connection_slots();
+    ASSERT_EQ(slots.size(), 2u);
+    EXPECT_EQ(slots.at(0), 1);
+    EXPECT_EQ(slots.at(1), 2);
+
+    const auto p1 = cm.get_network_connection_profile(1);
+    ASSERT_TRUE(p1.has_value());
+    EXPECT_EQ(p1->ocppInterface, OCPPInterfaceEnum::Wired0);
+
+    const auto p2 = cm.get_network_connection_profile(2);
+    ASSERT_TRUE(p2.has_value());
+    EXPECT_EQ(p2->ocppInterface, OCPPInterfaceEnum::Wireless0);
+}
+
+// ---------------------------------------------------------------------------
+// Confirmed security profile (SecurityCtrlr.SecurityProfile)
+// ---------------------------------------------------------------------------
+
+// The ConnectivityManager-facing get_security_profile() must report the confirmed SecurityCtrlr.SecurityProfile
+// cell, not the per-slot value of the (attempt-time persisted) active slot that the OCPP-1.6-key-facing
+// getSecurityProfile() keeps serving.
+TEST_F(DeviceModelConnectivityTest, GetSecurityProfileReadsConfirmedCellNotActiveSlot) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 3, OCPPInterfaceEnum::Wired0));
+    config->set_active_network_profile_slot(1, "test");
+
+    // Shipped component config seeds the confirmed cell with 1.
+    EXPECT_EQ(config->get_security_profile(), 1);
+    EXPECT_EQ(config->getSecurityProfile(), 3) << "the per-slot getter must keep following the active slot";
+
+    config->set_security_ctrl_security_profile(2, "test");
+    EXPECT_EQ(config->get_security_profile(), 2);
+    EXPECT_EQ(config->getSecurityProfile(), 3);
+}
+
+// Both confirmed-profile setters write the SecurityCtrlr cell (as in the 2.x device model) and leave the
+// per-slot NetworkConfiguration value untouched.
+TEST_F(DeviceModelConnectivityTest, SetActiveSecurityProfileWritesSecurityCtrlrCell) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 1, OCPPInterfaceEnum::Wired0));
+
+    config->set_active_security_profile(3, "test");
+
+    EXPECT_EQ(dm->get_value<int>(CC::SecurityProfile), 3);
+    EXPECT_EQ(config->getSecurityProfile(), 1) << "the per-slot value must not change";
+}
+
+// Security profile 0 is legitimate in OCPP 1.6 (and in 2.x with AllowSecurityLevelZeroConnections); the confirmed
+// cell must accept it - pins the SecurityCtrlr.json minLimit relaxation to 0.
+TEST_F(DeviceModelConnectivityTest, SetActiveSecurityProfileAcceptsZero) {
+    config->set_active_security_profile(0, "test");
+
+    EXPECT_EQ(dm->get_value<int>(CC::SecurityProfile), 0);
+    EXPECT_EQ(config->get_security_profile(), 0) << "the getter must surface the confirmed 0, not treat it as unset";
+}
+
+// A stripped component config without SecurityCtrlr.SecurityProfile must read as confirmed profile 0 ("nothing
+// confirmed yet", prunes nothing) instead of throwing into the ConnectivityManager's pre-connect check.
+TEST_F(DeviceModelConnectivityTest, GetSecurityProfileZeroWhenCellAbsent) {
+    ASSERT_TRUE(CC::SecurityProfile.variable.has_value());
+    ASSERT_EQ(dm->clear_value(CC::SecurityProfile.component, CC::SecurityProfile.variable.value(),
+                              AttributeEnum::Actual, "test"),
+              SetVariableStatusEnum::Accepted)
+        << "fixture precondition: clearing SecurityCtrlr.SecurityProfile must succeed";
+
+    EXPECT_EQ(config->get_security_profile(), 0);
+}
+
+// Regression: persisting the active slot at attempt time (what the ConnectivityManager does before connecting)
+// must not prune lower-security-profile slots - only a confirmed connection may raise the prune threshold.
+TEST_F(DeviceModelConnectivityTest, AttemptingSlotDoesNotPruneLowerSecuritySlots) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 1, OCPPInterfaceEnum::Wired0));
+    write_slot_profile(2, make_slot_profile("wss://slot2.example.com/ocpp", 3, OCPPInterfaceEnum::Wireless0));
+    set_priority("1,2");
+
+    auto evse_security = std::make_shared<NiceMock<ocpp::EvseSecurityMock>>();
+    ocpp::ConnectivityManager cm(*config, evse_security, "");
+
+    // Simulate an attempt on the high-SP slot 2: the active slot is persisted, but nothing was confirmed.
+    config->set_active_network_profile_slot(2, "test");
+    cm.check_cache_for_invalid_security_profiles();
+
+    EXPECT_EQ(cm.get_network_connection_slots().size(), 2u)
+        << "an unconfirmed attempt must not prune the lower-security-profile slot";
+}
+
+// A confirmed connection (on_websocket_connected -> set_security_ctrl_security_profile) raises the prune
+// threshold: lower-security-profile slots are removed from the failover cache - upgrades are one-way.
+TEST_F(DeviceModelConnectivityTest, ConfirmedConnectionRaisesCellAndPrunesLowerSlots) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 3, OCPPInterfaceEnum::Wired0));
+    write_slot_profile(2, make_slot_profile("wss://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+    set_priority("1,2");
+
+    auto evse_security = std::make_shared<NiceMock<ocpp::EvseSecurityMock>>();
+    ocpp::ConnectivityManager cm(*config, evse_security, "");
+
+    config->set_security_ctrl_security_profile(3, "test"); // what a successful SP-3 connect writes
+    cm.check_cache_for_invalid_security_profiles();
+
+    const auto slots = cm.get_network_connection_slots();
+    ASSERT_EQ(slots.size(), 1u);
+    EXPECT_EQ(slots.at(0), 1);
+    EXPECT_FALSE(cm.get_network_connection_profile(2).has_value());
+
+    // Lowering the confirmed cell afterwards must not resurrect the pruned slot: the cache only ever shrinks
+    // until a rebuild (reload_network_profiles) re-reads the priority string.
+    config->set_active_security_profile(1, "test");
+    cm.check_cache_for_invalid_security_profiles();
+
+    const auto slots_after_downgrade = cm.get_network_connection_slots();
+    ASSERT_EQ(slots_after_downgrade.size(), 1u) << "lowering the confirmed profile must not resurrect pruned slots";
+    EXPECT_EQ(slots_after_downgrade.at(0), 1);
+    EXPECT_FALSE(cm.get_network_connection_profile(2).has_value());
+}
+
+// A cache rebuild resurrects every slot listed in the priority string; the next check must re-prune against the
+// confirmed profile instead of early-returning on an unchanged level - otherwise a reload would reopen a
+// security downgrade window.
+TEST_F(DeviceModelConnectivityTest, ReloadDoesNotResurrectPrunedLowerSlots) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 3, OCPPInterfaceEnum::Wired0));
+    write_slot_profile(2, make_slot_profile("wss://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+    set_priority("1,2");
+
+    auto evse_security = std::make_shared<NiceMock<ocpp::EvseSecurityMock>>();
+    ocpp::ConnectivityManager cm(*config, evse_security, "");
+
+    config->set_security_ctrl_security_profile(3, "test");
+    cm.check_cache_for_invalid_security_profiles();
+    ASSERT_EQ(cm.get_network_connection_slots().size(), 1u);
+
+    // The rebuild restores both slots from the priority string; the check that runs before every connect attempt
+    // must then re-prune.
+    cm.reload_network_profiles();
+    cm.check_cache_for_invalid_security_profiles();
+
+    const auto slots = cm.get_network_connection_slots();
+    ASSERT_EQ(slots.size(), 1u) << "the confirmed-SP threshold must be re-applied after a cache rebuild";
+    EXPECT_EQ(slots.at(0), 1);
+}
+
+// A reload must keep naming the same active slot when the priority list is reordered or extended - keeping the
+// raw index would silently point at a different slot (wrong security-profile confirms and slot reporting).
+TEST_F(DeviceModelConnectivityTest, ReloadRemapsActivePriorityToSameSlot) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 1, OCPPInterfaceEnum::Wired0));
+    write_slot_profile(2, make_slot_profile("wss://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+    set_priority("1,2");
+
+    auto evse_security = std::make_shared<NiceMock<ocpp::EvseSecurityMock>>();
+    ocpp::ConnectivityManager cm(*config, evse_security, "");
+    ASSERT_EQ(cm.get_active_network_configuration_slot(), 1);
+
+    // Prepending slot 2 shifts slot 1 to index 1; the reload must follow the slot, not the index.
+    set_priority("2,1");
+    cm.reload_network_profiles();
+    EXPECT_EQ(cm.get_active_network_configuration_slot(), 1);
+}
+
+// The slot-pinned setter must write the named slot's SecurityProfile even when another slot is active - the
+// security-profile switch captures the slot at switch time so a late revert cannot clobber a failover slot.
+TEST_F(DeviceModelConnectivityTest, SetSecurityProfileForSlotWritesNamedSlotNotActive) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 1, OCPPInterfaceEnum::Wired0));
+    write_slot_profile(2, make_slot_profile("wss://slot2.example.com/ocpp", 3, OCPPInterfaceEnum::Wireless0));
+    config->set_active_network_profile_slot(2, "test");
+
+    config->set_security_profile_for_slot(1, 2);
+
+    EXPECT_EQ(dm->get_value<int>(NC::get_component_variable(1, NC::SecurityProfile)), 2)
+        << "the named slot must be written";
+    EXPECT_EQ(dm->get_value<int>(NC::get_component_variable(2, NC::SecurityProfile)), 3)
+        << "the active slot must stay untouched";
+}
+
+// Missing device-model cells in the legacy synthesis must yield nullopt instead of an exception escaping into
+// the ConnectivityManager's profile caching (which runs at construction and on reload without a try/catch).
+// Reachable e.g. when the active slot names a NetworkConfiguration component that does not exist.
+TEST_F(DeviceModelConnectivityTest, ReadProfileSynthesisForMissingComponentYieldsNulloptNotThrow) {
+    config->set_active_network_profile_slot(7, "test"); // no NetworkConfiguration(7) component exists
+
+    std::optional<ocpp::v2::NetworkConnectionProfile> result;
+    EXPECT_NO_THROW(result = config->read_network_connection_profile(7));
+    EXPECT_FALSE(result.has_value());
+}
+
+// ---------------------------------------------------------------------------
+// ocpp16 component-config patcher: NetworkConfiguration[slot].OcppInterface pinning
+// ---------------------------------------------------------------------------
+
+const std::string STANDARD_CONFIGS_PATH = "./resources/example_config/v2/component_config";
+
+// Locate the Actual-attribute value of NetworkConfiguration[slot].OcppInterface in a component-config map.
+std::optional<std::string>
+read_nc_interface(std::map<ocpp::v2::ComponentKey, std::vector<ocpp::v2::DeviceModelVariable>>& configs, int slot) {
+    for (auto& [key, vars] : configs) {
+        if (key.name != "NetworkConfiguration" || !key.instance.has_value() ||
+            key.instance.value() != std::to_string(slot)) {
+            continue;
+        }
+        for (auto& var : vars) {
+            if (var.name != "OcppInterface") {
+                continue;
+            }
+            for (auto& attr : var.attributes) {
+                if (attr.variable_attribute.type == AttributeEnum::Actual) {
+                    if (attr.variable_attribute.value.has_value()) {
+                        return attr.variable_attribute.value->get();
+                    }
+                    return std::nullopt;
+                }
+            }
+        }
+    }
+    return std::nullopt;
+}
+
+// Force an explicit Actual-attribute value onto NetworkConfiguration[slot].OcppInterface, mimicking an integrator
+// who set the interface explicitly in their component config.
+void set_nc_interface(std::map<ocpp::v2::ComponentKey, std::vector<ocpp::v2::DeviceModelVariable>>& configs, int slot,
+                      const std::string& value) {
+    for (auto& [key, vars] : configs) {
+        if (key.name != "NetworkConfiguration" || !key.instance.has_value() ||
+            key.instance.value() != std::to_string(slot)) {
+            continue;
+        }
+        for (auto& var : vars) {
+            if (var.name != "OcppInterface") {
+                continue;
+            }
+            for (auto& attr : var.attributes) {
+                if (attr.variable_attribute.type == AttributeEnum::Actual) {
+                    attr.variable_attribute.value = value;
+                    return;
+                }
+            }
+        }
+    }
+    FAIL() << "NetworkConfiguration[" << slot << "].OcppInterface Actual attribute not found";
+}
+
+// The migration pins NetworkConfiguration[slot].OcppInterface to "Any": legacy 1.6 configs have no interface notion,
+// and pinning "Any" keeps post-migration behavior identical to the pre-device-model single-profile synthesis. The
+// shipped config's "Wired0" default lives in the default value and does not block the pin.
+TEST(DeviceModelConnectivityPatcher, MigrationPinsOcppInterfaceToAny) {
+    const auto ocpp16_config = std::make_unique<ocpp::v16::ChargePointConfiguration>(
+        ocpp::tests::make_ocpp16_test_config_full(), CONFIG_DIR_V16, USER_CONFIG_FILE_LOCATION_V16);
+
+    auto component_configs = ocpp::v2::get_all_component_configs(STANDARD_CONFIGS_PATH);
+    ocpp::v2::patch_component_config_with_ocpp16(component_configs, *ocpp16_config, {}, /*network_config_slot=*/1);
+
+    EXPECT_EQ(read_nc_interface(component_configs, 1), std::optional<std::string>("Any"));
+}
+
+// An explicit attribute value set by the integrator wins: the pin uses allow_override=false, so a
+// NetworkConfiguration[slot].OcppInterface that already carries an Actual value is left untouched.
+TEST(DeviceModelConnectivityPatcher, MigrationKeepsExplicitOcppInterface) {
+    const auto ocpp16_config = std::make_unique<ocpp::v16::ChargePointConfiguration>(
+        ocpp::tests::make_ocpp16_test_config_full(), CONFIG_DIR_V16, USER_CONFIG_FILE_LOCATION_V16);
+
+    auto component_configs = ocpp::v2::get_all_component_configs(STANDARD_CONFIGS_PATH);
+    set_nc_interface(component_configs, 1, "Wireless0");
+
+    ocpp::v2::patch_component_config_with_ocpp16(component_configs, *ocpp16_config, {}, /*network_config_slot=*/1);
+
+    EXPECT_EQ(read_nc_interface(component_configs, 1), std::optional<std::string>("Wireless0"))
+        << "An explicit OcppInterface value must survive the migration pin";
+}
+
+// Locate a variable in a component-config map (component name + optional instance + variable name).
+ocpp::v2::DeviceModelVariable*
+find_config_variable(std::map<ocpp::v2::ComponentKey, std::vector<ocpp::v2::DeviceModelVariable>>& configs,
+                     const std::string& component_name, const std::optional<std::string>& component_instance,
+                     const std::string& variable_name) {
+    for (auto& [key, vars] : configs) {
+        if (key.name != component_name || key.instance != component_instance) {
+            continue;
+        }
+        for (auto& var : vars) {
+            if (var.name == variable_name) {
+                return &var;
+            }
+        }
+    }
+    return nullptr;
+}
+
+// Read a variable's Actual-attribute value from a component-config map.
+std::optional<std::string>
+read_config_value(std::map<ocpp::v2::ComponentKey, std::vector<ocpp::v2::DeviceModelVariable>>& configs,
+                  const std::string& component_name, const std::optional<std::string>& component_instance,
+                  const std::string& variable_name) {
+    const auto* var = find_config_variable(configs, component_name, component_instance, variable_name);
+    if (var == nullptr) {
+        return std::nullopt;
+    }
+    for (const auto& attr : var->attributes) {
+        if (attr.variable_attribute.type == AttributeEnum::Actual && attr.variable_attribute.value.has_value()) {
+            return attr.variable_attribute.value->get();
+        }
+    }
+    return std::nullopt;
+}
+
+// The migration stamps the confirmed security profile (SecurityCtrlr.SecurityProfile) from the legacy config -
+// overriding the shipped component-config value - so migrated installs prune slots against the profile that was
+// actually in use.
+TEST(DeviceModelConnectivityPatcher, MigrationStampsConfirmedSecurityProfile) {
+    auto config_json = nlohmann::json::parse(ocpp::tests::make_ocpp16_test_config_full());
+    config_json["Security"]["SecurityProfile"] = 2; // differs from the shipped component-config value (1)
+    const auto ocpp16_config = std::make_unique<ocpp::v16::ChargePointConfiguration>(config_json.dump(), CONFIG_DIR_V16,
+                                                                                     USER_CONFIG_FILE_LOCATION_V16);
+
+    auto component_configs = ocpp::v2::get_all_component_configs(STANDARD_CONFIGS_PATH);
+    ocpp::v2::patch_component_config_with_ocpp16(component_configs, *ocpp16_config, {}, /*network_config_slot=*/1);
+
+    EXPECT_EQ(read_config_value(component_configs, "SecurityCtrlr", std::nullopt, "SecurityProfile"),
+              std::optional<std::string>("2"))
+        << "the legacy SecurityProfile must override the shipped component-config value";
+}
+
+// The migration never modifies NetworkConfigurationPriority or its valuesList: reaching the migrated slot
+// through the priority is the integrator's component-config responsibility (a mismatch is only warned about).
+// Migrating to slot 2 must still write the slot's values and seed ActiveNetworkProfile.
+TEST(DeviceModelConnectivityPatcher, MigrationDoesNotTouchPriorityOrValuesList) {
+    const auto ocpp16_config = std::make_unique<ocpp::v16::ChargePointConfiguration>(
+        ocpp::tests::make_ocpp16_test_config_full(), CONFIG_DIR_V16, USER_CONFIG_FILE_LOCATION_V16);
+
+    auto component_configs = ocpp::v2::get_all_component_configs(STANDARD_CONFIGS_PATH);
+    const auto* priority_before =
+        find_config_variable(component_configs, "OCPPCommCtrlr", std::nullopt, "NetworkConfigurationPriority");
+    ASSERT_NE(priority_before, nullptr);
+    const auto values_list_before = priority_before->characteristics.valuesList;
+
+    ocpp::v2::patch_component_config_with_ocpp16(component_configs, *ocpp16_config, {}, /*network_config_slot=*/2);
+
+    EXPECT_EQ(read_config_value(component_configs, "OCPPCommCtrlr", std::nullopt, "NetworkConfigurationPriority"),
+              std::optional<std::string>("1"))
+        << "the migration must not rewrite the priority, even when the migrated slot is not listed";
+    const auto* priority =
+        find_config_variable(component_configs, "OCPPCommCtrlr", std::nullopt, "NetworkConfigurationPriority");
+    ASSERT_NE(priority, nullptr);
+    EXPECT_EQ(priority->characteristics.valuesList, values_list_before)
+        << "the migration must not extend the priority's valuesList";
+
+    EXPECT_TRUE(read_config_value(component_configs, "NetworkConfiguration", "2", "OcppCsmsUrl").has_value())
+        << "the legacy connection settings must still be migrated into the configured slot";
+}
+
+// The migration seeds ActiveNetworkProfile with the migrated slot so the OCPP 1.6 key surface targets it
+// already before the first successful connect.
+TEST(DeviceModelConnectivityPatcher, MigrationSeedsActiveNetworkProfile) {
+    const auto ocpp16_config = std::make_unique<ocpp::v16::ChargePointConfiguration>(
+        ocpp::tests::make_ocpp16_test_config_full(), CONFIG_DIR_V16, USER_CONFIG_FILE_LOCATION_V16);
+
+    auto component_configs = ocpp::v2::get_all_component_configs(STANDARD_CONFIGS_PATH);
+    ocpp::v2::patch_component_config_with_ocpp16(component_configs, *ocpp16_config, {}, /*network_config_slot=*/2);
+
+    EXPECT_EQ(read_config_value(component_configs, "OCPPCommCtrlr", std::nullopt, "ActiveNetworkProfile"),
+              std::optional<std::string>("2"));
+}
+
+// A slot without a NetworkConfiguration_<N> component config is never synthesized: the network connection
+// migration is skipped with an error log, and the rest of the migration is unaffected.
+TEST(DeviceModelConnectivityPatcher, MigrationSkipsSlotWithoutComponentConfig) {
+    const auto ocpp16_config = std::make_unique<ocpp::v16::ChargePointConfiguration>(
+        ocpp::tests::make_ocpp16_test_config_full(), CONFIG_DIR_V16, USER_CONFIG_FILE_LOCATION_V16);
+
+    auto component_configs = ocpp::v2::get_all_component_configs(STANDARD_CONFIGS_PATH);
+    ocpp::v2::patch_component_config_with_ocpp16(component_configs, *ocpp16_config, {}, /*network_config_slot=*/3);
+
+    ocpp::v2::ComponentKey nc3_key;
+    nc3_key.name = "NetworkConfiguration";
+    nc3_key.instance = "3";
+    EXPECT_EQ(component_configs.find(nc3_key), component_configs.end())
+        << "no NetworkConfiguration[3] component may be synthesized";
+    EXPECT_EQ(read_config_value(component_configs, "OCPPCommCtrlr", std::nullopt, "NetworkConfigurationPriority"),
+              std::optional<std::string>("1"));
+    EXPECT_NE(read_config_value(component_configs, "OCPPCommCtrlr", std::nullopt, "ActiveNetworkProfile"),
+              std::optional<std::string>("3"))
+        << "ActiveNetworkProfile must not point at a skipped slot";
+    // The non-network migration still ran.
+    EXPECT_EQ(read_config_value(component_configs, "SecurityCtrlr", std::nullopt, "SecurityProfile"),
+              std::optional<std::string>(std::to_string(ocpp16_config->getSecurityProfile())));
+}
+
+} // namespace
+} // namespace v16
+} // namespace ocpp

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/test_devicemodel_connectivity.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/test_devicemodel_connectivity.cpp
@@ -1,0 +1,907 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+/// \file test_devicemodel_connectivity.cpp
+/// \brief Unit tests for the device-model-backed v16 connectivity overrides on
+/// ocpp::v16::ChargePointConfigurationDeviceModel.
+///
+/// Unlike the JSON backend (single slot-1 profile, hardcoded ocppInterface Any, slot-ignoring websocket options),
+/// the device-model adapter sources per-slot connection details from the v2 device-model NetworkConfiguration[N]
+/// components; the same data 2.x uses.
+/// These tests exercise the four overrides against a real sqlite-backed ocpp::v2::DeviceModel seeded with the shipped
+/// example component config (which carries NetworkConfiguration_1 / _2 slots):
+///   * get_network_configuration_priority() - DM CSL, 2.x-version filtering, empty->active-slot fallback,
+///   * read_network_connection_profile(slot) - configured slot, legacy-synthesis fallback, version filter, nullopt,
+///   * get_websocket_connection_options(slot) - per-slot fields + identity/password fallbacks + base equivalence,
+///   * set_active_network_profile_slot(slot) - persistence + getter redirection,
+///   * a ConnectivityManager smoke test built over the adapter, and
+///   * the ocpp16 component-config patcher pinning NetworkConfiguration[slot].OcppInterface to "Any".
+
+#include <chrono>
+#include <filesystem>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include <ocpp/common/connectivity_manager.hpp>
+#include <ocpp/common/websocket/websocket_uri.hpp>
+#include <ocpp/v16/charge_point_configuration.hpp>
+#include <ocpp/v16/charge_point_configuration_devicemodel.hpp>
+#include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v2/device_model.hpp>
+#include <ocpp/v2/device_model_interface.hpp>
+#include <ocpp/v2/init_device_model_db.hpp>
+#include <ocpp/v2/ocpp16_component_config_patcher.hpp>
+#include <ocpp/v2/ocpp_enums.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
+
+#include "evse_security_mock.hpp"
+#include "ocpp16_test_config.hpp"
+#include "v2/device_model_test_helper.hpp"
+
+using ::testing::NiceMock;
+
+namespace ocpp {
+namespace v16 {
+namespace {
+
+namespace NC = ocpp::v2::NetworkConfigurationComponentVariables;
+namespace CC = ocpp::v2::ControllerComponentVariables;
+
+using ocpp::v2::AttributeEnum;
+using ocpp::v2::OCPPInterfaceEnum;
+using ocpp::v2::OCPPTransportEnum;
+using ocpp::v2::SetVariableStatusEnum;
+
+/// \brief Non-owning forwarding proxy for a v2::DeviceModelInterface. The ChargePointConfigurationDeviceModel
+/// constructor takes ownership of a unique_ptr<DeviceModelInterface>, but the tests need to keep a raw handle to
+/// the underlying DeviceModel to seed per-slot NetworkConfiguration values. The proxy is handed to the config
+/// (single owner) while the test retains the real DeviceModel* owned by DeviceModelTestHelper.
+class DeviceModelProxy : public ocpp::v2::DeviceModelInterface {
+public:
+    using VariableAttribute = ocpp::v2::VariableAttribute;
+    using Component = ocpp::v2::Component;
+    using ComponentVariable = ocpp::v2::ComponentVariable;
+    using ComponentCriterionEnum = ocpp::v2::ComponentCriterionEnum;
+    using Variable = ocpp::v2::Variable;
+    using GetVariableStatusEnum = ocpp::v2::GetVariableStatusEnum;
+    using VariableMonitoringMeta = ocpp::v2::VariableMonitoringMeta;
+    using SetMonitoringData = ocpp::v2::SetMonitoringData;
+    using SetMonitoringResult = ocpp::v2::SetMonitoringResult;
+    using VariableMonitorType = ocpp::v2::VariableMonitorType;
+    using VariableMonitoringPeriodic = ocpp::v2::VariableMonitoringPeriodic;
+    using MonitoringCriterionEnum = ocpp::v2::MonitoringCriterionEnum;
+    using MonitoringData = ocpp::v2::MonitoringData;
+    using ClearMonitoringResult = ocpp::v2::ClearMonitoringResult;
+    using MutabilityEnum = ocpp::v2::MutabilityEnum;
+    using VariableCharacteristics = ocpp::v2::VariableCharacteristics;
+    using VariableMetaData = ocpp::v2::VariableMetaData;
+    using ReportData = ocpp::v2::ReportData;
+    using ReportBaseEnum = ocpp::v2::ReportBaseEnum;
+
+    explicit DeviceModelProxy(ocpp::v2::DeviceModelInterface& storage) : storage(storage) {
+    }
+
+    GetVariableStatusEnum get_variable(const Component& component_id, const Variable& variable_id,
+                                       const AttributeEnum& attribute_enum, std::string& value,
+                                       bool allow_write_only) const override {
+        return storage.get_variable(component_id, variable_id, attribute_enum, value, allow_write_only);
+    }
+
+    SetVariableStatusEnum set_value(const Component& component_id, const Variable& variable_id,
+                                    const AttributeEnum& attribute_enum, const std::string& value,
+                                    const std::string& source, bool allow_read_only) override {
+        return storage.set_value(component_id, variable_id, attribute_enum, value, source, allow_read_only);
+    }
+
+    SetVariableStatusEnum set_read_only_value(const Component& component_id, const Variable& variable_id,
+                                              const AttributeEnum& attribute_enum, const std::string& value,
+                                              const std::string& source) override {
+        return storage.set_read_only_value(component_id, variable_id, attribute_enum, value, source);
+    }
+
+    SetVariableStatusEnum clear_value(const Component& component_id, const Variable& variable_id,
+                                      const AttributeEnum& attribute_enum, const std::string& source) override {
+        return storage.clear_value(component_id, variable_id, attribute_enum, source);
+    }
+
+    std::optional<MutabilityEnum> get_mutability(const Component& component_id, const Variable& variable_id,
+                                                 const AttributeEnum& attribute_enum) override {
+        return storage.get_mutability(component_id, variable_id, attribute_enum);
+    }
+
+    std::optional<VariableMetaData> get_variable_meta_data(const Component& component_id,
+                                                           const Variable& variable_id) override {
+        return storage.get_variable_meta_data(component_id, variable_id);
+    }
+
+    std::vector<ReportData> get_base_report_data(const ReportBaseEnum& report_base) override {
+        return storage.get_base_report_data(report_base);
+    }
+
+    std::vector<ReportData>
+    get_custom_report_data(const std::optional<std::vector<ComponentVariable>>& component_variables,
+                           const std::optional<std::vector<ComponentCriterionEnum>>& component_criteria) override {
+        return storage.get_custom_report_data(component_variables, component_criteria);
+    }
+
+    std::vector<SetMonitoringResult>
+    set_monitors(const std::vector<SetMonitoringData>& requests,
+                 const VariableMonitorType type = VariableMonitorType::CustomMonitor) override {
+        return storage.set_monitors(requests, type);
+    }
+
+    bool update_monitor_reference(std::int32_t monitor_id, const std::string& reference_value) override {
+        return storage.update_monitor_reference(monitor_id, reference_value);
+    }
+
+    std::vector<VariableMonitoringPeriodic> get_periodic_monitors() override {
+        return storage.get_periodic_monitors();
+    }
+
+    std::vector<MonitoringData> get_monitors(const std::vector<MonitoringCriterionEnum>& criteria,
+                                             const std::vector<ComponentVariable>& component_variables) override {
+        return storage.get_monitors(criteria, component_variables);
+    }
+
+    std::vector<ClearMonitoringResult> clear_monitors(const std::vector<int>& request_ids,
+                                                      bool allow_protected) override {
+        return storage.clear_monitors(request_ids, allow_protected);
+    }
+
+    std::int32_t clear_custom_monitors() override {
+        return storage.clear_custom_monitors();
+    }
+
+    void register_variable_listener(
+        std::function<void(const std::unordered_map<std::int64_t, VariableMonitoringMeta>& monitors,
+                           const Component& component, const Variable& variable,
+                           const VariableCharacteristics& characteristics, const VariableAttribute& attribute,
+                           const std::string& value_previous, const std::string& value_current)>&& listener) override {
+        return storage.register_variable_listener(std::move(listener));
+    }
+
+    void register_monitor_listener(
+        std::function<void(const VariableMonitoringMeta& updated_monitor, const Component& component,
+                           const Variable& variable, const VariableCharacteristics& characteristics,
+                           const VariableAttribute& attribute, const std::string& current_value)>&& listener) override {
+        return storage.register_monitor_listener(std::move(listener));
+    }
+
+    void check_integrity(const std::map<std::int32_t, std::int32_t>& evse_connector_structure) override {
+        return storage.check_integrity(evse_connector_structure);
+    }
+
+private:
+    ocpp::v2::DeviceModelInterface& storage;
+};
+
+/// \brief Build a fully-specified NetworkConnectionProfile for a slot (URL + security profile + interface).
+ocpp::v2::NetworkConnectionProfile make_slot_profile(const std::string& url, int security_profile,
+                                                     OCPPInterfaceEnum iface) {
+    ocpp::v2::NetworkConnectionProfile p;
+    p.ocppCsmsUrl = url;
+    p.securityProfile = security_profile;
+    p.ocppInterface = iface;
+    p.ocppTransport = OCPPTransportEnum::JSON;
+    p.messageTimeout = 30;
+    return p;
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: real in-memory sqlite v2 DeviceModel over the shipped example
+// component config (InternalCtrlr, OCPPCommCtrlr, SecurityCtrlr,
+// NetworkConfiguration_1 / _2). The ChargePointConfigurationDeviceModel under
+// test owns a forwarding proxy; the fixture keeps the raw DeviceModel* to seed
+// per-slot values.
+// ---------------------------------------------------------------------------
+class DeviceModelConnectivityTest : public ::testing::Test {
+protected:
+    ocpp::v2::DeviceModelTestHelper dm_helper;
+    ocpp::v2::DeviceModel* dm{nullptr};
+    std::unique_ptr<ChargePointConfigurationDeviceModel> config;
+
+    DeviceModelConnectivityTest() : dm_helper() {
+        dm = dm_helper.get_device_model();
+        config = std::make_unique<ChargePointConfigurationDeviceModel>(CONFIG_DIR_V16,
+                                                                       std::make_unique<DeviceModelProxy>(*dm));
+    }
+
+    void write_slot_profile(int slot, const ocpp::v2::NetworkConnectionProfile& profile) {
+        ASSERT_TRUE(NC::write_profile_to_device_model(*dm, slot, profile, "test"))
+            << "seeding NetworkConfiguration[" << slot << "] failed";
+    }
+
+    void set_priority(const std::string& csl) {
+        ASSERT_TRUE(CC::NetworkConfigurationPriority.variable.has_value());
+        ASSERT_EQ(dm->set_value(CC::NetworkConfigurationPriority.component,
+                                CC::NetworkConfigurationPriority.variable.value(), AttributeEnum::Actual, csl, "test"),
+                  SetVariableStatusEnum::Accepted)
+            << "setting NetworkConfigurationPriority to '" << csl << "' was rejected";
+    }
+
+    void set_slot_ocpp_version(int slot, const std::string& version) {
+        ASSERT_EQ(dm->set_value(NC::get_component_variable(slot, NC::OcppVersion).component,
+                                NC::get_component_variable(slot, NC::OcppVersion).variable.value(),
+                                AttributeEnum::Actual, version, "test"),
+                  SetVariableStatusEnum::Accepted)
+            << "setting NetworkConfiguration[" << slot << "].OcppVersion to '" << version << "' was rejected";
+    }
+
+    void set_slot_identity(int slot, const std::string& identity) {
+        ASSERT_EQ(dm->set_value(NC::get_component_variable(slot, NC::Identity).component,
+                                NC::get_component_variable(slot, NC::Identity).variable.value(), AttributeEnum::Actual,
+                                identity, "test"),
+                  SetVariableStatusEnum::Accepted);
+    }
+
+    void set_slot_hostname(int slot, const std::string& hostname) {
+        const auto cv = NC::get_component_variable(slot, ocpp::v2::Variable{"HostName"});
+        ASSERT_TRUE(cv.variable.has_value());
+        // HostName is ReadOnly in the component config; seed it the way write_profile_to_device_model writes
+        // profile fields (forced set_value).
+        ASSERT_EQ(dm->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, hostname, "test", true),
+                  SetVariableStatusEnum::Accepted);
+    }
+};
+
+// Compare two WebsocketConnectionOptions field-by-field. Uri::string() is non-const, so parameters are taken by
+// value.
+void expect_ws_options_equal(WebsocketConnectionOptions a, WebsocketConnectionOptions b) {
+    EXPECT_EQ(a.ocpp_versions, b.ocpp_versions);
+    EXPECT_EQ(a.csms_uri.string(), b.csms_uri.string());
+    EXPECT_EQ(a.security_profile, b.security_profile);
+    EXPECT_EQ(a.authorization_key, b.authorization_key);
+    EXPECT_EQ(a.message_timeout, b.message_timeout);
+    EXPECT_EQ(a.retry_backoff_random_range_s, b.retry_backoff_random_range_s);
+    EXPECT_EQ(a.retry_backoff_repeat_times, b.retry_backoff_repeat_times);
+    EXPECT_EQ(a.retry_backoff_wait_minimum_s, b.retry_backoff_wait_minimum_s);
+    EXPECT_EQ(a.max_connection_attempts, b.max_connection_attempts);
+    EXPECT_EQ(a.supported_ciphers_12, b.supported_ciphers_12);
+    EXPECT_EQ(a.supported_ciphers_13, b.supported_ciphers_13);
+    EXPECT_EQ(a.ping_interval_s, b.ping_interval_s);
+    EXPECT_EQ(a.ping_payload, b.ping_payload);
+    EXPECT_EQ(a.pong_timeout_s, b.pong_timeout_s);
+    EXPECT_EQ(a.use_ssl_default_verify_paths, b.use_ssl_default_verify_paths);
+    EXPECT_EQ(a.additional_root_certificate_check, b.additional_root_certificate_check);
+    EXPECT_EQ(a.hostName, b.hostName);
+    EXPECT_EQ(a.verify_csms_common_name, b.verify_csms_common_name);
+    EXPECT_EQ(a.use_tpm_tls, b.use_tpm_tls);
+    EXPECT_EQ(a.verify_csms_allow_wildcards, b.verify_csms_allow_wildcards);
+    EXPECT_EQ(a.iface, b.iface);
+    EXPECT_EQ(a.enable_tls_keylog, b.enable_tls_keylog);
+    EXPECT_EQ(a.keylog_file, b.keylog_file);
+    EXPECT_EQ(a.everest_version, b.everest_version);
+}
+
+// ---------------------------------------------------------------------------
+// get_network_configuration_priority()
+// ---------------------------------------------------------------------------
+
+// An empty NetworkConfigurationPriority yields no usable slots, so the priority falls back to the active slot as a
+// single-element list.
+TEST_F(DeviceModelConnectivityTest, PriorityDefaultsToActiveSlotWhenDmEmpty) {
+    config->set_active_network_profile_slot(2, "test");
+    set_priority("");
+
+    EXPECT_EQ(config->get_network_configuration_priority(), "2");
+}
+
+// The device-model CSL is exposed verbatim when every listed slot is usable for OCPP 1.6 (OcppVersion unset).
+TEST_F(DeviceModelConnectivityTest, PriorityExposesDeviceModelCsl) {
+    set_priority("1,2");
+
+    EXPECT_EQ(config->get_network_configuration_priority(), "1,2");
+}
+
+// Slots pinned to a 2.x-only OcppVersion are filtered out of the priority list; when all listed slots are filtered
+// the result falls back to the active slot.
+TEST_F(DeviceModelConnectivityTest, PriorityFiltersTwoXOnlySlots) {
+    // Slot 2 is pinned to a 2.x-only version and must be dropped, leaving slot 1.
+    set_priority("1,2");
+    set_slot_ocpp_version(2, "OCPP201");
+    EXPECT_EQ(config->get_network_configuration_priority(), "1");
+
+    // All listed slots filtered -> fall back to the active slot (1).
+    config->set_active_network_profile_slot(1, "test");
+    set_priority("2");
+    EXPECT_EQ(config->get_network_configuration_priority(), "1");
+}
+
+// ---------------------------------------------------------------------------
+// read_network_connection_profile(slot)
+// ---------------------------------------------------------------------------
+
+// An unconfigured ACTIVE slot (default slot 1 has an empty OcppCsmsUrl) falls back to the legacy single-profile
+// synthesis: byte-equivalent to the base ChargePointConfigurationConnectivity behavior (Any / JSON / 10 s + global
+// URL/identity/password getters).
+TEST_F(DeviceModelConnectivityTest, ReadProfileFallsBackToLegacySynthesisWhenUnconfigured) {
+    // Active slot defaults to 1; do not seed slot 1 so read_profile_from_device_model returns nullopt.
+    const auto fallback = config->read_network_connection_profile(1);
+    ASSERT_TRUE(fallback.has_value()) << "Unconfigured active slot must fall back to legacy synthesis";
+
+    // Constant parts of the legacy synthesis.
+    EXPECT_EQ(fallback->ocppInterface, OCPPInterfaceEnum::Any);
+    EXPECT_EQ(fallback->ocppTransport, OCPPTransportEnum::JSON);
+    EXPECT_EQ(fallback->messageTimeout, 10);
+
+    // Byte-equivalence with the global getters.
+    EXPECT_EQ(fallback->ocppCsmsUrl.get(), config->getCentralSystemURI());
+    EXPECT_EQ(fallback->securityProfile, config->getSecurityProfile());
+    if (const auto id = config->getChargePointId(); !id.empty()) {
+        ASSERT_TRUE(fallback->identity.has_value());
+        EXPECT_EQ(fallback->identity->get(), id);
+    }
+
+    // The override result must be identical to the base-class synthesis, field for field.
+    const auto base = config->ChargePointConfigurationConnectivity::read_network_connection_profile(1);
+    ASSERT_TRUE(base.has_value());
+    EXPECT_EQ(fallback->ocppCsmsUrl.get(), base->ocppCsmsUrl.get());
+    EXPECT_EQ(fallback->securityProfile, base->securityProfile);
+    EXPECT_EQ(fallback->ocppInterface, base->ocppInterface);
+    EXPECT_EQ(fallback->ocppTransport, base->ocppTransport);
+    EXPECT_EQ(fallback->messageTimeout, base->messageTimeout);
+    EXPECT_EQ(fallback->identity.has_value(), base->identity.has_value());
+    if (fallback->identity.has_value() && base->identity.has_value()) {
+        EXPECT_EQ(fallback->identity->get(), base->identity->get());
+    }
+    EXPECT_EQ(fallback->basicAuthPassword.has_value(), base->basicAuthPassword.has_value());
+    if (fallback->basicAuthPassword.has_value() && base->basicAuthPassword.has_value()) {
+        EXPECT_EQ(fallback->basicAuthPassword->get(), base->basicAuthPassword->get());
+    }
+}
+
+// A configured (non-active) slot is returned verbatim, including the interface selection and APN sub-fields.
+TEST_F(DeviceModelConnectivityTest, ReadProfileReturnsConfiguredSlot) {
+    auto profile = make_slot_profile("wss://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0);
+    ocpp::v2::APN apn;
+    apn.apn = "internet";
+    apn.apnAuthentication = ocpp::v2::APNAuthenticationEnum::AUTO;
+    apn.apnUserName = "user";
+    apn.apnPassword = "pass";
+    profile.apn = apn;
+    write_slot_profile(2, profile);
+
+    const auto result = config->read_network_connection_profile(2);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->ocppCsmsUrl.get(), "wss://slot2.example.com/ocpp");
+    EXPECT_EQ(result->ocppInterface, OCPPInterfaceEnum::Wireless0);
+    ASSERT_TRUE(result->apn.has_value());
+    EXPECT_EQ(result->apn->apn, "internet");
+    EXPECT_EQ(result->apn->apnUserName, "user");
+    EXPECT_EQ(result->apn->apnPassword, "pass");
+}
+
+// A configured slot pinned to a 2.x-only OcppVersion is filtered out and reads as nullopt.
+TEST_F(DeviceModelConnectivityTest, ReadProfileFiltersOcppVersion) {
+    write_slot_profile(2, make_slot_profile("wss://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+    set_slot_ocpp_version(2, "OCPP201");
+
+    EXPECT_FALSE(config->read_network_connection_profile(2).has_value())
+        << "A 2.x-pinned slot must not be usable for OCPP 1.6";
+}
+
+// Regression: a 2.x-only OcppVersion pin on the active slot must not dead-end the charge point; the read falls
+// back to the legacy synthesis rather than returning nullopt.
+TEST_F(DeviceModelConnectivityTest, ReadProfilePinnedActiveSlotFallsBackToLegacySynthesis) {
+    write_slot_profile(1, make_slot_profile("wss://active.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+    config->set_active_network_profile_slot(1, "test");
+    set_slot_ocpp_version(1, "OCPP201");
+
+    const auto result = config->read_network_connection_profile(1);
+    ASSERT_TRUE(result.has_value()) << "Pinned active slot must fall back to legacy synthesis, not dead-end";
+
+    // Synthesis (Any / JSON / 10 s), not the stored per-slot profile (which was Wireless0).
+    EXPECT_EQ(result->ocppInterface, OCPPInterfaceEnum::Any);
+    EXPECT_EQ(result->ocppTransport, OCPPTransportEnum::JSON);
+    EXPECT_EQ(result->messageTimeout, 10);
+
+    const auto base = config->ChargePointConfigurationConnectivity::read_network_connection_profile(1);
+    ASSERT_TRUE(base.has_value());
+    EXPECT_EQ(result->ocppCsmsUrl.get(), base->ocppCsmsUrl.get());
+    EXPECT_EQ(result->securityProfile, base->securityProfile);
+}
+
+// An unconfigured NON-active slot reads as nullopt (no legacy fallback - that only applies to the active slot).
+TEST_F(DeviceModelConnectivityTest, ReadProfileNullForUnconfiguredNonActiveSlot) {
+    // Active slot is 1 by default; slot 2 has no configured URL.
+    EXPECT_FALSE(config->read_network_connection_profile(2).has_value());
+}
+
+// ---------------------------------------------------------------------------
+// get_websocket_connection_options(slot)
+// ---------------------------------------------------------------------------
+
+// A configured slot yields per-slot uri/securityProfile/identity/password/hostname; remaining fields come from the
+// global getters, including iface == getIFace().
+TEST_F(DeviceModelConnectivityTest, WsOptionsPerSlotFields) {
+    auto profile = make_slot_profile("ws://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0);
+    profile.identity = "slot2id";
+    profile.basicAuthPassword = ocpp::CiString<64>("Slot2PasswordSlot2Pw");
+    write_slot_profile(2, profile);
+    set_slot_hostname(2, "slot2.host");
+
+    auto opts = config->get_websocket_connection_options(2); // non-const: Uri accessors are non-const
+    ASSERT_TRUE(opts.has_value());
+    EXPECT_EQ(opts->security_profile, 1);
+    EXPECT_EQ(opts->csms_uri.get_chargepoint_id(), "slot2id") << "per-slot Identity must drive the websocket URI";
+    EXPECT_EQ(opts->csms_uri.get_hostname(), "slot2.example.com");
+    ASSERT_TRUE(opts->authorization_key.has_value());
+    EXPECT_EQ(opts->authorization_key.value(), "Slot2PasswordSlot2Pw");
+    ASSERT_TRUE(opts->hostName.has_value());
+    EXPECT_EQ(opts->hostName.value(), "slot2.host");
+    EXPECT_EQ(opts->message_timeout, std::chrono::seconds(30))
+        << "per-slot NetworkConfiguration[N].MessageTimeout must drive the message timeout";
+    EXPECT_EQ(opts->iface, config->getIFace()) << "static iface default must come from Internal/IFace (getIFace())";
+}
+
+// Per-slot options honor OCPPCommCtrlr/NetworkProfileConnectionAttempts so the websocket gives up on an
+// unreachable CSMS and the ConnectivityManager can advance to the next priority slot (multi-slot failover).
+TEST_F(DeviceModelConnectivityTest, WsOptionsUseNetworkProfileConnectionAttempts) {
+    write_slot_profile(2, make_slot_profile("ws://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+
+    ASSERT_TRUE(CC::NetworkProfileConnectionAttempts.variable.has_value());
+    ASSERT_EQ(dm->set_value(CC::NetworkProfileConnectionAttempts.component,
+                            CC::NetworkProfileConnectionAttempts.variable.value(), AttributeEnum::Actual, "5", "test"),
+              SetVariableStatusEnum::Accepted);
+
+    auto opts = config->get_websocket_connection_options(2); // non-const: Uri accessors are non-const
+    ASSERT_TRUE(opts.has_value());
+    EXPECT_EQ(opts->max_connection_attempts, 5)
+        << "device-model slots must use a finite attempt count, not the legacy unlimited (-1)";
+}
+
+// A stripped component config without OCPPCommCtrlr/NetworkProfileConnectionAttempts falls back to a finite
+// default (3, the shipped config value) instead of -1 (retry forever), which would silently disable
+// websocket-failure-driven failover.
+TEST_F(DeviceModelConnectivityTest, WsOptionsDefaultNetworkProfileConnectionAttemptsWhenAbsent) {
+    write_slot_profile(2, make_slot_profile("ws://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+
+    ASSERT_TRUE(CC::NetworkProfileConnectionAttempts.variable.has_value());
+    ASSERT_EQ(dm->clear_value(CC::NetworkProfileConnectionAttempts.component,
+                              CC::NetworkProfileConnectionAttempts.variable.value(), AttributeEnum::Actual, "test"),
+              SetVariableStatusEnum::Accepted)
+        << "fixture precondition: clearing NetworkProfileConnectionAttempts must succeed";
+
+    auto opts = config->get_websocket_connection_options(2); // non-const: Uri accessors are non-const
+    ASSERT_TRUE(opts.has_value());
+    EXPECT_EQ(opts->max_connection_attempts, 3);
+}
+
+// When a configured slot has no per-slot Identity, the websocket identity falls back to SecurityCtrlr/Identity.
+TEST_F(DeviceModelConnectivityTest, WsOptionsPerSlotFallsBackToSecurityCtrlrIdentity) {
+    // Configure slot 2 with a URL but leave the per-slot Identity empty (default).
+    write_slot_profile(2, make_slot_profile("ws://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+
+    const auto expected_identity = dm->get_value<std::string>(CC::SecurityCtrlrIdentity);
+    ASSERT_FALSE(expected_identity.empty()) << "fixture precondition: SecurityCtrlr/Identity must be set";
+
+    auto opts = config->get_websocket_connection_options(2); // non-const: Uri accessors are non-const
+    ASSERT_TRUE(opts.has_value());
+    EXPECT_EQ(opts->csms_uri.get_chargepoint_id(), expected_identity);
+}
+
+// An unconfigured slot delegates to the base ChargePointConfigurationConnectivity implementation, producing options
+// identical to the base (which ignores the slot and uses the global getters of the active slot) - except for
+// max_connection_attempts, where the base's -1 (retry forever) would disable failover to the other slots.
+TEST_F(DeviceModelConnectivityTest, WsOptionsFallbackEqualsBaseExceptFiniteAttempts) {
+    // Make the active slot (1) configured with a valid URL + identity so the base impl produces a real result.
+    auto active = make_slot_profile("ws://active.example.com/ocpp", 1, OCPPInterfaceEnum::Any);
+    active.identity = "cp001";
+    write_slot_profile(1, active);
+
+    // Slot 3 is unconfigured -> override delegates to base.
+    const auto via_override = config->get_websocket_connection_options(3);
+    auto via_base = config->ChargePointConfigurationConnectivity::get_websocket_connection_options(3);
+    ASSERT_EQ(via_override.has_value(), via_base.has_value());
+    ASSERT_TRUE(via_override.has_value()) << "base synthesis over a configured active slot must yield options";
+    EXPECT_EQ(via_base->max_connection_attempts, -1) << "precondition: the base still retries forever";
+    EXPECT_EQ(via_override->max_connection_attempts, 3)
+        << "fallback options must use OCPPCommCtrlr/NetworkProfileConnectionAttempts (shipped default 3), not -1";
+    via_base->max_connection_attempts = via_override->max_connection_attempts;
+    expect_ws_options_equal(via_override.value(), via_base.value());
+}
+
+// ---------------------------------------------------------------------------
+// set_active_network_profile_slot(slot)
+// ---------------------------------------------------------------------------
+
+// Persisting the active slot must redirect the active-slot getters (getCentralSystemURI) to that slot's URL.
+TEST_F(DeviceModelConnectivityTest, SetActiveNetworkProfileSlotPersistsAndRedirectsGetters) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 1, OCPPInterfaceEnum::Wired0));
+    write_slot_profile(2, make_slot_profile("wss://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+
+    config->set_active_network_profile_slot(2, "test");
+
+    // The persisted ActiveNetworkProfile is observable and drives the active-slot getters.
+    EXPECT_EQ(dm->get_value<int>(CC::ActiveNetworkProfile), 2);
+    EXPECT_EQ(config->getCentralSystemURI(), "wss://slot2.example.com/ocpp");
+
+    config->set_active_network_profile_slot(1, "test");
+    EXPECT_EQ(dm->get_value<int>(CC::ActiveNetworkProfile), 1);
+    EXPECT_EQ(config->getCentralSystemURI(), "wss://slot1.example.com/ocpp");
+}
+
+// ---------------------------------------------------------------------------
+// ConnectivityManager smoke test over the adapter
+// ---------------------------------------------------------------------------
+
+// The shared ConnectivityManager, built over the v16 device-model adapter with two configured slots and priority
+// "1,2", must cache both slots with their respective interfaces - proving the adapter feeds the failover machinery.
+TEST_F(DeviceModelConnectivityTest, ConnectivityManagerCachesBothConfiguredSlots) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 1, OCPPInterfaceEnum::Wired0));
+    write_slot_profile(2, make_slot_profile("wss://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+    set_priority("1,2");
+
+    auto evse_security = std::make_shared<NiceMock<ocpp::EvseSecurityMock>>();
+    ocpp::ConnectivityManager cm(*config, evse_security, "");
+
+    const auto slots = cm.get_network_connection_slots();
+    ASSERT_EQ(slots.size(), 2u);
+    EXPECT_EQ(slots.at(0), 1);
+    EXPECT_EQ(slots.at(1), 2);
+
+    const auto p1 = cm.get_network_connection_profile(1);
+    ASSERT_TRUE(p1.has_value());
+    EXPECT_EQ(p1->ocppInterface, OCPPInterfaceEnum::Wired0);
+
+    const auto p2 = cm.get_network_connection_profile(2);
+    ASSERT_TRUE(p2.has_value());
+    EXPECT_EQ(p2->ocppInterface, OCPPInterfaceEnum::Wireless0);
+}
+
+// ---------------------------------------------------------------------------
+// Confirmed security profile (SecurityCtrlr.SecurityProfile)
+// ---------------------------------------------------------------------------
+
+// The ConnectivityManager-facing get_security_profile() must report the confirmed SecurityCtrlr.SecurityProfile
+// cell, not the per-slot value of the (attempt-time persisted) active slot that the OCPP-1.6-key-facing
+// getSecurityProfile() keeps serving.
+TEST_F(DeviceModelConnectivityTest, GetSecurityProfileReadsConfirmedCellNotActiveSlot) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 3, OCPPInterfaceEnum::Wired0));
+    config->set_active_network_profile_slot(1, "test");
+
+    // Shipped component config seeds the confirmed cell with 1.
+    EXPECT_EQ(config->get_security_profile(), 1);
+    EXPECT_EQ(config->getSecurityProfile(), 3) << "the per-slot getter must keep following the active slot";
+
+    config->set_security_ctrl_security_profile(2, "test");
+    EXPECT_EQ(config->get_security_profile(), 2);
+    EXPECT_EQ(config->getSecurityProfile(), 3);
+}
+
+// Both confirmed-profile setters write the SecurityCtrlr cell (as in the 2.x device model) and leave the
+// per-slot NetworkConfiguration value untouched.
+TEST_F(DeviceModelConnectivityTest, SetActiveSecurityProfileWritesSecurityCtrlrCell) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 1, OCPPInterfaceEnum::Wired0));
+
+    config->set_active_security_profile(3, "test");
+
+    EXPECT_EQ(dm->get_value<int>(CC::SecurityProfile), 3);
+    EXPECT_EQ(config->getSecurityProfile(), 1) << "the per-slot value must not change";
+}
+
+// Security profile 0 is legitimate in OCPP 1.6 (and in 2.x with AllowSecurityLevelZeroConnections); the confirmed
+// cell must accept it - pins the SecurityCtrlr.json minLimit relaxation to 0.
+TEST_F(DeviceModelConnectivityTest, SetActiveSecurityProfileAcceptsZero) {
+    config->set_active_security_profile(0, "test");
+
+    EXPECT_EQ(dm->get_value<int>(CC::SecurityProfile), 0);
+}
+
+// Regression: persisting the active slot at attempt time (what the ConnectivityManager does before connecting)
+// must not prune lower-security-profile slots - only a confirmed connection may raise the prune threshold.
+TEST_F(DeviceModelConnectivityTest, AttemptingSlotDoesNotPruneLowerSecuritySlots) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 1, OCPPInterfaceEnum::Wired0));
+    write_slot_profile(2, make_slot_profile("wss://slot2.example.com/ocpp", 3, OCPPInterfaceEnum::Wireless0));
+    set_priority("1,2");
+
+    auto evse_security = std::make_shared<NiceMock<ocpp::EvseSecurityMock>>();
+    ocpp::ConnectivityManager cm(*config, evse_security, "");
+
+    // Simulate an attempt on the high-SP slot 2: the active slot is persisted, but nothing was confirmed.
+    config->set_active_network_profile_slot(2, "test");
+    cm.check_cache_for_invalid_security_profiles();
+
+    EXPECT_EQ(cm.get_network_connection_slots().size(), 2u)
+        << "an unconfirmed attempt must not prune the lower-security-profile slot";
+}
+
+// A confirmed connection (on_websocket_connected -> set_security_ctrl_security_profile) raises the prune
+// threshold: lower-security-profile slots are removed from the failover cache - upgrades are one-way.
+TEST_F(DeviceModelConnectivityTest, ConfirmedConnectionRaisesCellAndPrunesLowerSlots) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 3, OCPPInterfaceEnum::Wired0));
+    write_slot_profile(2, make_slot_profile("wss://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+    set_priority("1,2");
+
+    auto evse_security = std::make_shared<NiceMock<ocpp::EvseSecurityMock>>();
+    ocpp::ConnectivityManager cm(*config, evse_security, "");
+
+    config->set_security_ctrl_security_profile(3, "test"); // what a successful SP-3 connect writes
+    cm.check_cache_for_invalid_security_profiles();
+
+    const auto slots = cm.get_network_connection_slots();
+    ASSERT_EQ(slots.size(), 1u);
+    EXPECT_EQ(slots.at(0), 1);
+    EXPECT_FALSE(cm.get_network_connection_profile(2).has_value());
+}
+
+// A cache rebuild resurrects every slot listed in the priority string; the next check must re-prune against the
+// confirmed profile instead of early-returning on an unchanged level - otherwise a reload would reopen a
+// security downgrade window.
+TEST_F(DeviceModelConnectivityTest, ReloadDoesNotResurrectPrunedLowerSlots) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 3, OCPPInterfaceEnum::Wired0));
+    write_slot_profile(2, make_slot_profile("wss://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+    set_priority("1,2");
+
+    auto evse_security = std::make_shared<NiceMock<ocpp::EvseSecurityMock>>();
+    ocpp::ConnectivityManager cm(*config, evse_security, "");
+
+    config->set_security_ctrl_security_profile(3, "test");
+    cm.check_cache_for_invalid_security_profiles();
+    ASSERT_EQ(cm.get_network_connection_slots().size(), 1u);
+
+    // The rebuild restores both slots from the priority string; the check that runs before every connect attempt
+    // must then re-prune.
+    cm.reload_network_profiles();
+    cm.check_cache_for_invalid_security_profiles();
+
+    const auto slots = cm.get_network_connection_slots();
+    ASSERT_EQ(slots.size(), 1u) << "the confirmed-SP threshold must be re-applied after a cache rebuild";
+    EXPECT_EQ(slots.at(0), 1);
+}
+
+// A reload must keep naming the same active slot when the priority list is reordered or extended - keeping the
+// raw index would silently point at a different slot (wrong security-profile confirms and slot reporting).
+TEST_F(DeviceModelConnectivityTest, ReloadRemapsActivePriorityToSameSlot) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 1, OCPPInterfaceEnum::Wired0));
+    write_slot_profile(2, make_slot_profile("wss://slot2.example.com/ocpp", 1, OCPPInterfaceEnum::Wireless0));
+    set_priority("1,2");
+
+    auto evse_security = std::make_shared<NiceMock<ocpp::EvseSecurityMock>>();
+    ocpp::ConnectivityManager cm(*config, evse_security, "");
+    ASSERT_EQ(cm.get_active_network_configuration_slot(), 1);
+
+    // Prepending slot 2 shifts slot 1 to index 1; the reload must follow the slot, not the index.
+    set_priority("2,1");
+    cm.reload_network_profiles();
+    EXPECT_EQ(cm.get_active_network_configuration_slot(), 1);
+}
+
+// The slot-pinned setter must write the named slot's SecurityProfile even when another slot is active - the
+// security-profile switch captures the slot at switch time so a late revert cannot clobber a failover slot.
+TEST_F(DeviceModelConnectivityTest, SetSecurityProfileForSlotWritesNamedSlotNotActive) {
+    write_slot_profile(1, make_slot_profile("wss://slot1.example.com/ocpp", 1, OCPPInterfaceEnum::Wired0));
+    write_slot_profile(2, make_slot_profile("wss://slot2.example.com/ocpp", 3, OCPPInterfaceEnum::Wireless0));
+    config->set_active_network_profile_slot(2, "test");
+
+    config->set_security_profile_for_slot(1, 2);
+
+    EXPECT_EQ(dm->get_value<int>(NC::get_component_variable(1, NC::SecurityProfile)), 2)
+        << "the named slot must be written";
+    EXPECT_EQ(dm->get_value<int>(NC::get_component_variable(2, NC::SecurityProfile)), 3)
+        << "the active slot must stay untouched";
+}
+
+// Missing device-model cells in the legacy synthesis must yield nullopt instead of an exception escaping into
+// the ConnectivityManager's profile caching (which runs at construction and on reload without a try/catch).
+// Reachable e.g. when the active slot names a NetworkConfiguration component that does not exist.
+TEST_F(DeviceModelConnectivityTest, ReadProfileSynthesisForMissingComponentYieldsNulloptNotThrow) {
+    config->set_active_network_profile_slot(7, "test"); // no NetworkConfiguration(7) component exists
+
+    std::optional<ocpp::v2::NetworkConnectionProfile> result;
+    EXPECT_NO_THROW(result = config->read_network_connection_profile(7));
+    EXPECT_FALSE(result.has_value());
+}
+
+// ---------------------------------------------------------------------------
+// ocpp16 component-config patcher: NetworkConfiguration[slot].OcppInterface pinning
+// ---------------------------------------------------------------------------
+
+const std::string STANDARD_CONFIGS_PATH = "./resources/example_config/v2/component_config";
+
+// Locate the Actual-attribute value of NetworkConfiguration[slot].OcppInterface in a component-config map.
+std::optional<std::string>
+read_nc_interface(std::map<ocpp::v2::ComponentKey, std::vector<ocpp::v2::DeviceModelVariable>>& configs, int slot) {
+    for (auto& [key, vars] : configs) {
+        if (key.name != "NetworkConfiguration" || !key.instance.has_value() ||
+            key.instance.value() != std::to_string(slot)) {
+            continue;
+        }
+        for (auto& var : vars) {
+            if (var.name != "OcppInterface") {
+                continue;
+            }
+            for (auto& attr : var.attributes) {
+                if (attr.variable_attribute.type == AttributeEnum::Actual) {
+                    if (attr.variable_attribute.value.has_value()) {
+                        return attr.variable_attribute.value->get();
+                    }
+                    return std::nullopt;
+                }
+            }
+        }
+    }
+    return std::nullopt;
+}
+
+// Force an explicit Actual-attribute value onto NetworkConfiguration[slot].OcppInterface, mimicking an integrator
+// who set the interface explicitly in their component config.
+void set_nc_interface(std::map<ocpp::v2::ComponentKey, std::vector<ocpp::v2::DeviceModelVariable>>& configs, int slot,
+                      const std::string& value) {
+    for (auto& [key, vars] : configs) {
+        if (key.name != "NetworkConfiguration" || !key.instance.has_value() ||
+            key.instance.value() != std::to_string(slot)) {
+            continue;
+        }
+        for (auto& var : vars) {
+            if (var.name != "OcppInterface") {
+                continue;
+            }
+            for (auto& attr : var.attributes) {
+                if (attr.variable_attribute.type == AttributeEnum::Actual) {
+                    attr.variable_attribute.value = value;
+                    return;
+                }
+            }
+        }
+    }
+    FAIL() << "NetworkConfiguration[" << slot << "].OcppInterface Actual attribute not found";
+}
+
+// The migration pins NetworkConfiguration[slot].OcppInterface to "Any": legacy 1.6 configs have no interface notion,
+// and pinning "Any" keeps post-migration behavior identical to the pre-device-model single-profile synthesis. The
+// shipped config's "Wired0" default lives in the default value and does not block the pin.
+TEST(DeviceModelConnectivityPatcher, MigrationPinsOcppInterfaceToAny) {
+    const auto ocpp16_config = std::make_unique<ocpp::v16::ChargePointConfiguration>(
+        ocpp::tests::make_ocpp16_test_config_full(), CONFIG_DIR_V16, USER_CONFIG_FILE_LOCATION_V16);
+
+    auto component_configs = ocpp::v2::get_all_component_configs(STANDARD_CONFIGS_PATH);
+    ocpp::v2::patch_component_config_with_ocpp16(component_configs, *ocpp16_config, {}, /*network_config_slot=*/1);
+
+    EXPECT_EQ(read_nc_interface(component_configs, 1), std::optional<std::string>("Any"));
+}
+
+// An explicit attribute value set by the integrator wins: the pin uses allow_override=false, so a
+// NetworkConfiguration[slot].OcppInterface that already carries an Actual value is left untouched.
+TEST(DeviceModelConnectivityPatcher, MigrationKeepsExplicitOcppInterface) {
+    const auto ocpp16_config = std::make_unique<ocpp::v16::ChargePointConfiguration>(
+        ocpp::tests::make_ocpp16_test_config_full(), CONFIG_DIR_V16, USER_CONFIG_FILE_LOCATION_V16);
+
+    auto component_configs = ocpp::v2::get_all_component_configs(STANDARD_CONFIGS_PATH);
+    set_nc_interface(component_configs, 1, "Wireless0");
+
+    ocpp::v2::patch_component_config_with_ocpp16(component_configs, *ocpp16_config, {}, /*network_config_slot=*/1);
+
+    EXPECT_EQ(read_nc_interface(component_configs, 1), std::optional<std::string>("Wireless0"))
+        << "An explicit OcppInterface value must survive the migration pin";
+}
+
+// Locate a variable in a component-config map (component name + optional instance + variable name).
+ocpp::v2::DeviceModelVariable*
+find_config_variable(std::map<ocpp::v2::ComponentKey, std::vector<ocpp::v2::DeviceModelVariable>>& configs,
+                     const std::string& component_name, const std::optional<std::string>& component_instance,
+                     const std::string& variable_name) {
+    for (auto& [key, vars] : configs) {
+        if (key.name != component_name || key.instance != component_instance) {
+            continue;
+        }
+        for (auto& var : vars) {
+            if (var.name == variable_name) {
+                return &var;
+            }
+        }
+    }
+    return nullptr;
+}
+
+// Read a variable's Actual-attribute value from a component-config map.
+std::optional<std::string>
+read_config_value(std::map<ocpp::v2::ComponentKey, std::vector<ocpp::v2::DeviceModelVariable>>& configs,
+                  const std::string& component_name, const std::optional<std::string>& component_instance,
+                  const std::string& variable_name) {
+    const auto* var = find_config_variable(configs, component_name, component_instance, variable_name);
+    if (var == nullptr) {
+        return std::nullopt;
+    }
+    for (const auto& attr : var->attributes) {
+        if (attr.variable_attribute.type == AttributeEnum::Actual && attr.variable_attribute.value.has_value()) {
+            return attr.variable_attribute.value->get();
+        }
+    }
+    return std::nullopt;
+}
+
+// The migration stamps the confirmed security profile (SecurityCtrlr.SecurityProfile) from the legacy config -
+// overriding the shipped component-config value - so migrated installs prune slots against the profile that was
+// actually in use.
+TEST(DeviceModelConnectivityPatcher, MigrationStampsConfirmedSecurityProfile) {
+    auto config_json = nlohmann::json::parse(ocpp::tests::make_ocpp16_test_config_full());
+    config_json["Security"]["SecurityProfile"] = 2; // differs from the shipped component-config value (1)
+    const auto ocpp16_config = std::make_unique<ocpp::v16::ChargePointConfiguration>(config_json.dump(), CONFIG_DIR_V16,
+                                                                                     USER_CONFIG_FILE_LOCATION_V16);
+
+    auto component_configs = ocpp::v2::get_all_component_configs(STANDARD_CONFIGS_PATH);
+    ocpp::v2::patch_component_config_with_ocpp16(component_configs, *ocpp16_config, {}, /*network_config_slot=*/1);
+
+    EXPECT_EQ(read_config_value(component_configs, "SecurityCtrlr", std::nullopt, "SecurityProfile"),
+              std::optional<std::string>("2"))
+        << "the legacy SecurityProfile must override the shipped component-config value";
+}
+
+// The migration never modifies NetworkConfigurationPriority or its valuesList: reaching the migrated slot
+// through the priority is the integrator's component-config responsibility (a mismatch is only warned about).
+// Migrating to slot 2 must still write the slot's values and seed ActiveNetworkProfile.
+TEST(DeviceModelConnectivityPatcher, MigrationDoesNotTouchPriorityOrValuesList) {
+    const auto ocpp16_config = std::make_unique<ocpp::v16::ChargePointConfiguration>(
+        ocpp::tests::make_ocpp16_test_config_full(), CONFIG_DIR_V16, USER_CONFIG_FILE_LOCATION_V16);
+
+    auto component_configs = ocpp::v2::get_all_component_configs(STANDARD_CONFIGS_PATH);
+    const auto* priority_before =
+        find_config_variable(component_configs, "OCPPCommCtrlr", std::nullopt, "NetworkConfigurationPriority");
+    ASSERT_NE(priority_before, nullptr);
+    const auto values_list_before = priority_before->characteristics.valuesList;
+
+    ocpp::v2::patch_component_config_with_ocpp16(component_configs, *ocpp16_config, {}, /*network_config_slot=*/2);
+
+    EXPECT_EQ(read_config_value(component_configs, "OCPPCommCtrlr", std::nullopt, "NetworkConfigurationPriority"),
+              std::optional<std::string>("1"))
+        << "the migration must not rewrite the priority, even when the migrated slot is not listed";
+    const auto* priority =
+        find_config_variable(component_configs, "OCPPCommCtrlr", std::nullopt, "NetworkConfigurationPriority");
+    ASSERT_NE(priority, nullptr);
+    EXPECT_EQ(priority->characteristics.valuesList, values_list_before)
+        << "the migration must not extend the priority's valuesList";
+
+    EXPECT_TRUE(read_config_value(component_configs, "NetworkConfiguration", "2", "OcppCsmsUrl").has_value())
+        << "the legacy connection settings must still be migrated into the configured slot";
+}
+
+// The migration seeds ActiveNetworkProfile with the migrated slot so the OCPP 1.6 key surface targets it
+// already before the first successful connect.
+TEST(DeviceModelConnectivityPatcher, MigrationSeedsActiveNetworkProfile) {
+    const auto ocpp16_config = std::make_unique<ocpp::v16::ChargePointConfiguration>(
+        ocpp::tests::make_ocpp16_test_config_full(), CONFIG_DIR_V16, USER_CONFIG_FILE_LOCATION_V16);
+
+    auto component_configs = ocpp::v2::get_all_component_configs(STANDARD_CONFIGS_PATH);
+    ocpp::v2::patch_component_config_with_ocpp16(component_configs, *ocpp16_config, {}, /*network_config_slot=*/2);
+
+    EXPECT_EQ(read_config_value(component_configs, "OCPPCommCtrlr", std::nullopt, "ActiveNetworkProfile"),
+              std::optional<std::string>("2"));
+}
+
+// A slot without a NetworkConfiguration_<N> component config is never synthesized: the network connection
+// migration is skipped with an error log, and the rest of the migration is unaffected.
+TEST(DeviceModelConnectivityPatcher, MigrationSkipsSlotWithoutComponentConfig) {
+    const auto ocpp16_config = std::make_unique<ocpp::v16::ChargePointConfiguration>(
+        ocpp::tests::make_ocpp16_test_config_full(), CONFIG_DIR_V16, USER_CONFIG_FILE_LOCATION_V16);
+
+    auto component_configs = ocpp::v2::get_all_component_configs(STANDARD_CONFIGS_PATH);
+    ocpp::v2::patch_component_config_with_ocpp16(component_configs, *ocpp16_config, {}, /*network_config_slot=*/3);
+
+    ocpp::v2::ComponentKey nc3_key;
+    nc3_key.name = "NetworkConfiguration";
+    nc3_key.instance = "3";
+    EXPECT_EQ(component_configs.find(nc3_key), component_configs.end())
+        << "no NetworkConfiguration[3] component may be synthesized";
+    EXPECT_EQ(read_config_value(component_configs, "OCPPCommCtrlr", std::nullopt, "NetworkConfigurationPriority"),
+              std::optional<std::string>("1"));
+    EXPECT_NE(read_config_value(component_configs, "OCPPCommCtrlr", std::nullopt, "ActiveNetworkProfile"),
+              std::optional<std::string>("3"))
+        << "ActiveNetworkProfile must not point at a skipped slot";
+    // The non-network migration still ran.
+    EXPECT_EQ(read_config_value(component_configs, "SecurityCtrlr", std::nullopt, "SecurityProfile"),
+              std::optional<std::string>(std::to_string(ocpp16_config->getSecurityProfile())));
+}
+
+} // namespace
+} // namespace v16
+} // namespace ocpp

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/test_variable_resolver.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/test_variable_resolver.cpp
@@ -187,6 +187,17 @@ TEST(VariableResolver, CustomMappingReverseAmbiguousCollidesWithStandard) {
     EXPECT_EQ(reverse.key.value(), "HeartbeatInterval");
 }
 
+TEST(VariableResolver, IsConnectionConfigCvPredicate) {
+    // the public predicate backs both classify() and the custom-mapping load-time rejection
+    using ocpp::v16::is_connection_config_cv;
+    EXPECT_TRUE(is_connection_config_cv(make_component("NetworkConfiguration", "1"), make_variable("OcppCsmsUrl")));
+    EXPECT_TRUE(is_connection_config_cv(make_component("OCPPCommCtrlr"), make_variable("ActiveNetworkProfile")));
+    EXPECT_TRUE(is_connection_config_cv(make_component("SecurityCtrlr"), make_variable("BasicAuthPassword")));
+    EXPECT_FALSE(is_connection_config_cv(make_component("SecurityCtrlr"), make_variable("CertificateEntries")));
+    EXPECT_FALSE(is_connection_config_cv(make_component("OCPPCommCtrlr"), make_variable("HeartbeatInterval")));
+    EXPECT_FALSE(is_connection_config_cv(make_component("VendorCtrlr"), make_variable("BarSetting")));
+}
+
 TEST(VariableResolver, ClassifyConnectionConfig) {
     const VariableResolver resolver{{}};
     EXPECT_EQ(resolver.classify(make_component("NetworkConfiguration", "1"), make_variable("OcppCsmsUrl")),

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_ocpp16_custom_config_mappings.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_ocpp16_custom_config_mappings.cpp
@@ -121,4 +121,61 @@ TEST_F(Ocpp16CustomConfigMappingsTest, missing_file_throws) {
     EXPECT_THROW((void)load_ocpp16_custom_config_mappings_from_yaml(missing_file), Ocpp16CustomConfigMappingsError);
 }
 
+TEST_F(Ocpp16CustomConfigMappingsTest, network_configuration_target_throws) {
+    // any NetworkConfiguration slot instance counts as connection config
+    const auto yaml_file = write_yaml_file("network_configuration.yaml", R"yaml(
+mappings:
+  - ocpp16_key: MyBackendUrl
+    component:
+      name: NetworkConfiguration
+      instance: "1"
+    variable:
+      name: OcppCsmsUrl
+)yaml");
+
+    EXPECT_THROW((void)load_ocpp16_custom_config_mappings_from_yaml(yaml_file), Ocpp16CustomConfigMappingsError);
+}
+
+TEST_F(Ocpp16CustomConfigMappingsTest, network_profile_selector_target_throws) {
+    const auto yaml_file = write_yaml_file("profile_selector.yaml", R"yaml(
+mappings:
+  - ocpp16_key: MyNetworkPriority
+    component:
+      name: OCPPCommCtrlr
+    variable:
+      name: NetworkConfigurationPriority
+)yaml");
+
+    EXPECT_THROW((void)load_ocpp16_custom_config_mappings_from_yaml(yaml_file), Ocpp16CustomConfigMappingsError);
+}
+
+TEST_F(Ocpp16CustomConfigMappingsTest, security_ctrlr_fallback_target_throws) {
+    const auto yaml_file = write_yaml_file("security_fallback.yaml", R"yaml(
+mappings:
+  - ocpp16_key: MyAuthKey
+    component:
+      name: SecurityCtrlr
+    variable:
+      name: BasicAuthPassword
+)yaml");
+
+    EXPECT_THROW((void)load_ocpp16_custom_config_mappings_from_yaml(yaml_file), Ocpp16CustomConfigMappingsError);
+}
+
+TEST_F(Ocpp16CustomConfigMappingsTest, non_connection_security_ctrlr_target_is_allowed) {
+    // the ban covers the connection fallback CVs, not the whole SecurityCtrlr component
+    const auto yaml_file = write_yaml_file("security_other.yaml", R"yaml(
+mappings:
+  - ocpp16_key: MyCertificateEntries
+    component:
+      name: SecurityCtrlr
+    variable:
+      name: CertificateEntries
+)yaml");
+
+    const auto mappings = load_ocpp16_custom_config_mappings_from_yaml(yaml_file);
+    ASSERT_EQ(mappings.size(), 1);
+    ASSERT_TRUE(mappings.find("MyCertificateEntries") != mappings.end());
+}
+
 } // namespace ocpp::v2

--- a/modules/EVSE/OCPP/docs/index.rst
+++ b/modules/EVSE/OCPP/docs/index.rst
@@ -440,10 +440,18 @@ The following module configuration parameters are relevant for device model back
 * **DeviceModelConfigMappings**: optional YAML file mapping non-standard OCPP 1.6 keys to device model
   component/variable targets; only used with **"device_model_with_migration"**. The built-in mapping for
   standard OCPP 1.6 keys is documented in
-  `lib/everest/ocpp/config/v16_to_v2_mapping.md <https://github.com/EVerest/everest-core/blob/main/lib/everest/ocpp/config/v16_to_v2_mapping.md>`_
+  `lib/everest/ocpp/config/v16_to_v2_mapping.md <https://github.com/EVerest/everest-core/blob/main/lib/everest/ocpp/config/v16_to_v2_mapping.md>`_.
+  Mappings must not target the connection configuration (``NetworkConfiguration`` slots, the
+  ``OCPPCommCtrlr`` network profile selectors, or the ``SecurityCtrlr`` connection fallbacks ``Identity``
+  and ``BasicAuthPassword``); those are managed via the standardized OCPP 1.6 keys, and a mapping file
+  containing such a target is rejected at startup
 * **Ocpp16NetworkConfigSlot**: ``NetworkConfiguration`` slot number that OCPP 1.6 network connection
   details (``CentralSystemURI``, ``SecurityProfile``, ``AuthorizationKey``, ``HostName``,
-  ``ChargePointId``) are migrated to during the one-time migration (default: ``1``; set to ``0`` to skip)
+  ``ChargePointId``) are migrated to during the one-time migration (default: ``1``; set to ``0`` to skip).
+  The migration pins the slot's ``OcppInterface`` to ``"Any"`` unless the component config sets an explicit
+  attribute value, points ``OCPPCommCtrlr/ActiveNetworkProfile`` at the slot, and requires a
+  ``NetworkConfiguration_<N>`` component config for the slot (missing: the network part is skipped with an
+  error log)
 * **EnableDeviceModelFallbackToLegacyJson**: if ``true`` and device model initialization or integrity check
   fails at startup, the module falls back to the legacy JSON backend; requires **ChargePointConfigPath** to
   exist (default: ``false``)

--- a/modules/EVSE/OCPP/docs/index.rst
+++ b/modules/EVSE/OCPP/docs/index.rst
@@ -443,7 +443,11 @@ The following module configuration parameters are relevant for device model back
   `lib/everest/ocpp/config/v16_to_v2_mapping.md <https://github.com/EVerest/everest-core/blob/main/lib/everest/ocpp/config/v16_to_v2_mapping.md>`_
 * **Ocpp16NetworkConfigSlot**: ``NetworkConfiguration`` slot number that OCPP 1.6 network connection
   details (``CentralSystemURI``, ``SecurityProfile``, ``AuthorizationKey``, ``HostName``,
-  ``ChargePointId``) are migrated to during the one-time migration (default: ``1``; set to ``0`` to skip)
+  ``ChargePointId``) are migrated to during the one-time migration (default: ``1``; set to ``0`` to skip).
+  The migration pins the slot's ``OcppInterface`` to ``"Any"`` unless the component config sets an explicit
+  attribute value, points ``OCPPCommCtrlr/ActiveNetworkProfile`` at the slot, and requires a
+  ``NetworkConfiguration_<N>`` component config for the slot (missing: the network part is skipped with an
+  error log)
 * **EnableDeviceModelFallbackToLegacyJson**: if ``true`` and device model initialization or integrity check
   fails at startup, the module falls back to the legacy JSON backend; requires **ChargePointConfigPath** to
   exist (default: ``false``)

--- a/modules/EVSE/OCPPmulti/CMakeLists.txt
+++ b/modules/EVSE/OCPPmulti/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(${MODULE_NAME}
     grid_support/grid_support_state.cpp
     v2_chargepoint.cpp
     v16_chargepoint.cpp
+    v16_connection_config_validator.cpp
     v16_conversions.cpp
     v16_variable_access.cpp
 )

--- a/modules/EVSE/OCPPmulti/docs/index.rst
+++ b/modules/EVSE/OCPPmulti/docs/index.rst
@@ -137,9 +137,60 @@ In both paths, the built-in mappings from OCPP 1.6 configuration keys to device 
 combinations are documented in
 `lib/everest/ocpp/config/v16_to_v2_mapping.md <https://github.com/EVerest/everest-core/blob/main/lib/everest/ocpp/config/v16_to_v2_mapping.md>`_.
 ``DeviceModelConfigMappings`` can point to a YAML file with custom mappings on top; it is applied both when migrating
-the legacy JSON into the device model and when serving the device-model-backed configuration at runtime. OCPP 1.6
+the legacy JSON into the device model and when serving the device-model-backed configuration at runtime. Custom
+mappings must not target the connection configuration (the ``NetworkConfiguration`` slots, the ``OCPPCommCtrlr``
+network profile selectors, or the ``SecurityCtrlr`` connection fallbacks ``Identity`` and ``BasicAuthPassword``):
+those are managed via the standardized OCPP 1.6 keys with their reboot/reconnect semantics, and a mapping file
+containing such a target is rejected at startup. OCPP 1.6
 keys without a standardized device model counterpart are kept in a dedicated ``OCPP16LegacyCtrlr`` component, whose
 ``NumberOfConnectors`` value is automatically patched to the actual number of connected EVSEs.
+
+.. _handwritten_ocppmulti_network-profiles-ocpp16:
+
+Network connection profiles (OCPP 1.6)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In device-model-backed configuration, OCPP 1.6 sources its network connection profiles from the same per-slot
+``NetworkConfiguration_<N>`` components as OCPP 2.x rather than from the single-URL legacy keys. The slot model,
+the failover behavior, the runtime reconfiguration workflow and the few points where the two protocol versions
+behave differently are described once in
+:ref:`Network connection configuration <handwritten_ocppmulti_network-connection-configuration>`; what follows
+here is only what is specific to OCPP 1.6.
+
+``Ocpp16NetworkConfigSlot`` selects the slot the legacy migration writes into (default ``1``). It populates that one
+slot (``CentralSystemURI`` → ``OcppCsmsUrl``, ``SecurityProfile`` → ``SecurityProfile``, ``AuthorizationKey`` →
+``BasicAuthPassword``, ``HostName`` → ``HostName``, ``ChargePointId`` → ``Identity``), sets that slot's
+``OcppInterface`` to ``"Any"`` unless the component config sets an explicit attribute ``value`` (a ``default``,
+like slot 1's ``"Wired0"``, does not count and applies only when the slot is not migrated into), and points
+``OCPPCommCtrlr/ActiveNetworkProfile`` at the slot. The target slot must be defined by the component configuration:
+when no ``NetworkConfiguration_<N>`` component config exists for it, the network connection migration is skipped
+with an error log, and when the slot is missing from ``NetworkConfigurationPriority`` (or its ``valuesList``), a
+warning is logged and the migrated profile is not used until the priority is configured accordingly. The shipped
+example configs cover the default slot ``1``, so a migrated legacy deployment connects as before with a single
+profile on interface ``"Any"``; for any other slot, ship the matching component config and priority.
+
+The migration also initializes the *confirmed* security profile (``SecurityCtrlr``/``SecurityProfile``) from the
+legacy config's ``SecurityProfile``. Setups configured purely through the device model (no migration) that use
+security profile ``0`` must set ``SecurityCtrlr``/``SecurityProfile`` to ``0`` in their component config, since the
+shipped default is ``1`` and every profile below the confirmed one is pruned from the failover list.
+
+A slot whose ``NetworkConfiguration_<N>.OcppVersion`` names any version other than ``"OCPP16"`` is ignored in OCPP
+1.6 mode; leaving ``OcppVersion`` unset or setting it to ``"OCPP16"`` makes the slot usable. Runtime writes of
+``OcppVersion`` are validated against the variable's ``valuesList``, so a custom component config must list
+``OCPP16`` there for such a write to be accepted (the shipped slot configs do). The *active* slot is exempt from
+this filter: when every listed slot is version-filtered (typically because the device model database was
+previously used with OCPP 2.x, which writes back the negotiated version; OCPP 1.6 itself never writes
+``OcppVersion``), the active slot still connects using the legacy single-profile connection settings instead of
+leaving the charge point unable to connect. The same fallback applies when the active slot's profile is
+incomplete; in OCPP 2.x an incomplete slot is simply skipped.
+
+The ``interface_address`` returned by the ``system`` provider's **configure_network** *replaces* the static
+``Internal``/``IFace`` configuration key when binding the websocket - including clearing it when the provider
+answers ``Ready`` or ``NotSupported`` without an address. Since this module always performs the configure_network
+round-trip, ``IFace`` is effectively not used on successful attempts.
+
+The legacy JSON configuration backend (OCPP 1.6 without a device model, as used by the ``OCPP`` module) is
+unaffected by this and keeps the previous single-profile behavior.
 
 OCPP device model vs. EVerest device model
 ==========================================
@@ -209,6 +260,30 @@ module via the interfaces it provides and requires.
 📌 **Note:** The ``ocpp_1_6_charge_point`` interface (``main`` implementation) of the deprecated
 :ref:`OCPP <everest_modules_OCPP>` module is NOT provided by this module. The ``ocpp_generic`` interface
 covers the same functionality.
+
+.. _handwritten_ocppmulti_control-from-outside-everest:
+
+Control from outside EVerest
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The interfaces below are EVerest-internal: they are consumed by other modules
+in the same EVerest configuration. To drive OCPPmulti from outside EVerest -
+a web interface, a commissioning tool, a factory test rig, a vendor cloud
+agent - add the :ref:`ocpp_consumer_API
+<everest_modules_handwritten_ocpp_consumer_API>` module to the configuration.
+It requires OCPPmulti's ``ocpp`` interface and republishes it on the EVerest
+API MQTT surface, so the OCPP stack is controllable without writing an EVerest
+module: device model access (and with it the whole configuration surface
+described under `Configuration access`_), DataTransfer, and the stack state
+OCPPmulti publishes. Its documentation and the generated API reference it
+links to are authoritative for the exact commands, variables and payloads.
+
+The API is a trusted local integrator channel and is not rate-limited or
+authenticated by OCPPmulti; expose it accordingly. Its writes are subject to
+the same validation as any other EVerest-side write, including the in-use
+network configuration protection described under
+:ref:`Network connection configuration
+<handwritten_ocppmulti_network-connection-configuration>`.
 
 Provides: auth_validator
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -402,9 +477,13 @@ for production use without modification). Used to execute and control system-wid
 * **is_reset_allowed** and **reset** for reset requests
 * **set_system_time** to apply the time communicated by the CSMS
 * **get_boot_reason** for the boot notification at startup
+* **configure_network** to prepare the network for a connection attempt on a network profile slot (see
+  :ref:`Network connection configuration <handwritten_ocppmulti_network-connection-configuration>`); a provider
+  without special network handling answers ``NotSupported``
 
 The **log_status** and **firmware_update_status** variables are received to report the corresponding status
-notifications to the CSMS.
+notifications to the CSMS, and **configure_network_status** reports the asynchronous outcome of
+**configure_network** requests.
 
 Error reporting
 ===============
@@ -508,9 +587,16 @@ OCPP configuration can be read, written and monitored through three channels:
 - **EVerest modules**: require the ``ocpp`` interface and call
   ``call_get_variables`` / ``call_set_variables`` / ``call_monitor_variables``;
   subscribe ``event_data`` for monitor notifications.
-- **External integrations** (web interface, configuration tools): the
-  ``ocpp_consumer_API``; see its own documentation for transport and message
-  details.
+- **External integrations** (web interface, configuration tools, vendor cloud
+  agents): the :ref:`ocpp_consumer_API
+  <everest_modules_handwritten_ocpp_consumer_API>` module, which republishes
+  OCPPmulti's ``ocpp`` interface on the EVerest API MQTT surface. Every
+  ``get_variables`` / ``set_variables`` / ``monitor_variables`` example in this
+  section applies verbatim there; the payloads shown *are* the API payloads.
+  Configuration access is only part of what it exposes; see
+  :ref:`Control from outside EVerest
+  <handwritten_ocppmulti_control-from-outside-everest>`, and its own
+  documentation for the full surface and the transport details.
 
 On the two EVerest-side channels, addressing and semantics are identical,
 regardless of whether OCPP 1.6 or 2.x is active. The CSMS channel
@@ -519,7 +605,7 @@ uses whatever the active protocol version prescribes (configuration keys in
 EVerest-side channels.
 
 Reading and writing (canonical form)
-------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Read (``get_variables``):
 
@@ -540,9 +626,14 @@ Write (``set_variables``):
 
 Results echo the requested ``component_variable`` and carry a status:
 ``Accepted``, ``RebootRequired`` (writes only; persisted; takes effect on next
-(re)connect or reboot), ``Rejected`` (with ``statusInfo`` explaining why and, where
-applicable, what to use instead), ``UnknownComponent`` / ``UnknownVariable``,
+(re)connect or reboot), ``Rejected``, ``UnknownComponent`` / ``UnknownVariable``,
 or ``NotSupportedAttributeType``.
+
+The status is the whole answer: the reason codes the stack computes internally
+(``PriorityNetworkConf``, ``NoSecurityDowngrade``, ``InvalidNetworkConf``, ...)
+are **currently not** carried on this interface; its result has no ``statusInfo`` field,
+in either protocol mode. A rejected write therefore has to be diagnosed from the
+module log, which names the reason code and the offending component/variable.
 
 Addressing rules:
 
@@ -554,13 +645,40 @@ Addressing rules:
 - The deprecation warning emitted for legacy requests names the canonical
   address for each key in use — the simplest migration discovery mechanism.
 
-Changing OCPP connection details
---------------------------------
+.. _handwritten_ocppmulti_network-connection-configuration:
 
-Connection settings live in network profile **slots**, addressed as component
-``NetworkConfiguration`` with the slot number as component ``instance``. Both
-protocol stacks read this same representation (shared connectivity manager),
-so the workflow below is identical for OCPP 1.6 and 2.x.
+Network connection configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Connection settings live in network profile **slots**: one
+``NetworkConfiguration`` component per slot, addressed with the slot number as
+component ``instance``, plus
+``OCPPCommCtrlr``/``NetworkConfigurationPriority`` - a comma-separated, ordered
+list of the slots to try. Slots are set up in the component configuration and can be changed at runtime through this API. Both
+protocol versions read this same representation, so everything below applies to
+OCPP 1.6 and 2.x alike; the handful of behavioral differences is collected at
+the end of this section.
+
+Setting up slots
+""""""""""""""""
+
+Which slots exist is decided by the component configuration: ship one
+``NetworkConfiguration_<N>.json`` per slot and list every usable slot in
+``NetworkConfigurationPriority`` - both in its value (or default) and in its
+``valuesList``, which gates runtime priority writes. The shipped configuration
+contains two slots as an example; provide as many as your setup needs. A
+typical setup is slot 1 on a cellular modem (``OcppInterface`` ``"Wireless0"``
+plus APN settings) with slot 2 as a wired fallback (``"Wired0"``).
+
+A slot is only usable once its profile is complete: ``OcppCsmsUrl``,
+``SecurityProfile``, ``OcppInterface``, ``OcppTransport`` and ``MessageTimeout``
+are all mandatory, and a slot missing any of them is skipped. The example
+``NetworkConfiguration_1.json`` carries defaults for everything except the URL
+(``SecurityProfile`` ``1``, ``OcppInterface`` ``"Wired0"``, ``OcppTransport``
+``"JSON"``, ``MessageTimeout`` ``30``), so slot 1 only needs an
+``OcppCsmsUrl``; ``NetworkConfiguration_2.json`` deliberately carries no
+defaults for the mandatory fields, so each of them must be set explicitly - in
+the component config or at runtime.
 
 .. list-table::
    :header-rows: 1
@@ -571,9 +689,15 @@ so the workflow below is identical for OCPP 1.6 and 2.x.
    * - CSMS endpoint URL
      - ``NetworkConfiguration`` / instance ``<slot>``
      - ``OcppCsmsUrl``
-   * - Security profile (1–3)
+   * - Security profile (0–3)
      - ``NetworkConfiguration`` / instance ``<slot>``
      - ``SecurityProfile``
+   * - Network interface
+     - ``NetworkConfiguration`` / instance ``<slot>``
+     - ``OcppInterface``
+   * - Transport and message timeout
+     - ``NetworkConfiguration`` / instance ``<slot>``
+     - ``OcppTransport``, ``MessageTimeout``
    * - Basic-auth password (AuthorizationKey)
      - ``NetworkConfiguration`` / instance ``<slot>``
      - ``BasicAuthPassword`` (write-only)
@@ -590,7 +714,46 @@ so the workflow below is identical for OCPP 1.6 and 2.x.
      - ``OCPPCommCtrlr``
      - ``ActiveNetworkProfile`` (ReadOnly)
 
-Workflow — prepare a profile (here: slot 2):
+Failover between slots
+""""""""""""""""""""""
+
+Slots are tried in priority order, and the list wraps around. A slot is skipped
+when the ``system`` provider's **configure_network** answers
+``Failed``/``Rejected`` (or does not respond within
+``InternalCtrlr``/``NetworkConfigTimeout`` seconds, default 60), when the
+resulting profile is invalid, or when the websocket connection fails
+``OCPPCommCtrlr``/``NetworkProfileConnectionAttempts`` times in a row. Setting
+``NetworkProfileConnectionAttempts`` to ``-1`` means retry-forever and thereby
+disables the websocket-failure-driven part of the failover; only do that
+deliberately. There is no automatic fall-back to a higher-priority slot while a
+lower-priority one is connected. The address the ``system`` provider returns
+from **configure_network** is what the websocket is bound to for that attempt.
+
+Profiles with a ``SecurityProfile`` below the *confirmed* security profile -
+the ``SecurityCtrlr``/``SecurityProfile`` value, which is raised only after a
+successful connect - are pruned from the failover list, so security profile
+upgrades are one-way. Failed attempts on a higher-security-profile slot do not
+prune anything.
+
+Changing connection details at runtime
+""""""""""""""""""""""""""""""""""""""
+
+The whole reconfiguration below is doable from outside EVerest: the
+:ref:`ocpp_consumer_API <everest_modules_handwritten_ocpp_consumer_API>`
+module exposes ``get_variables`` / ``set_variables`` / ``monitor_variables``
+on the EVerest API MQTT surface, and the payloads in this section are exactly
+what that API takes. A web interface or commissioning tool can therefore
+repoint the charging station at a different CSMS, rotate credentials or switch
+to a fallback interface without an EVerest module and without CSMS
+involvement. The same API is the natural way to *observe* the result; monitor
+``OCPPCommCtrlr``/``ActiveNetworkProfile`` for the slot actually in use. It
+controls the OCPP stack well beyond network configuration; see
+:ref:`Control from outside EVerest
+<handwritten_ocppmulti_control-from-outside-everest>`.
+
+Workflow - fully populate a spare profile slot (here: slot 2, which ships
+without defaults, so every field has to be written; an incomplete slot cannot
+be put into the priority):
 
 .. code-block:: json
 
@@ -601,6 +764,15 @@ Workflow — prepare a profile (here: slot 2):
      {"component_variable": {"component": {"name": "NetworkConfiguration", "instance": "2"},
                              "variable": {"name": "SecurityProfile"}},
       "value": "2"},
+     {"component_variable": {"component": {"name": "NetworkConfiguration", "instance": "2"},
+                             "variable": {"name": "OcppInterface"}},
+      "value": "Any"},
+     {"component_variable": {"component": {"name": "NetworkConfiguration", "instance": "2"},
+                             "variable": {"name": "OcppTransport"}},
+      "value": "JSON"},
+     {"component_variable": {"component": {"name": "NetworkConfiguration", "instance": "2"},
+                             "variable": {"name": "MessageTimeout"}},
+      "value": "30"},
      {"component_variable": {"component": {"name": "NetworkConfiguration", "instance": "2"},
                              "variable": {"name": "BasicAuthPassword"}},
       "value": "0123456789abcdef"}
@@ -615,18 +787,85 @@ then activate it by putting slot 2 first in the priority order:
       "value": "2,1"}
    ]}, "source": "webinterface"}
 
-Each of these returns ``RebootRequired``: the values are validated and
-persisted immediately and take effect on the next (re)connect or reboot.
-Editing the currently active slot in place is equally allowed (same
-``RebootRequired`` semantics). ``BasicAuthPassword`` is write-only — reads do
-not return it. ``ActiveNetworkProfile`` reports which slot is in use and is
-ReadOnly (per OCPP 2.x); writes to it are rejected by mutability in both
-modes. In v16 mode this workflow is semantically equivalent to the legacy
-``CentralSystemURI`` / ``SecurityProfile`` / ``AuthorizationKey`` key writes,
-which remain available (deprecated) and operate on the active slot.
+Keeping slot 1 in the list retains it as a fallback, but with only the two
+shipped slots it also means no slot is left that can be rewritten (see the
+protection rules below). Write ``"2"`` instead if you want to keep slot 1 free
+for the next reconfiguration, or ship a third slot to rotate through.
+
+Committed writes persist immediately, are picked up right away and take effect
+on the next (re)connect; an already-established connection is not interrupted.
+The status returned for a connection-config write differs between the protocol
+versions (see below), but in neither case is a reboot actually required.
+
+The in-use configuration is protected (B09.FR.21/22), which is why the workflow
+above prepares a spare slot first:
+
+- Writes targeting the currently *active* slot, or any slot listed in
+  ``NetworkConfigurationPriority``, are rejected with ``PriorityNetworkConf``.
+  Keep at least one slot out of the priority list so there is always a slot you
+  can rewrite.
+- A ``NetworkConfigurationPriority`` write naming a slot without a complete
+  profile is rejected with ``InvalidNetworkConf``, as is a change that would
+  make a slot's URL scheme inconsistent with its security profile (``ws://``
+  needs profile < 2, ``wss://`` needs >= 2).
+- Lowering a slot's ``SecurityProfile`` below the confirmed one is rejected
+  with ``NoSecurityDowngrade``.
+
+Because the active slot is always protected, credentials for the running
+connection cannot be rotated per slot. Write the ``SecurityCtrlr`` globals
+instead: a committed write to ``SecurityCtrlr``/``Identity`` or
+``SecurityCtrlr``/``BasicAuthPassword`` clears the corresponding per-slot
+override on the active slot (B09.FR.26/27), so the new global value is what the
+next connection attempt uses - even when a legacy migration had populated the
+per-slot value. ``BasicAuthPassword`` is write-only; reads do not return it.
+
+``set_variables`` on this API may write ReadOnly variables: it is a trusted
+local integrator channel, and ReadOnly mutability models the CSMS-facing
+contract, not this API (the protection above still applies regardless of
+mutability). Some cells are nevertheless stack-owned runtime state, written on
+every successful connect; writing them here desyncs the device model from the
+connection logic. Do not write:
+
+- ``OCPPCommCtrlr``/``ActiveNetworkProfile`` - reports which slot is in use;
+  a manual write is corrected only on the next successful connect.
+- ``SecurityCtrlr``/``SecurityProfile`` - the *confirmed* security profile,
+  raised after a successful connect and used to permanently prune slots below
+  it from the failover list; raising it by hand can leave no attemptable slot.
+- ``NetworkConfiguration``/``OcppVersion`` - written back with the negotiated
+  version on 2.x connects; a value other than ``"OCPP16"`` removes the slot
+  from the usable set in OCPP 1.6 mode.
+
+Where the protocol versions differ
+""""""""""""""""""""""""""""""""""
+
+- **Status of a committed write.** OCPP 1.6 answers connection-config writes
+  with ``RebootRequired``, OCPP 2.x with ``Accepted``. The persisted value and
+  the moment it takes effect are the same.
+- **Priority changes.** In OCPP 1.6 a ``NetworkConfigurationPriority`` write is
+  picked up immediately and is effective on the next (re)connect. In OCPP 2.x
+  it is persisted but only taken into account after a reboot; plan one when
+  switching slots this way.
+- **Unusable slots.** OCPP 1.6 additionally ignores slots whose ``OcppVersion``
+  names another version, and falls back to the legacy single-profile settings
+  when the *active* slot is filtered out or incomplete; OCPP 2.x uses every
+  listed slot and simply skips incomplete ones. See
+  :ref:`Network connection profiles (OCPP 1.6) <handwritten_ocppmulti_network-profiles-ocpp16>`
+  for the details.
+- **Deprecated key-only writes.** Only in OCPP 1.6 mode, the legacy
+  ``SecurityProfile`` and ``AuthorizationKey`` keys can still be written
+  (empty component name); they act on the active slot and bypass the validation
+  above, and the profile used for **configure_network** and for
+  security-profile pruning keeps its previous contents until a canonical write,
+  a security-profile switch or a restart. ``SecurityProfile`` is not a quiet
+  write either: it triggers the 1.6 security-profile switch, which reconnects
+  immediately and falls back to the previous profile if the new one does not
+  connect within ``SwitchSecurityProfileConnectionTimeout``.
+  ``CentralSystemURI`` is *not* writable this way; it is read-only in the key
+  path, so the canonical ``NetworkConfiguration`` addressing is the only way to
+  change a CSMS URL.
 
 Monitoring configuration changes
---------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``monitor_variables`` with canonical addresses; changes are published on
 ``event_data`` with the same ``component_variable`` used at registration:
@@ -659,7 +898,7 @@ to canonical addressing. Requests with a non-empty component name are never
 reinterpreted as configuration keys.
 
 Behavioral difference to the legacy OCPP module
------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The legacy ``OCPP`` module ignores ``component.name`` entirely and always
 treats ``variable.name`` as a configuration key. OCPPmulti resolves the

--- a/modules/EVSE/OCPPmulti/docs/index.rst
+++ b/modules/EVSE/OCPPmulti/docs/index.rst
@@ -141,6 +141,53 @@ the legacy JSON into the device model and when serving the device-model-backed c
 keys without a standardized device model counterpart are kept in a dedicated ``OCPP16LegacyCtrlr`` component, whose
 ``NumberOfConnectors`` value is automatically patched to the actual number of connected EVSEs.
 
+.. _handwritten_ocppmulti_network-profiles-ocpp16:
+
+Network connection profiles (OCPP 1.6)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In device-model-backed configuration, OCPP 1.6 sources its network connection profiles from the same per-slot
+``NetworkConfiguration_<N>`` components as OCPP 2.x rather than from the single-URL legacy keys. The slot model,
+the failover behavior, the runtime reconfiguration workflow and the few points where the two protocol versions
+behave differently are described once in
+:ref:`Network connection configuration <handwritten_ocppmulti_network-connection-configuration>`; what follows
+here is only what is specific to OCPP 1.6.
+
+``Ocpp16NetworkConfigSlot`` selects the slot the legacy migration writes into (default ``1``). It populates that one
+slot (``CentralSystemURI`` → ``OcppCsmsUrl``, ``SecurityProfile`` → ``SecurityProfile``, ``AuthorizationKey`` →
+``BasicAuthPassword``, ``HostName`` → ``HostName``, ``ChargePointId`` → ``Identity``), sets that slot's
+``OcppInterface`` to ``"Any"`` unless the component config sets an explicit attribute ``value`` (a ``default``,
+like slot 1's ``"Wired0"``, does not count and applies only when the slot is not migrated into), and points
+``OCPPCommCtrlr/ActiveNetworkProfile`` at the slot. The target slot must be defined by the component configuration:
+when no ``NetworkConfiguration_<N>`` component config exists for it, the network connection migration is skipped
+with an error log, and when the slot is missing from ``NetworkConfigurationPriority`` (or its ``valuesList``), a
+warning is logged and the migrated profile is not used until the priority is configured accordingly. The shipped
+example configs cover the default slot ``1``, so a migrated legacy deployment connects as before with a single
+profile on interface ``"Any"``; for any other slot, ship the matching component config and priority.
+
+The migration also initializes the *confirmed* security profile (``SecurityCtrlr``/``SecurityProfile``) from the
+legacy config's ``SecurityProfile``. Setups configured purely through the device model (no migration) that use
+security profile ``0`` must set ``SecurityCtrlr``/``SecurityProfile`` to ``0`` in their component config, since the
+shipped default is ``1`` and every profile below the confirmed one is pruned from the failover list.
+
+A slot whose ``NetworkConfiguration_<N>.OcppVersion`` names any version other than ``"OCPP16"`` is ignored in OCPP
+1.6 mode; leaving ``OcppVersion`` unset or setting it to ``"OCPP16"`` makes the slot usable. Runtime writes of
+``OcppVersion`` are validated against the variable's ``valuesList``, so a custom component config must list
+``OCPP16`` there for such a write to be accepted (the shipped slot configs do). The *active* slot is exempt from
+this filter: when every listed slot is version-filtered (typically because the device model database was
+previously used with OCPP 2.x, which writes back the negotiated version; OCPP 1.6 itself never writes
+``OcppVersion``), the active slot still connects using the legacy single-profile connection settings instead of
+leaving the charge point unable to connect. The same fallback applies when the active slot's profile is
+incomplete; in OCPP 2.x an incomplete slot is simply skipped.
+
+The ``interface_address`` returned by the ``system`` provider's **configure_network** *replaces* the static
+``Internal``/``IFace`` configuration key when binding the websocket - including clearing it when the provider
+answers ``Ready`` or ``NotSupported`` without an address. Since this module always performs the configure_network
+round-trip, ``IFace`` is effectively not used on successful attempts.
+
+The legacy JSON configuration backend (OCPP 1.6 without a device model, as used by the ``OCPP`` module) is
+unaffected by this and keeps the previous single-profile behavior.
+
 OCPP device model vs. EVerest device model
 ==========================================
 
@@ -209,6 +256,30 @@ module via the interfaces it provides and requires.
 📌 **Note:** The ``ocpp_1_6_charge_point`` interface (``main`` implementation) of the deprecated
 :ref:`OCPP <everest_modules_OCPP>` module is NOT provided by this module. The ``ocpp_generic`` interface
 covers the same functionality.
+
+.. _handwritten_ocppmulti_control-from-outside-everest:
+
+Control from outside EVerest
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The interfaces below are EVerest-internal: they are consumed by other modules
+in the same EVerest configuration. To drive OCPPmulti from outside EVerest -
+a web interface, a commissioning tool, a factory test rig, a vendor cloud
+agent - add the :ref:`ocpp_consumer_API
+<everest_modules_handwritten_ocpp_consumer_API>` module to the configuration.
+It requires OCPPmulti's ``ocpp`` interface and republishes it on the EVerest
+API MQTT surface, so the OCPP stack is controllable without writing an EVerest
+module: device model access (and with it the whole configuration surface
+described under `Configuration access`_), DataTransfer, and the stack state
+OCPPmulti publishes. Its documentation and the generated API reference it
+links to are authoritative for the exact commands, variables and payloads.
+
+The API is a trusted local integrator channel and is not rate-limited or
+authenticated by OCPPmulti; expose it accordingly. Its writes are subject to
+the same validation as any other EVerest-side write, including the in-use
+network configuration protection described under
+:ref:`Network connection configuration
+<handwritten_ocppmulti_network-connection-configuration>`.
 
 Provides: auth_validator
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -402,9 +473,13 @@ for production use without modification). Used to execute and control system-wid
 * **is_reset_allowed** and **reset** for reset requests
 * **set_system_time** to apply the time communicated by the CSMS
 * **get_boot_reason** for the boot notification at startup
+* **configure_network** to prepare the network for a connection attempt on a network profile slot (see
+  :ref:`Network connection configuration <handwritten_ocppmulti_network-connection-configuration>`); a provider
+  without special network handling answers ``NotSupported``
 
 The **log_status** and **firmware_update_status** variables are received to report the corresponding status
-notifications to the CSMS.
+notifications to the CSMS, and **configure_network_status** reports the asynchronous outcome of
+**configure_network** requests.
 
 Error reporting
 ===============
@@ -508,9 +583,16 @@ OCPP configuration can be read, written and monitored through three channels:
 - **EVerest modules**: require the ``ocpp`` interface and call
   ``call_get_variables`` / ``call_set_variables`` / ``call_monitor_variables``;
   subscribe ``event_data`` for monitor notifications.
-- **External integrations** (web interface, configuration tools): the
-  ``ocpp_consumer_API``; see its own documentation for transport and message
-  details.
+- **External integrations** (web interface, configuration tools, vendor cloud
+  agents): the :ref:`ocpp_consumer_API
+  <everest_modules_handwritten_ocpp_consumer_API>` module, which republishes
+  OCPPmulti's ``ocpp`` interface on the EVerest API MQTT surface. Every
+  ``get_variables`` / ``set_variables`` / ``monitor_variables`` example in this
+  section applies verbatim there; the payloads shown *are* the API payloads.
+  Configuration access is only part of what it exposes; see
+  :ref:`Control from outside EVerest
+  <handwritten_ocppmulti_control-from-outside-everest>`, and its own
+  documentation for the full surface and the transport details.
 
 On the two EVerest-side channels, addressing and semantics are identical,
 regardless of whether OCPP 1.6 or 2.x is active. The CSMS channel
@@ -519,7 +601,7 @@ uses whatever the active protocol version prescribes (configuration keys in
 EVerest-side channels.
 
 Reading and writing (canonical form)
-------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Read (``get_variables``):
 
@@ -540,9 +622,14 @@ Write (``set_variables``):
 
 Results echo the requested ``component_variable`` and carry a status:
 ``Accepted``, ``RebootRequired`` (writes only; persisted; takes effect on next
-(re)connect or reboot), ``Rejected`` (with ``statusInfo`` explaining why and, where
-applicable, what to use instead), ``UnknownComponent`` / ``UnknownVariable``,
+(re)connect or reboot), ``Rejected``, ``UnknownComponent`` / ``UnknownVariable``,
 or ``NotSupportedAttributeType``.
+
+The status is the whole answer: the reason codes the stack computes internally
+(``PriorityNetworkConf``, ``NoSecurityDowngrade``, ``InvalidNetworkConf``, ...)
+are **currently not** carried on this interface; its result has no ``statusInfo`` field,
+in either protocol mode. A rejected write therefore has to be diagnosed from the
+module log, which names the reason code and the offending component/variable.
 
 Addressing rules:
 
@@ -554,13 +641,40 @@ Addressing rules:
 - The deprecation warning emitted for legacy requests names the canonical
   address for each key in use — the simplest migration discovery mechanism.
 
-Changing OCPP connection details
---------------------------------
+.. _handwritten_ocppmulti_network-connection-configuration:
 
-Connection settings live in network profile **slots**, addressed as component
-``NetworkConfiguration`` with the slot number as component ``instance``. Both
-protocol stacks read this same representation (shared connectivity manager),
-so the workflow below is identical for OCPP 1.6 and 2.x.
+Network connection configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Connection settings live in network profile **slots**: one
+``NetworkConfiguration`` component per slot, addressed with the slot number as
+component ``instance``, plus
+``OCPPCommCtrlr``/``NetworkConfigurationPriority`` - a comma-separated, ordered
+list of the slots to try. Slots are set up in the component configuration and can be changed at runtime through this API. Both
+protocol versions read this same representation, so everything below applies to
+OCPP 1.6 and 2.x alike; the handful of behavioral differences is collected at
+the end of this section.
+
+Setting up slots
+""""""""""""""""
+
+Which slots exist is decided by the component configuration: ship one
+``NetworkConfiguration_<N>.json`` per slot and list every usable slot in
+``NetworkConfigurationPriority`` - both in its value (or default) and in its
+``valuesList``, which gates runtime priority writes. The shipped configuration
+contains two slots as an example; provide as many as your setup needs. A
+typical setup is slot 1 on a cellular modem (``OcppInterface`` ``"Wireless0"``
+plus APN settings) with slot 2 as a wired fallback (``"Wired0"``).
+
+A slot is only usable once its profile is complete: ``OcppCsmsUrl``,
+``SecurityProfile``, ``OcppInterface``, ``OcppTransport`` and ``MessageTimeout``
+are all mandatory, and a slot missing any of them is skipped. The example
+``NetworkConfiguration_1.json`` carries defaults for everything except the URL
+(``SecurityProfile`` ``1``, ``OcppInterface`` ``"Wired0"``, ``OcppTransport``
+``"JSON"``, ``MessageTimeout`` ``30``), so slot 1 only needs an
+``OcppCsmsUrl``; ``NetworkConfiguration_2.json`` deliberately carries no
+defaults for the mandatory fields, so each of them must be set explicitly - in
+the component config or at runtime.
 
 .. list-table::
    :header-rows: 1
@@ -571,9 +685,15 @@ so the workflow below is identical for OCPP 1.6 and 2.x.
    * - CSMS endpoint URL
      - ``NetworkConfiguration`` / instance ``<slot>``
      - ``OcppCsmsUrl``
-   * - Security profile (1–3)
+   * - Security profile (0–3)
      - ``NetworkConfiguration`` / instance ``<slot>``
      - ``SecurityProfile``
+   * - Network interface
+     - ``NetworkConfiguration`` / instance ``<slot>``
+     - ``OcppInterface``
+   * - Transport and message timeout
+     - ``NetworkConfiguration`` / instance ``<slot>``
+     - ``OcppTransport``, ``MessageTimeout``
    * - Basic-auth password (AuthorizationKey)
      - ``NetworkConfiguration`` / instance ``<slot>``
      - ``BasicAuthPassword`` (write-only)
@@ -590,7 +710,46 @@ so the workflow below is identical for OCPP 1.6 and 2.x.
      - ``OCPPCommCtrlr``
      - ``ActiveNetworkProfile`` (ReadOnly)
 
-Workflow — prepare a profile (here: slot 2):
+Failover between slots
+""""""""""""""""""""""
+
+Slots are tried in priority order, and the list wraps around. A slot is skipped
+when the ``system`` provider's **configure_network** answers
+``Failed``/``Rejected`` (or does not respond within
+``InternalCtrlr``/``NetworkConfigTimeout`` seconds, default 60), when the
+resulting profile is invalid, or when the websocket connection fails
+``OCPPCommCtrlr``/``NetworkProfileConnectionAttempts`` times in a row. Setting
+``NetworkProfileConnectionAttempts`` to ``-1`` means retry-forever and thereby
+disables the websocket-failure-driven part of the failover; only do that
+deliberately. There is no automatic fall-back to a higher-priority slot while a
+lower-priority one is connected. The address the ``system`` provider returns
+from **configure_network** is what the websocket is bound to for that attempt.
+
+Profiles with a ``SecurityProfile`` below the *confirmed* security profile -
+the ``SecurityCtrlr``/``SecurityProfile`` value, which is raised only after a
+successful connect - are pruned from the failover list, so security profile
+upgrades are one-way. Failed attempts on a higher-security-profile slot do not
+prune anything.
+
+Changing connection details at runtime
+""""""""""""""""""""""""""""""""""""""
+
+The whole reconfiguration below is doable from outside EVerest: the
+:ref:`ocpp_consumer_API <everest_modules_handwritten_ocpp_consumer_API>`
+module exposes ``get_variables`` / ``set_variables`` / ``monitor_variables``
+on the EVerest API MQTT surface, and the payloads in this section are exactly
+what that API takes. A web interface or commissioning tool can therefore
+repoint the charging station at a different CSMS, rotate credentials or switch
+to a fallback interface without an EVerest module and without CSMS
+involvement. The same API is the natural way to *observe* the result; monitor
+``OCPPCommCtrlr``/``ActiveNetworkProfile`` for the slot actually in use. It
+controls the OCPP stack well beyond network configuration; see
+:ref:`Control from outside EVerest
+<handwritten_ocppmulti_control-from-outside-everest>`.
+
+Workflow - fully populate a spare profile slot (here: slot 2, which ships
+without defaults, so every field has to be written; an incomplete slot cannot
+be put into the priority):
 
 .. code-block:: json
 
@@ -601,6 +760,15 @@ Workflow — prepare a profile (here: slot 2):
      {"component_variable": {"component": {"name": "NetworkConfiguration", "instance": "2"},
                              "variable": {"name": "SecurityProfile"}},
       "value": "2"},
+     {"component_variable": {"component": {"name": "NetworkConfiguration", "instance": "2"},
+                             "variable": {"name": "OcppInterface"}},
+      "value": "Any"},
+     {"component_variable": {"component": {"name": "NetworkConfiguration", "instance": "2"},
+                             "variable": {"name": "OcppTransport"}},
+      "value": "JSON"},
+     {"component_variable": {"component": {"name": "NetworkConfiguration", "instance": "2"},
+                             "variable": {"name": "MessageTimeout"}},
+      "value": "30"},
      {"component_variable": {"component": {"name": "NetworkConfiguration", "instance": "2"},
                              "variable": {"name": "BasicAuthPassword"}},
       "value": "0123456789abcdef"}
@@ -615,18 +783,85 @@ then activate it by putting slot 2 first in the priority order:
       "value": "2,1"}
    ]}, "source": "webinterface"}
 
-Each of these returns ``RebootRequired``: the values are validated and
-persisted immediately and take effect on the next (re)connect or reboot.
-Editing the currently active slot in place is equally allowed (same
-``RebootRequired`` semantics). ``BasicAuthPassword`` is write-only — reads do
-not return it. ``ActiveNetworkProfile`` reports which slot is in use and is
-ReadOnly (per OCPP 2.x); writes to it are rejected by mutability in both
-modes. In v16 mode this workflow is semantically equivalent to the legacy
-``CentralSystemURI`` / ``SecurityProfile`` / ``AuthorizationKey`` key writes,
-which remain available (deprecated) and operate on the active slot.
+Keeping slot 1 in the list retains it as a fallback, but with only the two
+shipped slots it also means no slot is left that can be rewritten (see the
+protection rules below). Write ``"2"`` instead if you want to keep slot 1 free
+for the next reconfiguration, or ship a third slot to rotate through.
+
+Committed writes persist immediately, are picked up right away and take effect
+on the next (re)connect; an already-established connection is not interrupted.
+The status returned for a connection-config write differs between the protocol
+versions (see below), but in neither case is a reboot actually required.
+
+The in-use configuration is protected (B09.FR.21/22), which is why the workflow
+above prepares a spare slot first:
+
+- Writes targeting the currently *active* slot, or any slot listed in
+  ``NetworkConfigurationPriority``, are rejected with ``PriorityNetworkConf``.
+  Keep at least one slot out of the priority list so there is always a slot you
+  can rewrite.
+- A ``NetworkConfigurationPriority`` write naming a slot without a complete
+  profile is rejected with ``InvalidNetworkConf``, as is a change that would
+  make a slot's URL scheme inconsistent with its security profile (``ws://``
+  needs profile < 2, ``wss://`` needs >= 2).
+- Lowering a slot's ``SecurityProfile`` below the confirmed one is rejected
+  with ``NoSecurityDowngrade``.
+
+Because the active slot is always protected, credentials for the running
+connection cannot be rotated per slot. Write the ``SecurityCtrlr`` globals
+instead: a committed write to ``SecurityCtrlr``/``Identity`` or
+``SecurityCtrlr``/``BasicAuthPassword`` clears the corresponding per-slot
+override on the active slot (B09.FR.26/27), so the new global value is what the
+next connection attempt uses - even when a legacy migration had populated the
+per-slot value. ``BasicAuthPassword`` is write-only; reads do not return it.
+
+``set_variables`` on this API may write ReadOnly variables: it is a trusted
+local integrator channel, and ReadOnly mutability models the CSMS-facing
+contract, not this API (the protection above still applies regardless of
+mutability). Some cells are nevertheless stack-owned runtime state, written on
+every successful connect; writing them here desyncs the device model from the
+connection logic. Do not write:
+
+- ``OCPPCommCtrlr``/``ActiveNetworkProfile`` - reports which slot is in use;
+  a manual write is corrected only on the next successful connect.
+- ``SecurityCtrlr``/``SecurityProfile`` - the *confirmed* security profile,
+  raised after a successful connect and used to permanently prune slots below
+  it from the failover list; raising it by hand can leave no attemptable slot.
+- ``NetworkConfiguration``/``OcppVersion`` - written back with the negotiated
+  version on 2.x connects; a value other than ``"OCPP16"`` removes the slot
+  from the usable set in OCPP 1.6 mode.
+
+Where the protocol versions differ
+""""""""""""""""""""""""""""""""""
+
+- **Status of a committed write.** OCPP 1.6 answers connection-config writes
+  with ``RebootRequired``, OCPP 2.x with ``Accepted``. The persisted value and
+  the moment it takes effect are the same.
+- **Priority changes.** In OCPP 1.6 a ``NetworkConfigurationPriority`` write is
+  picked up immediately and is effective on the next (re)connect. In OCPP 2.x
+  it is persisted but only taken into account after a reboot; plan one when
+  switching slots this way.
+- **Unusable slots.** OCPP 1.6 additionally ignores slots whose ``OcppVersion``
+  names another version, and falls back to the legacy single-profile settings
+  when the *active* slot is filtered out or incomplete; OCPP 2.x uses every
+  listed slot and simply skips incomplete ones. See
+  :ref:`Network connection profiles (OCPP 1.6) <handwritten_ocppmulti_network-profiles-ocpp16>`
+  for the details.
+- **Deprecated key-only writes.** Only in OCPP 1.6 mode, the legacy
+  ``SecurityProfile`` and ``AuthorizationKey`` keys can still be written
+  (empty component name); they act on the active slot and bypass the validation
+  above, and the profile used for **configure_network** and for
+  security-profile pruning keeps its previous contents until a canonical write,
+  a security-profile switch or a restart. ``SecurityProfile`` is not a quiet
+  write either: it triggers the 1.6 security-profile switch, which reconnects
+  immediately and falls back to the previous profile if the new one does not
+  connect within ``SwitchSecurityProfileConnectionTimeout``.
+  ``CentralSystemURI`` is *not* writable this way; it is read-only in the key
+  path, so the canonical ``NetworkConfiguration`` addressing is the only way to
+  change a CSMS URL.
 
 Monitoring configuration changes
---------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``monitor_variables`` with canonical addresses; changes are published on
 ``event_data`` with the same ``component_variable`` used at registration:
@@ -659,7 +894,7 @@ to canonical addressing. Requests with a non-empty component name are never
 reinterpreted as configuration keys.
 
 Behavioral difference to the legacy OCPP module
------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The legacy ``OCPP`` module ignores ``component.name`` entirely and always
 treats ``variable.name`` as a configuration key. OCPPmulti resolves the

--- a/modules/EVSE/OCPPmulti/manifest.yaml
+++ b/modules/EVSE/OCPPmulti/manifest.yaml
@@ -131,8 +131,17 @@ config:
       OCPP 1.6
       NetworkConfiguration slot number that OCPP 1.6 connection details (CentralSystemURI, SecurityProfile,
       AuthorizationKey, HostName, ChargePointId) are migrated to during the one-time device model migration.
-      Any existing attribute values in the target slot are overwritten.
-      Set to 0 to skip migration of network connection details entirely.
+      Any existing attribute values in the target slot are overwritten, the slot's OcppInterface is set to
+      "Any" unless the component config sets an explicit attribute value (a "default" does not count), and
+      OCPPCommCtrlr/ActiveNetworkProfile is pointed at the slot. The target slot must be defined in the
+      component configuration: a NetworkConfiguration_<N> component config must exist for it (otherwise the
+      migration of network connection details is skipped with an error log). The slot must also be listed in
+      the OCPPCommCtrlr/NetworkConfigurationPriority value for the profile to be used, and in that variable's
+      valuesList for runtime priority writes naming the slot to be accepted (a warning is logged when either
+      is missing).
+      The shipped example configs cover the default slot 1. Set to 0 to skip migration of network connection
+      details; the confirmed security profile (SecurityCtrlr/SecurityProfile) is still initialized from the
+      legacy config's SecurityProfile in that case.
     type: integer
     default: 1
   RequestCompositeScheduleDurationS:

--- a/modules/EVSE/OCPPmulti/tests/CMakeLists.txt
+++ b/modules/EVSE/OCPPmulti/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ target_sources(${TEST_TARGET_NAME}
     ../generic_ocpp.cpp
     ../grid_support/grid_support_state.cpp
     ../v16_chargepoint.cpp
+    ../v16_connection_config_validator.cpp
     ../v16_conversions.cpp
     ../v16_variable_access.cpp
     ../v2_chargepoint.cpp

--- a/modules/EVSE/OCPPmulti/tests/v16_variable_access_tests.cpp
+++ b/modules/EVSE/OCPPmulti/tests/v16_variable_access_tests.cpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <ocpp/v16/variable_resolver.hpp>
@@ -71,9 +72,11 @@ protected:
         m_keys["AuthorizationKey"] = ""; // derived key, write-only in 1.6
     }
 
-    ocpp_multi::V16VariableAccess make_access() {
+    ocpp_multi::V16VariableAccess
+    make_access(ocpp_multi::V16VariableAccess::on_connection_config_changed_fn on_connection_config_changed = nullptr,
+                const ocpp::v16::VariableResolver* resolver = nullptr) {
         return ocpp_multi::V16VariableAccess(
-            m_resolver, m_device_model,
+            resolver != nullptr ? *resolver : m_resolver, m_device_model,
             [this](const std::vector<ocpp::CiString<50>>& keys) {
                 ++m_get_keys_calls;
                 ocpp::v16::GetConfigurationResponse response;
@@ -110,7 +113,19 @@ protected:
                 }
                 m_keys[key.get()] = value.get();
                 return ocpp::v16::ConfigurationStatus::Accepted;
-            });
+            },
+            std::move(on_connection_config_changed));
+    }
+
+    // Seeds the five mandatory NetworkConnectionProfile variables so read_profile_from_device_model()
+    // sees a complete profile for the slot (as the B09-style write validation requires).
+    void add_complete_network_slot(int slot, const std::string& url, const std::string& security_profile = "1") {
+        const auto component = make_component("NetworkConfiguration", std::to_string(slot));
+        m_device_model.add(component, make_variable("OcppCsmsUrl"), url);
+        m_device_model.add(component, make_variable("SecurityProfile"), security_profile);
+        m_device_model.add(component, make_variable("OcppInterface"), "Any");
+        m_device_model.add(component, make_variable("OcppTransport"), "JSON");
+        m_device_model.add(component, make_variable("MessageTimeout"), "30");
     }
 
     ocpp::v16::VariableResolver m_resolver;
@@ -278,16 +293,20 @@ TEST_F(V16VariableAccess, freeCvReadsAndWritesDeviceModel) {
     EXPECT_TRUE(m_set_calls.empty()); // never touched the 1.6 key path
 }
 
-TEST_F(V16VariableAccess, freeCvReadOnlyMutabilityRejectsWrite) {
+// Mirrors the 2.x consumer path (Provisioning::set_variables, allow_read_only=true): this API is a
+// trusted local channel, so ReadOnly mutability does not reject writes in either mode.
+TEST_F(V16VariableAccess, freeCvReadOnlyMutabilityIsWritableLikeThe2xConsumerPath) {
     m_device_model.add(make_component("VendorCtrlr"), make_variable("FrozenSetting"), "fixed",
                        ocpp::v2::MutabilityEnum::ReadOnly);
     auto access = make_access();
 
-    const auto results = access.set({make_set("VendorCtrlr", "FrozenSetting", "nope")}, "csms");
+    const auto results = access.set({make_set("VendorCtrlr", "FrozenSetting", "thawed")}, "csms");
     ASSERT_EQ(results.size(), 1);
-    EXPECT_EQ(results[0].result.attributeStatus, ocpp::v2::SetVariableStatusEnum::Rejected);
-    EXPECT_FALSE(results[0].monitor_value.has_value());
-    EXPECT_EQ(m_device_model.entry(make_component("VendorCtrlr"), make_variable("FrozenSetting")).value, "fixed");
+    EXPECT_EQ(results[0].result.attributeStatus, ocpp::v2::SetVariableStatusEnum::Accepted);
+    ASSERT_TRUE(results[0].monitor_value.has_value());
+    EXPECT_EQ(results[0].monitor_value.value(), "thawed");
+    EXPECT_EQ(m_device_model.entry(make_component("VendorCtrlr"), make_variable("FrozenSetting")).value, "thawed");
+    // still routed through set_value (with allow_read_only), never set_read_only_value
     EXPECT_EQ(m_device_model.set_read_only_calls(), 0);
 }
 
@@ -353,9 +372,10 @@ TEST_F(V16VariableAccess, freeCvDirectRebootRequiredStillFlagsWrite) {
 }
 
 TEST_F(V16VariableAccess, connectionConfigWriteIsRebootRequired) {
-    m_device_model.add(make_component("NetworkConfiguration", std::string("2")), make_variable("OcppCsmsUrl"),
-                       "wss://old");
+    // the portable configuration flow: write a spare slot (2), then flip the priority to it
+    add_complete_network_slot(2, "wss://old", "2");
     m_device_model.add(make_component("OCPPCommCtrlr"), make_variable("NetworkConfigurationPriority"), "1");
+    m_device_model.add(make_component("OCPPCommCtrlr"), make_variable("ActiveNetworkProfile"), "1");
     auto access = make_access();
 
     const auto results = access.set({make_set("NetworkConfiguration", "OcppCsmsUrl", "wss://new", std::string("2")),
@@ -389,6 +409,277 @@ TEST_F(V16VariableAccess, connectionConfigReadsDeviceModel) {
     EXPECT_EQ(results[0].attributeValue.value().get(), "wss://csms");
     ASSERT_TRUE(results[0].component.instance.has_value());
     EXPECT_EQ(results[0].component.instance.value().get(), "2");
+}
+
+// ---- connection-config change callback (network profile reload trigger) ----
+
+TEST_F(V16VariableAccess, connectionConfigWriteFiresCallbackOncePerBatch) {
+    m_device_model.add(make_component("NetworkConfiguration", std::string("1")), make_variable("OcppCsmsUrl"),
+                       "wss://old1");
+    m_device_model.add(make_component("NetworkConfiguration", std::string("2")), make_variable("OcppCsmsUrl"),
+                       "wss://old2");
+    m_device_model.add(make_component("VendorCtrlr"), make_variable("BazSetting"), "baz"); // Free CV
+    int callback_count = 0;
+    auto access = make_access([&callback_count]() { ++callback_count; });
+
+    const auto results = access.set({make_set("NetworkConfiguration", "OcppCsmsUrl", "wss://new1", std::string("1")),
+                                     make_set("NetworkConfiguration", "OcppCsmsUrl", "wss://new2", std::string("2")),
+                                     make_set("VendorCtrlr", "BazSetting", "new-baz")},
+                                    "test");
+
+    ASSERT_EQ(results.size(), 3);
+    EXPECT_EQ(callback_count, 1) << "one refresh per batch, not one per connection-config write";
+}
+
+TEST_F(V16VariableAccess, freeWriteDoesNotFireCallback) {
+    m_device_model.add(make_component("VendorCtrlr"), make_variable("BazSetting"), "baz");
+    int callback_count = 0;
+    auto access = make_access([&callback_count]() { ++callback_count; });
+
+    const auto results = access.set({make_set("VendorCtrlr", "BazSetting", "new-baz")}, "test");
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results[0].result.attributeStatus, ocpp::v2::SetVariableStatusEnum::Accepted);
+    EXPECT_EQ(callback_count, 0);
+}
+
+TEST_F(V16VariableAccess, rejectedConnectionConfigWriteDoesNotFireCallback) {
+    // NetworkConfiguration slot 7 is absent from the device model -> the write is not committed.
+    int callback_count = 0;
+    auto access = make_access([&callback_count]() { ++callback_count; });
+
+    const auto results =
+        access.set({make_set("NetworkConfiguration", "OcppCsmsUrl", "wss://new", std::string("7"))}, "test");
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_NE(results[0].result.attributeStatus, ocpp::v2::SetVariableStatusEnum::RebootRequired);
+    EXPECT_EQ(callback_count, 0);
+}
+
+TEST_F(V16VariableAccess, priorityAndSecurityCtrlrCredentialWritesFireCallback) {
+    add_complete_network_slot(1, "wss://one", "2");
+    add_complete_network_slot(2, "wss://two", "2");
+    m_device_model.add(make_component("OCPPCommCtrlr"), make_variable("NetworkConfigurationPriority"), "1");
+    m_device_model.add(make_component("SecurityCtrlr"), make_variable("BasicAuthPassword"), "old-secret");
+    int callback_count = 0;
+    auto access = make_access([&callback_count]() { ++callback_count; });
+
+    access.set({make_set("OCPPCommCtrlr", "NetworkConfigurationPriority", "2,1")}, "test");
+    EXPECT_EQ(callback_count, 1);
+
+    access.set({make_set("SecurityCtrlr", "BasicAuthPassword", "new-secret")}, "test");
+    EXPECT_EQ(callback_count, 2);
+}
+
+// B09.FR.27 mirror: a committed write to the SecurityCtrlr/BasicAuthPassword global clears the per-slot
+// override on the active slot (and only there), so connection-time reads fall back to the new global.
+TEST_F(V16VariableAccess, securityGlobalPasswordWriteClearsActiveSlotOverride) {
+    add_complete_network_slot(1, "wss://one", "2");
+    add_complete_network_slot(2, "wss://two", "2");
+    const auto slot1 = make_component("NetworkConfiguration", std::string("1"));
+    const auto slot2 = make_component("NetworkConfiguration", std::string("2"));
+    m_device_model.add(slot1, make_variable("BasicAuthPassword"), "slot-one-secret-16");
+    m_device_model.add(slot2, make_variable("BasicAuthPassword"), "slot-two-secret-16");
+    m_device_model.add(make_component("OCPPCommCtrlr"), make_variable("ActiveNetworkProfile"), "1");
+    m_device_model.add(make_component("SecurityCtrlr"), make_variable("BasicAuthPassword"), "old-global-secret");
+    auto access = make_access();
+
+    const auto results = access.set({make_set("SecurityCtrlr", "BasicAuthPassword", "new-global-secret")}, "test");
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results[0].result.attributeStatus, ocpp::v2::SetVariableStatusEnum::RebootRequired);
+    EXPECT_EQ(m_device_model.entry(make_component("SecurityCtrlr"), make_variable("BasicAuthPassword")).value,
+              "new-global-secret");
+    EXPECT_EQ(m_device_model.entry(slot1, make_variable("BasicAuthPassword")).value, "");
+    EXPECT_EQ(m_device_model.entry(slot2, make_variable("BasicAuthPassword")).value, "slot-two-secret-16");
+}
+
+// B09.FR.26 mirror: same clearing for SecurityCtrlr/Identity.
+TEST_F(V16VariableAccess, securityGlobalIdentityWriteClearsActiveSlotOverride) {
+    add_complete_network_slot(1, "wss://one", "2");
+    const auto slot1 = make_component("NetworkConfiguration", std::string("1"));
+    m_device_model.add(slot1, make_variable("Identity"), "slot-identity");
+    m_device_model.add(make_component("OCPPCommCtrlr"), make_variable("ActiveNetworkProfile"), "1");
+    m_device_model.add(make_component("SecurityCtrlr"), make_variable("Identity"), "old-identity");
+    auto access = make_access();
+
+    const auto results = access.set({make_set("SecurityCtrlr", "Identity", "new-identity")}, "test");
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results[0].result.attributeStatus, ocpp::v2::SetVariableStatusEnum::RebootRequired);
+    EXPECT_EQ(m_device_model.entry(slot1, make_variable("Identity")).value, "");
+}
+
+TEST_F(V16VariableAccess, securityGlobalWriteWithoutActiveSlotLeavesOverrides) {
+    add_complete_network_slot(1, "wss://one", "2");
+    const auto slot1 = make_component("NetworkConfiguration", std::string("1"));
+    m_device_model.add(slot1, make_variable("BasicAuthPassword"), "slot-one-secret-16");
+    m_device_model.add(make_component("SecurityCtrlr"), make_variable("BasicAuthPassword"), "old-global-secret");
+    auto access = make_access();
+
+    const auto results = access.set({make_set("SecurityCtrlr", "BasicAuthPassword", "new-global-secret")}, "test");
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results[0].result.attributeStatus, ocpp::v2::SetVariableStatusEnum::RebootRequired);
+    EXPECT_EQ(m_device_model.entry(slot1, make_variable("BasicAuthPassword")).value, "slot-one-secret-16");
+}
+
+TEST_F(V16VariableAccess, rejectedSecurityGlobalWriteLeavesOverrides) {
+    add_complete_network_slot(1, "wss://one", "2");
+    const auto slot1 = make_component("NetworkConfiguration", std::string("1"));
+    m_device_model.add(slot1, make_variable("BasicAuthPassword"), "slot-one-secret-16");
+    m_device_model.add(make_component("OCPPCommCtrlr"), make_variable("ActiveNetworkProfile"), "1");
+    // SecurityCtrlr exists but BasicAuthPassword does not -> UnknownVariable, write not committed
+    m_device_model.add(make_component("SecurityCtrlr"), make_variable("Identity"), "identity");
+    auto access = make_access();
+
+    const auto results = access.set({make_set("SecurityCtrlr", "BasicAuthPassword", "new-global-secret")}, "test");
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results[0].result.attributeStatus, ocpp::v2::SetVariableStatusEnum::UnknownVariable);
+    EXPECT_EQ(m_device_model.entry(slot1, make_variable("BasicAuthPassword")).value, "slot-one-secret-16");
+}
+
+// Custom config mappings can target connection-config CVs; both the legacy key path (path 1) and the key-backed
+// canonical path (path 2) must then fire the callback on a committed write.
+TEST_F(V16VariableAccess, customMappedConnectionConfigKeyFiresCallback) {
+    ocpp::v2::Ocpp16CustomConfigMappings mappings;
+    mappings.emplace("VendorCsmsUrl", std::make_pair(make_component("NetworkConfiguration", std::string("2")),
+                                                     make_variable("OcppCsmsUrl")));
+    const ocpp::v16::VariableResolver resolver(mappings);
+    m_keys["VendorCsmsUrl"] = "wss://old";
+    int callback_count = 0;
+    auto access = make_access([&callback_count]() { ++callback_count; }, &resolver);
+
+    // path 1: legacy write by key name
+    const auto legacy = access.set({make_set("", "VendorCsmsUrl", "wss://new")}, "test");
+    ASSERT_EQ(legacy.size(), 1);
+    EXPECT_EQ(callback_count, 1);
+
+    // path 2: canonical write via the mapped CV routes through the same key
+    const auto canonical =
+        access.set({make_set("NetworkConfiguration", "OcppCsmsUrl", "wss://newer", std::string("2"))}, "test");
+    ASSERT_EQ(canonical.size(), 1);
+    EXPECT_EQ(callback_count, 2);
+}
+
+// ---- B09-style protection of the in-use network configuration (mirrors 2.x SetVariables validation) ----
+
+TEST_F(V16VariableAccess, writeToActiveSlotIsRejectedWithPriorityNetworkConf) {
+    add_complete_network_slot(2, "wss://two", "2");
+    m_device_model.add(make_component("OCPPCommCtrlr"), make_variable("ActiveNetworkProfile"), "2");
+    int callback_count = 0;
+    auto access = make_access([&callback_count]() { ++callback_count; });
+
+    const auto results =
+        access.set({make_set("NetworkConfiguration", "OcppCsmsUrl", "wss://new", std::string("2"))}, "test");
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results[0].result.attributeStatus, ocpp::v2::SetVariableStatusEnum::Rejected);
+    ASSERT_TRUE(results[0].result.attributeStatusInfo.has_value());
+    EXPECT_EQ(results[0].result.attributeStatusInfo.value().reasonCode.get(), "PriorityNetworkConf");
+    EXPECT_EQ(
+        m_device_model.entry(make_component("NetworkConfiguration", std::string("2")), make_variable("OcppCsmsUrl"))
+            .value,
+        "wss://two");
+    EXPECT_EQ(callback_count, 0);
+}
+
+TEST_F(V16VariableAccess, writeToPriorityListedSlotIsRejectedWithPriorityNetworkConf) {
+    add_complete_network_slot(2, "wss://two", "2");
+    m_device_model.add(make_component("OCPPCommCtrlr"), make_variable("NetworkConfigurationPriority"), "1,2");
+    int callback_count = 0;
+    auto access = make_access([&callback_count]() { ++callback_count; });
+
+    const auto results =
+        access.set({make_set("NetworkConfiguration", "OcppCsmsUrl", "wss://new", std::string("2"))}, "test");
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results[0].result.attributeStatus, ocpp::v2::SetVariableStatusEnum::Rejected);
+    ASSERT_TRUE(results[0].result.attributeStatusInfo.has_value());
+    EXPECT_EQ(results[0].result.attributeStatusInfo.value().reasonCode.get(), "PriorityNetworkConf");
+    EXPECT_EQ(callback_count, 0);
+}
+
+TEST_F(V16VariableAccess, priorityWriteReferencingIncompleteSlotIsRejected) {
+    add_complete_network_slot(1, "wss://one", "2");
+    m_device_model.add(make_component("OCPPCommCtrlr"), make_variable("NetworkConfigurationPriority"), "1");
+    int callback_count = 0;
+    auto access = make_access([&callback_count]() { ++callback_count; });
+
+    // slot 3 holds no complete profile -> the priority must not point at it
+    const auto results = access.set({make_set("OCPPCommCtrlr", "NetworkConfigurationPriority", "3,1")}, "test");
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results[0].result.attributeStatus, ocpp::v2::SetVariableStatusEnum::Rejected);
+    ASSERT_TRUE(results[0].result.attributeStatusInfo.has_value());
+    EXPECT_EQ(results[0].result.attributeStatusInfo.value().reasonCode.get(), "InvalidNetworkConf");
+    EXPECT_EQ(
+        m_device_model.entry(make_component("OCPPCommCtrlr"), make_variable("NetworkConfigurationPriority")).value,
+        "1");
+    EXPECT_EQ(callback_count, 0);
+}
+
+TEST_F(V16VariableAccess, slotSecurityProfileDowngradeBelowConfirmedIsRejected) {
+    add_complete_network_slot(2, "wss://two", "2");
+    m_device_model.add(make_component("SecurityCtrlr"), make_variable("SecurityProfile"), "2");
+    auto access = make_access();
+
+    const auto results =
+        access.set({make_set("NetworkConfiguration", "SecurityProfile", "1", std::string("2"))}, "test");
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results[0].result.attributeStatus, ocpp::v2::SetVariableStatusEnum::Rejected);
+    ASSERT_TRUE(results[0].result.attributeStatusInfo.has_value());
+    EXPECT_EQ(results[0].result.attributeStatusInfo.value().reasonCode.get(), "NoSecurityDowngrade");
+    EXPECT_EQ(
+        m_device_model.entry(make_component("NetworkConfiguration", std::string("2")), make_variable("SecurityProfile"))
+            .value,
+        "2");
+}
+
+TEST_F(V16VariableAccess, slotUrlSchemeSecurityProfileMismatchIsRejected) {
+    add_complete_network_slot(2, "ws://plain", "1");
+    auto access = make_access();
+
+    // raising the slot to security profile 2 while its URL is still ws:// yields an inconsistent profile
+    const auto results =
+        access.set({make_set("NetworkConfiguration", "SecurityProfile", "2", std::string("2"))}, "test");
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results[0].result.attributeStatus, ocpp::v2::SetVariableStatusEnum::Rejected);
+    ASSERT_TRUE(results[0].result.attributeStatusInfo.has_value());
+    EXPECT_EQ(results[0].result.attributeStatusInfo.value().reasonCode.get(), "InvalidNetworkConf");
+}
+
+TEST_F(V16VariableAccess, customMappedWriteToActiveSlotIsRejected) {
+    // the B09-style gate must also cover key-routed writes (paths 1 and 2) targeting slot CVs
+    ocpp::v2::Ocpp16CustomConfigMappings mappings;
+    mappings.emplace("VendorCsmsUrl", std::make_pair(make_component("NetworkConfiguration", std::string("2")),
+                                                     make_variable("OcppCsmsUrl")));
+    const ocpp::v16::VariableResolver resolver(mappings);
+    m_keys["VendorCsmsUrl"] = "wss://old";
+    add_complete_network_slot(2, "wss://two", "2");
+    m_device_model.add(make_component("OCPPCommCtrlr"), make_variable("ActiveNetworkProfile"), "2");
+    int callback_count = 0;
+    auto access = make_access([&callback_count]() { ++callback_count; }, &resolver);
+
+    // path 1: legacy write by key name
+    const auto legacy = access.set({make_set("", "VendorCsmsUrl", "wss://new")}, "test");
+    ASSERT_EQ(legacy.size(), 1);
+    EXPECT_EQ(legacy[0].result.attributeStatus, ocpp::v2::SetVariableStatusEnum::Rejected);
+    ASSERT_TRUE(legacy[0].result.attributeStatusInfo.has_value());
+    EXPECT_EQ(legacy[0].result.attributeStatusInfo.value().reasonCode.get(), "PriorityNetworkConf");
+
+    // path 2: canonical write via the mapped CV
+    const auto canonical =
+        access.set({make_set("NetworkConfiguration", "OcppCsmsUrl", "wss://newer", std::string("2"))}, "test");
+    ASSERT_EQ(canonical.size(), 1);
+    EXPECT_EQ(canonical[0].result.attributeStatus, ocpp::v2::SetVariableStatusEnum::Rejected);
+
+    EXPECT_TRUE(m_set_calls.empty()); // the 1.6 key path was never reached
+    EXPECT_EQ(m_keys["VendorCsmsUrl"], "wss://old");
+    EXPECT_EQ(callback_count, 0);
 }
 
 TEST_F(V16VariableAccess, readOnlyDerivedReadsDeviceModelAndRejectsWrite) {

--- a/modules/EVSE/OCPPmulti/v16_chargepoint.cpp
+++ b/modules/EVSE/OCPPmulti/v16_chargepoint.cpp
@@ -484,6 +484,8 @@ void ChargePointV16::configure_callbacks() {
         [this](auto&&... args) { return m_callbacks_ptr->cb_all_connectors_unavailable(args...); });
     m_charge_point->register_cancel_reservation_callback(
         [this](auto&&... args) { return m_callbacks_ptr->cb_cancel_reservation(args...); });
+    m_charge_point->register_configure_network_connection_profile_callback(
+        [this](auto&&... args) { return m_callbacks_ptr->cb_configure_network_connection_profile(args...); });
     m_charge_point->register_get_15118_ev_certificate_response_callback(
         [this](auto&&... args) { return m_callbacks_ptr->cb_get_15118_ev_certificate_response(args...); });
     m_charge_point->register_pause_charging_callback([this](std::int32_t ocpp_connector_id) {
@@ -571,6 +573,11 @@ void ChargePointV16::configure_data_model(const config_info_t& config) {
         },
         [this](const ocpp::CiString<50>& key, const ocpp::CiString<500>& value) {
             return m_charge_point->set_configuration_key(key, value);
+        },
+        [this]() {
+            // Connection-config write via the EVerest ocpp interface: refresh the stack's cached network
+            // profiles so priority/slot changes take effect on the next (re)connect; 2.x parity.
+            m_charge_point->reload_network_profiles();
         });
 
     // The factory does not create the message-log directory; retain that here.

--- a/modules/EVSE/OCPPmulti/v16_connection_config_validator.cpp
+++ b/modules/EVSE/OCPPmulti/v16_connection_config_validator.cpp
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "v16_connection_config_validator.hpp"
+
+#include <everest/logging.hpp>
+#include <ocpp/common/utils.hpp>
+#include <ocpp/v2/comparators.hpp>
+#include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v2/device_model_helpers.hpp>
+
+namespace ocpp_multi {
+
+V16ConnectionConfigValidator::V16ConnectionConfigValidator(ocpp::v2::DeviceModelInterface& device_model) :
+    m_device_model(device_model) {
+}
+
+std::optional<std::string> V16ConnectionConfigValidator::validate_write(const ocpp::v2::Component& component,
+                                                                        const ocpp::v2::Variable& variable,
+                                                                        const std::string& value) const {
+    if (component.name == "NetworkConfiguration" && component.instance.has_value()) {
+        return validate_network_configuration_slot_write(component, variable, value);
+    }
+    const ocpp::v2::ComponentVariable cv = {component, variable, std::nullopt};
+    if (cv == ocpp::v2::ControllerComponentVariables::NetworkConfigurationPriority) {
+        return validate_network_configuration_priority_write(value);
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> V16ConnectionConfigValidator::validate_network_configuration_slot_write(
+    const ocpp::v2::Component& component, const ocpp::v2::Variable& variable, const std::string& value) const {
+    namespace CC = ocpp::v2::ControllerComponentVariables;
+    namespace NC = ocpp::v2::NetworkConfigurationComponentVariables;
+    try {
+        const int slot = std::stoi(component.instance.value().get());
+
+        // B09.FR.22: Reject writes targeting the currently active slot or any slot listed in the
+        // current NetworkConfigurationPriority. Single reasonCode PriorityNetworkConf, like 2.x.
+        const auto active_slot_opt = ocpp::v2::get_optional_value<int>(m_device_model, CC::ActiveNetworkProfile);
+        if (active_slot_opt.has_value() && slot == active_slot_opt.value()) {
+            EVLOG_warning << "Cannot set NetworkConfiguration variable for slot " << slot
+                          << " which is the currently active network profile";
+            return "PriorityNetworkConf";
+        }
+        const auto priority_opt =
+            ocpp::v2::get_optional_value<std::string>(m_device_model, CC::NetworkConfigurationPriority);
+        if (priority_opt.has_value()) {
+            for (const auto& priority_slot_str : ocpp::split_string(priority_opt.value(), ',')) {
+                int priority_slot = 0;
+                try {
+                    priority_slot = std::stoi(priority_slot_str);
+                } catch (const std::exception& e) {
+                    EVLOG_warning << "NetworkConfigurationPriority contains non-integer token '" << priority_slot_str
+                                  << "': " << e.what();
+                    continue;
+                }
+                if (priority_slot == slot) {
+                    EVLOG_warning << "Cannot set NetworkConfiguration variable for slot " << slot
+                                  << " which is a priority network profile";
+                    return "PriorityNetworkConf";
+                }
+            }
+        }
+
+        // B09.FR.35: Reject security profile downgrades below the confirmed profile. An absent
+        // confirmed cell counts as 0 ("nothing confirmed yet"), matching get_security_profile().
+        if (variable.name == "SecurityProfile") {
+            const int new_profile = std::stoi(value);
+            const int confirmed_profile =
+                ocpp::v2::get_optional_value<int>(m_device_model, CC::SecurityProfile).value_or(0);
+            if (new_profile < confirmed_profile) {
+                EVLOG_warning << "Cannot downgrade SecurityProfile from " << confirmed_profile << " to " << new_profile;
+                return "NoSecurityDowngrade";
+            }
+        }
+
+        // URL-scheme / security-profile consistency of the resulting profile (current state + proposed
+        // change), checked only once the slot holds a complete profile, like 2.x.
+        if (auto profile_opt = NC::read_profile_from_device_model(m_device_model, slot); profile_opt.has_value()) {
+            auto profile = *profile_opt;
+            if (variable.name == "SecurityProfile") {
+                profile.securityProfile = std::stoi(value);
+            } else if (variable.name == "OcppCsmsUrl") {
+                profile.ocppCsmsUrl = ocpp::CiString<2000>(value);
+            }
+            const std::string url = profile.ocppCsmsUrl.get();
+            if (url.find("wss://") == 0 && profile.securityProfile < 2) {
+                EVLOG_warning << "configurationSlot " << slot << ": wss:// URL requires securityProfile >= 2, got "
+                              << profile.securityProfile;
+                return "InvalidNetworkConf";
+            }
+            if (url.find("ws://") == 0 && profile.securityProfile >= 2) {
+                EVLOG_warning << "configurationSlot " << slot
+                              << ": ws:// URL is not allowed with securityProfile >= 2, got "
+                              << profile.securityProfile;
+                return "InvalidNetworkConf";
+            }
+        }
+    } catch (const std::exception& e) {
+        EVLOG_warning << "Error validating NetworkConfiguration: " << e.what();
+        return "InvalidNetworkConf";
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string>
+V16ConnectionConfigValidator::validate_network_configuration_priority_write(const std::string& value) const {
+    namespace NC = ocpp::v2::NetworkConfigurationComponentVariables;
+    try {
+        for (const auto& slot_str : ocpp::split_string(value, ',')) {
+            const int slot = std::stoi(slot_str);
+            if (!NC::read_profile_from_device_model(m_device_model, slot).has_value()) {
+                EVLOG_warning << "Could not find network profile for configurationSlot: " << slot_str;
+                return "InvalidNetworkConf";
+            }
+        }
+    } catch (const std::exception& e) {
+        EVLOG_warning << "NetworkConfigurationPriority contains at least one value which is not an integer: " << value;
+        return "InvalidNetworkConf";
+    }
+    return std::nullopt;
+}
+
+} // namespace ocpp_multi

--- a/modules/EVSE/OCPPmulti/v16_connection_config_validator.hpp
+++ b/modules/EVSE/OCPPmulti/v16_connection_config_validator.hpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include <ocpp/v2/device_model_interface.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
+
+namespace ocpp_multi {
+
+/// \brief B09-style validation of connection-config writes in v16 mode, mirroring the 2.x
+///        Provisioning::validate_set_variable. The 2.x certificate-installation checks are not
+///        mirrored; a missing certificate surfaces at connect time through slot failover.
+class V16ConnectionConfigValidator {
+public:
+    explicit V16ConnectionConfigValidator(ocpp::v2::DeviceModelInterface& device_model);
+
+    /// \returns the reasonCode when the write must be rejected
+    std::optional<std::string> validate_write(const ocpp::v2::Component& component, const ocpp::v2::Variable& variable,
+                                              const std::string& value) const;
+
+private:
+    std::optional<std::string> validate_network_configuration_slot_write(const ocpp::v2::Component& component,
+                                                                         const ocpp::v2::Variable& variable,
+                                                                         const std::string& value) const;
+    std::optional<std::string> validate_network_configuration_priority_write(const std::string& value) const;
+
+    ocpp::v2::DeviceModelInterface& m_device_model;
+};
+
+} // namespace ocpp_multi

--- a/modules/EVSE/OCPPmulti/v16_variable_access.cpp
+++ b/modules/EVSE/OCPPmulti/v16_variable_access.cpp
@@ -3,12 +3,15 @@
 
 #include "v16_variable_access.hpp"
 
-#include <algorithm>
 #include <utility>
 
 #include <fmt/core.h>
 
 #include <everest/logging.hpp>
+#include <ocpp/common/constants.hpp>
+#include <ocpp/v2/comparators.hpp>
+#include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v2/device_model_helpers.hpp>
 
 namespace {
 
@@ -32,6 +35,12 @@ ocpp::v2::StatusInfo read_only_derived_status_info() {
     ocpp::v2::StatusInfo info;
     info.reasonCode = "ReadOnly";
     info.additionalInfo = ocpp::CiString<1024>(READ_ONLY_DERIVED_INFO);
+    return info;
+}
+
+ocpp::v2::StatusInfo reason_code_status_info(const std::string& reason_code) {
+    ocpp::v2::StatusInfo info;
+    info.reasonCode = reason_code;
     return info;
 }
 
@@ -67,8 +76,13 @@ namespace ocpp_multi {
 
 V16VariableAccess::V16VariableAccess(const ocpp::v16::VariableResolver& resolver,
                                      ocpp::v2::DeviceModelInterface& device_model, get_keys_fn get_keys,
-                                     set_key_fn set_key) :
-    m_resolver(resolver), m_device_model(device_model), m_get_keys(std::move(get_keys)), m_set_key(std::move(set_key)) {
+                                     set_key_fn set_key, on_connection_config_changed_fn on_connection_config_changed) :
+    m_resolver(resolver),
+    m_device_model(device_model),
+    m_connection_config_validator(device_model),
+    m_get_keys(std::move(get_keys)),
+    m_set_key(std::move(set_key)),
+    m_on_connection_config_changed(std::move(on_connection_config_changed)) {
 }
 
 void V16VariableAccess::warn_deprecated_key(const std::string& key) {
@@ -89,6 +103,9 @@ void V16VariableAccess::warn_deprecated_key(const std::string& key) {
 //   path 3, direct:     no 1.6 key -> device-model access; writes moderated by CVClass
 //   path 4, ambiguous:  CV mapped by several custom keys -> Rejected, never a silent pick
 // Checked in order 1, 4, 2, 3: ambiguity must be ruled out before a key counts as usable.
+// Connection config (CVClass::ConnectionConfig) is only reachable via path 3 or a standard key whose
+// reboot/reconnect semantics live in the 1.6 stack: custom mappings targeting connection-config CVs
+// are rejected when the mapping file is loaded, so a custom key on paths 1/2 can never carry one.
 std::vector<ocpp::v2::GetVariableResult>
 V16VariableAccess::get(const std::vector<ocpp::v2::GetVariableData>& requests) {
     std::vector<ocpp::v2::GetVariableResult> results;
@@ -198,6 +215,12 @@ std::vector<SetVariableOutcome> V16VariableAccess::set(const std::vector<ocpp::v
     std::vector<SetVariableOutcome> outcomes;
     outcomes.reserve(requests.size());
 
+    const auto is_committed = [](ocpp::v2::SetVariableStatusEnum status) {
+        return status == ocpp::v2::SetVariableStatusEnum::Accepted ||
+               status == ocpp::v2::SetVariableStatusEnum::RebootRequired;
+    };
+    bool connection_config_changed = false;
+
     for (const auto& request : requests) {
         SetVariableOutcome outcome;
         outcome.result.component = request.component;
@@ -206,8 +229,24 @@ std::vector<SetVariableOutcome> V16VariableAccess::set(const std::vector<ocpp::v
         if (request.component.name.get().empty()) {
             // path 1, legacy key routing
             warn_deprecated_key(request.variable.name.get());
+            // a custom key mapping can target a connection-config CV (no standard key does)
+            const auto cv = m_resolver.key_to_cv(request.variable.name.get());
+            const bool connection_config =
+                cv.has_value() && m_resolver.classify(cv->first, cv->second) == ocpp::v16::CVClass::ConnectionConfig;
+            if (connection_config) {
+                if (const auto reason = m_connection_config_validator.validate_write(cv->first, cv->second,
+                                                                                     request.attributeValue.get())) {
+                    outcome.result.attributeStatus = ocpp::v2::SetVariableStatusEnum::Rejected;
+                    outcome.result.attributeStatusInfo = reason_code_status_info(reason.value());
+                    outcomes.push_back(std::move(outcome));
+                    continue;
+                }
+            }
             const ocpp::CiString<500> value = static_cast<std::string>(request.attributeValue);
             outcome.result.attributeStatus = convert(m_set_key(request.variable.name, value));
+            if (connection_config && is_committed(outcome.result.attributeStatus)) {
+                connection_config_changed = true;
+            }
             outcomes.push_back(std::move(outcome));
             continue;
         }
@@ -228,8 +267,22 @@ std::vector<SetVariableOutcome> V16VariableAccess::set(const std::vector<ocpp::v
                 outcomes.push_back(std::move(outcome));
                 continue;
             }
+            const bool connection_config =
+                m_resolver.classify(request.component, request.variable) == ocpp::v16::CVClass::ConnectionConfig;
+            if (connection_config) {
+                if (const auto reason = m_connection_config_validator.validate_write(
+                        request.component, request.variable, request.attributeValue.get())) {
+                    outcome.result.attributeStatus = ocpp::v2::SetVariableStatusEnum::Rejected;
+                    outcome.result.attributeStatusInfo = reason_code_status_info(reason.value());
+                    outcomes.push_back(std::move(outcome));
+                    continue;
+                }
+            }
             const ocpp::CiString<500> value = static_cast<std::string>(request.attributeValue);
             outcome.result.attributeStatus = convert(m_set_key(reverse.key.value(), value));
+            if (connection_config && is_committed(outcome.result.attributeStatus)) {
+                connection_config_changed = true;
+            }
             outcomes.push_back(std::move(outcome));
             continue;
         }
@@ -261,10 +314,23 @@ std::vector<SetVariableOutcome> V16VariableAccess::set(const std::vector<ocpp::v
             continue;
         }
 
-        // Free / ConnectionConfig: set_value only, never set_read_only_value
+        if (cv_class == ocpp::v16::CVClass::ConnectionConfig) {
+            // B09-style protection of the in-use network configuration, mirroring the 2.x SetVariables path
+            if (const auto reason = m_connection_config_validator.validate_write(request.component, request.variable,
+                                                                                 request.attributeValue.get())) {
+                outcome.result.attributeStatus = ocpp::v2::SetVariableStatusEnum::Rejected;
+                outcome.result.attributeStatusInfo = reason_code_status_info(reason.value());
+                outcomes.push_back(std::move(outcome));
+                continue;
+            }
+        }
+
+        // Free / ConnectionConfig: allow writing ReadOnly variables, mirroring the 2.x consumer path
+        // (Provisioning::set_variables); this API is a trusted local channel, and mutability models the
+        // CSMS-facing contract. ReadOnlyDerived CVs stay rejected above.
         const auto attribute = request.attributeType.value_or(ocpp::v2::AttributeEnum::Actual);
         const auto status = m_device_model.set_value(request.component, request.variable, attribute,
-                                                     request.attributeValue.get(), source);
+                                                     request.attributeValue.get(), source, true);
         // every committed write carries a monitor value (write-only values masked);
         // ConnectionConfig then forces RebootRequired semantics
         const bool committed = (status == ocpp::v2::SetVariableStatusEnum::Accepted) ||
@@ -276,13 +342,66 @@ std::vector<SetVariableOutcome> V16VariableAccess::set(const std::vector<ocpp::v
             outcome.result.attributeStatus = (cv_class == ocpp::v16::CVClass::ConnectionConfig)
                                                  ? ocpp::v2::SetVariableStatusEnum::RebootRequired
                                                  : status;
+            if (cv_class == ocpp::v16::CVClass::ConnectionConfig) {
+                connection_config_changed = true;
+            }
+            if (is_actual(request.attributeType)) {
+                clear_active_slot_override(request.component, request.variable);
+            }
         } else {
             outcome.result.attributeStatus = status;
         }
         outcomes.push_back(std::move(outcome));
     }
 
+    // Once per batch, mirroring the 2.x SetVariables handling
+    if (connection_config_changed && m_on_connection_config_changed) {
+        m_on_connection_config_changed();
+    }
+
     return outcomes;
+}
+
+// Mirrors the 2.x SetVariables path (Provisioning::handle_variable_changed, B09.FR.26/27): a committed
+// write to the SecurityCtrlr Identity/BasicAuthPassword global clears the per-slot override on the active
+// NetworkConfiguration slot, so connection-time reads fall back to the new global per B09.FR.16. Without
+// this, a per-slot value (e.g. written by the legacy 1.6 migration) masks the new global indefinitely.
+void V16VariableAccess::clear_active_slot_override(const ocpp::v2::Component& component,
+                                                   const ocpp::v2::Variable& variable) {
+    namespace CC = ocpp::v2::ControllerComponentVariables;
+    namespace NC = ocpp::v2::NetworkConfigurationComponentVariables;
+    const ocpp::v2::ComponentVariable cv = {component, variable, std::nullopt};
+    const ocpp::v2::Variable* slot_variable = nullptr;
+    const char* reason_tag = nullptr;
+    if (cv == CC::BasicAuthPassword) {
+        slot_variable = &NC::BasicAuthPassword;
+        reason_tag = "B09.FR.27";
+    } else if (cv == CC::SecurityCtrlrIdentity) {
+        slot_variable = &NC::Identity;
+        reason_tag = "B09.FR.26";
+    } else {
+        return;
+    }
+    const auto active_slot = ocpp::v2::get_optional_value<int>(m_device_model, CC::ActiveNetworkProfile);
+    if (!active_slot.has_value()) {
+        return;
+    }
+    const auto slot_cv = NC::get_component_variable(active_slot.value(), *slot_variable);
+    if (!slot_cv.variable.has_value()) {
+        return;
+    }
+    // clear_value bypasses value validation; per-slot BasicAuthPassword declares minLimit=16, which
+    // would reject the empty-string sentinel through set_value.
+    const auto status =
+        m_device_model.clear_value(slot_cv.component, slot_cv.variable.value(), ocpp::v2::AttributeEnum::Actual,
+                                   ocpp::VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
+    if (status == ocpp::v2::SetVariableStatusEnum::Accepted) {
+        EVLOG_info << "Cleared " << slot_variable->name.get() << " on active NetworkConfiguration slot "
+                   << active_slot.value() << " (" << reason_tag << ")";
+    } else {
+        EVLOG_warning << "Could not clear " << slot_variable->name.get() << " on active NetworkConfiguration slot "
+                      << active_slot.value() << " (" << reason_tag << "): set rejected";
+    }
 }
 
 } // namespace ocpp_multi

--- a/modules/EVSE/OCPPmulti/v16_variable_access.cpp
+++ b/modules/EVSE/OCPPmulti/v16_variable_access.cpp
@@ -3,12 +3,15 @@
 
 #include "v16_variable_access.hpp"
 
-#include <algorithm>
 #include <utility>
 
 #include <fmt/core.h>
 
 #include <everest/logging.hpp>
+#include <ocpp/common/constants.hpp>
+#include <ocpp/v2/comparators.hpp>
+#include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v2/device_model_helpers.hpp>
 
 namespace {
 
@@ -32,6 +35,12 @@ ocpp::v2::StatusInfo read_only_derived_status_info() {
     ocpp::v2::StatusInfo info;
     info.reasonCode = "ReadOnly";
     info.additionalInfo = ocpp::CiString<1024>(READ_ONLY_DERIVED_INFO);
+    return info;
+}
+
+ocpp::v2::StatusInfo reason_code_status_info(const std::string& reason_code) {
+    ocpp::v2::StatusInfo info;
+    info.reasonCode = reason_code;
     return info;
 }
 
@@ -67,8 +76,13 @@ namespace ocpp_multi {
 
 V16VariableAccess::V16VariableAccess(const ocpp::v16::VariableResolver& resolver,
                                      ocpp::v2::DeviceModelInterface& device_model, get_keys_fn get_keys,
-                                     set_key_fn set_key) :
-    m_resolver(resolver), m_device_model(device_model), m_get_keys(std::move(get_keys)), m_set_key(std::move(set_key)) {
+                                     set_key_fn set_key, on_connection_config_changed_fn on_connection_config_changed) :
+    m_resolver(resolver),
+    m_device_model(device_model),
+    m_connection_config_validator(device_model),
+    m_get_keys(std::move(get_keys)),
+    m_set_key(std::move(set_key)),
+    m_on_connection_config_changed(std::move(on_connection_config_changed)) {
 }
 
 void V16VariableAccess::warn_deprecated_key(const std::string& key) {
@@ -198,6 +212,12 @@ std::vector<SetVariableOutcome> V16VariableAccess::set(const std::vector<ocpp::v
     std::vector<SetVariableOutcome> outcomes;
     outcomes.reserve(requests.size());
 
+    const auto is_committed = [](ocpp::v2::SetVariableStatusEnum status) {
+        return status == ocpp::v2::SetVariableStatusEnum::Accepted ||
+               status == ocpp::v2::SetVariableStatusEnum::RebootRequired;
+    };
+    bool connection_config_changed = false;
+
     for (const auto& request : requests) {
         SetVariableOutcome outcome;
         outcome.result.component = request.component;
@@ -206,8 +226,24 @@ std::vector<SetVariableOutcome> V16VariableAccess::set(const std::vector<ocpp::v
         if (request.component.name.get().empty()) {
             // path 1, legacy key routing
             warn_deprecated_key(request.variable.name.get());
+            // a custom key mapping can target a connection-config CV (no standard key does)
+            const auto cv = m_resolver.key_to_cv(request.variable.name.get());
+            const bool connection_config =
+                cv.has_value() && m_resolver.classify(cv->first, cv->second) == ocpp::v16::CVClass::ConnectionConfig;
+            if (connection_config) {
+                if (const auto reason = m_connection_config_validator.validate_write(cv->first, cv->second,
+                                                                                     request.attributeValue.get())) {
+                    outcome.result.attributeStatus = ocpp::v2::SetVariableStatusEnum::Rejected;
+                    outcome.result.attributeStatusInfo = reason_code_status_info(reason.value());
+                    outcomes.push_back(std::move(outcome));
+                    continue;
+                }
+            }
             const ocpp::CiString<500> value = static_cast<std::string>(request.attributeValue);
             outcome.result.attributeStatus = convert(m_set_key(request.variable.name, value));
+            if (connection_config && is_committed(outcome.result.attributeStatus)) {
+                connection_config_changed = true;
+            }
             outcomes.push_back(std::move(outcome));
             continue;
         }
@@ -228,8 +264,22 @@ std::vector<SetVariableOutcome> V16VariableAccess::set(const std::vector<ocpp::v
                 outcomes.push_back(std::move(outcome));
                 continue;
             }
+            const bool connection_config =
+                m_resolver.classify(request.component, request.variable) == ocpp::v16::CVClass::ConnectionConfig;
+            if (connection_config) {
+                if (const auto reason = m_connection_config_validator.validate_write(
+                        request.component, request.variable, request.attributeValue.get())) {
+                    outcome.result.attributeStatus = ocpp::v2::SetVariableStatusEnum::Rejected;
+                    outcome.result.attributeStatusInfo = reason_code_status_info(reason.value());
+                    outcomes.push_back(std::move(outcome));
+                    continue;
+                }
+            }
             const ocpp::CiString<500> value = static_cast<std::string>(request.attributeValue);
             outcome.result.attributeStatus = convert(m_set_key(reverse.key.value(), value));
+            if (connection_config && is_committed(outcome.result.attributeStatus)) {
+                connection_config_changed = true;
+            }
             outcomes.push_back(std::move(outcome));
             continue;
         }
@@ -261,10 +311,23 @@ std::vector<SetVariableOutcome> V16VariableAccess::set(const std::vector<ocpp::v
             continue;
         }
 
-        // Free / ConnectionConfig: set_value only, never set_read_only_value
+        if (cv_class == ocpp::v16::CVClass::ConnectionConfig) {
+            // B09-style protection of the in-use network configuration, mirroring the 2.x SetVariables path
+            if (const auto reason = m_connection_config_validator.validate_write(request.component, request.variable,
+                                                                                 request.attributeValue.get())) {
+                outcome.result.attributeStatus = ocpp::v2::SetVariableStatusEnum::Rejected;
+                outcome.result.attributeStatusInfo = reason_code_status_info(reason.value());
+                outcomes.push_back(std::move(outcome));
+                continue;
+            }
+        }
+
+        // Free / ConnectionConfig: allow writing ReadOnly variables, mirroring the 2.x consumer path
+        // (Provisioning::set_variables); this API is a trusted local channel, and mutability models the
+        // CSMS-facing contract. ReadOnlyDerived CVs stay rejected above.
         const auto attribute = request.attributeType.value_or(ocpp::v2::AttributeEnum::Actual);
         const auto status = m_device_model.set_value(request.component, request.variable, attribute,
-                                                     request.attributeValue.get(), source);
+                                                     request.attributeValue.get(), source, true);
         // every committed write carries a monitor value (write-only values masked);
         // ConnectionConfig then forces RebootRequired semantics
         const bool committed = (status == ocpp::v2::SetVariableStatusEnum::Accepted) ||
@@ -276,13 +339,66 @@ std::vector<SetVariableOutcome> V16VariableAccess::set(const std::vector<ocpp::v
             outcome.result.attributeStatus = (cv_class == ocpp::v16::CVClass::ConnectionConfig)
                                                  ? ocpp::v2::SetVariableStatusEnum::RebootRequired
                                                  : status;
+            if (cv_class == ocpp::v16::CVClass::ConnectionConfig) {
+                connection_config_changed = true;
+            }
+            if (is_actual(request.attributeType)) {
+                clear_active_slot_override(request.component, request.variable);
+            }
         } else {
             outcome.result.attributeStatus = status;
         }
         outcomes.push_back(std::move(outcome));
     }
 
+    // Once per batch, mirroring the 2.x SetVariables handling
+    if (connection_config_changed && m_on_connection_config_changed) {
+        m_on_connection_config_changed();
+    }
+
     return outcomes;
+}
+
+// Mirrors the 2.x SetVariables path (Provisioning::handle_variable_changed, B09.FR.26/27): a committed
+// write to the SecurityCtrlr Identity/BasicAuthPassword global clears the per-slot override on the active
+// NetworkConfiguration slot, so connection-time reads fall back to the new global per B09.FR.16. Without
+// this, a per-slot value (e.g. written by the legacy 1.6 migration) masks the new global indefinitely.
+void V16VariableAccess::clear_active_slot_override(const ocpp::v2::Component& component,
+                                                   const ocpp::v2::Variable& variable) {
+    namespace CC = ocpp::v2::ControllerComponentVariables;
+    namespace NC = ocpp::v2::NetworkConfigurationComponentVariables;
+    const ocpp::v2::ComponentVariable cv = {component, variable, std::nullopt};
+    const ocpp::v2::Variable* slot_variable = nullptr;
+    const char* reason_tag = nullptr;
+    if (cv == CC::BasicAuthPassword) {
+        slot_variable = &NC::BasicAuthPassword;
+        reason_tag = "B09.FR.27";
+    } else if (cv == CC::SecurityCtrlrIdentity) {
+        slot_variable = &NC::Identity;
+        reason_tag = "B09.FR.26";
+    } else {
+        return;
+    }
+    const auto active_slot = ocpp::v2::get_optional_value<int>(m_device_model, CC::ActiveNetworkProfile);
+    if (!active_slot.has_value()) {
+        return;
+    }
+    const auto slot_cv = NC::get_component_variable(active_slot.value(), *slot_variable);
+    if (!slot_cv.variable.has_value()) {
+        return;
+    }
+    // clear_value bypasses value validation; per-slot BasicAuthPassword declares minLimit=16, which
+    // would reject the empty-string sentinel through set_value.
+    const auto status =
+        m_device_model.clear_value(slot_cv.component, slot_cv.variable.value(), ocpp::v2::AttributeEnum::Actual,
+                                   ocpp::VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
+    if (status == ocpp::v2::SetVariableStatusEnum::Accepted) {
+        EVLOG_info << "Cleared " << slot_variable->name.get() << " on active NetworkConfiguration slot "
+                   << active_slot.value() << " (" << reason_tag << ")";
+    } else {
+        EVLOG_warning << "Could not clear " << slot_variable->name.get() << " on active NetworkConfiguration slot "
+                      << active_slot.value() << " (" << reason_tag << "): set rejected";
+    }
 }
 
 } // namespace ocpp_multi

--- a/modules/EVSE/OCPPmulti/v16_variable_access.hpp
+++ b/modules/EVSE/OCPPmulti/v16_variable_access.hpp
@@ -15,6 +15,7 @@
 #include <ocpp/v2/ocpp_types.hpp>
 
 #include "generic_chargepoint_interface.hpp"
+#include "v16_connection_config_validator.hpp"
 
 namespace ocpp_multi {
 
@@ -25,9 +26,14 @@ public:
     using get_keys_fn = std::function<ocpp::v16::GetConfigurationResponse(const std::vector<ocpp::CiString<50>>&)>;
     using set_key_fn =
         std::function<ocpp::v16::ConfigurationStatus(const ocpp::CiString<50>&, const ocpp::CiString<500>&)>;
+    /// \brief Invoked at most once per set() batch when a committed write touched a connection-config CV
+    ///        (NetworkConfiguration components, network priority/active slot, SecurityCtrlr credentials), so the
+    ///        owner can refresh the OCPP1.6 stack's cached network profiles - mirroring the 2.x SetVariables path.
+    using on_connection_config_changed_fn = std::function<void()>;
 
     V16VariableAccess(const ocpp::v16::VariableResolver& resolver, ocpp::v2::DeviceModelInterface& device_model,
-                      get_keys_fn get_keys, set_key_fn set_key);
+                      get_keys_fn get_keys, set_key_fn set_key,
+                      on_connection_config_changed_fn on_connection_config_changed = nullptr);
 
     std::vector<ocpp::v2::GetVariableResult> get(const std::vector<ocpp::v2::GetVariableData>& requests);
     std::vector<SetVariableOutcome> set(const std::vector<ocpp::v2::SetVariableData>& requests,
@@ -40,11 +46,14 @@ public:
 
 private:
     void warn_deprecated_key(const std::string& key);
+    void clear_active_slot_override(const ocpp::v2::Component& component, const ocpp::v2::Variable& variable);
 
     const ocpp::v16::VariableResolver& m_resolver;
     ocpp::v2::DeviceModelInterface& m_device_model;
+    V16ConnectionConfigValidator m_connection_config_validator;
     get_keys_fn m_get_keys;
     set_key_fn m_set_key;
+    on_connection_config_changed_fn m_on_connection_config_changed;
     std::set<std::string> m_warned_keys;
 };
 

--- a/tests/ocpp_tests/pytest.ini
+++ b/tests/ocpp_tests/pytest.ini
@@ -12,6 +12,7 @@ markers=
     use_temporary_persistent_store: Use a test-local temporary file for the persistent store database
     csms_tls: Use a CSMS with TLS
     ocpp_config_adaptions: Adaptions to the libocpp configuration
+    ocpp16_component_config_adaptions: Adaptions to the OCPP1.6 device-model component config
     ocpp_config: Select a specific libocpp configuration file
     everest_config_adaptions: Adaptions to the EVerest configuration
     ocpp_multi_only: Only run against the combined OCPPmulti module (never legacy OCPP/OCPP201)

--- a/tests/ocpp_tests/test_sets/everest_test_utils_probe_modules.py
+++ b/tests/ocpp_tests/test_sets/everest_test_utils_probe_modules.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Pionix GmbH and Contributors to EVerest
+
+import logging
+from unittest.mock import Mock
+
 import pytest
 import pytest_asyncio
 
@@ -73,3 +79,98 @@ class ProbeModuleCostAndPriceSessionCostConfigurationAdjustment(EverestConfigAdj
             {"module_id": "ocpp", "implementation_id": "session_cost"}]
 
         return adjusted_config
+
+
+def implement_ocpp16_probe_commands(
+    probe_module: ProbeModule, skip_implementation=None, overwrite_implementation=None
+) -> Dict:
+    """Implement the probe-module commands the everest-config-ocpp16-probe-module.yaml wiring expects.
+
+    That config satisfies the OCPP module's requirements (evse_manager/security/auth/reservation/
+    system) with probe implementations; every command the module may call during boot/connect needs
+    a handler, otherwise the call blocks.
+
+    Every command gets a Mock handler with a canned return value so tests can assert on calls.
+    Commands listed in ``skip_implementation`` ({impl_id: [command, ...]}) are left unimplemented
+    (the test provides its own handler); return values in ``overwrite_implementation``
+    ({impl_id: {command: value}}) replace the default.
+
+    Returns {implementation_id: {command: Mock}}.
+    """
+    command_mocks: Dict = {}
+
+    def _add(implementation_id, command, value):
+        if skip_implementation and command in skip_implementation.get(implementation_id, []):
+            logging.info(f"Skipping implementation of {command}")
+            return
+        if overwrite_implementation and command in overwrite_implementation.get(
+            implementation_id, {}
+        ):
+            logging.info(f"Overwriting implementation of {command}")
+            value = overwrite_implementation[implementation_id][command]
+        mock = Mock()
+        mock.return_value = value
+        command_mocks.setdefault(implementation_id, {})[command] = mock
+        probe_module.implement_command(
+            implementation_id=implementation_id,
+            command_name=command,
+            handler=mock,
+        )
+
+    for idx, evse_manager in enumerate(["evse_manager", "evse_manager_b"]):
+        _add(evse_manager, "get_evse", {"id": idx + 1, "connectors": [{"id": 1}]})
+        _add(evse_manager, "enable_disable", True)
+        _add(evse_manager, "authorize_response", None)
+        _add(evse_manager, "withdraw_authorization", None)
+        _add(evse_manager, "reserve", False)
+        _add(evse_manager, "cancel_reservation", None)
+        _add(evse_manager, "pause_charging", True)
+        _add(evse_manager, "resume_charging", True)
+        _add(evse_manager, "stop_transaction", True)
+        _add(evse_manager, "force_unlock", True)
+        _add(evse_manager, "update_allowed_energy_transfer_modes", None)
+        _add(evse_manager, "external_ready_to_start_charging", True)
+        _add(evse_manager, "set_plug_and_charge_configuration", True)
+        _add(evse_manager, "set_der_available", "Accepted")
+
+    _add("security", "get_leaf_expiry_days_count", 42)
+    _add("security", "get_v2g_ocsp_request_data", {"ocsp_request_data_list": []})
+    _add("security", "get_mo_ocsp_request_data", {"ocsp_request_data_list": []})
+    _add("security", "install_ca_certificate", "Accepted")
+    _add("security", "delete_certificate", "Accepted")
+    _add("security", "update_leaf_certificate", "Accepted")
+    _add("security", "verify_certificate", "Valid")
+    _add(
+        "security",
+        "get_installed_certificates",
+        {"status": "Accepted", "certificate_hash_data_chain": []},
+    )
+    _add("security", "update_ocsp_cache", None)
+    _add("security", "is_ca_certificate_installed", False)
+    _add("security", "generate_certificate_signing_request", {"status": "Accepted"})
+    _add("security", "get_leaf_certificate_info", {"status": "Accepted"})
+    _add("security", "get_verify_file", "")
+    _add("security", "verify_file_signature", True)
+    _add("security", "get_all_valid_certificates_info", {"status": "NotFound", "info": []})
+    _add("security", "get_verify_location", "")
+
+    _add("auth", "set_connection_timeout", None)
+    _add("auth", "withdraw_authorization", "Accepted")
+    _add("auth", "set_master_pass_group_id", None)
+
+    _add("reservation", "cancel_reservation", "Accepted")
+    _add("reservation", "reserve_now", False)
+    _add("reservation", "exists_reservation", False)
+
+    _add("system", "get_boot_reason", "PowerUp")
+    _add("system", "update_firmware", "Accepted")
+    _add("system", "allow_firmware_installation", None)
+    _add("system", "upload_logs", "Accepted")
+    _add("system", "is_reset_allowed", True)
+    _add("system", "reset", None)
+    _add("system", "set_system_time", True)
+    # Called on every connect attempt once the OCPP module delegates network configuration
+    # (OCPPmulti); NotSupported preserves the legacy connect-as-before behavior.
+    _add("system", "configure_network", {"status": "NotSupported"})
+
+    return command_mocks

--- a/tests/ocpp_tests/test_sets/everest_test_utils_probe_modules.py
+++ b/tests/ocpp_tests/test_sets/everest_test_utils_probe_modules.py
@@ -1,3 +1,6 @@
+import logging
+from unittest.mock import Mock
+
 import pytest
 import pytest_asyncio
 
@@ -73,3 +76,98 @@ class ProbeModuleCostAndPriceSessionCostConfigurationAdjustment(EverestConfigAdj
             {"module_id": "ocpp", "implementation_id": "session_cost"}]
 
         return adjusted_config
+
+
+def implement_ocpp16_probe_commands(
+    probe_module: ProbeModule, skip_implementation=None, overwrite_implementation=None
+) -> Dict:
+    """Implement the probe-module commands the everest-config-ocpp16-probe-module.yaml wiring expects.
+
+    That config satisfies the OCPP module's requirements (evse_manager/security/auth/reservation/
+    system) with probe implementations; every command the module may call during boot/connect needs
+    a handler, otherwise the call blocks.
+
+    Every command gets a Mock handler with a canned return value so tests can assert on calls.
+    Commands listed in ``skip_implementation`` ({impl_id: [command, ...]}) are left unimplemented
+    (the test provides its own handler); return values in ``overwrite_implementation``
+    ({impl_id: {command: value}}) replace the default.
+
+    Returns {implementation_id: {command: Mock}}.
+    """
+    command_mocks: Dict = {}
+
+    def _add(implementation_id, command, value):
+        if skip_implementation and command in skip_implementation.get(implementation_id, []):
+            logging.info(f"Skipping implementation of {command}")
+            return
+        if overwrite_implementation and command in overwrite_implementation.get(
+            implementation_id, {}
+        ):
+            logging.info(f"Overwriting implementation of {command}")
+            value = overwrite_implementation[implementation_id][command]
+        mock = Mock()
+        mock.return_value = value
+        command_mocks.setdefault(implementation_id, {})[command] = mock
+        probe_module.implement_command(
+            implementation_id=implementation_id,
+            command_name=command,
+            handler=mock,
+        )
+
+    for idx, evse_manager in enumerate(["evse_manager", "evse_manager_b"]):
+        _add(evse_manager, "get_evse", {"id": idx + 1, "connectors": [{"id": 1}]})
+        _add(evse_manager, "enable_disable", True)
+        _add(evse_manager, "authorize_response", None)
+        _add(evse_manager, "withdraw_authorization", None)
+        _add(evse_manager, "reserve", False)
+        _add(evse_manager, "cancel_reservation", None)
+        _add(evse_manager, "pause_charging", True)
+        _add(evse_manager, "resume_charging", True)
+        _add(evse_manager, "stop_transaction", True)
+        _add(evse_manager, "force_unlock", True)
+        _add(evse_manager, "update_allowed_energy_transfer_modes", None)
+        _add(evse_manager, "external_ready_to_start_charging", True)
+        _add(evse_manager, "set_plug_and_charge_configuration", True)
+        _add(evse_manager, "set_der_available", "Accepted")
+
+    _add("security", "get_leaf_expiry_days_count", 42)
+    _add("security", "get_v2g_ocsp_request_data", {"ocsp_request_data_list": []})
+    _add("security", "get_mo_ocsp_request_data", {"ocsp_request_data_list": []})
+    _add("security", "install_ca_certificate", "Accepted")
+    _add("security", "delete_certificate", "Accepted")
+    _add("security", "update_leaf_certificate", "Accepted")
+    _add("security", "verify_certificate", "Valid")
+    _add(
+        "security",
+        "get_installed_certificates",
+        {"status": "Accepted", "certificate_hash_data_chain": []},
+    )
+    _add("security", "update_ocsp_cache", None)
+    _add("security", "is_ca_certificate_installed", False)
+    _add("security", "generate_certificate_signing_request", {"status": "Accepted"})
+    _add("security", "get_leaf_certificate_info", {"status": "Accepted"})
+    _add("security", "get_verify_file", "")
+    _add("security", "verify_file_signature", True)
+    _add("security", "get_all_valid_certificates_info", {"status": "NotFound", "info": []})
+    _add("security", "get_verify_location", "")
+
+    _add("auth", "set_connection_timeout", None)
+    _add("auth", "withdraw_authorization", "Accepted")
+    _add("auth", "set_master_pass_group_id", None)
+
+    _add("reservation", "cancel_reservation", "Accepted")
+    _add("reservation", "reserve_now", False)
+    _add("reservation", "exists_reservation", False)
+
+    _add("system", "get_boot_reason", "PowerUp")
+    _add("system", "update_firmware", "Accepted")
+    _add("system", "allow_firmware_installation", None)
+    _add("system", "upload_logs", "Accepted")
+    _add("system", "is_reset_allowed", True)
+    _add("system", "reset", None)
+    _add("system", "set_system_time", True)
+    # Called on every connect attempt once the OCPP module delegates network configuration
+    # (OCPPmulti); NotSupported preserves the legacy connect-as-before behavior.
+    _add("system", "configure_network", {"status": "NotSupported"})
+
+    return command_mocks

--- a/tests/ocpp_tests/test_sets/ocpp16/configure_network_ocpp16.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/configure_network_ocpp16.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Pionix GmbH and Contributors to EVerest
+
+"""Integration tests for the OCPP1.6 -> system provider `configure_network` delegation.
+
+Covers the NotSupported / Ready direct answers and the deferred Processing variant
+(completed via the configure_network_status var). Only the combined OCPPmulti module
+implements the delegation, so the tests are pinned via ocpp_multi_only; the config
+rewrite swaps the legacy OCPP module in the probe config for OCPPmulti (Mode Only1.6).
+
+In OCPP1.6 libocpp synthesizes a single network connection profile from
+CentralSystemURI/SecurityProfile with configuration slot 1 and ocppInterface "Any"
+(vs the explicit "Wired0" profile the 2.x tests observe). request_id is a
+module-generated opaque id.
+"""
+
+import asyncio
+import logging
+import threading
+
+import pytest
+
+from everest.testing.core_utils.probe_module import ProbeModule
+from everest.testing.core_utils._configuration.libocpp_configuration_helper import (
+    GenericOCPP2XConfigAdjustment,
+    OCPP2XConfigVariableIdentifier,
+)
+from everest.testing.ocpp_utils.central_system import CentralSystem
+
+from everest_test_utils_probe_modules import implement_ocpp16_probe_commands
+
+log = logging.getLogger("OCPPmultiConfigureNetwork16")
+
+# The v16 profile is synthesized by libocpp with ocppInterface "Any" (not used for OCPP1.6).
+EXPECTED_INTERFACE = "Any"
+
+
+@pytest.fixture
+def probe_module(started_test_controller, everest_core, skip_implementation) -> ProbeModule:
+    """Local probe fixture for the ocpp16 probe config (implementation ids `system`,
+    `evse_manager`/`evse_manager_b`, ... - different from the 2.x `ProbeModule*` ids the
+    shared conftest fixture implements)."""
+    module = ProbeModule(everest_core.get_runtime_session())
+    implement_ocpp16_probe_commands(module, skip_implementation)
+    return module
+
+
+async def _connect(probe_module):
+    """Standard probe-module bring-up: start, ready, publish EVSE manager readiness."""
+    probe_module.start()
+    await probe_module.wait_to_be_ready()
+    probe_module.publish_variable("evse_manager", "ready", True)
+    probe_module.publish_variable("evse_manager_b", "ready", True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp1.6")
+@pytest.mark.ocpp_multi_only
+@pytest.mark.everest_core_config("everest-config-ocpp16-probe-module.yaml")
+@pytest.mark.probe_module
+class TestConfigureNetwork16:
+
+    async def test_configure_network_not_supported_fallback(
+        self, probe_module, central_system: CentralSystem
+    ):
+        """Case 1: NotSupported (helper default) -> connects as before."""
+        await _connect(probe_module)
+        chargepoint = await central_system.wait_for_chargepoint()
+        assert chargepoint is not None
+
+    @pytest.mark.parametrize(
+        "skip_implementation",
+        [{"system": ["configure_network"]}],
+    )
+    async def test_configure_network_ready_direct(
+        self, skip_implementation, probe_module, central_system: CentralSystem
+    ):
+        """Case 2: Ready direct (no interface_address, so no fake-iface bind)."""
+        captured = []
+        capture_lock = threading.Lock()
+
+        def handler(arg):
+            # Runs in the ProbeModule worker thread.
+            with capture_lock:
+                captured.append(arg["request"])
+            return {"status": "Ready"}
+
+        probe_module.implement_command("system", "configure_network", handler)
+
+        await _connect(probe_module)
+        chargepoint = await central_system.wait_for_chargepoint()
+        assert chargepoint is not None
+
+        with capture_lock:
+            assert len(captured) >= 1, "configure_network was never called"
+            request = captured[0]
+
+        # request_id is an opaque module-generated id; the v16 profile carries interface "Any".
+        assert isinstance(request["request_id"], int)
+        assert request["request_id"] > 0
+        assert request["interface"] == EXPECTED_INTERFACE
+
+    @pytest.mark.parametrize(
+        "skip_implementation",
+        [{"system": ["configure_network"]}],
+    )
+    @pytest.mark.ocpp16_component_config_adaptions(
+        GenericOCPP2XConfigAdjustment(
+            [
+                # Slot 1: only the interface is set explicitly (survives the migration `Any` pin);
+                # URL/SecurityProfile/Identity are supplied by the legacy JSON migration.
+                (OCPP2XConfigVariableIdentifier("NetworkConfiguration_1", "OcppInterface"), "Wireless0"),
+                # Slot 2: fully device-model configured. The placeholder OcppCsmsUrl is rewritten to
+                # the mock CSMS by the everest-testing default component-config strategy.
+                (OCPP2XConfigVariableIdentifier("NetworkConfiguration_2", "OcppCsmsUrl"), "ws://replaced.invalid/cp"),
+                (OCPP2XConfigVariableIdentifier("NetworkConfiguration_2", "SecurityProfile"), 0),
+                (OCPP2XConfigVariableIdentifier("NetworkConfiguration_2", "OcppTransport"), "JSON"),
+                (OCPP2XConfigVariableIdentifier("NetworkConfiguration_2", "MessageTimeout"), 30),
+                (OCPP2XConfigVariableIdentifier("NetworkConfiguration_2", "OcppInterface"), "Wired0"),
+                # Try slot 1 (wireless) first, then fail over to slot 2 (wired).
+                (OCPP2XConfigVariableIdentifier("OCPPCommCtrlr", "NetworkConfigurationPriority"), "1,2"),
+            ]
+        )
+    )
+    async def test_configure_network_failover_two_slots(
+        self, skip_implementation, probe_module, central_system: CentralSystem
+    ):
+        """Multi-slot failover: slot 1 (Wireless0) configure_network fails, the ConnectivityManager
+        hops to slot 2 (Wired0) after ~2s and connects there."""
+        interfaces = []
+        capture_lock = threading.Lock()
+
+        def handler(arg):
+            # Runs in the ProbeModule worker thread.
+            with capture_lock:
+                interfaces.append(arg["request"]["interface"])
+                attempt = len(interfaces)
+            # First attempt (slot 1 / Wireless0) fails -> CM hops to the next priority slot;
+            # every subsequent attempt (slot 2 / Wired0) is Ready.
+            return {"status": "Failed"} if attempt == 1 else {"status": "Ready"}
+
+        probe_module.implement_command("system", "configure_network", handler)
+
+        await _connect(probe_module)
+        chargepoint = await central_system.wait_for_chargepoint()
+        assert chargepoint is not None
+
+        with capture_lock:
+            assert len(interfaces) >= 2, f"expected failover across slots, got {interfaces}"
+            assert interfaces[0] == "Wireless0"
+            assert "Wired0" in interfaces[1:]
+
+    @pytest.mark.parametrize(
+        "skip_implementation",
+        [{"system": ["configure_network"]}],
+    )
+    async def test_configure_network_processing_then_status(
+        self, skip_implementation, probe_module, central_system: CentralSystem
+    ):
+        """Case 3: Processing -> connects only after configure_network_status is published."""
+        captured_request_ids = []
+        capture_lock = threading.Lock()
+
+        def handler(arg):
+            with capture_lock:
+                captured_request_ids.append(arg["request"]["request_id"])
+            return {"status": "Processing"}
+
+        probe_module.implement_command("system", "configure_network", handler)
+
+        await _connect(probe_module)
+
+        # bounded poll until configure_network was invoked (avoids a flaky fixed sleep)
+        request_id = None
+        for _ in range(50):  # up to ~10s
+            with capture_lock:
+                if captured_request_ids:
+                    request_id = captured_request_ids[0]
+                    break
+            await asyncio.sleep(0.2)
+        assert request_id is not None, "configure_network was never called"
+        assert isinstance(request_id, int) and request_id > 0
+
+        # while Processing the websocket must not open yet (bootnotification=False:
+        # assert on the socket, not on a slow boot, and don't consume the connect event)
+        with pytest.raises(asyncio.TimeoutError):
+            await central_system.wait_for_chargepoint(
+                timeout=5, wait_for_bootnotification=False
+            )
+
+        # Publish the deferred outcome; libocpp should now proceed to connect.
+        probe_module.publish_variable(
+            "system",
+            "configure_network_status",
+            {"request_id": request_id, "status": "Ready"},
+        )
+
+        chargepoint = await central_system.wait_for_chargepoint()
+        assert chargepoint is not None

--- a/tests/ocpp_tests/test_sets/ocpp16/ocpp_generic_interface_integration_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/ocpp_generic_interface_integration_tests.py
@@ -4,7 +4,6 @@
 import asyncio
 from dataclasses import dataclass
 from unittest.mock import Mock, call as mock_call, ANY
-import logging
 
 import pytest
 import pytest_asyncio
@@ -18,6 +17,7 @@ from ocpp.v16.call import SetChargingProfile
 from everest.testing.core_utils._configuration.libocpp_configuration_helper import (
     GenericOCPP16ConfigAdjustment,
 )
+from everest_test_utils_probe_modules import implement_ocpp16_probe_commands
 
 
 @dataclass
@@ -42,168 +42,9 @@ async def _env(
     csms_mock = central_system.mock
 
     probe_module = ProbeModule(everest_core.get_runtime_session())
-    probe_module_command_mocks = {}
-
-    def _add_pm_command_mock(implementation_id, command, value, skip_implementation):
-        skip = False
-        if skip_implementation:
-            if implementation_id in skip_implementation:
-                to_skip = skip_implementation[implementation_id]
-                if command in to_skip:
-                    logging.info(f"Skipping implementation of {command}")
-                    skip = True
-        if not skip:
-            if overwrite_implementation:
-                logging.info(f"OVERW: {overwrite_implementation}")
-                if implementation_id in overwrite_implementation:
-                    to_overwrite = overwrite_implementation[implementation_id]
-                    if command in to_overwrite:
-                        logging.info(
-                            f"Overwriting implementation of {command}")
-                        value = to_overwrite[command]
-            probe_module_command_mocks.setdefault(implementation_id, {})[
-                command
-            ] = Mock()
-            probe_module_command_mocks[implementation_id][command].return_value = value
-            probe_module.implement_command(
-                implementation_id=implementation_id,
-                command_name=command,
-                handler=probe_module_command_mocks[implementation_id][command],
-            )
-
-    for idx, evse_manager in enumerate(["evse_manager", "evse_manager_b"]):
-        _add_pm_command_mock(
-            evse_manager,
-            "get_evse",
-            {"id": idx + 1, "connectors": [{"id": 1}]},
-            skip_implementation,
-        )
-        _add_pm_command_mock(evse_manager, "enable_disable",
-                             True, skip_implementation)
-        _add_pm_command_mock(
-            evse_manager, "authorize_response", None, skip_implementation
-        )
-        _add_pm_command_mock(
-            evse_manager, "withdraw_authorization", None, skip_implementation
-        )
-        _add_pm_command_mock(evse_manager, "reserve",
-                             False, skip_implementation)
-        _add_pm_command_mock(
-            evse_manager, "cancel_reservation", None, skip_implementation
-        )
-        _add_pm_command_mock(evse_manager, "pause_charging",
-                             True, skip_implementation)
-        _add_pm_command_mock(evse_manager, "resume_charging",
-                             True, skip_implementation)
-        _add_pm_command_mock(
-            evse_manager, "stop_transaction", True, skip_implementation
-        )
-        _add_pm_command_mock(evse_manager, "force_unlock",
-                             True, skip_implementation)
-        _add_pm_command_mock(
-            evse_manager, "update_allowed_energy_transfer_modes", None, skip_implementation)
-        _add_pm_command_mock(
-            evse_manager, "external_ready_to_start_charging", True, skip_implementation
-        )
-        _add_pm_command_mock(
-            evse_manager, "set_plug_and_charge_configuration", True, skip_implementation)
-        _add_pm_command_mock(
-            evse_manager, "set_der_available", "Accepted", skip_implementation)
-    _add_pm_command_mock(
-        "security", "get_leaf_expiry_days_count", 42, skip_implementation
+    probe_module_command_mocks = implement_ocpp16_probe_commands(
+        probe_module, skip_implementation, overwrite_implementation
     )
-    _add_pm_command_mock(
-        "security",
-        "get_v2g_ocsp_request_data",
-        {"ocsp_request_data_list": []},
-        skip_implementation,
-    )
-    _add_pm_command_mock(
-        "security",
-        "get_mo_ocsp_request_data",
-        {"ocsp_request_data_list": []},
-        skip_implementation,
-    )
-    _add_pm_command_mock(
-        "security", "install_ca_certificate", "Accepted", skip_implementation
-    )
-    _add_pm_command_mock(
-        "security", "delete_certificate", "Accepted", skip_implementation
-    )
-    _add_pm_command_mock(
-        "security", "update_leaf_certificate", "Accepted", skip_implementation
-    )
-    _add_pm_command_mock("security", "verify_certificate",
-                         "Valid", skip_implementation)
-    _add_pm_command_mock(
-        "security",
-        "get_installed_certificates",
-        {"status": "Accepted", "certificate_hash_data_chain": []},
-        skip_implementation,
-    )
-    _add_pm_command_mock("security", "update_ocsp_cache",
-                         None, skip_implementation)
-    _add_pm_command_mock(
-        "security", "is_ca_certificate_installed", False, skip_implementation
-    )
-    _add_pm_command_mock(
-        "security",
-        "generate_certificate_signing_request",
-        {"status": "Accepted"},
-        skip_implementation,
-    )
-    _add_pm_command_mock(
-        "security",
-        "get_leaf_certificate_info",
-        {"status": "Accepted"},
-        skip_implementation,
-    )
-    _add_pm_command_mock("security", "get_verify_file",
-                         "", skip_implementation)
-    _add_pm_command_mock("security", "verify_file_signature",
-                         True, skip_implementation)
-    _add_pm_command_mock(
-        "security",
-        "get_all_valid_certificates_info",
-        {"status": "NotFound", "info": []},
-        skip_implementation,
-    )
-    _add_pm_command_mock(
-        "security",
-        "get_verify_location",
-        "",
-        skip_implementation,
-    )
-    _add_pm_command_mock("auth", "set_connection_timeout",
-                         None, skip_implementation)
-    _add_pm_command_mock("auth", "withdraw_authorization",
-                         "Accepted", skip_implementation)
-    _add_pm_command_mock("auth", "set_master_pass_group_id",
-                         None, skip_implementation)
-    _add_pm_command_mock(
-        "reservation", "cancel_reservation", "Accepted", skip_implementation
-    )
-    _add_pm_command_mock("reservation", "reserve_now",
-                         False, skip_implementation)
-    _add_pm_command_mock(
-        "reservation", "exists_reservation", False, skip_implementation
-    )
-    _add_pm_command_mock("system", "get_boot_reason",
-                         "PowerUp", skip_implementation)
-    _add_pm_command_mock("system", "update_firmware",
-                         "Accepted", skip_implementation)
-    _add_pm_command_mock(
-        "system", "allow_firmware_installation", None, skip_implementation
-    )
-    _add_pm_command_mock("system", "upload_logs",
-                         "Accepted", skip_implementation)
-    _add_pm_command_mock("system", "is_reset_allowed",
-                         True, skip_implementation)
-    _add_pm_command_mock("system", "reset", None, skip_implementation)
-    _add_pm_command_mock("system", "set_system_time",
-                         True, skip_implementation)
-    _add_pm_command_mock("system", "configure_network",
-                         {"status": "NotSupported"}, skip_implementation)
 
     probe_module.start()
     await probe_module.wait_to_be_ready()


### PR DESCRIPTION

## Motivation

OCPP1.6 only allowed a single Network Configuration via the configuration parameters CentralSystemURI, SecurityProfile, AuthorizationKey, etc.

With OCPPmulti and the harmonized adressing of component variables that has been added recently,  a logical follow up is to also harmonize the network connection configuration so that integrators can configure the CSMS connection details for OCPP1.6 just like they can for OCPP2.x. That functionality is provided by this PR.

## Describe your changes

Source OCPP1.6 network connection profiles from device-model slots instead of the legacy single-connection config, enabling multi-slot failover:

- v16 device-model config reads/writes NetworkConnectionProfiles, slot priority ordering and security-profile pruning (confirm-gated)
- connectivity_manager honors the slot list for failover and retries
- OCPPmulti delegates configure_network to the 1.6 stack, reloads profiles on consumer variable writes, and guards edits to the in-use slot the same way 2.x SetVariables does
- allow OCPP16 in the NetworkConfiguration_2 OcppVersion valuesList
- unit tests for device-model connectivity + OCPPmulti variable access, integration test for configure_network in 1.6, docs updates

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

