### PR TITLE
fix(ocpp): infinite loop in MonitoringUpdater::process_monitors_internal wedges inbound message processing

### DIFF
--- a/lib/everest/ocpp/lib/ocpp/v2/monitoring_updater.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/monitoring_updater.cpp
@@ -607,6 +607,7 @@ void MonitoringUpdater::process_monitors_internal(bool allow_periodics, bool all
 
         if (((allow_periodics == false) && (updater_monitor_meta.type == UpdateMonitorMetaType::PERIODIC)) ||
             ((allow_trigger == false) && (updater_monitor_meta.type == UpdateMonitorMetaType::TRIGGER))) {
+            ++it;
             continue;
         }
 
@@ -635,9 +636,10 @@ void MonitoringUpdater::process_monitors_internal(bool allow_periodics, bool all
             if (updater_monitor_meta.type == UpdateMonitorMetaType::TRIGGER) {
                 // The triggers that are not active, should simply pe discarded
                 it = updater_monitors_meta.erase(it);
-            } else if (updater_monitor_meta.type == UpdateMonitorMetaType::PERIODIC) {
+            } else {
                 // Just clear the events, since we don't require them cached
                 updater_monitor_meta.generated_monitor_events.clear();
+                ++it;
             }
 
             continue;


### PR DESCRIPTION
## Describe your changes

`MonitoringUpdater::process_monitors_internal()` iterates `updater_monitors_meta` with manual iterator control, but two branches `continue` without advancing the iterator:

1. the `allow_periodics` / `allow_trigger` type filter at the top of the loop
2. the `!should_process` branch for `PERIODIC` monitors

Consequence: whenever `process_triggered_monitors()` (= `process_monitors_internal(false, true)`) runs while a periodic monitor is registered, the first `PERIODIC` entry hits branch 1 and the loop spins forever. `Provisioning::handle_variables_changed()` calls `process_triggered_monitors()` on the message-processing thread after answering SetVariables — so **one accepted `SetVariables` while any periodic custom monitor is installed permanently wedges the station's inbound OCPP processing at 100% CPU**. Outbound Calls continue (and all time out); the websocket stays connected because ping/pong is handled by the transport, so no reconnect ever happens and the station becomes unreachable for the CSMS — including `Reset` — until the process is restarted locally.

**Reproduced on hardware** (AM62x-based DC charger, OCPP 2.0.1 against CitrineOS), 3/3:
1. `SetVariableMonitoring` with a `Periodic` monitor (e.g. on `OCPPCommCtrlr`/`HeartbeatInterval`)
2. any `SetVariables` that returns `Accepted`
3. station answers the SetVariables, then processes no further inbound messages

Verified with tcpdump on the device (inbound Calls arrive and are TCP-ACKed but never dispatched) and `eu-stack` (one thread spinning in the recv path, all others parked). After clearing the monitor, the identical sequence works repeatedly. With this fix the same sequence processes normally.

The fix advances the iterator in both branches and folds the `PERIODIC` else-if into a plain `else`, so every path through the loop either erases or advances.

## Issue ticket number and link

None filed — happy to open one if preferred.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (n/a — behavioral bug fix)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements