### PR TITLE
feat(tls): wrap an already connecting descriptor

### DIFF
--- a/lib/everest/tls/include/everest/tls/tls.hpp
+++ b/lib/everest/tls/include/everest/tls/tls.hpp
@@ -72,10 +72,18 @@ public:
     TlsKeyLoggingServer(const std::string& interface_name, uint16_t port_);
     ~TlsKeyLoggingServer();
 
-    ssize_t send(const char* line);
+    /**
+     * \brief send one key-log line to the multicast destination
+     * \returns false when the socket is unusable or the line was not sent in full
+     */
+    bool send(const char* line);
 
-    auto get_fd() const {
-        return fd;
+    /**
+     * \brief whether the multicast socket was set up
+     * \returns false when the constructor failed, in which case the object cannot send
+     */
+    [[nodiscard]] bool is_valid() const {
+        return fd != -1;
     }
 
     auto get_port() const {
@@ -138,7 +146,7 @@ public:
 protected:
     std::unique_ptr<connection_ctx> m_context; //!< opaque connection data
     state_t m_state{state_t::idle};            //!< connection state
-    std::string m_ip;                          //!< peer IP address
+    std::string m_peer_host;                   //!< peer host, a DNS hostname or IP literal
     std::string m_service;                     //!< peer port
     std::int32_t m_timeout_ms;                 //!< default operation timeout
     std::string
@@ -225,10 +233,11 @@ public:
     }
 
     /**
-     * IP address of the connection's peer
+     * Host of the connection's peer: a DNS hostname or IP literal. The name is
+     * kept for API stability.
      */
     [[nodiscard]] const std::string& ip_address() const {
-        return m_ip;
+        return m_peer_host;
     }
 
     /**
@@ -261,6 +270,25 @@ public:
      * \returns the underlying socket or INVALID_SOCKET on error
      */
     [[nodiscard]] int socket() const;
+
+    /**
+     * \brief whether the SSL object and its socket BIO were allocated
+     * \returns false when allocation failed, in which case no BIO_CLOSE owner
+     *          adopted the socket fd and the caller still owns it
+     */
+    [[nodiscard]] bool is_valid() const;
+
+    /**
+     * \brief whether the TLS record layer still holds buffered data
+     * \returns true when a further read() can return data without the socket
+     *          becoming readable again
+     * \note SSL_has_pending() is used rather than SSL_pending(): the latter
+     *       counts only the decrypted remainder of the record being processed
+     *       and returns 0 while a complete but still unprocessed record sits in
+     *       the read buffer. A drain loop guarded on that count would stop with
+     *       data stranded in userspace and never be woken again.
+     */
+    [[nodiscard]] bool has_pending() const;
 
     /**
      * \brief obtain the peer certificate
@@ -353,7 +381,8 @@ public:
  */
 class ClientConnection : public Connection {
 public:
-    ClientConnection(SslContext* ctx, int soc, const char* ip_in, const char* service_in, std::int32_t timeout_ms);
+    ClientConnection(SslContext* ctx, int soc, const char* ip_in, const char* service_in, std::int32_t timeout_ms,
+                     bool verify_subject_name);
     ClientConnection() = delete;
     ClientConnection(const ClientConnection&) = delete;
     ClientConnection(ClientConnection&&) = delete;
@@ -699,7 +728,14 @@ public:
         std::int32_t io_timeout_ms{-1};              //!< default socket timeout in milliseconds (recommend > 1 sec)
         //!< minimum TLS protocol version, e.g. TLS1_2_VERSION or TLS1_3_VERSION; 0 means use default
         int min_proto_version{0};
-        bool verify_server{true};      //!< verify the server certificate
+        bool verify_server{true}; //!< verify the server certificate
+
+        //! verify_subject_name: match the peer certificate subject/SAN against the SNI host via
+        //! SSL_set1_host. Requires verify_server, init() rejects the combination without it because the
+        //! host cannot be enforced. The default (false) is chain-of-trust ONLY: a certificate signed by
+        //! any trusted CA is accepted whatever host it was issued for. Leave it false for a PKI whose
+        //! certificates carry no hostname; set true for a hostname-bearing PKI.
+        bool verify_subject_name{false};
         bool status_request{false};    //!< include a status request extension in the client hello
         bool status_request_v2{false}; //!< include a status request v2 extension in the client hello
         bool trusted_ca_keys{false};   //!< include a trusted ca keys extension in the client hello
@@ -710,6 +746,7 @@ public:
 private:
     std::unique_ptr<client_ctx> m_context;                      //!< opaque object data
     std::int32_t m_timeout_ms{-1};                              //!< default operation timeout
+    bool m_verify_subject_name{false};                          //!< applied to new connections
     trusted_ca_keys_t m_trusted_ca_keys;                        //!< trusted CA keys configuration data
     std::unique_ptr<ClientStatusRequestV2> m_status_request_v2; //!< status request extension handler
 
@@ -749,6 +786,19 @@ public:
     [[nodiscard]] inline ConnectionPtr connect(const char* host, const char* service, bool ipv6_only) {
         return connect(host, service, ipv6_only, m_timeout_ms);
     }
+
+    /**
+     * \brief wrap an already-connected or still-connecting TCP socket as a TLS client connection
+     * \param[in] fd TCP socket file descriptor
+     * \param[in] host_for_sni host for the peer-id / SNI slot, may be nullptr
+     * \return nullptr if the SSL_CTX is not initialised or SSL/BIO allocation fails
+     * \note A DNS \p host_for_sni is sent in the SNI extension, an IP literal is not
+     *       (RFC 6066 §3). With config_t::verify_subject_name the peer certificate is
+     *       pinned to \p host_for_sni and a pin failure fails the handshake closed.
+     * \note Ownership: on success the connection owns \p fd and closes it. On a
+     *       nullptr return the caller still owns \p fd; this factory never closes it.
+     */
+    [[nodiscard]] ConnectionPtr wrap_connecting_fd(int fd, const char* host_for_sni);
 
     /**
      * \brief the default SSL callbacks

--- a/lib/everest/tls/src/tls.cpp
+++ b/lib/everest/tls/src/tls.cpp
@@ -11,6 +11,7 @@
 #include <arpa/inet.h>
 #include <array>
 #include <cassert>
+#include <charconv>
 #include <csignal>
 #include <cstddef>
 #include <cstdint>
@@ -35,6 +36,7 @@
 #include <openssl/ssl.h>
 #include <openssl/tls1.h>
 #include <openssl/types.h>
+#include <openssl/x509_vfy.h>
 #include <utility>
 
 #ifdef UNIT_TEST
@@ -724,7 +726,7 @@ struct client_ctx {
 // Connection represents a TLS connection (client and server)
 
 Connection::Connection(SslContext* ctx, int soc, const char* ip_in, const char* service_in, std::int32_t timeout_ms) :
-    m_context(std::make_unique<connection_ctx>()), m_ip(ip_in), m_service(service_in), m_timeout_ms(timeout_ms) {
+    m_context(std::make_unique<connection_ctx>()), m_peer_host(ip_in), m_service(service_in), m_timeout_ms(timeout_ms) {
     m_context->ctx = SSL_ptr(SSL_new(ctx));
     m_context->soc = soc;
 
@@ -800,6 +802,16 @@ int Connection::socket() const {
     return m_context->soc;
 }
 
+bool Connection::is_valid() const {
+    // soc_bio is the fd's BIO_CLOSE owner, null only when the ctor's SSL_new or
+    // BIO_new_socket failed, in which case the fd was never adopted.
+    return m_context != nullptr && m_context->soc_bio != nullptr;
+}
+
+bool Connection::has_pending() const {
+    return m_context != nullptr && m_context->ctx != nullptr && SSL_has_pending(m_context->ctx.get()) == 1;
+}
+
 const Certificate* Connection::peer_certificate() const {
     assert(m_context != nullptr);
     return SSL_get0_peer_certificate(m_context->ctx.get());
@@ -823,18 +835,17 @@ int ssl_keylog_server_index{-1};
 
 void keylog_callback(const SSL* ssl, const char* line) {
 
+    // Registered CTX-wide, so it also fires for connections that skipped the
+    // per-connection key-log server and therefore carry no ex_data.
     auto keylog_server = static_cast<TlsKeyLoggingServer*>(SSL_get_ex_data(ssl, ssl_keylog_server_index));
 
-    std::string key_log_msg = "TLS Handshake keys on port ";
-    key_log_msg += std::to_string(keylog_server->get_port()) + ": ";
-    key_log_msg += std::string(line);
-
-    log_info(key_log_msg);
-
-    if (keylog_server->get_fd() != -1) {
-        const auto result = keylog_server->send(line);
-        if (result not_eq strlen(line)) {
-            log_error("key_logging_server send() failed!");
+    if (keylog_server != nullptr) {
+        // ex_data is only set for a server that came up, so there is nothing to re-check here.
+        const auto port = std::to_string(keylog_server->get_port());
+        if (keylog_server->send(line)) {
+            log_info("TLS handshake keys sent to port " + port + ": " + std::string(line));
+        } else {
+            log_error("key-log send to port " + port + " failed");
         }
     }
 
@@ -864,9 +875,30 @@ ServerConnection::ServerConnection(SslContext* ctx, int soc, const char* ip_in, 
         ServerTrustedCaKeys::set_data(m_context->ctx.get(), &m_tck_data);
 
         if (tls_key_interface != nullptr) {
-            const auto port = std::stoul(service_in);
-            m_keylog_server = std::make_unique<TlsKeyLoggingServer>(std::string(tls_key_interface), port);
-            SSL_set_ex_data(m_context->ctx.get(), ssl_keylog_server_index, m_keylog_server.get());
+            // service_in comes from the accept path and may be empty or
+            // non-numeric, so parse it without throwing.
+            std::uint16_t port{0};
+            bool port_valid{false};
+            if (service_in != nullptr && *service_in != '\0') {
+                const char* const end = service_in + std::strlen(service_in);
+                const auto [ptr, ec] = std::from_chars(service_in, end, port);
+                port_valid = (ec == std::errc{}) && (ptr == end);
+            }
+            if (!port_valid) {
+                log_warning("ServerConnection: service string is not a port number; TLS key logging disabled for this "
+                            "connection");
+            } else {
+                // Keep the server only when it can actually send, so a non-null m_keylog_server
+                // always means a usable one and the key-log callback needs no further check.
+                auto keylog_server = std::make_unique<TlsKeyLoggingServer>(std::string(tls_key_interface), port);
+                if (keylog_server->is_valid()) {
+                    m_keylog_server = std::move(keylog_server);
+                    SSL_set_ex_data(m_context->ctx.get(), ssl_keylog_server_index, m_keylog_server.get());
+                } else {
+                    log_warning("ServerConnection: key-log server setup failed; TLS key logging disabled for this "
+                                "connection");
+                }
+            }
         }
     }
 }
@@ -913,11 +945,48 @@ void ServerConnection::wait_all_closed() {
 // ----------------------------------------------------------------------------
 // ClientConnection represents a TLS client connection
 
+namespace {
+/// true when host is a numeric IPv4 or IPv6 address rather than a DNS name
+bool is_ip_literal(const std::string& host) {
+    unsigned char buf[sizeof(struct in6_addr)];
+    return ::inet_pton(AF_INET, host.c_str(), buf) == 1 || ::inet_pton(AF_INET6, host.c_str(), buf) == 1;
+}
+} // namespace
+
 ClientConnection::ClientConnection(SslContext* ctx, int soc, const char* ip_in, const char* service_in,
-                                   std::int32_t timeout_ms) :
+                                   std::int32_t timeout_ms, bool verify_subject_name) :
     Connection(ctx, soc, ip_in, service_in, timeout_ms) {
-    if (m_context->soc_bio != nullptr) {
-        SSL_set_connect_state(m_context->ctx.get());
+    if (m_context->soc_bio == nullptr) {
+        return;
+    }
+    SSL_set_connect_state(m_context->ctx.get());
+    if (m_peer_host.empty()) {
+        return;
+    }
+
+    auto* const ssl = m_context->ctx.get();
+    const bool ip_literal = is_ip_literal(m_peer_host);
+
+    // RFC 6066 section 3 does not permit a literal IP address in the SNI extension.
+    if (!ip_literal) {
+        SSL_set_tlsext_host_name(ssl, m_peer_host.c_str());
+    }
+
+    if (verify_subject_name) {
+        // An IP is pinned through X509_VERIFY_PARAM_set1_ip_asc so that it is matched against the
+        // certificate's iPAddress SAN entries. Whether SSL_set1_host recognises an IP literal and
+        // does the same varies by OpenSSL version, so the call is made explicitly rather than
+        // relying on it.
+        // A failed pin faults the connection so the handshake fails closed
+        // instead of silently downgrading to chain-of-trust only.
+        const int pinned = ip_literal ? X509_VERIFY_PARAM_set1_ip_asc(SSL_get0_param(ssl), m_peer_host.c_str())
+                                      : SSL_set1_host(ssl, m_peer_host.c_str());
+        if (pinned != 1) {
+            log_error(ip_literal ? "X509_VERIFY_PARAM_set1_ip_asc" : "SSL_set1_host");
+            m_state = state_t::fault;
+            return;
+        }
+        SSL_set_hostflags(ssl, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
     }
 }
 
@@ -1284,8 +1353,13 @@ Server::ConnectionPtr Server::wrap_accepted_fd(int soc, const char* ip, const ch
     if ((m_context == nullptr) || (m_context->ctx == nullptr)) {
         return nullptr;
     }
-    return std::make_unique<ServerConnection>(m_context->ctx.get(), soc, ip, service, m_timeout_ms,
-                                              m_tls_key_interface);
+    auto conn =
+        std::make_unique<ServerConnection>(m_context->ctx.get(), soc, ip, service, m_timeout_ms, m_tls_key_interface);
+    if (!conn->is_valid()) {
+        // No BIO_CLOSE owner took the fd, so the caller still owns it.
+        return nullptr;
+    }
+    return conn;
 }
 
 void Server::configure_signal_handler(int interrupt_signal) {
@@ -1446,7 +1520,14 @@ bool Client::init(const config_t& cfg, const override_t& override) {
     assert(override.trusted_ca_keys_add != nullptr);
     assert(override.trusted_ca_keys_free != nullptr);
 
+    if (cfg.verify_subject_name && !cfg.verify_server) {
+        log_error("verify_subject_name requires verify_server; refusing to initialise the client because the "
+                  "hostname it was asked to pin cannot be enforced");
+        return false;
+    }
+
     m_timeout_ms = cfg.io_timeout_ms;
+    m_verify_subject_name = cfg.verify_subject_name;
     m_trusted_ca_keys = cfg.trusted_ca_keys_data;
     SSL_CTX* ctx = nullptr;
     Server::certificate_config_t cert_config{};
@@ -1574,12 +1655,27 @@ std::unique_ptr<ClientConnection> Client::connect(const char* host, const char* 
             }
 
             if (connected) {
-                result = std::make_unique<ClientConnection>(m_context->ctx.get(), socket, host, service, m_timeout_ms);
+                result = std::make_unique<ClientConnection>(m_context->ctx.get(), socket, host, service, m_timeout_ms,
+                                                            m_verify_subject_name);
             }
         }
     }
 
     return result;
+}
+
+Client::ConnectionPtr Client::wrap_connecting_fd(int fd, const char* host_for_sni) {
+    if (m_context == nullptr) {
+        return nullptr;
+    }
+    auto conn =
+        std::make_unique<ClientConnection>(m_context->ctx.get(), fd, (host_for_sni != nullptr) ? host_for_sni : "", "",
+                                           m_timeout_ms, m_verify_subject_name);
+    if (!conn->is_valid()) {
+        // No BIO_CLOSE owner took the fd, so the caller still owns it.
+        return nullptr;
+    }
+    return conn;
 }
 
 Client::override_t Client::default_overrides() {
@@ -1662,9 +1758,14 @@ TlsKeyLoggingServer::~TlsKeyLoggingServer() {
     }
 }
 
-ssize_t TlsKeyLoggingServer::send(const char* line) {
-    return sendto(fd, line, strlen(line), 0, reinterpret_cast<const sockaddr*>(&destination_address),
-                  sizeof(destination_address));
+bool TlsKeyLoggingServer::send(const char* line) {
+    if (fd == -1 || line == nullptr) {
+        return false;
+    }
+    const auto length = std::strlen(line);
+    const auto sent = sendto(fd, line, length, 0, reinterpret_cast<const sockaddr*>(&destination_address),
+                             sizeof(destination_address));
+    return sent >= 0 && static_cast<std::size_t>(sent) == length;
 }
 
 } // namespace tls

--- a/lib/everest/tls/tests/CMakeLists.txt
+++ b/lib/everest/tls/tests/CMakeLists.txt
@@ -8,10 +8,16 @@ set(TLS_TEST_FILES
         pki-tpm.sh
 )
 
+set(TLS_TEST_FILE_SOURCES "")
+foreach(_tls_test_file ${TLS_TEST_FILES})
+    list(APPEND TLS_TEST_FILE_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/pki/${_tls_test_file})
+endforeach()
+
 add_custom_command(
     OUTPUT ${TLS_TEST_FILES}
     COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/pki
     COMMAND cd pki && cp ${TLS_TEST_FILES} ${CMAKE_CURRENT_BINARY_DIR}/
+    DEPENDS ${TLS_TEST_FILE_SOURCES}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -40,6 +46,7 @@ target_sources(${TLS_GTEST_NAME} PRIVATE
     tls_test.cpp
     tls_connection_test.cpp
     tls_connection_tls13_test.cpp
+    tls_client_wrap_test.cpp
     ../extensions/helpers.cpp
     ../extensions/status_request.cpp
     ../extensions/trusted_ca_keys.cpp
@@ -158,4 +165,7 @@ target_link_libraries(${TLS_PATCH_NAME}
 )
 
 add_test(${TLS_GTEST_NAME} ${TLS_GTEST_NAME})
+# Serialize with everest_io_tls_test: both regenerate the PKI fixture via
+# ./pki.sh in this directory at startup.
+set_tests_properties(${TLS_GTEST_NAME} PROPERTIES RESOURCE_LOCK tls_pki)
 ev_register_test_target(${TLS_GTEST_NAME})

--- a/lib/everest/tls/tests/pki/openssl-pki.conf
+++ b/lib/everest/tls/tests/pki/openssl-pki.conf
@@ -78,7 +78,7 @@ subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid:always
 keyUsage = digitalSignature, keyEncipherment, keyAgreement
 extendedKeyUsage = serverAuth, clientAuth
-subjectAltName = IP:192.168.245.1, DNS:evse.pionix.de
+subjectAltName = IP:192.168.245.1, IP:127.0.0.1, DNS:evse.pionix.de, DNS:localhost
 
 # client section
 # ==============

--- a/lib/everest/tls/tests/tls_client_wrap_test.cpp
+++ b/lib/everest/tls/tests/tls_client_wrap_test.cpp
@@ -1,0 +1,453 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Pionix GmbH and Contributors to EVerest
+
+#include "tls_connection_test.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <poll.h>
+#include <tuple>
+#include <unistd.h>
+
+// Empty derived fixture: gives these cases their own suite name so they stay
+// addressable via --gtest_filter.
+struct TlsClientWrapTest : TlsTest {};
+
+TEST_F(TlsClientWrapTest, WrapConnectingFdHandshake) {
+    using state_t = tls::Server::state_t;
+    using result_t = tls::Connection::result_t;
+
+    // Passed via server_config.socket so init() skips its own bind/listen path.
+    const auto listener = make_loopback_listener();
+    ASSERT_GE(listener.fd, 0);
+
+    server_config.socket = listener.fd;
+    const auto init_state = server.init(server_config, nullptr);
+    ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
+
+    std::thread server_side([&]() {
+        auto server_conn = accept_and_wrap(server, listener.fd);
+        if (server_conn) {
+            std::ignore = server_conn->accept(1000);
+            std::ignore = server_conn->shutdown(1000);
+        }
+    });
+
+    const int client_fd = connect_loopback_nonblocking(listener.port);
+    ASSERT_GE(client_fd, 0);
+
+    ClientTest local_client;
+    local_client.init(client_config);
+
+    auto conn = local_client.wrap_connecting_fd(client_fd, "localhost");
+    ASSERT_TRUE(conn);
+    EXPECT_EQ(conn->socket(), client_fd);
+
+    const auto drive = drive_client_handshake(*conn, client_fd);
+    EXPECT_EQ(drive.result, result_t::success);
+    EXPECT_NE(conn->peer_certificate(), nullptr);
+
+    std::ignore = conn->shutdown(1000);
+
+    if (server_side.joinable()) {
+        server_side.join();
+    }
+    std::ignore = ::close(listener.fd);
+}
+
+// The PKI server leaf carries DNS:localhost, so pinning to "localhost" passes.
+TEST_F(TlsClientWrapTest, WrapConnectingFdVerifiesHostname) {
+    using state_t = tls::Server::state_t;
+    using result_t = tls::Connection::result_t;
+
+    const auto listener = make_loopback_listener();
+    ASSERT_GE(listener.fd, 0);
+
+    server_config.socket = listener.fd;
+    const auto init_state = server.init(server_config, nullptr);
+    ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
+
+    std::thread server_side([&]() {
+        auto server_conn = accept_and_wrap(server, listener.fd);
+        if (server_conn) {
+            std::ignore = server_conn->accept(1000);
+            std::ignore = server_conn->shutdown(1000);
+        }
+    });
+
+    const int client_fd = connect_loopback_nonblocking(listener.port);
+    ASSERT_GE(client_fd, 0);
+
+    tls::Client::config_t verify_config = client_config;
+    verify_config.verify_subject_name = true;
+
+    ClientTest local_client;
+    local_client.init(verify_config);
+
+    auto conn = local_client.wrap_connecting_fd(client_fd, "localhost");
+    ASSERT_TRUE(conn);
+
+    const auto drive = drive_client_handshake(*conn, client_fd);
+    EXPECT_EQ(drive.result, result_t::success);
+    EXPECT_NE(conn->peer_certificate(), nullptr);
+
+    std::ignore = conn->shutdown(1000);
+
+    if (server_side.joinable()) {
+        server_side.join();
+    }
+    std::ignore = ::close(listener.fd);
+}
+
+// Covers the IP-literal pinning branch, which is otherwise never executed: the peer
+// is named by an IP so the pin goes through X509_VERIFY_PARAM_set1_ip_asc and must
+// match the leaf's iPAddress SAN entry. A negative IP test is deliberately absent, it
+// would fail whichever pinning call the code made and so could not tell them apart.
+TEST_F(TlsClientWrapTest, WrapConnectingFdVerifiesIpLiteral) {
+    using state_t = tls::Server::state_t;
+    using result_t = tls::Connection::result_t;
+
+    const auto listener = make_loopback_listener();
+    ASSERT_GE(listener.fd, 0);
+
+    server_config.socket = listener.fd;
+    const auto init_state = server.init(server_config, nullptr);
+    ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
+
+    std::thread server_side([&]() {
+        auto server_conn = accept_and_wrap(server, listener.fd);
+        if (server_conn) {
+            std::ignore = server_conn->accept(1000);
+            std::ignore = server_conn->shutdown(1000);
+        }
+    });
+
+    const int client_fd = connect_loopback_nonblocking(listener.port);
+    ASSERT_GE(client_fd, 0);
+
+    tls::Client::config_t verify_config = client_config;
+    verify_config.verify_subject_name = true;
+
+    ClientTest local_client;
+    local_client.init(verify_config);
+
+    auto conn = local_client.wrap_connecting_fd(client_fd, "127.0.0.1");
+    ASSERT_TRUE(conn);
+
+    const auto drive = drive_client_handshake(*conn, client_fd);
+    EXPECT_EQ(drive.result, result_t::success);
+    EXPECT_NE(conn->peer_certificate(), nullptr);
+
+    std::ignore = conn->shutdown(1000);
+
+    if (server_side.joinable()) {
+        server_side.join();
+    }
+    std::ignore = ::close(listener.fd);
+}
+
+// The server leaf carries DNS:localhost and DNS:evse.pionix.de, so
+// "wrong.example" matches no subject/SAN entry.
+TEST_F(TlsClientWrapTest, WrapConnectingFdRejectsWrongHostname) {
+    using state_t = tls::Server::state_t;
+    using result_t = tls::Connection::result_t;
+
+    const auto listener = make_loopback_listener();
+    ASSERT_GE(listener.fd, 0);
+
+    server_config.socket = listener.fd;
+    const auto init_state = server.init(server_config, nullptr);
+    ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
+
+    std::thread server_side([&]() {
+        auto server_conn = accept_and_wrap(server, listener.fd);
+        if (server_conn) {
+            std::ignore = server_conn->accept(1000);
+            std::ignore = server_conn->shutdown(1000);
+        }
+    });
+
+    const int client_fd = connect_loopback_nonblocking(listener.port);
+    ASSERT_GE(client_fd, 0);
+
+    tls::Client::config_t verify_config = client_config;
+    verify_config.verify_subject_name = true;
+
+    ClientTest local_client;
+    local_client.init(verify_config);
+
+    auto conn = local_client.wrap_connecting_fd(client_fd, "wrong.example");
+    ASSERT_TRUE(conn);
+
+    const auto drive = drive_client_handshake(*conn, client_fd);
+    EXPECT_NE(drive.result, result_t::success);
+
+    std::ignore = conn->shutdown(1000);
+
+    if (server_side.joinable()) {
+        server_side.join();
+    }
+    std::ignore = ::close(listener.fd);
+}
+
+// A non-numeric service string must not throw out of ServerConnection; only key
+// logging is skipped. The CTX-wide keylog callback still fires for such a
+// connection, so the handshake is driven to completion to cover that path.
+TEST_F(TlsClientWrapTest, WrapAcceptedFdToleratesNonNumericService) {
+    using state_t = tls::Server::state_t;
+    using result_t = tls::Connection::result_t;
+
+    const auto listener = make_loopback_listener();
+    ASSERT_GE(listener.fd, 0);
+
+    server_config.socket = listener.fd;
+    server_config.tls_key_logging = true;
+    server_config.tls_key_logging_path = ::testing::TempDir();
+    const auto init_state = server.init(server_config, nullptr);
+    ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
+
+    // Empty service string.
+    {
+        const int client_fd = connect_loopback_nonblocking(listener.port);
+        ASSERT_GE(client_fd, 0);
+
+        const int accepted_fd = ::accept(listener.fd, nullptr, nullptr);
+        ASSERT_GE(accepted_fd, 0);
+
+        tls::Server::ConnectionPtr conn;
+        ASSERT_NO_THROW(conn = server.wrap_accepted_fd(accepted_fd, "::1", ""));
+        ASSERT_TRUE(conn);
+
+        auto server_result = result_t::timeout;
+        std::thread server_side([&]() {
+            server_result = conn->accept(1000);
+            std::ignore = conn->shutdown(1000);
+        });
+
+        client.init(client_config);
+        auto client_conn = client.wrap_connecting_fd(client_fd, "localhost");
+        ASSERT_TRUE(client_conn);
+
+        const auto drive = drive_client_handshake(*client_conn, client_fd);
+        EXPECT_EQ(drive.result, result_t::success);
+
+        std::ignore = client_conn->shutdown(1000);
+
+        if (server_side.joinable()) {
+            server_side.join();
+        }
+        EXPECT_EQ(server_result, result_t::success);
+    }
+
+    // Garbage service string.
+    {
+        const int client_fd = connect_loopback_nonblocking(listener.port);
+        ASSERT_GE(client_fd, 0);
+
+        const int accepted_fd = ::accept(listener.fd, nullptr, nullptr);
+        ASSERT_GE(accepted_fd, 0);
+
+        tls::Server::ConnectionPtr conn;
+        ASSERT_NO_THROW(conn = server.wrap_accepted_fd(accepted_fd, "::1", "not-a-port"));
+        EXPECT_TRUE(conn);
+
+        // conn owns accepted_fd, only the client fd needs closing here.
+        std::ignore = ::close(client_fd);
+    }
+
+    std::ignore = ::close(listener.fd);
+}
+
+// A reader draining a message must be able to tell that decrypted plaintext is
+// still buffered. One TLS record can carry more plaintext than the caller's
+// buffer holds, so a short read leaves the remainder in the record layer, and
+// the socket will not necessarily become readable again to deliver it. A drain
+// loop keyed only on socket readability would strand that remainder.
+TEST_F(TlsClientWrapTest, WrapConnectingFdReportsBufferedPlaintext) {
+    using state_t = tls::Server::state_t;
+    using result_t = tls::Connection::result_t;
+
+    const auto listener = make_loopback_listener();
+    ASSERT_GE(listener.fd, 0);
+
+    server_config.socket = listener.fd;
+    const auto init_state = server.init(server_config, nullptr);
+    ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
+
+    // Sent with a single write(), hence a single TLS record, and read back in
+    // chunks far smaller than the record's plaintext.
+    constexpr std::size_t payload_size = 512;
+    constexpr std::size_t chunk_size = 64;
+    std::array<std::byte, payload_size> payload{};
+    for (std::size_t i = 0; i < payload.size(); ++i) {
+        payload[i] = static_cast<std::byte>('a' + (i % 26));
+    }
+
+    std::thread server_side([&]() {
+        auto server_conn = accept_and_wrap(server, listener.fd);
+        if (!server_conn) {
+            return;
+        }
+        if (server_conn->accept(1000) == result_t::success) {
+            std::size_t sent = 0;
+            std::ignore = server_conn->write(payload.data(), payload.size(), sent, 1000);
+        }
+        std::ignore = server_conn->shutdown(1000);
+    });
+
+    const int client_fd = connect_loopback_nonblocking(listener.port);
+    ASSERT_GE(client_fd, 0);
+
+    ClientTest local_client;
+    local_client.init(client_config);
+
+    auto conn = local_client.wrap_connecting_fd(client_fd, "localhost");
+    ASSERT_TRUE(conn);
+
+    const auto drive = drive_client_handshake(*conn, client_fd);
+    ASSERT_EQ(drive.result, result_t::success);
+
+    std::array<std::byte, payload_size> received{};
+    std::size_t got = 0;
+    EXPECT_EQ(conn->read(received.data(), chunk_size, got, 1000), result_t::success);
+    EXPECT_EQ(got, chunk_size);
+    EXPECT_LT(got, payload.size());
+
+    // The record was decrypted in full, so its remainder is held by the record
+    // layer rather than by the socket.
+    EXPECT_TRUE(conn->has_pending());
+
+    std::size_t total = got;
+    auto drain_result = result_t::success;
+    while (total < payload.size() && drain_result == result_t::success) {
+        std::size_t chunk = 0;
+        const auto want = std::min(chunk_size, payload.size() - total);
+        drain_result = conn->read(received.data() + total, want, chunk, 1000);
+        total += chunk;
+    }
+    EXPECT_EQ(drain_result, result_t::success);
+    EXPECT_EQ(total, payload.size());
+    EXPECT_EQ(std::memcmp(received.data(), payload.data(), payload.size()), 0);
+
+    EXPECT_FALSE(conn->has_pending());
+
+    std::ignore = conn->shutdown(1000);
+
+    if (server_side.joinable()) {
+        server_side.join();
+    }
+    std::ignore = ::close(listener.fd);
+}
+
+TEST_F(TlsClientWrapTest, WrapConnectingFdNonBlocking) {
+    using state_t = tls::Server::state_t;
+    using result_t = tls::Connection::result_t;
+
+    const auto listener = make_loopback_listener();
+    ASSERT_GE(listener.fd, 0);
+
+    server_config.socket = listener.fd;
+    const auto init_state = server.init(server_config, nullptr);
+    ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
+
+    // Echo 4 bytes back so the client's non-blocking write/read paths run.
+    std::thread server_side([&]() {
+        auto server_conn = accept_and_wrap(server, listener.fd);
+        if (!server_conn) {
+            return;
+        }
+        if (server_conn->accept(1000) == result_t::success) {
+            std::array<std::byte, 4> buf{};
+            std::size_t total = 0;
+            int timeouts = 0;
+            while (total < buf.size() && timeouts <= 10) {
+                std::size_t got = 0;
+                const auto rres = server_conn->read(buf.data() + total, buf.size() - total, got, 1000);
+                if (rres == result_t::success) {
+                    total += got;
+                } else if (rres == result_t::timeout) {
+                    ++timeouts;
+                } else {
+                    break;
+                }
+            }
+            if (total == buf.size()) {
+                std::size_t sent = 0;
+                std::ignore = server_conn->write(buf.data(), buf.size(), sent, 1000);
+            }
+        }
+        std::ignore = server_conn->shutdown(1000);
+    });
+
+    const int client_fd = connect_loopback_nonblocking(listener.port);
+    ASSERT_GE(client_fd, 0);
+
+    // timeout 0 forces purely non-blocking operation.
+    tls::Client::config_t nb_config = client_config;
+    nb_config.io_timeout_ms = 0;
+
+    ClientTest local_client;
+    local_client.init(nb_config);
+
+    auto conn = local_client.wrap_connecting_fd(client_fd, "localhost");
+    ASSERT_TRUE(conn);
+
+    const auto drive = drive_client_handshake(*conn, client_fd, 0, 200, 500);
+    ASSERT_EQ(drive.result, result_t::success);
+
+    EXPECT_TRUE(drive.want_read > 0 || drive.want_write > 0)
+        << "expected at least one want_read or want_write during non-blocking handshake";
+
+    const std::array<std::byte, 4> ping{std::byte{'p'}, std::byte{'i'}, std::byte{'n'}, std::byte{'g'}};
+    std::size_t written = 0;
+    for (int i = 0; i < 50 && written < ping.size(); ++i) {
+        const auto wres = conn->write(ping.data(), ping.size(), written, 0);
+        if (wres == result_t::want_write) {
+            pollfd pfd{client_fd, POLLOUT, 0};
+            std::ignore = ::poll(&pfd, 1, 100);
+        } else if (wres == result_t::want_read) {
+            pollfd pfd{client_fd, POLLIN, 0};
+            std::ignore = ::poll(&pfd, 1, 100);
+        } else if (wres != result_t::success) {
+            break;
+        }
+    }
+    ASSERT_EQ(written, ping.size());
+
+    std::array<std::byte, 4> echo{};
+    std::size_t echoed = 0;
+    for (int i = 0; i < 50 && echoed < echo.size(); ++i) {
+        std::size_t got = 0;
+        const auto rres = conn->read(echo.data() + echoed, echo.size() - echoed, got, 0);
+        if (rres == result_t::success) {
+            echoed += got;
+        } else if (rres == result_t::want_read) {
+            pollfd pfd{client_fd, POLLIN, 0};
+            std::ignore = ::poll(&pfd, 1, 500);
+        } else if (rres == result_t::want_write) {
+            pollfd pfd{client_fd, POLLOUT, 0};
+            std::ignore = ::poll(&pfd, 1, 500);
+        } else {
+            break;
+        }
+    }
+    ASSERT_EQ(echoed, echo.size());
+    EXPECT_EQ(std::memcmp(echo.data(), ping.data(), ping.size()), 0);
+
+    result_t sr = result_t::timeout;
+    for (int i = 0; i < 50 && sr != result_t::closed; ++i) {
+        sr = conn->shutdown(0);
+        if (sr == result_t::want_read) {
+            pollfd pfd{client_fd, POLLIN, 0};
+            std::ignore = ::poll(&pfd, 1, 200);
+        } else if (sr == result_t::want_write) {
+            pollfd pfd{client_fd, POLLOUT, 0};
+            std::ignore = ::poll(&pfd, 1, 200);
+        }
+    }
+
+    if (server_side.joinable()) {
+        server_side.join();
+    }
+    std::ignore = ::close(listener.fd);
+}

--- a/lib/everest/tls/tests/tls_connection_test.hpp
+++ b/lib/everest/tls/tests/tls_connection_test.hpp
@@ -8,14 +8,24 @@
 #include <everest/tls/openssl_util.hpp>
 
 #include <array>
+#include <cerrno>
 #include <chrono>
 #include <csignal>
+#include <cstdint>
 #include <everest/tls/tls.hpp>
 #include <gtest/gtest.h>
 #include <memory>
 #include <openssl/ssl.h>
 #include <thread>
+#include <tuple>
 #include <unistd.h>
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
 
 #include <everest/util/enum/EnumFlags.hpp>
 
@@ -152,6 +162,120 @@ inline void handler(tls::Server::ConnectionPtr&& con) {
 
 inline void run_server(tls::Server& server) {
     server.serve(&handler);
+}
+
+// ----------------------------------------------------------------------------
+// Socket helpers shared by the wrap_accepted_fd / wrap_connecting_fd tests.
+// They return error values rather than assert, because ASSERT_* requires a void
+// return type; callers assert at the call site.
+
+// Test-owned loopback listen socket on an ephemeral port; fd is -1 on failure.
+struct LoopbackListener {
+    int fd{-1};
+    std::uint16_t port{0};
+};
+
+inline LoopbackListener make_loopback_listener() {
+    LoopbackListener listener;
+    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return listener;
+    }
+    int reuse = 1;
+    std::ignore = ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+
+    sockaddr_in bound{};
+    socklen_t bound_len = sizeof(bound);
+    if ((::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) || (::listen(fd, 1) != 0) ||
+        (::getsockname(fd, reinterpret_cast<sockaddr*>(&bound), &bound_len) != 0)) {
+        std::ignore = ::close(fd);
+        return listener;
+    }
+    listener.fd = fd;
+    listener.port = ntohs(bound.sin_port);
+    return listener;
+}
+
+// Returns nullptr when accept(2), name resolution, or the wrap fails.
+inline tls::Server::ConnectionPtr accept_and_wrap(tls::Server& server, int listen_fd) {
+    sockaddr_in peer_addr{};
+    socklen_t peer_len = sizeof(peer_addr);
+    const int accepted_fd = ::accept(listen_fd, reinterpret_cast<sockaddr*>(&peer_addr), &peer_len);
+    if (accepted_fd < 0) {
+        return nullptr;
+    }
+    char ip_buf[INET_ADDRSTRLEN]{};
+    char service_buf[NI_MAXSERV]{};
+    if (::getnameinfo(reinterpret_cast<sockaddr*>(&peer_addr), peer_len, ip_buf, sizeof(ip_buf), service_buf,
+                      sizeof(service_buf), NI_NUMERICHOST | NI_NUMERICSERV) != 0) {
+        std::ignore = ::close(accepted_fd);
+        return nullptr;
+    }
+    return server.wrap_accepted_fd(accepted_fd, ip_buf, service_buf);
+}
+
+// Polls out an in-flight EINPROGRESS connect. Returns -1 on failure.
+inline int connect_loopback_nonblocking(std::uint16_t port) {
+    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    const int flags = ::fcntl(fd, F_GETFL, 0);
+    if ((flags == -1) || (::fcntl(fd, F_SETFL, flags | O_NONBLOCK) != 0)) {
+        std::ignore = ::close(fd);
+        return -1;
+    }
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(port);
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        if (errno != EINPROGRESS) {
+            std::ignore = ::close(fd);
+            return -1;
+        }
+        pollfd pfd{fd, POLLOUT, 0};
+        int err = 0;
+        socklen_t err_len = sizeof(err);
+        if ((::poll(&pfd, 1, 2000) <= 0) || (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &err_len) != 0) ||
+            (err != 0)) {
+            std::ignore = ::close(fd);
+            return -1;
+        }
+    }
+    return fd;
+}
+
+struct HandshakeDrive {
+    tls::Connection::result_t result{tls::Connection::result_t::timeout};
+    int want_read{0};
+    int want_write{0};
+};
+
+// Polls for socket readiness whenever connect() reports want_read / want_write.
+inline HandshakeDrive drive_client_handshake(tls::ClientConnection& conn, int fd, int connect_timeout_ms = 1000,
+                                             int max_attempts = 50, int poll_timeout_ms = 1000) {
+    using result_t = tls::Connection::result_t;
+    HandshakeDrive drive;
+    for (int i = 0; i < max_attempts && drive.result != result_t::success && drive.result != result_t::closed; ++i) {
+        drive.result = conn.connect(connect_timeout_ms);
+        if (drive.result == result_t::want_read) {
+            ++drive.want_read;
+            pollfd pfd{fd, POLLIN, 0};
+            std::ignore = ::poll(&pfd, 1, poll_timeout_ms);
+        } else if (drive.result == result_t::want_write) {
+            ++drive.want_write;
+            pollfd pfd{fd, POLLOUT, 0};
+            std::ignore = ::poll(&pfd, 1, poll_timeout_ms);
+        }
+    }
+    return drive;
 }
 
 class TlsTest : public testing::Test {

--- a/lib/everest/tls/tests/tls_connection_tls13_test.cpp
+++ b/lib/everest/tls/tests/tls_connection_tls13_test.cpp
@@ -3,76 +3,19 @@
 
 #include "tls_connection_test.hpp"
 
-#include <arpa/inet.h>
 #include <array>
 #include <condition_variable>
 #include <cstring>
 #include <fcntl.h>
 #include <mutex>
-#include <netdb.h>
-#include <netinet/in.h>
 #include <openssl/x509.h>
 #include <optional>
-#include <sys/socket.h>
 #include <thread>
+#include <tuple>
 
 using namespace std::chrono_literals;
 
 namespace {
-
-// Test-owned loopback listen socket on an ephemeral port, for tests that
-// bypass init_socket()'s fixed-port bind by passing the fd to the Server via
-// server_config.socket. fd is -1 on failure; ASSERT_* requires a void return
-// type, so callers assert validity at the call site.
-struct LoopbackListener {
-    int fd{-1};
-    std::string service; // bound port, as a service string for Client::connect()
-};
-
-LoopbackListener make_loopback_listener() {
-    LoopbackListener listener;
-    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
-    if (fd < 0) {
-        return listener;
-    }
-    int reuse = 1;
-    (void)::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
-    sockaddr_in listen_addr{};
-    listen_addr.sin_family = AF_INET;
-    listen_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    listen_addr.sin_port = 0;
-    if ((::bind(fd, reinterpret_cast<sockaddr*>(&listen_addr), sizeof(listen_addr)) != 0) || (::listen(fd, 1) != 0)) {
-        (void)::close(fd);
-        return listener;
-    }
-    sockaddr_in bound_addr{};
-    socklen_t bound_len = sizeof(bound_addr);
-    if (::getsockname(fd, reinterpret_cast<sockaddr*>(&bound_addr), &bound_len) != 0) {
-        (void)::close(fd);
-        return listener;
-    }
-    listener.fd = fd;
-    listener.service = std::to_string(ntohs(bound_addr.sin_port));
-    return listener;
-}
-
-// Returns nullptr on failure; callers assert.
-tls::Server::ConnectionPtr accept_and_wrap(tls::Server& server, int listen_fd) {
-    sockaddr_in peer_addr{};
-    socklen_t peer_len = sizeof(peer_addr);
-    const int accepted_fd = ::accept(listen_fd, reinterpret_cast<sockaddr*>(&peer_addr), &peer_len);
-    if (accepted_fd < 0) {
-        return nullptr;
-    }
-    char ip_buf[INET_ADDRSTRLEN]{};
-    char service_buf[NI_MAXSERV]{};
-    if (::getnameinfo(reinterpret_cast<sockaddr*>(&peer_addr), peer_len, ip_buf, sizeof(ip_buf), service_buf,
-                      sizeof(service_buf), NI_NUMERICHOST | NI_NUMERICSERV) != 0) {
-        (void)::close(accepted_fd);
-        return nullptr;
-    }
-    return server.wrap_accepted_fd(accepted_fd, ip_buf, service_buf);
-}
 
 TEST_F(TlsTest, EnforceTls13RejectsTls12Client) {
     // Server enforces TLS 1.3; a TLS-1.2-only client must be rejected.
@@ -194,7 +137,7 @@ TEST_F(TlsTest, EnforceTls13EmptyCiphersuitesFailsInit) {
 
     const auto init_state = server.init(server_config, nullptr);
     EXPECT_NE(init_state, state_t::init_complete);
-    (void)::close(test_socket);
+    std::ignore = ::close(test_socket);
 }
 
 TEST_F(TlsTest, AdditionalVerifyAnchorVerifiesClientChainedToIt) {
@@ -367,7 +310,7 @@ TEST_F(TlsTest, PeerCertificateSha512Tls13WithCert) {
         if (con && con->accept() == tls::Connection::result_t::success) {
             accept_ok = true;
             server_digest = con->peer_certificate_sha512();
-            (void)con->shutdown();
+            std::ignore = con->shutdown();
         }
         {
             std::lock_guard<std::mutex> lock(result_mutex);
@@ -419,7 +362,7 @@ TEST_F(TlsTest, PeerCertificateSha512Tls12WithoutCert) {
             accept_ok = true;
             server_digest = con->peer_certificate_sha512();
             digest_set = true;
-            (void)con->shutdown();
+            std::ignore = con->shutdown();
         }
         {
             std::lock_guard<std::mutex> lock(result_mutex);
@@ -459,14 +402,16 @@ TEST_F(TlsTest, WrapAcceptedFdHandshake) {
     const auto init_state = server.init(server_config, nullptr);
     ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
 
+    const std::string bound_service = std::to_string(listener.port);
+
     // Client thread: open a TLS 1.2 connection to our listen socket.
     std::thread client_thread([&]() {
         ClientTest local_client;
         local_client.init(client_config);
-        auto conn = local_client.connect("127.0.0.1", listener.service.c_str(), false, 1000);
+        auto conn = local_client.connect("127.0.0.1", bound_service.c_str(), false, 1000);
         if (conn) {
-            (void)conn->connect();
-            (void)conn->shutdown();
+            std::ignore = conn->connect();
+            std::ignore = conn->shutdown();
         }
     });
 
@@ -476,12 +421,12 @@ TEST_F(TlsTest, WrapAcceptedFdHandshake) {
     // Drive the SSL handshake.
     EXPECT_EQ(server_conn->accept(1000), tls::Connection::result_t::success);
     EXPECT_EQ(server_conn->state(), tls::Connection::state_t::connected);
-    (void)server_conn->shutdown();
+    std::ignore = server_conn->shutdown();
 
     if (client_thread.joinable()) {
         client_thread.join();
     }
-    (void)::close(listener.fd);
+    std::ignore = ::close(listener.fd);
 }
 
 TEST_F(TlsTest, WrapAcceptedFdOnUninitServerReturnsNull) {
@@ -501,8 +446,8 @@ TEST_F(TlsTest, WrapAcceptedFdOnUninitServerReturnsNull) {
     EXPECT_NE(::fcntl(sv[0], F_GETFD), -1);
 
     conn.reset();
-    (void)::close(sv[0]);
-    (void)::close(sv[1]);
+    std::ignore = ::close(sv[0]);
+    std::ignore = ::close(sv[1]);
 }
 
 TEST_F(TlsTest, LastErrorPopulatedOnFailedAccept) {
@@ -540,7 +485,7 @@ TEST_F(TlsTest, LastErrorPopulatedOnFailedAccept) {
             const auto rc = con->accept();
             accept_failed = (rc != tls::Connection::result_t::success);
             server_last_error = con->last_error();
-            (void)con->shutdown();
+            std::ignore = con->shutdown();
         }
         {
             std::lock_guard<std::mutex> lock(result_mutex);
@@ -570,6 +515,8 @@ TEST_F(TlsTest, LastErrorDoesNotBleedIntoGracefulClose) {
     // here on the main thread, so the bleed (if present) is on this thread.
     using state_t = tls::Server::state_t;
 
+    // Passed to the Server via server_config.socket so init_socket() does not
+    // bind the fixture's fixed port.
     const auto listener = make_loopback_listener();
     ASSERT_GE(listener.fd, 0);
 
@@ -581,6 +528,8 @@ TEST_F(TlsTest, LastErrorDoesNotBleedIntoGracefulClose) {
     server_config.verify_locations_file = "client_root_cert.pem";
     const auto init_state = server.init(server_config, nullptr);
     ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
+
+    const std::string bound_service = std::to_string(listener.port);
 
     // Spawn a TLS 1.3 client (on its own thread) presenting the given cert pair,
     // then gracefully shut down so the server observes a clean close_notify.
@@ -594,10 +543,10 @@ TEST_F(TlsTest, LastErrorDoesNotBleedIntoGracefulClose) {
             cc.certificate_chain_file = chain;
             cc.private_key_file = key;
             local_client.init(cc);
-            auto conn = local_client.connect("127.0.0.1", listener.service.c_str(), false, 1000);
+            auto conn = local_client.connect("127.0.0.1", bound_service.c_str(), false, 1000);
             if (conn) {
-                (void)conn->connect();
-                (void)conn->shutdown();
+                std::ignore = conn->connect();
+                std::ignore = conn->shutdown();
             }
         });
     };
@@ -632,7 +581,7 @@ TEST_F(TlsTest, LastErrorDoesNotBleedIntoGracefulClose) {
     if (client2.joinable()) {
         client2.join();
     }
-    (void)::close(listener.fd);
+    std::ignore = ::close(listener.fd);
 }
 
 } // namespace


### PR DESCRIPTION
## Describe your changes

`libtls` could only produce a connection by doing the TCP connect itself inside `Client::connect`. That
forecloses any design where something else owns the connect, for example a caller that wants it driven on
its own event loop rather than blocking a thread.

This adds `Client::wrap_connecting_fd`, which takes a descriptor whose TCP connect the caller has already
started and returns a `ClientConnection` around it without handshaking. Driving the handshake afterwards
is the caller's job.

Alongside it:

- **`Connection::has_pending()`** reports whether decrypted plaintext is still buffered in the record
  layer, which is what lets a reader drain a whole message rather than one chunk per wakeup. It uses
  `SSL_has_pending()` rather than `SSL_pending()`. That is hardening, not a fix: the two only diverge
  under read-ahead, DTLS or kTLS, none of which are enabled here.

- **Descriptor ownership is explicit on the failure path.** When wrapping fails, no `BIO_CLOSE` owner has
  taken the descriptor, so it stays the caller's to close. Both wrap entry points say so, and neither
  closes it, which would be a double close.

- **SNI and optional hostname pinning.** `ClientConnection` now sends the server name in the SNI extension
  and, when `verify_subject_name` is set, pins the peer certificate to that name. Neither existed in
  libtls before, so verification was chain of trust only: a certificate signed by any trusted CA was
  accepted regardless of who it was issued to.

  Pinning is off by default, because enabling it unconditionally would break every PKI whose certificates
  carry no hostname. `Client::init` now **rejects** `verify_subject_name` without `verify_server`: under
  `SSL_VERIFY_NONE` the name check is installed but its result is never enforced, so the combination
  cannot be honored and failing init beats leaving the caller believing it pinned a host. IP literals are
  pinned through the verification parameter and kept out of SNI, which RFC 6066 section 3 does not permit.

`has_pending()` and the SNI/pinning work have no in-tree caller yet; the consumer is #2564. Keeping them
here rather than in the consuming PR avoids widening that PR's scope into `lib/everest/tls`, and a TLS
client with no way to verify who it is talking to is not a complete client, so the capability belongs with
the entry point that exposes it.

## Issue ticket number and link

N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

---

### Stack

Root of an eight PR series. #2561 through #2565 all descend from this one, so it wants to land first.

| Order | PR | Branch | Base |
|---|---|---|---|
| 1 | #2558 | `fix/iso15118-listen-socket-helper` | `main` |
| **2** | **#2559 (this PR)** | **`feat/tls-wrap-connecting-fd`** | `main` |
| 3 | #2561 | `fix/io-event-handler-truthfulness` | #2559 |
| 4 | #2562 | `feat/io-client-tx-tristate` | #2561 |
| 5 | #2563 | `feat/io-fd-event-client-handshake-phase` | #2562 |
| 6 | #2564 | `feat/io-tls-policies-rebuilt` | #2563 |
| 7 | #2560 | `fix/io-connect-errno-and-backoff` | `main` |
| 8 | #2565 | `refactor/chargebridge-drop-hand-rolled-tx-gates` | #2562 |
