### PR TITLE
fix(iso15118): extract the listen socket helper

### DIFF
--- a/lib/everest/iso15118/include/iso15118/detail/io/socket_helper.hpp
+++ b/lib/everest/iso15118/include/iso15118/detail/io/socket_helper.hpp
@@ -2,6 +2,7 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -9,9 +10,15 @@
 
 namespace iso15118::io {
 
+constexpr auto DEFAULT_SOCKET_BACKLOG = 4;
+
 bool check_and_update_interface(std::string& interface_name);
 
 bool get_first_sockaddr_in6_for_interface(const std::string& interface_name, sockaddr_in6& address);
+
+// creates a listening ipv6 TCP socket; throws on failure.
+// interface_name names the interface address belongs to, for the bind failure message.
+int create_tcp_listen_socket(sockaddr_in6 address, uint16_t port, int backlog, const std::string& interface_name);
 
 std::unique_ptr<char[]> sockaddr_in6_to_name(const sockaddr_in6&);
 

--- a/lib/everest/iso15118/src/iso15118/io/connection_plain.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_plain.cpp
@@ -17,8 +17,6 @@
 
 namespace iso15118::io {
 
-static constexpr auto DEFAULT_SOCKET_BACKLOG = 4;
-
 ConnectionPlain::ConnectionPlain(PollManager& poll_manager_, const std::string& interface_name) :
     poll_manager(poll_manager_) {
     sockaddr_in6 address{};
@@ -31,35 +29,7 @@ ConnectionPlain::ConnectionPlain(PollManager& poll_manager_, const std::string& 
     end_point.port = 50000;
     memcpy(&end_point.address, &address.sin6_addr, sizeof(address.sin6_addr));
 
-    fd = socket(AF_INET6, SOCK_STREAM, 0);
-    if (fd == -1) {
-        log_and_throw("Failed to create an ipv6 socket");
-    }
-
-    // before bind, set the port
-    address.sin6_port = htons(end_point.port);
-
-    int optval_tmp{1};
-    const auto set_reuseaddr = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval_tmp, sizeof(optval_tmp));
-    if (set_reuseaddr == -1) {
-        log_and_throw("setsockopt(SO_REUSEADDR) failed");
-    }
-
-    const auto set_reuseport = setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &optval_tmp, sizeof(optval_tmp));
-    if (set_reuseport == -1) {
-        log_and_throw("setsockopt(SO_REUSEPORT) failed");
-    }
-
-    const auto bind_result = bind(fd, reinterpret_cast<const struct sockaddr*>(&address), sizeof(address));
-    if (bind_result == -1) {
-        const auto error = "Failed to bind ipv6 socket to interface " + interface_name;
-        log_and_throw(error.c_str());
-    }
-
-    const auto listen_result = listen(fd, DEFAULT_SOCKET_BACKLOG);
-    if (listen_result == -1) {
-        log_and_throw("Listen on socket failed");
-    }
+    fd = create_tcp_listen_socket(address, end_point.port, DEFAULT_SOCKET_BACKLOG, interface_name);
 
     poll_manager.register_fd(fd, [this]() { this->handle_connect(); });
 }

--- a/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
@@ -31,7 +31,6 @@ struct SSLContext {
 
 namespace {
 
-constexpr auto DEFAULT_SOCKET_BACKLOG = 4;
 constexpr auto TLS_PORT = 50000;
 
 std::string_view result_name(tls::Connection::result_t r) {
@@ -130,34 +129,7 @@ ConnectionSSL::ConnectionSSL(PollManager& poll_manager_, const std::string& inte
 
     logf_info("Start TLS server [%s]:%" PRIu16, address_name.get(), end_point.port);
 
-    ssl->listen_fd = socket(AF_INET6, SOCK_STREAM, 0);
-    if (ssl->listen_fd == -1) {
-        log_and_throw("Failed to create an ipv6 socket");
-    }
-
-    address.sin6_port = htons(end_point.port);
-
-    int optval_tmp{1};
-    const auto set_reuseaddr = setsockopt(ssl->listen_fd, SOL_SOCKET, SO_REUSEADDR, &optval_tmp, sizeof(optval_tmp));
-    if (set_reuseaddr == -1) {
-        log_and_throw("setsockopt(SO_REUSEADDR) failed");
-    }
-
-    const auto set_reuseport = setsockopt(ssl->listen_fd, SOL_SOCKET, SO_REUSEPORT, &optval_tmp, sizeof(optval_tmp));
-    if (set_reuseport == -1) {
-        log_and_throw("setsockopt(SO_REUSEPORT) failed");
-    }
-
-    const auto bind_result = bind(ssl->listen_fd, reinterpret_cast<const struct sockaddr*>(&address), sizeof(address));
-    if (bind_result == -1) {
-        const auto error = "Failed to bind ipv6 socket to interface " + interface_name_;
-        log_and_throw(error.c_str());
-    }
-
-    const auto listen_result = listen(ssl->listen_fd, DEFAULT_SOCKET_BACKLOG);
-    if (listen_result == -1) {
-        log_and_throw("Listen on socket failed");
-    }
+    ssl->listen_fd = create_tcp_listen_socket(address, end_point.port, DEFAULT_SOCKET_BACKLOG, interface_name_);
 
     auto chains = build_chain_configs(ssl_config);
     auto cfg = make_tls_server_config(ssl_config, interface_name_, ssl->listen_fd, std::move(chains));

--- a/lib/everest/iso15118/src/iso15118/io/socket_helper.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/socket_helper.cpp
@@ -3,6 +3,7 @@
 #include <iso15118/detail/io/socket_helper.hpp>
 
 #include <cstring>
+#include <utility>
 
 #include <arpa/inet.h>
 #include <ifaddrs.h>
@@ -11,6 +12,7 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <sys/socket.h>
+#include <unistd.h>
 
 #include <iso15118/detail/helper.hpp>
 
@@ -45,6 +47,26 @@ auto choose_first_ipv6_interface() {
 
     return interface_name;
 }
+
+// owns an fd until released, so that a throwing setup path cannot leak it
+class fd_guard {
+public:
+    explicit fd_guard(int fd) : fd_{fd} {
+    }
+    fd_guard(const fd_guard&) = delete;
+    fd_guard& operator=(const fd_guard&) = delete;
+    ~fd_guard() {
+        if (fd_ != -1) {
+            ::close(fd_);
+        }
+    }
+    int release() {
+        return std::exchange(fd_, -1);
+    }
+
+private:
+    int fd_;
+};
 
 } // namespace
 
@@ -140,6 +162,36 @@ bool set_tcp_keepalive(int fd) {
     }
 
     return true;
+}
+
+int create_tcp_listen_socket(sockaddr_in6 address, uint16_t port, int backlog, const std::string& interface_name) {
+    const auto fd = socket(AF_INET6, SOCK_STREAM, 0);
+    if (fd == -1) {
+        log_and_throw("Failed to create an ipv6 socket");
+    }
+    fd_guard guard{fd};
+
+    address.sin6_port = htons(port);
+
+    int optval_tmp{1};
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval_tmp, sizeof(optval_tmp)) == -1) {
+        log_and_throw("setsockopt(SO_REUSEADDR) failed");
+    }
+
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &optval_tmp, sizeof(optval_tmp)) == -1) {
+        log_and_throw("setsockopt(SO_REUSEPORT) failed");
+    }
+
+    if (bind(fd, reinterpret_cast<const struct sockaddr*>(&address), sizeof(address)) == -1) {
+        const auto msg = "Failed to bind ipv6 socket to interface " + interface_name;
+        log_and_throw(msg.c_str());
+    }
+
+    if (listen(fd, backlog) == -1) {
+        log_and_throw("Listen on socket failed");
+    }
+
+    return guard.release();
 }
 
 std::unique_ptr<char[]> sockaddr_in6_to_name(const sockaddr_in6& address) {

--- a/lib/everest/iso15118/test/iso15118/io/CMakeLists.txt
+++ b/lib/everest/iso15118/test/iso15118/io/CMakeLists.txt
@@ -10,6 +10,14 @@ target_link_libraries(test_logging
 
 catch_discover_tests(test_logging)
 
+add_executable(socket_helper_test socket_helper_test.cpp)
+target_link_libraries(socket_helper_test
+    PRIVATE
+        iso15118
+        Catch2::Catch2WithMain
+)
+catch_discover_tests(socket_helper_test)
+
 add_executable(test_sdp_server sdp_server_test.cpp)
 target_link_libraries(test_sdp_server PRIVATE iso15118 Catch2::Catch2WithMain)
 catch_discover_tests(test_sdp_server)

--- a/lib/everest/iso15118/test/iso15118/io/socket_helper_test.cpp
+++ b/lib/everest/iso15118/test/iso15118/io/socket_helper_test.cpp
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstring>
+
+#include <dirent.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <iso15118/detail/io/socket_helper.hpp>
+
+namespace {
+
+// the scan itself holds an fd, but both invocations scan identically so the
+// transient cancels out on compare
+int count_open_fds() {
+    auto* dir = opendir("/proc/self/fd");
+    REQUIRE(dir != nullptr);
+
+    int count = 0;
+    while (auto* entry = readdir(dir)) {
+        if (strcmp(entry->d_name, ".") == 0 or strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+        ++count;
+    }
+    closedir(dir);
+    return count;
+}
+
+} // namespace
+
+TEST_CASE("socket_helper: create_tcp_listen_socket binds and listens") {
+    sockaddr_in6 address{};
+    address.sin6_family = AF_INET6;
+    address.sin6_addr = in6addr_loopback;
+
+    const auto fd = iso15118::io::create_tcp_listen_socket(address, /*port=*/0, /*backlog=*/4, "lo");
+    REQUIRE(fd >= 0);
+
+    sockaddr_in6 bound_address{};
+    socklen_t bound_address_len = sizeof(bound_address);
+    REQUIRE(getsockname(fd, reinterpret_cast<sockaddr*>(&bound_address), &bound_address_len) == 0);
+    REQUIRE(ntohs(bound_address.sin6_port) != 0);
+
+    // a successful loopback connect proves the socket is in listen state
+    const auto client_fd = socket(AF_INET6, SOCK_STREAM, 0);
+    REQUIRE(client_fd >= 0);
+    const auto connect_result =
+        connect(client_fd, reinterpret_cast<const sockaddr*>(&bound_address), sizeof(bound_address));
+    CHECK(connect_result == 0);
+
+    close(client_fd);
+    close(fd);
+}
+
+TEST_CASE("socket_helper: create_tcp_listen_socket closes the fd when setup fails") {
+    // an AF_INET address family on an AF_INET6 socket makes bind fail deterministically
+    sockaddr_in6 address{};
+    address.sin6_family = AF_INET;
+    address.sin6_addr = in6addr_loopback;
+
+    // repeated so that one leaked fd per call outweighs any descriptor opened
+    // lazily in between, the logger being the likeliest
+    constexpr int FAILING_CALL_COUNT = 20;
+    constexpr int NOISE_ALLOWANCE = 1;
+
+    const auto fds_before = count_open_fds();
+    for (int i = 0; i < FAILING_CALL_COUNT; ++i) {
+        REQUIRE_THROWS(iso15118::io::create_tcp_listen_socket(address, /*port=*/0, /*backlog=*/4, "lo"));
+    }
+    const auto fds_after = count_open_fds();
+
+    REQUIRE(fds_after - fds_before <= NOISE_ALLOWANCE);
+}


### PR DESCRIPTION
## Describe your changes

`connection_plain` and `connection_ssl` each built their own listening socket with the same sequence of
`socket`, `setsockopt`, `bind` and `listen` calls, and each cleaned up by hand on every error path. This
extracts that into one `create_tcp_listen_socket` helper in `detail/io/socket_helper` and points both
connections at it.

The extraction is not purely mechanical. Four things changed deliberately:

- The interface name is back in the bind failure message. Losing it makes a bind failure much harder to
  diagnose on a machine with several interfaces, since the message no longer says which one it was.
- Descriptor cleanup is RAII rather than four separate `::close(fd)` calls. Each of those calls was an
  opportunity to return early and leak the descriptor, which is exactly the kind of error path that
  never gets exercised.
- The IPv6 address is passed by value instead of by pointer. It is 16 bytes, so there is nothing to save
  by indirecting, and by value there is no lifetime question at the call site.
- The test loops the descriptor leak check rather than probing once. A single probe cannot distinguish
  "does not leak" from "leaked once and we did not look again".

The helper reports failure through the return value and leaves the caller to decide, rather than
throwing or exiting, which keeps it usable from both connection types.

## Issue ticket number and link

N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

---

### Stack

This branch is part of an eight PR series. Three are rooted on `main` (#2558, #2559, #2560);
the rest form a chain that forks at #2562.

| Order | PR | Branch | Base |
|---|---|---|---|
| **1** | **#2558 (this PR)** | **`fix/iso15118-listen-socket-helper`** | `main` |
| 2 | #2559 | `feat/tls-wrap-connecting-fd` | `main` |
| 3 | #2561 | `fix/io-event-handler-truthfulness` | #2559 |
| 4 | #2562 | `feat/io-client-tx-tristate` | #2561 |
| 5 | #2563 | `feat/io-fd-event-client-handshake-phase` | #2562 |
| 6 | #2564 | `feat/io-tls-policies-rebuilt` | #2563 |
| 7 | #2560 | `fix/io-connect-errno-and-backoff` | `main` |
| 8 | #2565 | `refactor/chargebridge-drop-hand-rolled-tx-gates` | #2562 |

Independent of the rest of the series, so it can be reviewed and merged on its own.
