### PR TITLE
fix(io): carry the connect errno and name the retry delay

### DIFF
--- a/applications/pionix_chargebridge/src/bsp_bridge.cpp
+++ b/applications/pionix_chargebridge/src/bsp_bridge.cpp
@@ -9,8 +9,6 @@
 #include <protocol/evse_bsp_host_to_cb.h>
 
 namespace {
-const int default_udp_timeout_ms = 1000;
-
 const char* cp_state_to_string(CpState state) {
     switch (state) {
     case CpState_A:
@@ -65,7 +63,7 @@ bsp_bridge::bsp_bridge(bsp_bridge_config const& config, everest::lib::io::event:
 }
 
 void bsp_bridge::create_udp_client(std::string const& remote, uint16_t remote_port, std::string const& identifier) {
-    m_udp = std::make_unique<everest::lib::io::udp::udp_client>(remote, remote_port, default_udp_timeout_ms);
+    m_udp = std::make_unique<everest::lib::io::udp::udp_client>(remote, remote_port);
     m_udp_ready = false;
     m_udp_on_error = false;
     m_udp->set_rx_handler([this](auto const& data, auto&) {

--- a/applications/pionix_chargebridge/src/can_bridge.cpp
+++ b/applications/pionix_chargebridge/src/can_bridge.cpp
@@ -10,10 +10,6 @@
 #include <memory>
 #include <protocol/cb_can_message.h>
 
-namespace {
-const int default_udp_timeout_ms = 1000;
-}
-
 namespace charge_bridge {
 using namespace std::chrono_literals;
 
@@ -116,7 +112,7 @@ can_bridge::can_bridge(can_bridge_config const& config, everest::lib::io::event:
 }
 
 void can_bridge::create_udp_client(std::string const& remote, uint16_t remote_port) {
-    m_udp = std::make_unique<everest::lib::io::udp::udp_client>(remote, remote_port, default_udp_timeout_ms);
+    m_udp = std::make_unique<everest::lib::io::udp::udp_client>(remote, remote_port);
     m_udp->set_rx_handler([this](auto const& data, auto&) {
         // The MCU may omit trailing data bytes (see cb_can_message: "data bytes at the end may be
         // omitted"), so the datagram can be shorter than the full struct but must at least cover the

--- a/applications/pionix_chargebridge/src/heartbeat_service.cpp
+++ b/applications/pionix_chargebridge/src/heartbeat_service.cpp
@@ -12,7 +12,6 @@
 #include <protocol/cb_management.h>
 
 namespace {
-const int default_udp_timeout_ms = 1000;
 const std::uint16_t s_to_ms_factor = 1000;
 } // namespace
 
@@ -42,7 +41,7 @@ heartbeat_service::heartbeat_service(heartbeat_config const& config,
 }
 
 void heartbeat_service::create_udp_client(std::string const& remote, uint16_t remote_port) {
-    m_udp = std::make_unique<everest::lib::io::udp::udp_client>(remote, remote_port, default_udp_timeout_ms);
+    m_udp = std::make_unique<everest::lib::io::udp::udp_client>(remote, remote_port);
     m_udp_on_error = false;
     m_udp_ready = false;
     m_udp->set_rx_handler([this](auto const& data, auto&) { handle_udp_rx(data); });

--- a/applications/pionix_chargebridge/src/io_bridge.cpp
+++ b/applications/pionix_chargebridge/src/io_bridge.cpp
@@ -24,7 +24,6 @@ using namespace std::chrono_literals;
 namespace mqtt = everest::lib::io::mqtt;
 
 namespace {
-const int default_udp_timeout_ms = 1000;
 const int mqtt_reconnect_timeout_ms = 1000;
 } // namespace
 
@@ -95,7 +94,7 @@ io_bridge::io_bridge(io_config const& config, everest::lib::io::event::event_fd&
 }
 
 void io_bridge::create_udp_client(std::string const& remote, uint16_t remote_port) {
-    m_udp = std::make_unique<everest::lib::io::udp::udp_client>(remote, remote_port, default_udp_timeout_ms);
+    m_udp = std::make_unique<everest::lib::io::udp::udp_client>(remote, remote_port);
     m_udp_ready = false;
     m_udp_on_error = false;
     m_udp->set_rx_handler([this](auto const& data, auto&) { handle_udp_rx(data); });

--- a/applications/pionix_chargebridge/src/plc_bridge.cpp
+++ b/applications/pionix_chargebridge/src/plc_bridge.cpp
@@ -6,10 +6,6 @@
 #include <everest/io/udp/udp_payload.hpp>
 #include <iostream>
 
-namespace {
-const int default_udp_timeout_ms = 1000;
-} // namespace
-
 namespace charge_bridge {
 
 plc_bridge::plc_bridge(plc_bridge_config const& config, everest::lib::io::event::event_fd& ready_notify) :
@@ -51,7 +47,7 @@ plc_bridge::plc_bridge(plc_bridge_config const& config, everest::lib::io::event:
 }
 
 void plc_bridge::create_udp_client(std::string const& remote, uint16_t remote_port, std::string const& identifier) {
-    m_udp = std::make_unique<everest::lib::io::udp::udp_client>(remote, remote_port, default_udp_timeout_ms);
+    m_udp = std::make_unique<everest::lib::io::udp::udp_client>(remote, remote_port);
     m_udp_ready = false;
     m_udp_on_error = false;
     m_udp->set_rx_handler([this](auto const& data, auto&) { m_tap.tx(data.buffer); });

--- a/lib/everest/io/examples/test_udp_client.cpp
+++ b/lib/everest/io/examples/test_udp_client.cpp
@@ -103,7 +103,7 @@ int main(int argc, char* argv[]) {
     }
 
     std::cout << "Connecting to ->  " << remote << ":" << port << std::endl;
-    udp_client client(remote, port, 1000);
+    udp_client client(remote, port);
     client.set_error_handler(make_error_cb(client));
     client.set_rx_handler(make_rx_callback(client));
 

--- a/lib/everest/io/include/everest/io/socket/socket.hpp
+++ b/lib/everest/io/include/everest/io/socket/socket.hpp
@@ -59,7 +59,8 @@ constexpr int reconnect_delay_ms{100};
  * @param[in] device Optional interface name (e.g. "eth0"). When non-empty the socket is bound
  * to that device via SO_BINDTODEVICE. Requires CAP_NET_RAW or root.
  * @return The managed file descriptor of the socket
- * @throws std::runtime_error if the operation fails.
+ * @throws socket_error if the operation fails. Catch it rather than
+ * std::runtime_error to recover the errno behind the failure.
  */
 event::unique_fd open_udp_server_socket(std::uint16_t port, std::string const& device = {});
 
@@ -70,7 +71,8 @@ event::unique_fd open_udp_server_socket(std::uint16_t port, std::string const& d
  * @param[in] device Optional interface name (e.g. "eth0"). When non-empty the socket is bound
  * to that device via SO_BINDTODEVICE before connect. Requires CAP_NET_RAW or root.
  * @return The managed file descriptor of the socket
- * @throws std::runtime_error if the operation fails.
+ * @throws socket_error if the operation fails. Catch it rather than
+ * std::runtime_error to recover the errno behind the failure.
  */
 event::unique_fd open_udp_client_socket(std::string const& host, std::uint16_t port, std::string const& device = {});
 
@@ -155,7 +157,8 @@ event::unique_fd open_mdns_socket6(std::string const& interface_name);
  * @param[in] host The host to connect to
  * @param[in] port The port to listen to
  * @return The managed file descriptor of the socket
- * @throws std::runtime_error if the operation fails.
+ * @throws socket_error if the operation fails. Catch it rather than
+ * std::runtime_error to recover the errno behind the failure.
  */
 event::unique_fd open_tcp_socket(const std::string& host, std::uint16_t port, const std::string& device = {});
 
@@ -168,7 +171,8 @@ event::unique_fd open_tcp_socket(const std::string& host, std::uint16_t port, co
  * to that device via SO_BINDTODEVICE before connect. If the caller lacks CAP_NET_RAW, falls back
  * to source-IP bind using the interface's IPv4 address (no privilege needed).
  * @return The managed file descriptor of the socket
- * @throws std::runtime_error if the operation fails.
+ * @throws socket_error if the operation fails. Catch it rather than
+ * std::runtime_error to recover the errno behind the failure.
  */
 event::unique_fd open_tcp_socket_with_timeout(const std::string& host, std::uint16_t port, unsigned int timeout_ms,
                                               const std::string& device = {});

--- a/lib/everest/io/include/everest/io/socket/socket.hpp
+++ b/lib/everest/io/include/everest/io/socket/socket.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstdint>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -13,6 +14,44 @@
 #include <everest/io/udp/endpoint.hpp>
 
 namespace everest::lib::io::socket {
+
+/**
+ * @brief A failed socket operation, carrying the errno that caused it.
+ * @details Thrown instead of a bare std::runtime_error wherever the cause is an
+ * errno: `errno` itself does not survive the unwind, because cleanup on the way
+ * out (close(), freeaddrinfo()) may overwrite it. The value is captured at the
+ * failure site.
+ */
+class socket_error : public std::runtime_error {
+public:
+    /**
+     * @param[in] what Human readable description.
+     * @param[in] error The errno captured at the failure site.
+     */
+    socket_error(std::string const& what, int error) : std::runtime_error(what), m_error(error) {
+    }
+
+    /**
+     * @brief The errno captured at the failure site.
+     */
+    int error() const {
+        return m_error;
+    }
+
+private:
+    int m_error;
+};
+
+/**
+ * @var reconnect_delay_ms
+ * @brief Throttle applied by a client between failed connect attempts.
+ * @details Deliberately independent of the connect timeout. A connect can fail
+ * without spending any of that timeout (refused peer, local bind failure), and
+ * consumers reset from the error handler, so without a throttle a client spins
+ * against the peer. Charging the connect timeout instead would double failure
+ * latency for the leg that did spend it.
+ */
+constexpr int reconnect_delay_ms{100};
 
 /**
  * @brief Open a UDP socket in server mode

--- a/lib/everest/io/include/everest/io/tcp/tcp_socket.hpp
+++ b/lib/everest/io/include/everest/io/tcp/tcp_socket.hpp
@@ -93,9 +93,10 @@ public:
     /**
      * @brief Get pending errors on the socket.
      * @details Implementation for \p ClientPolicy. With no socket owned, the errno
-     * of the last failed \ref connect is reported: SO_ERROR cannot be probed
-     * because no descriptor was assigned. That value is cached, so repeated calls
-     * report the same cause.
+     * of the last failed \ref open or \ref connect is reported: SO_ERROR cannot be
+     * probed because no descriptor was assigned. That value is cached, so repeated
+     * calls report the same cause. It is dropped whenever a descriptor is gained or
+     * released, so it cannot outlive the attempt it describes.
      * @return The current errno of the socket. Zero with no pending error.
      */
     int get_error() const;
@@ -130,6 +131,23 @@ public:
     bool set_user_timeout(uint32_t to_ms);
 
 private:
+    /**
+     * @brief Take ownership of \p fd and clear the recorded failure reason.
+     * @details The descriptor and the reason there is no descriptor move together,
+     * so a socket that owns a descriptor never carries a stale reason.
+     */
+    void adopt(event::unique_fd&& fd);
+
+    /**
+     * @brief Drop the descriptor and record \p error as the reason there is none.
+     */
+    void record_connect_failure(int error);
+
+    /**
+     * @brief Drop the descriptor and clear the recorded failure reason.
+     */
+    void discard();
+
     std::string m_remote;
     uint16_t m_port{0};
     event::unique_fd m_fd;

--- a/lib/everest/io/include/everest/io/tcp/tcp_socket.hpp
+++ b/lib/everest/io/include/everest/io/tcp/tcp_socket.hpp
@@ -92,7 +92,10 @@ public:
      */
     /**
      * @brief Get pending errors on the socket.
-     * @details Implementation for \p ClientPolicy
+     * @details Implementation for \p ClientPolicy. With no socket owned, the errno
+     * of the last failed \ref connect is reported: SO_ERROR cannot be probed
+     * because no descriptor was assigned. That value is cached, so repeated calls
+     * report the same cause.
      * @return The current errno of the socket. Zero with no pending error.
      */
     int get_error() const;
@@ -131,6 +134,7 @@ private:
     uint16_t m_port{0};
     event::unique_fd m_fd;
     int m_timeout_ms{0};
+    int m_connect_error{0};
     std::string m_device;
     static constexpr size_t default_buffer_size{1500};
 };

--- a/lib/everest/io/include/everest/io/udp/udp_socket.hpp
+++ b/lib/everest/io/include/everest/io/udp/udp_socket.hpp
@@ -83,9 +83,11 @@ public:
     /**
      * @brief Get pending errors on the socket.
      * @details Implementation for \p ClientPolicy. With no socket owned, the errno
-     * of the last failed \ref udp_client_socket::connect is reported: SO_ERROR
-     * cannot be probed because no descriptor was assigned. That value is cached, so
-     * repeated calls report the same cause.
+     * of the last failed open or \ref udp_client_socket::connect is reported:
+     * SO_ERROR cannot be probed because no descriptor was assigned. That value is
+     * cached, so repeated calls report the same cause. It is dropped whenever a
+     * descriptor is gained or released, so it cannot outlive the attempt it
+     * describes.
      * @return The current errno of the socket. Zero with no pending error.
      */
     int get_error() const;
@@ -134,8 +136,27 @@ protected:
      */
     std::optional<udp_info> rx_impl(void* buffer, size_t buffer_size, ssize_t& payload_size);
 
+    /**
+     * @brief Take ownership of \p fd and clear the recorded failure reason.
+     * @details The descriptor and the reason there is no descriptor move together,
+     * so a socket that owns a descriptor never carries a stale reason. Subclasses
+     * must gain a descriptor through here, never by assignment.
+     */
+    void adopt(event::unique_fd&& fd);
+
+    /**
+     * @brief Drop the descriptor and record \p error as the reason there is none.
+     */
+    void record_connect_failure(int error);
+
+    /**
+     * @brief Drop the descriptor and clear the recorded failure reason.
+     */
+    void discard();
+
+private:
     event::unique_fd m_owned_udp_fd;
-    /** errno of the last failed connect, reported while no socket is owned */
+    /** errno of the last failed open or connect, reported while no socket is owned */
     int m_connect_error{0};
 };
 /**

--- a/lib/everest/io/include/everest/io/udp/udp_socket.hpp
+++ b/lib/everest/io/include/everest/io/udp/udp_socket.hpp
@@ -82,7 +82,10 @@ public:
     int get_fd() const;
     /**
      * @brief Get pending errors on the socket.
-     * @details Implementation for \p ClientPolicy
+     * @details Implementation for \p ClientPolicy. With no socket owned, the errno
+     * of the last failed \ref udp_client_socket::connect is reported: SO_ERROR
+     * cannot be probed because no descriptor was assigned. That value is cached, so
+     * repeated calls report the same cause.
      * @return The current errno of the socket. Zero with no pending error.
      */
     int get_error() const;
@@ -132,6 +135,8 @@ protected:
     std::optional<udp_info> rx_impl(void* buffer, size_t buffer_size, ssize_t& payload_size);
 
     event::unique_fd m_owned_udp_fd;
+    /** errno of the last failed connect, reported while no socket is owned */
+    int m_connect_error{0};
 };
 /**
  * A basic <a href="https://man7.org/linux/man-pages/man7/udp.7.html">UDP</a> client.

--- a/lib/everest/io/include/everest/io/udp/udp_socket.hpp
+++ b/lib/everest/io/include/everest/io/udp/udp_socket.hpp
@@ -194,11 +194,10 @@ public:
      * @details Implementation for \p ClientPolicy
      * @param[in] remote The host to connect to
      * @param[in] port The port on host
-     * @param[in] timeout_ms Timeout for connecting to the remote
      * @param[in] device Optional interface name to bind to via SO_BINDTODEVICE. Empty = no binding.
      * @return True on success, false otherwise.
      */
-    bool setup(std::string const& remote, uint16_t port, int timeout_ms, std::string const& device = {});
+    bool setup(std::string const& remote, uint16_t port, std::string const& device = {});
 
     /**
      * @brief Long running part of the UDP connection process
@@ -225,7 +224,6 @@ public:
 private:
     std::string m_remote;
     uint16_t m_port{0};
-    int m_timeout_ms{0};
     std::string m_device;
 
     std::array<uint8_t, udp_payload::max_size> rx_buffer;

--- a/lib/everest/io/src/mdns/mdns_socket.cpp
+++ b/lib/everest/io/src/mdns/mdns_socket.cpp
@@ -27,23 +27,35 @@ namespace everest::lib::io::mdns {
 bool mdns_socket::open(std::string const& interface, int family) {
     // "family not available on this interface" is an expected condition with
     // dual-stack discovery, so socket setup failures map to a false return.
+    int error = 0;
     try {
         if (family == AF_INET6) {
             auto socket = socket::open_mdns_socket6(interface);
-            m_owned_udp_fd = std::move(socket);
+            adopt(std::move(socket));
             // the endpoint resolves the interface to sin6_scope_id, required
             // to send to the link-scoped group
             m_target = udp::endpoint(mdns_multicast_ipv6, mdns_port, interface);
         } else {
             auto socket = socket::open_mdns_socket(interface);
-            m_owned_udp_fd = std::move(socket);
+            adopt(std::move(socket));
             m_target = udp::endpoint(mdns_multicast_ipv4, mdns_port);
         }
-    } catch (std::exception const&) {
-        return false;
-    }
 
-    return socket::get_pending_error(m_owned_udp_fd) == 0;
+        // SO_ERROR is read-and-clear. The pending error is read once and kept, so a
+        // false return still carries the reason instead of a value already consumed.
+        error = socket::get_pending_error(get_fd());
+        if (error == 0) {
+            return true;
+        }
+    } catch (socket::socket_error const& e) {
+        error = e.error();
+    } catch (...) {
+        // An unusable interface fails the address lookup, which carries no errno.
+        // get_error() then falls through to probing an unassigned descriptor, which
+        // is nonzero, so the client still resets.
+    }
+    record_connect_failure(error);
+    return false;
 }
 
 bool mdns_socket::tx(PayloadT const& payload) {

--- a/lib/everest/io/src/socket/socket.cpp
+++ b/lib/everest/io/src/socket/socket.cpp
@@ -77,6 +77,18 @@ namespace socket {
 //
 
 namespace {
+[[noreturn]] void throw_error(std::string const& msg, int error) {
+    std::stringstream str;
+    str << msg << ": " << strerror(error) << " (" << error << ")";
+    throw socket_error(str.str(), error);
+}
+
+// Capture errno before the unwind, where cleanup may overwrite it.
+[[noreturn]] void throw_errno(std::string const& msg) {
+    const int error = errno;
+    throw_error(msg, error);
+}
+
 // Returns true when SO_BINDTODEVICE succeeded. Returns false on EPERM/EACCES
 // (caller decides on a fallback). Throws on any other failure.
 bool apply_so_bindtodevice(int fd, std::string const& device) {
@@ -86,7 +98,7 @@ bool apply_so_bindtodevice(int fd, std::string const& device) {
     if (errno == EPERM || errno == EACCES) {
         return false;
     }
-    throw std::runtime_error(build_errno_string("Failed to bind socket to device " + device));
+    throw_errno("Failed to bind socket to device " + device);
 }
 
 // True when the string is an IPv6 link-local (fe80::/10) literal without %scope suffix.
@@ -113,7 +125,7 @@ sa_family_t get_socket_family(int fd) {
 bool apply_unicast_if(int fd, std::string const& device) {
     unsigned int ifindex = if_nametoindex(device.c_str());
     if (ifindex == 0) {
-        throw std::runtime_error(build_errno_string("if_nametoindex(\"" + device + "\") failed"));
+        throw_errno("if_nametoindex(\"" + device + "\") failed");
     }
     sa_family_t family = get_socket_family(fd);
     if (family == AF_INET) {
@@ -121,14 +133,14 @@ bool apply_unicast_if(int fd, std::string const& device) {
         if (setsockopt(fd, IPPROTO_IP, IP_UNICAST_IF, &opt, sizeof(opt)) == 0) {
             return true;
         }
-        throw std::runtime_error(build_errno_string("setsockopt(IP_UNICAST_IF, " + device + ") failed"));
+        throw_errno("setsockopt(IP_UNICAST_IF, " + device + ") failed");
     }
     if (family == AF_INET6) {
         int opt = static_cast<int>(ifindex);
         if (setsockopt(fd, IPPROTO_IPV6, IPV6_UNICAST_IF, &opt, sizeof(opt)) == 0) {
             return true;
         }
-        throw std::runtime_error(build_errno_string("setsockopt(IPV6_UNICAST_IF, " + device + ") failed"));
+        throw_errno("setsockopt(IPV6_UNICAST_IF, " + device + ") failed");
     }
     return false;
 }
@@ -151,10 +163,10 @@ void set_multicast_if(int fd, std::string const& device, struct sockaddr* ai_add
         }
         unsigned int ifindex = if_nametoindex(device.c_str());
         if (ifindex == 0) {
-            throw std::runtime_error(build_errno_string("if_nametoindex(\"" + device + "\") failed"));
+            throw_errno("if_nametoindex(\"" + device + "\") failed");
         }
         if (setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_IF, &ifindex, sizeof(ifindex)) != 0) {
-            throw std::runtime_error(build_errno_string("setsockopt(IPV6_MULTICAST_IF, " + device + ") failed"));
+            throw_errno("setsockopt(IPV6_MULTICAST_IF, " + device + ") failed");
         }
         sin6->sin6_scope_id = ifindex;
         return;
@@ -166,12 +178,12 @@ void set_multicast_if(int fd, std::string const& device, struct sockaddr* ai_add
         }
         unsigned int ifindex = if_nametoindex(device.c_str());
         if (ifindex == 0) {
-            throw std::runtime_error(build_errno_string("if_nametoindex(\"" + device + "\") failed"));
+            throw_errno("if_nametoindex(\"" + device + "\") failed");
         }
         struct ip_mreqn mreq {};
         mreq.imr_ifindex = static_cast<int>(ifindex);
         if (setsockopt(fd, IPPROTO_IP, IP_MULTICAST_IF, &mreq, sizeof(mreq)) != 0) {
-            throw std::runtime_error(build_errno_string("setsockopt(IP_MULTICAST_IF, " + device + ") failed"));
+            throw_errno("setsockopt(IP_MULTICAST_IF, " + device + ") failed");
         }
     }
 }
@@ -191,8 +203,7 @@ void bind_socket_to_interface_address(int fd, std::string const& device, std::ui
         throw std::runtime_error("Failed to parse interface address " + ip);
     }
     if (::bind(fd, reinterpret_cast<struct sockaddr*>(&local), sizeof(local)) < 0) {
-        throw std::runtime_error(build_errno_string("Fallback bind to interface " + device + " (" + ip + ":" +
-                                                    std::to_string(port) + ") failed"));
+        throw_errno("Fallback bind to interface " + device + " (" + ip + ":" + std::to_string(port) + ") failed");
     }
 }
 } // namespace
@@ -270,11 +281,14 @@ event::unique_fd open_udp_client_socket(std::string const& host, std::uint16_t p
     handle_disposer<addrinfo, freeaddrinfo> addrinfo_disposer(servinfo);
 
     // open the first possible socket
+    int last_error = 0;
     for (auto* p = servinfo; p != NULL; p = p->ai_next) {
         const auto socket_fd = ::socket(p->ai_family, p->ai_socktype, p->ai_protocol);
 
-        if (socket_fd == -1)
+        if (socket_fd == -1) {
+            last_error = errno;
             continue;
+        }
 
         try {
             bind_socket_to_device(socket_fd, device);
@@ -285,6 +299,8 @@ event::unique_fd open_udp_client_socket(std::string const& host, std::uint16_t p
         }
 
         if (-1 == ::connect(socket_fd, p->ai_addr, p->ai_addrlen)) {
+            // Read before close(), which may overwrite errno.
+            last_error = errno;
             close(socket_fd);
             continue;
         }
@@ -292,7 +308,7 @@ event::unique_fd open_udp_client_socket(std::string const& host, std::uint16_t p
         return event::unique_fd{socket_fd};
     }
 
-    throw std::runtime_error(std::string("Could not open a socket for ") + host + ":" + std::to_string(port));
+    throw_error(std::string("Could not open a socket for ") + host + ":" + std::to_string(port), last_error);
 }
 
 event::unique_fd open_tcp_socket_with_timeout(const std::string& host, std::uint16_t port, unsigned int timeout_ms,
@@ -311,11 +327,14 @@ event::unique_fd open_tcp_socket_with_timeout(const std::string& host, std::uint
     handle_disposer<addrinfo, freeaddrinfo> addrinfo_disposer(servinfo);
 
     // open the first possible socket
+    int last_error = 0;
     for (auto* p = servinfo; p != NULL; p = p->ai_next) {
         const auto socket_fd = ::socket(p->ai_family, p->ai_socktype, p->ai_protocol);
 
-        if (socket_fd == -1)
+        if (socket_fd == -1) {
+            last_error = errno;
             continue;
+        }
 
         try {
             bind_socket_to_device(socket_fd, device);
@@ -325,6 +344,9 @@ event::unique_fd open_tcp_socket_with_timeout(const std::string& host, std::uint
         }
 
         if (-1 == connect_with_timeout(socket_fd, p->ai_addr, p->ai_addrlen, timeout_ms)) {
+            // connect_with_timeout forwards the genuine errno; read it before
+            // close(), which may overwrite it.
+            last_error = errno;
             close(socket_fd);
             continue;
         }
@@ -332,7 +354,7 @@ event::unique_fd open_tcp_socket_with_timeout(const std::string& host, std::uint
         return event::unique_fd{socket_fd};
     }
 
-    throw std::runtime_error(std::string("Could not open a socket for ") + host + ":" + std::to_string(port));
+    throw_error(std::string("Could not open a socket for ") + host + ":" + std::to_string(port), last_error);
 }
 
 event::unique_fd open_tcp_socket(const std::string& host, std::uint16_t port, const std::string& device) {

--- a/lib/everest/io/src/socket/socket.cpp
+++ b/lib/everest/io/src/socket/socket.cpp
@@ -89,6 +89,22 @@ namespace {
     throw_error(msg, error);
 }
 
+// getaddrinfo reports through its return value and leaves errno meaningful only
+// for EAI_SYSTEM, so the result is mapped instead of read off errno. The resolver
+// verdicts reachable here (EAI_NONAME, EAI_AGAIN, EAI_FAIL, EAI_SERVICE and the
+// like) name no errno of their own and become EHOSTUNREACH: an unresolvable
+// endpoint is an unreachable one. A zero errno on the EAI_SYSTEM leg says nothing
+// a caller can act on and would fail the descriptor guard in tcp_socket::open, so
+// it takes the same fallback.
+// Untested: EAI_SYSTEM is the only leg that yields a value other than
+// EHOSTUNREACH and cannot be forced without fault injection. The
+// open_udp_server_socket resolver leg has no forceable failure mode either.
+[[noreturn]] void throw_resolver_error(int result) {
+    const int sys_errno = errno;
+    const int error = (result == EAI_SYSTEM and sys_errno != 0) ? sys_errno : EHOSTUNREACH;
+    throw socket_error("Failed to resolve endpoint (getaddrinfo): " + std::string(gai_strerror(result)), error);
+}
+
 // Returns true when SO_BINDTODEVICE succeeded. Returns false on EPERM/EACCES
 // (caller decides on a fallback). Throws on any other failure.
 bool apply_so_bindtodevice(int fd, std::string const& device) {
@@ -235,8 +251,8 @@ event::unique_fd open_udp_server_socket(std::uint16_t port, std::string const& d
 
     const auto err = getaddrinfo(nullptr, std::to_string(port).c_str(), &hints, &servinfo);
     if (err) {
-        throw std::runtime_error("Failed to resolve endpoint (getaddrinfo): " + std::string(gai_strerror(err)));
-    };
+        throw_resolver_error(err);
+    }
 
     handle_disposer<addrinfo, freeaddrinfo> addrinfo_disposer(servinfo);
 
@@ -275,8 +291,8 @@ event::unique_fd open_udp_client_socket(std::string const& host, std::uint16_t p
 
     const auto err = getaddrinfo(host.c_str(), std::to_string(port).c_str(), &hints, &servinfo);
     if (err) {
-        throw std::runtime_error("Failed to resolve endpoint (getaddrinfo): " + std::string(gai_strerror(err)));
-    };
+        throw_resolver_error(err);
+    }
 
     handle_disposer<addrinfo, freeaddrinfo> addrinfo_disposer(servinfo);
 
@@ -321,8 +337,8 @@ event::unique_fd open_tcp_socket_with_timeout(const std::string& host, std::uint
 
     const auto err = getaddrinfo(host.c_str(), std::to_string(port).c_str(), &hints, &servinfo);
     if (err) {
-        throw std::runtime_error("Failed to resolve endpoint (getaddrinfo): " + std::string(gai_strerror(err)));
-    };
+        throw_resolver_error(err);
+    }
 
     handle_disposer<addrinfo, freeaddrinfo> addrinfo_disposer(servinfo);
 
@@ -366,8 +382,8 @@ event::unique_fd open_tcp_socket(const std::string& host, std::uint16_t port, co
 
     const auto err = getaddrinfo(host.c_str(), std::to_string(port).c_str(), &hints, &servinfo);
     if (err) {
-        throw std::runtime_error("Failed to resolve endpoint (getaddrinfo): " + std::string(gai_strerror(err)));
-    };
+        throw_resolver_error(err);
+    }
 
     handle_disposer<addrinfo, freeaddrinfo> addrinfo_disposer(servinfo);
 

--- a/lib/everest/io/src/tcp/tcp_socket.cpp
+++ b/lib/everest/io/src/tcp/tcp_socket.cpp
@@ -28,21 +28,29 @@ bool tcp_socket::setup(std::string const& remote, uint16_t port, int timeout_ms,
     m_port = port;
     m_timeout_ms = timeout_ms;
     m_device = device;
+    m_connect_error = 0;
     m_fd.close();
     return true;
 }
 
 void tcp_socket::connect(std::function<void(bool, int)> const& setup_cb) {
+    int error = 0;
     try {
         auto socket = socket::open_tcp_socket_with_timeout(m_remote, m_port, m_timeout_ms, m_device);
         socket::set_non_blocking(socket);
         const auto fd = static_cast<int>(socket);
         m_fd = std::move(socket);
+        m_connect_error = 0;
         setup_cb(true, fd);
+        return;
+    } catch (socket::socket_error const& e) {
+        error = e.error();
     } catch (...) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(m_timeout_ms));
-        setup_cb(false, -1);
     }
+    // No descriptor was assigned, so get_error() has nothing to probe.
+    m_connect_error = error;
+    std::this_thread::sleep_for(std::chrono::milliseconds(socket::reconnect_delay_ms));
+    setup_cb(false, -1);
 }
 
 bool tcp_socket::tx(PayloadT& payload) {
@@ -81,6 +89,9 @@ int tcp_socket::get_fd() const {
 }
 
 int tcp_socket::get_error() const {
+    if (not is_open() and m_connect_error != 0) {
+        return m_connect_error;
+    }
     if (socket::is_tcp_socket_alive(m_fd)) {
         return socket::get_pending_error(m_fd);
     } else if (is_open()) {

--- a/lib/everest/io/src/tcp/tcp_socket.cpp
+++ b/lib/everest/io/src/tcp/tcp_socket.cpp
@@ -8,18 +8,42 @@
 
 namespace everest::lib::io::tcp {
 
+void tcp_socket::adopt(event::unique_fd&& fd) {
+    m_fd = std::move(fd);
+    m_connect_error = 0;
+}
+
+void tcp_socket::record_connect_failure(int error) {
+    m_fd.close();
+    m_connect_error = error;
+}
+
+void tcp_socket::discard() {
+    m_fd.close();
+    m_connect_error = 0;
+}
+
 bool tcp_socket::open(std::string const& remote, uint16_t port, std::string const& device) {
     m_remote = remote;
     m_port = port;
     m_timeout_ms = 1000;
     m_device = device;
+    int error = 0;
     try {
         auto socket = socket::open_tcp_socket_with_timeout(remote, port, m_timeout_ms, m_device);
         socket::set_non_blocking(socket);
-        m_fd = std::move(socket);
-        return socket::get_pending_error(m_fd) == 0;
+        adopt(std::move(socket));
+        // SO_ERROR is read-and-clear. The pending error is read once and kept, so a
+        // false return still carries the reason instead of a value already consumed.
+        error = socket::get_pending_error(m_fd);
+        if (error == 0) {
+            return true;
+        }
+    } catch (socket::socket_error const& e) {
+        error = e.error();
     } catch (...) {
     }
+    record_connect_failure(error);
     return false;
 }
 
@@ -28,8 +52,7 @@ bool tcp_socket::setup(std::string const& remote, uint16_t port, int timeout_ms,
     m_port = port;
     m_timeout_ms = timeout_ms;
     m_device = device;
-    m_connect_error = 0;
-    m_fd.close();
+    discard();
     return true;
 }
 
@@ -39,16 +62,14 @@ void tcp_socket::connect(std::function<void(bool, int)> const& setup_cb) {
         auto socket = socket::open_tcp_socket_with_timeout(m_remote, m_port, m_timeout_ms, m_device);
         socket::set_non_blocking(socket);
         const auto fd = static_cast<int>(socket);
-        m_fd = std::move(socket);
-        m_connect_error = 0;
+        adopt(std::move(socket));
         setup_cb(true, fd);
         return;
     } catch (socket::socket_error const& e) {
         error = e.error();
     } catch (...) {
     }
-    // No descriptor was assigned, so get_error() has nothing to probe.
-    m_connect_error = error;
+    record_connect_failure(error);
     std::this_thread::sleep_for(std::chrono::milliseconds(socket::reconnect_delay_ms));
     setup_cb(false, -1);
 }
@@ -89,6 +110,9 @@ int tcp_socket::get_fd() const {
 }
 
 int tcp_socket::get_error() const {
+    // Zero means "nothing recorded", not "healthy": falling through to the probe of
+    // an unassigned descriptor yields EBADF, and that nonzero value is what makes
+    // the client reset and reconnect. Reporting zero here would read as healthy.
     if (not is_open() and m_connect_error != 0) {
         return m_connect_error;
     }
@@ -105,7 +129,7 @@ bool tcp_socket::is_open() const {
 }
 
 void tcp_socket::close() {
-    m_fd.close();
+    discard();
 }
 
 bool tcp_socket::set_keep_alive(uint32_t count, uint32_t idle_s, uint32_t intval_s) {

--- a/lib/everest/io/src/udp/udp_socket.cpp
+++ b/lib/everest/io/src/udp/udp_socket.cpp
@@ -140,10 +140,9 @@ std::optional<udp_info> udp_socket_base::rx_impl(void* buffer, size_t buffer_siz
 
 /////////////////////////////////////////////////
 
-bool udp_client_socket::setup(std::string const& remote, uint16_t port, int timeout_ms, std::string const& device) {
+bool udp_client_socket::setup(std::string const& remote, uint16_t port, std::string const& device) {
     m_remote = remote;
     m_port = port;
-    m_timeout_ms = timeout_ms;
     m_device = device;
     discard();
     return true;

--- a/lib/everest/io/src/udp/udp_socket.cpp
+++ b/lib/everest/io/src/udp/udp_socket.cpp
@@ -50,6 +50,9 @@ int udp_socket_base::get_fd() const {
 }
 
 int udp_socket_base::get_error() const {
+    if (not m_owned_udp_fd.is_fd() and m_connect_error != 0) {
+        return m_connect_error;
+    }
     return socket::get_pending_error(m_owned_udp_fd);
 }
 
@@ -104,20 +107,28 @@ bool udp_client_socket::setup(std::string const& remote, uint16_t port, int time
     m_port = port;
     m_timeout_ms = timeout_ms;
     m_device = device;
+    m_connect_error = 0;
     m_owned_udp_fd.close();
     return true;
 }
 
 void udp_client_socket::connect(std::function<void(bool, int)> const& setup_cb) {
+    int error = 0;
     try {
         auto socket = socket::open_udp_client_socket(m_remote, m_port, m_device);
         socket::set_non_blocking(socket);
+        m_connect_error = 0;
         setup_cb(true, socket);
         m_owned_udp_fd = std::move(socket);
+        return;
+    } catch (socket::socket_error const& e) {
+        error = e.error();
     } catch (...) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(m_timeout_ms));
-        setup_cb(false, -1);
     }
+    // No descriptor was assigned, so get_error() has nothing to probe.
+    m_connect_error = error;
+    std::this_thread::sleep_for(std::chrono::milliseconds(socket::reconnect_delay_ms));
+    setup_cb(false, -1);
 }
 
 bool udp_client_socket::open(std::string const& remote, uint16_t port, std::string const& device) {

--- a/lib/everest/io/src/udp/udp_socket.cpp
+++ b/lib/everest/io/src/udp/udp_socket.cpp
@@ -19,22 +19,57 @@
 
 namespace everest::lib::io::udp {
 
+void udp_socket_base::adopt(event::unique_fd&& fd) {
+    m_owned_udp_fd = std::move(fd);
+    m_connect_error = 0;
+}
+
+void udp_socket_base::record_connect_failure(int error) {
+    m_owned_udp_fd.close();
+    m_connect_error = error;
+}
+
+void udp_socket_base::discard() {
+    m_owned_udp_fd.close();
+    m_connect_error = 0;
+}
+
 bool udp_socket_base::open_as_client(std::string const& remote, uint16_t port, std::string const& device) {
+    int error = 0;
     try {
         auto socket = socket::open_udp_client_socket(remote, port, device);
         socket::set_non_blocking(socket);
-        m_owned_udp_fd = std::move(socket);
-        return socket::get_pending_error(m_owned_udp_fd) == 0;
+        adopt(std::move(socket));
+        // SO_ERROR is read-and-clear. The pending error is read once and kept, so a
+        // false return still carries the reason instead of a value already consumed.
+        error = socket::get_pending_error(m_owned_udp_fd);
+        if (error == 0) {
+            return true;
+        }
+    } catch (socket::socket_error const& e) {
+        error = e.error();
     } catch (...) {
     }
+    record_connect_failure(error);
     return false;
 }
 
 bool udp_socket_base::open_as_server(uint16_t port, std::string const& device) {
-    auto socket = socket::open_udp_server_socket(port, device);
-    socket::set_non_blocking(socket);
-    m_owned_udp_fd = std::move(socket);
-    return socket::get_pending_error(m_owned_udp_fd) == 0;
+    int error = 0;
+    try {
+        auto socket = socket::open_udp_server_socket(port, device);
+        socket::set_non_blocking(socket);
+        adopt(std::move(socket));
+        error = socket::get_pending_error(m_owned_udp_fd);
+        if (error == 0) {
+            return true;
+        }
+    } catch (socket::socket_error const& e) {
+        error = e.error();
+    } catch (...) {
+    }
+    record_connect_failure(error);
+    return false;
 }
 
 bool udp_socket_base::is_open() {
@@ -42,7 +77,7 @@ bool udp_socket_base::is_open() {
 }
 
 void udp_socket_base::close() {
-    m_owned_udp_fd.close();
+    discard();
 }
 
 int udp_socket_base::get_fd() const {
@@ -50,6 +85,9 @@ int udp_socket_base::get_fd() const {
 }
 
 int udp_socket_base::get_error() const {
+    // Zero means "nothing recorded", not "healthy": falling through to the probe of
+    // an unassigned descriptor yields EBADF, and that nonzero value is what makes
+    // the client reset and reconnect. Reporting zero here would read as healthy.
     if (not m_owned_udp_fd.is_fd() and m_connect_error != 0) {
         return m_connect_error;
     }
@@ -107,8 +145,7 @@ bool udp_client_socket::setup(std::string const& remote, uint16_t port, int time
     m_port = port;
     m_timeout_ms = timeout_ms;
     m_device = device;
-    m_connect_error = 0;
-    m_owned_udp_fd.close();
+    discard();
     return true;
 }
 
@@ -117,16 +154,15 @@ void udp_client_socket::connect(std::function<void(bool, int)> const& setup_cb) 
     try {
         auto socket = socket::open_udp_client_socket(m_remote, m_port, m_device);
         socket::set_non_blocking(socket);
-        m_connect_error = 0;
-        setup_cb(true, socket);
-        m_owned_udp_fd = std::move(socket);
+        const auto fd = static_cast<int>(socket);
+        adopt(std::move(socket));
+        setup_cb(true, fd);
         return;
     } catch (socket::socket_error const& e) {
         error = e.error();
     } catch (...) {
     }
-    // No descriptor was assigned, so get_error() has nothing to probe.
-    m_connect_error = error;
+    record_connect_failure(error);
     std::this_thread::sleep_for(std::chrono::milliseconds(socket::reconnect_delay_ms));
     setup_cb(false, -1);
 }

--- a/lib/everest/io/test/CMakeLists.txt
+++ b/lib/everest/io/test/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(everest_io_tests
   udp_unconnected_socket_test.cpp
   udp_dualstack_server_socket_test.cpp
   fd_event_client_async_test.cpp
+  client_connect_error_test.cpp
 )
 
 target_link_libraries(everest_io_tests

--- a/lib/everest/io/test/client_connect_error_test.cpp
+++ b/lib/everest/io/test/client_connect_error_test.cpp
@@ -5,6 +5,7 @@
 
 #include <everest/io/event/unique_fd.hpp>
 #include <everest/io/mdns/mdns_socket.hpp>
+#include <everest/io/socket/socket.hpp>
 #include <everest/io/tcp/tcp_socket.hpp>
 #include <everest/io/udp/udp_socket.hpp>
 
@@ -12,17 +13,21 @@
 #include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <exception>
 #include <functional>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include <arpa/inet.h>
+#include <netdb.h>
 #include <netinet/in.h>
 #include <poll.h>
 #include <sys/socket.h>
 
 #include <gtest/gtest.h>
+
+namespace socket_api = everest::lib::io::socket;
 
 using everest::lib::io::event::unique_fd;
 using everest::lib::io::mdns::mdns_socket;
@@ -44,8 +49,36 @@ constexpr int max_reconnect_delay_ms = 1000;
 // runner is root, and bind_socket_to_device never reaches its fallbacks.
 constexpr char unusable_device[] = "nosuchdev0";
 
-// Discard port, never contacted: the device bind fails first.
+// Discard port, never contacted: the device bind or the name resolve fails first,
+// depending on the case.
 constexpr std::uint16_t unused_remote_port = 9;
+
+// A DNS label may hold at most 63 octets (RFC 1035 2.3.1), so a 64 octet label is
+// rejected by the resolver's own parsing: getaddrinfo answers EAI_NONAME without
+// issuing a query, which keeps this file free of DNS. An unregistered name such as
+// "nonexistent.invalid" would not do: it costs a real lookup, and returns EAI_AGAIN
+// on a host with no reachable resolver.
+constexpr std::string::size_type oversized_label_length = 64;
+static_assert(oversized_label_length > 63, "a label of 63 octets or less is a live DNS query, not a local reject");
+
+std::string unresolvable_host() {
+    return std::string(oversized_label_length, 'a');
+}
+
+/// The resolver's own verdict on \p host for \p socktype, so a test can assert the
+/// precondition it rests on instead of assuming it. The socktype is explicit because
+/// the TCP and UDP entry points resolve with different ones.
+int resolve_result(std::string const& host, int socktype) {
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = socktype;
+    addrinfo* info = nullptr;
+    const int result = ::getaddrinfo(host.c_str(), std::to_string(unused_remote_port).c_str(), &hints, &info);
+    if (info != nullptr) {
+        ::freeaddrinfo(info);
+    }
+    return result;
+}
 
 // Let the kernel choose. A server bound to a nonexistent device never reaches
 // bind(), and open_udp_server_socket sets SO_REUSEADDR, so a duplicate bind is
@@ -470,6 +503,93 @@ TEST(client_connect_error_test, mdns_failed_open_reports_failure_instead_of_thro
 
     const int err = sock.get_error();
     EXPECT_NE(err, 0) << "a failed open left get_error() at 0, which reads as healthy and suppresses the client reset";
+}
+
+// A name that does not resolve is a failure like any other and has to reach the
+// caller as one. getaddrinfo leaves errno meaningful only for EAI_SYSTEM, so the
+// resolver result has to be mapped rather than read off errno.
+TEST(client_connect_error_test, unresolvable_host_throws_socket_error_carrying_resolver_reason) {
+    const auto host = unresolvable_host();
+    // Both socktypes, because the entry points below cover both. The specific code
+    // is claimed here for the gai_strerror() assertion at the end.
+    ASSERT_EQ(resolve_result(host, SOCK_STREAM), EAI_NONAME)
+        << "the fixture host no longer fails resolution locally, so this test would depend on DNS";
+    ASSERT_EQ(resolve_result(host, SOCK_DGRAM), EAI_NONAME)
+        << "the fixture host no longer fails resolution locally, so this test would depend on DNS";
+
+    // Every entry point that resolves a hostname, so the expectation covers all of
+    // them and not whichever one happened to be fixed.
+    const std::vector<std::pair<char const*, std::function<void()>>> resolving_opens{
+        {"open_tcp_socket", [&] { socket_api::open_tcp_socket(host, unused_remote_port); }},
+        {"open_tcp_socket_with_timeout",
+         [&] { socket_api::open_tcp_socket_with_timeout(host, unused_remote_port, 1000); }},
+        {"open_udp_client_socket", [&] { socket_api::open_udp_client_socket(host, unused_remote_port); }},
+    };
+
+    for (auto const& [name, open_call] : resolving_opens) {
+        SCOPED_TRACE(name);
+        try {
+            open_call();
+            ADD_FAILURE() << "opening a socket to an unresolvable host reported success";
+        } catch (socket_api::socket_error const& e) {
+            const int err = e.error();
+            EXPECT_NE(err, 0) << "a failed resolve carried errno 0, which reads as healthy";
+            // EAI_NONAME, asserted above, so errno holds nothing meaningful and the
+            // fixed unreachable-host mapping applies.
+            EXPECT_EQ(err, EHOSTUNREACH) << "a failed resolve carried errno " << err << " (" << ::strerror(err)
+                                         << ") instead of EHOSTUNREACH";
+            EXPECT_NE(std::string(e.what()).find(::gai_strerror(EAI_NONAME)), std::string::npos)
+                << "the resolver's own reason is missing from the message: " << e.what();
+        } catch (std::exception const& e) {
+            ADD_FAILURE() << "threw a plain exception instead of socket_error, so the reason cannot be recorded "
+                             "and the caller falls back to probing a descriptor it never got: "
+                          << e.what();
+        }
+    }
+}
+
+// The same failure seen through the policy that fd_event_client actually drives.
+// get_error() is what decides whether the client resets and reconnects, so the
+// resolver failure has to arrive there rather than as get_error()'s own EBADF
+// fallback for a descriptor that was never assigned.
+TEST(client_connect_error_test, tcp_unresolvable_host_open_reports_resolver_failure) {
+    const auto host = unresolvable_host();
+    // Any nonzero code will do: everything but EAI_SYSTEM maps to the same value,
+    // and a resolver stack such as nss-resolve may answer EAI_AGAIN instead.
+    ASSERT_NE(resolve_result(host, SOCK_STREAM), 0)
+        << "the fixture host no longer fails resolution locally, so this test would depend on DNS";
+
+    tcp_socket sock;
+    ASSERT_FALSE(sock.open(host, unused_remote_port)) << "open of an unresolvable host reported success";
+    EXPECT_FALSE(sock.is_open()) << "a failed open kept a descriptor the caller was told does not exist";
+
+    const int err = sock.get_error();
+    EXPECT_NE(err, EBADF) << "a failed open reported EBADF, which describes get_error()'s own probe of "
+                             "an unassigned descriptor rather than why the open failed";
+    EXPECT_NE(err, 0) << "a failed open left get_error() at 0, which reads as healthy and suppresses the client reset";
+    EXPECT_EQ(err, EHOSTUNREACH) << "a failed open reported errno " << err << " (" << ::strerror(err)
+                                 << ") instead of EHOSTUNREACH";
+}
+
+// The UDP mirror. udp_client_socket::open reaches open_udp_client_socket, a
+// separate getaddrinfo leg from the TCP one.
+TEST(client_connect_error_test, udp_unresolvable_host_open_reports_resolver_failure) {
+    const auto host = unresolvable_host();
+    // Any nonzero code will do: everything but EAI_SYSTEM maps to the same value,
+    // and a resolver stack such as nss-resolve may answer EAI_AGAIN instead.
+    ASSERT_NE(resolve_result(host, SOCK_DGRAM), 0)
+        << "the fixture host no longer fails resolution locally, so this test would depend on DNS";
+
+    udp_client_socket sock;
+    ASSERT_FALSE(sock.open(host, unused_remote_port)) << "open of an unresolvable host reported success";
+    EXPECT_FALSE(sock.is_open()) << "a failed open kept a descriptor the caller was told does not exist";
+
+    const int err = sock.get_error();
+    EXPECT_NE(err, EBADF) << "a failed open reported EBADF, which describes get_error()'s own probe of "
+                             "an unassigned descriptor rather than why the open failed";
+    EXPECT_NE(err, 0) << "a failed open left get_error() at 0, which reads as healthy and suppresses the client reset";
+    EXPECT_EQ(err, EHOSTUNREACH) << "a failed open reported errno " << err << " (" << ::strerror(err)
+                                 << ") instead of EHOSTUNREACH";
 }
 
 TEST(client_connect_error_test, udp_failed_connect_latency_ignores_connect_timeout) {

--- a/lib/everest/io/test/client_connect_error_test.cpp
+++ b/lib/everest/io/test/client_connect_error_test.cpp
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+//
+// A failed client connect has to answer two questions: why did it fail, and how
+// long did failing take. These tests pin both on tcp_socket::connect and
+// udp_client_socket::connect. Every fixture is loopback-only, so no test here
+// depends on DNS or on egress.
+
+#include <everest/io/tcp/tcp_socket.hpp>
+#include <everest/io/udp/udp_socket.hpp>
+
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+using everest::lib::io::tcp::tcp_socket;
+using everest::lib::io::udp::udp_client_socket;
+
+namespace {
+
+// A reconnect delay belongs to the retry policy, not to the connect timeout.
+// Bounds below are written as "time the connect legitimately took, plus this",
+// so a delay that merely copies the connect timeout breaks them.
+constexpr int max_reconnect_delay_ms = 250;
+
+// No such interface exists, so bind_socket_to_device exhausts SO_BINDTODEVICE,
+// IP_UNICAST_IF and the source-address fallback and throws. Reaches the connect
+// failure path without issuing a single packet.
+constexpr char unusable_device[] = "nosuchdev0";
+
+int make_loopback_socket(std::uint16_t& bound_port) {
+    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    addr.sin_port = 0;
+    if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        ::close(fd);
+        return -1;
+    }
+    socklen_t addr_len = sizeof(addr);
+    if (::getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &addr_len) != 0) {
+        ::close(fd);
+        return -1;
+    }
+    bound_port = ntohs(addr.sin_port);
+    return fd;
+}
+
+/// A 127.0.0.1 port bound but never listen()ed. The kernel answers a SYN with
+/// RST, so a connect is refused immediately. Holding the socket open for the
+/// object's lifetime keeps the port reserved, which is what makes the refusal
+/// reproducible rather than a bet on nothing else claiming the port.
+class refused_loopback_port {
+public:
+    refused_loopback_port() {
+        m_fd = make_loopback_socket(m_port);
+    }
+
+    refused_loopback_port(refused_loopback_port const&) = delete;
+    refused_loopback_port& operator=(refused_loopback_port const&) = delete;
+
+    ~refused_loopback_port() {
+        if (m_fd >= 0) {
+            ::close(m_fd);
+        }
+    }
+
+    bool reserved() const {
+        return m_fd >= 0;
+    }
+    std::uint16_t port() const {
+        return m_port;
+    }
+
+private:
+    int m_fd{-1};
+    std::uint16_t m_port{0};
+};
+
+/// Clean completion is POLLOUT without POLLERR/POLLHUP. A connect the kernel
+/// never completes reports nothing within the window.
+bool connect_completed(int fd, int wait_ms) {
+    pollfd pfd{fd, POLLOUT, 0};
+    return ::poll(&pfd, 1, wait_ms) == 1 && (pfd.revents & POLLOUT) != 0 && (pfd.revents & (POLLERR | POLLHUP)) == 0;
+}
+
+int start_nonblocking_connect(std::uint16_t port) {
+    const int fd = ::socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    addr.sin_port = htons(port);
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0 && errno != EINPROGRESS) {
+        ::close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+/// A 127.0.0.1 listen socket whose accept queue is deliberately saturated:
+/// listen(fd, 1), never accept, pre-connects issued until one stalls. With the
+/// queue full the kernel stops completing handshakes, so a later connect to
+/// port() stays pending until the caller's timeout expires. A loopback stand-in
+/// for an unreachable host. All fds stay open until destruction, so the block
+/// holds for the object's whole lifetime.
+class saturated_loopback_port {
+public:
+    saturated_loopback_port() {
+        m_listen_fd = make_loopback_socket(m_port);
+        if (m_listen_fd < 0 || ::listen(m_listen_fd, 1) != 0) {
+            return;
+        }
+        for (int i = 0; i < max_pre_connects; ++i) {
+            const int fd = start_nonblocking_connect(m_port);
+            if (fd < 0) {
+                return;
+            }
+            m_fds.push_back(fd);
+            if (not connect_completed(fd, 200)) {
+                m_saturated = true;
+                return;
+            }
+        }
+    }
+
+    saturated_loopback_port(saturated_loopback_port const&) = delete;
+    saturated_loopback_port& operator=(saturated_loopback_port const&) = delete;
+
+    ~saturated_loopback_port() {
+        for (int fd : m_fds) {
+            ::close(fd);
+        }
+        if (m_listen_fd >= 0) {
+            ::close(m_listen_fd);
+        }
+    }
+
+    bool saturated() const {
+        return m_saturated;
+    }
+    std::uint16_t port() const {
+        return m_port;
+    }
+
+private:
+    // ~3 connects saturate in practice on Linux; 8 is headroom, not a tuned value.
+    static constexpr int max_pre_connects = 8;
+    int m_listen_fd{-1};
+    std::uint16_t m_port{0};
+    std::vector<int> m_fds;
+    bool m_saturated{false};
+};
+
+struct connect_outcome {
+    bool ok{true};
+    int cb_fd{0};
+    int elapsed_ms{0};
+};
+
+/// Drives connect() and captures both what the callback saw and how long the
+/// call blocked. connect() is synchronous, so no worker thread is needed.
+template <typename SocketT> connect_outcome drive_connect(SocketT& sock) {
+    connect_outcome out;
+    const auto start = std::chrono::steady_clock::now();
+    sock.connect([&out](bool ok, int fd) {
+        out.ok = ok;
+        out.cb_fd = fd;
+    });
+    out.elapsed_ms = static_cast<int>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count());
+    return out;
+}
+
+} // namespace
+
+// The peer sent an RST, which is the one diagnosis a caller can act on: the host
+// is up and the port is closed. connect() drops it, so get_error() falls through
+// to get_pending_error() on a descriptor that was never assigned and getsockopt
+// reports EBADF instead.
+TEST(client_connect_error, tcp_refused_connect_reports_econnrefused) {
+    refused_loopback_port refused;
+    ASSERT_TRUE(refused.reserved()) << "could not reserve a closed loopback port";
+
+    tcp_socket sock;
+    ASSERT_TRUE(sock.setup("127.0.0.1", refused.port(), 1000));
+
+    const auto outcome = drive_connect(sock);
+
+    ASSERT_FALSE(outcome.ok) << "connect to a closed port reported success";
+    ASSERT_EQ(outcome.cb_fd, -1) << "a failed connect must report fd -1";
+    EXPECT_EQ(sock.get_error(), ECONNREFUSED) << "a refused connect reported errno " << sock.get_error() << " ("
+                                              << ::strerror(sock.get_error()) << ") instead of ECONNREFUSED";
+}
+
+// Same loss on the timeout leg. connect_with_timeout honors its contract and
+// sets ETIMEDOUT, then the layer above discards it.
+TEST(client_connect_error, tcp_unreachable_peer_connect_reports_etimedout) {
+    saturated_loopback_port blocked;
+    ASSERT_TRUE(blocked.saturated()) << "could not saturate the loopback accept queue";
+
+    tcp_socket sock;
+    ASSERT_TRUE(sock.setup("127.0.0.1", blocked.port(), 300));
+
+    const auto outcome = drive_connect(sock);
+
+    ASSERT_FALSE(outcome.ok) << "connect to a saturated backlog reported success";
+    ASSERT_EQ(outcome.cb_fd, -1) << "a failed connect must report fd -1";
+    EXPECT_EQ(sock.get_error(), ETIMEDOUT) << "a connect that timed out reported errno " << sock.get_error() << " ("
+                                           << ::strerror(sock.get_error()) << ") instead of ETIMEDOUT";
+}
+
+// An RST arrives in well under a millisecond, so nothing about this failure
+// justifies waiting out the connect timeout. connect() sleeps m_timeout_ms in
+// its catch block regardless, spending a full connect timeout on a connect that
+// never took any.
+TEST(client_connect_error, tcp_refused_connect_latency_excludes_connect_timeout) {
+    refused_loopback_port refused;
+    ASSERT_TRUE(refused.reserved()) << "could not reserve a closed loopback port";
+
+    constexpr int connect_timeout_ms = 1000;
+    tcp_socket sock;
+    ASSERT_TRUE(sock.setup("127.0.0.1", refused.port(), connect_timeout_ms));
+
+    const auto outcome = drive_connect(sock);
+
+    ASSERT_FALSE(outcome.ok) << "connect to a closed port reported success";
+    EXPECT_LT(outcome.elapsed_ms, max_reconnect_delay_ms)
+        << "an immediately refused connect took " << outcome.elapsed_ms << "ms, which spends the " << connect_timeout_ms
+        << "ms connect timeout on a connect that returned at once";
+}
+
+// The timeout leg compounds it: connect_with_timeout spends the whole timeout,
+// then the catch block sleeps it a second time, so failure latency is twice the
+// configured value instead of the timeout plus a reconnect delay.
+TEST(client_connect_error, tcp_timed_out_connect_latency_is_not_doubled) {
+    saturated_loopback_port blocked;
+    ASSERT_TRUE(blocked.saturated()) << "could not saturate the loopback accept queue";
+
+    constexpr int connect_timeout_ms = 500;
+    tcp_socket sock;
+    ASSERT_TRUE(sock.setup("127.0.0.1", blocked.port(), connect_timeout_ms));
+
+    const auto outcome = drive_connect(sock);
+
+    ASSERT_FALSE(outcome.ok) << "connect to a saturated backlog reported success";
+    EXPECT_GE(outcome.elapsed_ms, connect_timeout_ms) << "the connect timeout was not honored at all";
+    EXPECT_LT(outcome.elapsed_ms, connect_timeout_ms + max_reconnect_delay_ms)
+        << "a connect that timed out took " << outcome.elapsed_ms << "ms, about twice the " << connect_timeout_ms
+        << "ms timeout, so the reconnect delay is a second copy of the connect timeout";
+}
+
+// udp_client_socket::connect has the same shape and the same two defects. A UDP
+// connect() is a local operation, so it cannot be refused by the peer; binding
+// to a nonexistent device is the deterministic way to fail it. Whatever the
+// cause, EBADF is a claim about a descriptor that was never opened.
+TEST(client_connect_error, udp_failed_connect_does_not_report_ebadf) {
+    udp_client_socket sock;
+    ASSERT_TRUE(sock.setup("127.0.0.1", 9, 1000, unusable_device));
+
+    const auto outcome = drive_connect(sock);
+
+    ASSERT_FALSE(outcome.ok) << "connect bound to a nonexistent device reported success";
+    ASSERT_EQ(outcome.cb_fd, -1) << "a failed connect must report fd -1";
+    EXPECT_NE(sock.get_error(), EBADF) << "a failed connect reported EBADF, which describes get_error()'s own probe of "
+                                          "an unassigned descriptor rather than why the connect failed";
+    EXPECT_NE(sock.get_error(), 0) << "a failed connect left get_error() at 0";
+}
+
+// The device bind fails before any packet is sent, so there is nothing to wait
+// for, yet the catch block sleeps the whole connect timeout.
+TEST(client_connect_error, udp_failed_connect_latency_excludes_connect_timeout) {
+    constexpr int connect_timeout_ms = 1000;
+    udp_client_socket sock;
+    ASSERT_TRUE(sock.setup("127.0.0.1", 9, connect_timeout_ms, unusable_device));
+
+    const auto outcome = drive_connect(sock);
+
+    ASSERT_FALSE(outcome.ok) << "connect bound to a nonexistent device reported success";
+    EXPECT_LT(outcome.elapsed_ms, max_reconnect_delay_ms)
+        << "a connect that failed before touching the network took " << outcome.elapsed_ms << "ms, spending the "
+        << connect_timeout_ms << "ms connect timeout";
+}

--- a/lib/everest/io/test/client_connect_error_test.cpp
+++ b/lib/everest/io/test/client_connect_error_test.cpp
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 //
-// A failed client connect has to answer two questions: why did it fail, and how
-// long did failing take. These tests pin both on tcp_socket::connect and
-// udp_client_socket::connect. Every fixture is loopback-only, so no test here
-// depends on DNS or on egress.
+// Loopback-only fixtures: no test here depends on DNS or on egress.
 
+#include <everest/io/event/unique_fd.hpp>
 #include <everest/io/tcp/tcp_socket.hpp>
 #include <everest/io/udp/udp_socket.hpp>
 
@@ -15,83 +13,76 @@
 #include <cstring>
 #include <functional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <poll.h>
 #include <sys/socket.h>
-#include <unistd.h>
 
 #include <gtest/gtest.h>
 
+using everest::lib::io::event::unique_fd;
 using everest::lib::io::tcp::tcp_socket;
 using everest::lib::io::udp::udp_client_socket;
 
 namespace {
 
-// A reconnect delay belongs to the retry policy, not to the connect timeout.
-// Bounds below are written as "time the connect legitimately took, plus this",
-// so a delay that merely copies the connect timeout breaks them.
-constexpr int max_reconnect_delay_ms = 250;
+// Two unrelated budgets, so two names. jitter_slack_ms is scheduling noise on a
+// differential comparison; max_reconnect_delay_ms is only a coarse guard against
+// a fixed multi-second sleep and constrains no retry-policy choice. Once the
+// retry policy has a production header, that bound belongs there.
+constexpr int jitter_slack_ms = 100;
+constexpr int max_reconnect_delay_ms = 1000;
 
-// No such interface exists, so bind_socket_to_device exhausts SO_BINDTODEVICE,
-// IP_UNICAST_IF and the source-address fallback and throws. Reaches the connect
-// failure path without issuing a single packet.
+// No such interface exists. SO_BINDTODEVICE resolves the device name before the
+// CAP_NET_RAW check, so this fails ENODEV at the first step whether or not the
+// runner is root, and bind_socket_to_device never reaches its fallbacks.
 constexpr char unusable_device[] = "nosuchdev0";
 
-int make_loopback_socket(std::uint16_t& bound_port) {
-    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
-    if (fd < 0) {
-        return -1;
+// Discard port, never contacted: the device bind fails first.
+constexpr std::uint16_t unused_remote_port = 9;
+
+unique_fd make_loopback_socket(std::uint16_t& bound_port) {
+    unique_fd fd{::socket(AF_INET, SOCK_STREAM, 0)};
+    if (not fd.is_fd()) {
+        return {};
     }
     sockaddr_in addr{};
     addr.sin_family = AF_INET;
     addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
     addr.sin_port = 0;
     if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
-        ::close(fd);
-        return -1;
+        return {};
     }
     socklen_t addr_len = sizeof(addr);
     if (::getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &addr_len) != 0) {
-        ::close(fd);
-        return -1;
+        return {};
     }
     bound_port = ntohs(addr.sin_port);
     return fd;
 }
 
-/// A 127.0.0.1 port bound but never listen()ed. The kernel answers a SYN with
-/// RST, so a connect is refused immediately. Holding the socket open for the
-/// object's lifetime keeps the port reserved, which is what makes the refusal
-/// reproducible rather than a bet on nothing else claiming the port.
-class refused_loopback_port {
-public:
-    refused_loopback_port() {
-        m_fd = make_loopback_socket(m_port);
+/// Starts a nonblocking connect to 127.0.0.1:\p port. On failure the returned fd
+/// is empty and \p err holds the reason.
+unique_fd start_nonblocking_connect(std::uint16_t port, int& err) {
+    err = 0;
+    unique_fd fd{::socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0)};
+    if (not fd.is_fd()) {
+        err = errno;
+        return {};
     }
-
-    refused_loopback_port(refused_loopback_port const&) = delete;
-    refused_loopback_port& operator=(refused_loopback_port const&) = delete;
-
-    ~refused_loopback_port() {
-        if (m_fd >= 0) {
-            ::close(m_fd);
-        }
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    addr.sin_port = htons(port);
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0 && errno != EINPROGRESS) {
+        err = errno;
+        return {};
     }
-
-    bool reserved() const {
-        return m_fd >= 0;
-    }
-    std::uint16_t port() const {
-        return m_port;
-    }
-
-private:
-    int m_fd{-1};
-    std::uint16_t m_port{0};
-};
+    return fd;
+}
 
 /// Clean completion is POLLOUT without POLLERR/POLLHUP. A connect the kernel
 /// never completes reports nothing within the window.
@@ -100,21 +91,55 @@ bool connect_completed(int fd, int wait_ms) {
     return ::poll(&pfd, 1, wait_ms) == 1 && (pfd.revents & POLLOUT) != 0 && (pfd.revents & (POLLERR | POLLHUP)) == 0;
 }
 
-int start_nonblocking_connect(std::uint16_t port) {
-    const int fd = ::socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
-    if (fd < 0) {
-        return -1;
+/// Reports how the kernel answers a connect to 127.0.0.1:\p port. SO_ERROR is
+/// read-and-clear, so it is read exactly once.
+int probe_connect_error(std::uint16_t port, int wait_ms) {
+    int err = 0;
+    auto fd = start_nonblocking_connect(port, err);
+    if (not fd.is_fd()) {
+        return err;
     }
-    sockaddr_in addr{};
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
-    addr.sin_port = htons(port);
-    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0 && errno != EINPROGRESS) {
-        ::close(fd);
-        return -1;
+    pollfd pfd{fd, POLLOUT, 0};
+    if (::poll(&pfd, 1, wait_ms) != 1) {
+        return ETIMEDOUT;
     }
-    return fd;
+    socklen_t err_len = sizeof(err);
+    if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &err_len) != 0) {
+        return errno;
+    }
+    return err;
 }
+
+/// A 127.0.0.1 port bound but never listen()ed. The kernel answers a SYN with
+/// RST, so a connect is refused immediately. Holding the socket open for the
+/// object's lifetime keeps the port reserved, which is what makes the refusal
+/// reproducible rather than a bet on nothing else claiming the port. A throwaway
+/// probe connect confirms the refusal, so reserved() means "connects here are
+/// refused" and not merely "a port got bound": a bind to 127.0.0.1 also succeeds
+/// with lo down, where connects fail for routing reasons instead.
+class refused_loopback_port {
+public:
+    refused_loopback_port() {
+        m_fd = make_loopback_socket(m_port);
+        if (not m_fd.is_fd()) {
+            return;
+        }
+        m_refused = probe_connect_error(m_port, probe_wait_ms) == ECONNREFUSED;
+    }
+
+    bool reserved() const {
+        return m_refused;
+    }
+    std::uint16_t port() const {
+        return m_port;
+    }
+
+private:
+    static constexpr int probe_wait_ms = 500;
+    unique_fd m_fd;
+    std::uint16_t m_port{0};
+    bool m_refused{false};
+};
 
 /// A 127.0.0.1 listen socket whose accept queue is deliberately saturated:
 /// listen(fd, 1), never accept, pre-connects issued until one stalls. With the
@@ -126,31 +151,22 @@ class saturated_loopback_port {
 public:
     saturated_loopback_port() {
         m_listen_fd = make_loopback_socket(m_port);
-        if (m_listen_fd < 0 || ::listen(m_listen_fd, 1) != 0) {
+        if (not m_listen_fd.is_fd() || ::listen(m_listen_fd, 1) != 0) {
             return;
         }
         for (int i = 0; i < max_pre_connects; ++i) {
-            const int fd = start_nonblocking_connect(m_port);
-            if (fd < 0) {
+            int err = 0;
+            auto fd = start_nonblocking_connect(m_port, err);
+            if (not fd.is_fd()) {
                 return;
             }
-            m_fds.push_back(fd);
-            if (not connect_completed(fd, 200)) {
-                m_saturated = true;
+            m_fds.push_back(std::move(fd));
+            if (not connect_completed(m_fds.back(), pre_connect_wait_ms)) {
+                // A stall on the very first pre-connect is a stalled machine,
+                // not a full queue.
+                m_saturated = i > 0;
                 return;
             }
-        }
-    }
-
-    saturated_loopback_port(saturated_loopback_port const&) = delete;
-    saturated_loopback_port& operator=(saturated_loopback_port const&) = delete;
-
-    ~saturated_loopback_port() {
-        for (int fd : m_fds) {
-            ::close(fd);
-        }
-        if (m_listen_fd >= 0) {
-            ::close(m_listen_fd);
         }
     }
 
@@ -164,9 +180,10 @@ public:
 private:
     // ~3 connects saturate in practice on Linux; 8 is headroom, not a tuned value.
     static constexpr int max_pre_connects = 8;
-    int m_listen_fd{-1};
+    static constexpr int pre_connect_wait_ms = 200;
+    unique_fd m_listen_fd;
     std::uint16_t m_port{0};
-    std::vector<int> m_fds;
+    std::vector<unique_fd> m_fds;
     bool m_saturated{false};
 };
 
@@ -192,13 +209,9 @@ template <typename SocketT> connect_outcome drive_connect(SocketT& sock) {
 
 } // namespace
 
-// The peer sent an RST, which is the one diagnosis a caller can act on: the host
-// is up and the port is closed. connect() drops it, so get_error() falls through
-// to get_pending_error() on a descriptor that was never assigned and getsockopt
-// reports EBADF instead.
-TEST(client_connect_error, tcp_refused_connect_reports_econnrefused) {
+TEST(client_connect_error_test, tcp_refused_connect_reports_econnrefused) {
     refused_loopback_port refused;
-    ASSERT_TRUE(refused.reserved()) << "could not reserve a closed loopback port";
+    ASSERT_TRUE(refused.reserved()) << "could not reserve a closed loopback port that refuses connects";
 
     tcp_socket sock;
     ASSERT_TRUE(sock.setup("127.0.0.1", refused.port(), 1000));
@@ -207,13 +220,14 @@ TEST(client_connect_error, tcp_refused_connect_reports_econnrefused) {
 
     ASSERT_FALSE(outcome.ok) << "connect to a closed port reported success";
     ASSERT_EQ(outcome.cb_fd, -1) << "a failed connect must report fd -1";
-    EXPECT_EQ(sock.get_error(), ECONNREFUSED) << "a refused connect reported errno " << sock.get_error() << " ("
-                                              << ::strerror(sock.get_error()) << ") instead of ECONNREFUSED";
+    // SO_ERROR is read-and-clear, so get_error() is read once and only the copy
+    // is asserted on and reported.
+    const int err = sock.get_error();
+    EXPECT_EQ(err, ECONNREFUSED) << "a refused connect reported errno " << err << " (" << ::strerror(err)
+                                 << ") instead of ECONNREFUSED";
 }
 
-// Same loss on the timeout leg. connect_with_timeout honors its contract and
-// sets ETIMEDOUT, then the layer above discards it.
-TEST(client_connect_error, tcp_unreachable_peer_connect_reports_etimedout) {
+TEST(client_connect_error_test, tcp_unreachable_peer_connect_reports_etimedout) {
     saturated_loopback_port blocked;
     ASSERT_TRUE(blocked.saturated()) << "could not saturate the loopback accept queue";
 
@@ -224,78 +238,105 @@ TEST(client_connect_error, tcp_unreachable_peer_connect_reports_etimedout) {
 
     ASSERT_FALSE(outcome.ok) << "connect to a saturated backlog reported success";
     ASSERT_EQ(outcome.cb_fd, -1) << "a failed connect must report fd -1";
-    EXPECT_EQ(sock.get_error(), ETIMEDOUT) << "a connect that timed out reported errno " << sock.get_error() << " ("
-                                           << ::strerror(sock.get_error()) << ") instead of ETIMEDOUT";
+    const int err = sock.get_error();
+    EXPECT_EQ(err, ETIMEDOUT) << "a connect that timed out reported errno " << err << " (" << ::strerror(err)
+                              << ") instead of ETIMEDOUT";
 }
 
-// An RST arrives in well under a millisecond, so nothing about this failure
-// justifies waiting out the connect timeout. connect() sleeps m_timeout_ms in
-// its catch block regardless, spending a full connect timeout on a connect that
-// never took any.
-TEST(client_connect_error, tcp_refused_connect_latency_excludes_connect_timeout) {
+// Failure latency must not scale with the configured connect timeout. Driving
+// the same refused connect at two timeouts cancels any constant reconnect delay
+// out of the difference, so this holds for whatever delay the retry policy picks.
+TEST(client_connect_error_test, tcp_refused_connect_latency_ignores_connect_timeout) {
     refused_loopback_port refused;
-    ASSERT_TRUE(refused.reserved()) << "could not reserve a closed loopback port";
+    ASSERT_TRUE(refused.reserved()) << "could not reserve a closed loopback port that refuses connects";
 
-    constexpr int connect_timeout_ms = 1000;
+    constexpr int short_timeout_ms = 200;
+    constexpr int long_timeout_ms = 2000;
+
     tcp_socket sock;
-    ASSERT_TRUE(sock.setup("127.0.0.1", refused.port(), connect_timeout_ms));
+    ASSERT_TRUE(sock.setup("127.0.0.1", refused.port(), short_timeout_ms));
+    const auto short_run = drive_connect(sock);
+    ASSERT_FALSE(short_run.ok) << "connect to a closed port reported success";
 
-    const auto outcome = drive_connect(sock);
+    ASSERT_TRUE(sock.setup("127.0.0.1", refused.port(), long_timeout_ms));
+    const auto long_run = drive_connect(sock);
+    ASSERT_FALSE(long_run.ok) << "connect to a closed port reported success";
 
-    ASSERT_FALSE(outcome.ok) << "connect to a closed port reported success";
-    EXPECT_LT(outcome.elapsed_ms, max_reconnect_delay_ms)
-        << "an immediately refused connect took " << outcome.elapsed_ms << "ms, which spends the " << connect_timeout_ms
-        << "ms connect timeout on a connect that returned at once";
+    EXPECT_LT(short_run.elapsed_ms, max_reconnect_delay_ms)
+        << "an immediately refused connect took " << short_run.elapsed_ms << "ms";
+    EXPECT_LT(long_run.elapsed_ms - short_run.elapsed_ms, jitter_slack_ms)
+        << "raising the connect timeout from " << short_timeout_ms << "ms to " << long_timeout_ms << "ms moved failure "
+        << "latency from " << short_run.elapsed_ms << "ms to " << long_run.elapsed_ms
+        << "ms, so an immediately refused connect is charged the connect timeout";
 }
 
-// The timeout leg compounds it: connect_with_timeout spends the whole timeout,
-// then the catch block sleeps it a second time, so failure latency is twice the
-// configured value instead of the timeout plus a reconnect delay.
-TEST(client_connect_error, tcp_timed_out_connect_latency_is_not_doubled) {
+// Same property on the timeout leg. Here the connect legitimately spends its
+// timeout, so the difference must be the difference of the timeouts and nothing
+// more: the timeout is not allowed to be charged a second time.
+TEST(client_connect_error_test, tcp_timed_out_connect_latency_is_not_doubled) {
     saturated_loopback_port blocked;
     ASSERT_TRUE(blocked.saturated()) << "could not saturate the loopback accept queue";
 
-    constexpr int connect_timeout_ms = 500;
+    constexpr int short_timeout_ms = 300;
+    constexpr int long_timeout_ms = 900;
+
     tcp_socket sock;
-    ASSERT_TRUE(sock.setup("127.0.0.1", blocked.port(), connect_timeout_ms));
+    ASSERT_TRUE(sock.setup("127.0.0.1", blocked.port(), short_timeout_ms));
+    const auto short_run = drive_connect(sock);
+    ASSERT_FALSE(short_run.ok) << "connect to a saturated backlog reported success";
 
-    const auto outcome = drive_connect(sock);
+    ASSERT_TRUE(sock.setup("127.0.0.1", blocked.port(), long_timeout_ms));
+    const auto long_run = drive_connect(sock);
+    ASSERT_FALSE(long_run.ok) << "connect to a saturated backlog reported success";
 
-    ASSERT_FALSE(outcome.ok) << "connect to a saturated backlog reported success";
-    EXPECT_GE(outcome.elapsed_ms, connect_timeout_ms) << "the connect timeout was not honored at all";
-    EXPECT_LT(outcome.elapsed_ms, connect_timeout_ms + max_reconnect_delay_ms)
-        << "a connect that timed out took " << outcome.elapsed_ms << "ms, about twice the " << connect_timeout_ms
-        << "ms timeout, so the reconnect delay is a second copy of the connect timeout";
+    EXPECT_GE(short_run.elapsed_ms, short_timeout_ms) << "the connect timeout was not honored at all";
+    EXPECT_GE(long_run.elapsed_ms, long_timeout_ms) << "the connect timeout was not honored at all";
+    EXPECT_LT(short_run.elapsed_ms - short_timeout_ms, max_reconnect_delay_ms)
+        << "a connect that timed out after " << short_timeout_ms << "ms took " << short_run.elapsed_ms << "ms";
+    EXPECT_LT(long_run.elapsed_ms - short_run.elapsed_ms, long_timeout_ms - short_timeout_ms + jitter_slack_ms)
+        << "raising the connect timeout by " << long_timeout_ms - short_timeout_ms << "ms moved failure latency from "
+        << short_run.elapsed_ms << "ms to " << long_run.elapsed_ms << "ms, so the connect timeout is charged twice";
 }
 
 // udp_client_socket::connect has the same shape and the same two defects. A UDP
 // connect() is a local operation, so it cannot be refused by the peer; binding
-// to a nonexistent device is the deterministic way to fail it. Whatever the
-// cause, EBADF is a claim about a descriptor that was never opened.
-TEST(client_connect_error, udp_failed_connect_does_not_report_ebadf) {
+// to a nonexistent device is the deterministic way to fail it.
+TEST(client_connect_error_test, udp_failed_connect_reports_enodev) {
     udp_client_socket sock;
-    ASSERT_TRUE(sock.setup("127.0.0.1", 9, 1000, unusable_device));
+    ASSERT_TRUE(sock.setup("127.0.0.1", unused_remote_port, 1000, unusable_device));
 
     const auto outcome = drive_connect(sock);
 
     ASSERT_FALSE(outcome.ok) << "connect bound to a nonexistent device reported success";
     ASSERT_EQ(outcome.cb_fd, -1) << "a failed connect must report fd -1";
-    EXPECT_NE(sock.get_error(), EBADF) << "a failed connect reported EBADF, which describes get_error()'s own probe of "
-                                          "an unassigned descriptor rather than why the connect failed";
-    EXPECT_NE(sock.get_error(), 0) << "a failed connect left get_error() at 0";
+    const int err = sock.get_error();
+    EXPECT_NE(err, EBADF) << "a failed connect reported EBADF, which describes get_error()'s own probe of "
+                             "an unassigned descriptor rather than why the connect failed";
+    EXPECT_NE(err, 0) << "a failed connect left get_error() at 0";
+    // The device lookup precedes the capability check, so ENODEV is the answer at
+    // any privilege level. Satisfying this needs errno carried across the
+    // std::runtime_error unwind.
+    EXPECT_EQ(err, ENODEV) << "a failed connect reported errno " << err << " (" << ::strerror(err)
+                           << ") instead of ENODEV";
 }
 
-// The device bind fails before any packet is sent, so there is nothing to wait
-// for, yet the catch block sleeps the whole connect timeout.
-TEST(client_connect_error, udp_failed_connect_latency_excludes_connect_timeout) {
-    constexpr int connect_timeout_ms = 1000;
+TEST(client_connect_error_test, udp_failed_connect_latency_ignores_connect_timeout) {
+    constexpr int short_timeout_ms = 200;
+    constexpr int long_timeout_ms = 2000;
+
     udp_client_socket sock;
-    ASSERT_TRUE(sock.setup("127.0.0.1", 9, connect_timeout_ms, unusable_device));
+    ASSERT_TRUE(sock.setup("127.0.0.1", unused_remote_port, short_timeout_ms, unusable_device));
+    const auto short_run = drive_connect(sock);
+    ASSERT_FALSE(short_run.ok) << "connect bound to a nonexistent device reported success";
 
-    const auto outcome = drive_connect(sock);
+    ASSERT_TRUE(sock.setup("127.0.0.1", unused_remote_port, long_timeout_ms, unusable_device));
+    const auto long_run = drive_connect(sock);
+    ASSERT_FALSE(long_run.ok) << "connect bound to a nonexistent device reported success";
 
-    ASSERT_FALSE(outcome.ok) << "connect bound to a nonexistent device reported success";
-    EXPECT_LT(outcome.elapsed_ms, max_reconnect_delay_ms)
-        << "a connect that failed before touching the network took " << outcome.elapsed_ms << "ms, spending the "
-        << connect_timeout_ms << "ms connect timeout";
+    EXPECT_LT(short_run.elapsed_ms, max_reconnect_delay_ms)
+        << "a connect that failed before touching the network took " << short_run.elapsed_ms << "ms";
+    EXPECT_LT(long_run.elapsed_ms - short_run.elapsed_ms, jitter_slack_ms)
+        << "raising the connect timeout from " << short_timeout_ms << "ms to " << long_timeout_ms << "ms moved failure "
+        << "latency from " << short_run.elapsed_ms << "ms to " << long_run.elapsed_ms
+        << "ms, so a connect that never touched the network is charged the connect timeout";
 }

--- a/lib/everest/io/test/client_connect_error_test.cpp
+++ b/lib/everest/io/test/client_connect_error_test.cpp
@@ -441,7 +441,7 @@ TEST(client_connect_error_test, tcp_successful_open_clears_recorded_connect_erro
 // to a nonexistent device is the deterministic way to fail it.
 TEST(client_connect_error_test, udp_failed_connect_reports_enodev) {
     udp_client_socket sock;
-    ASSERT_TRUE(sock.setup("127.0.0.1", unused_remote_port, 1000, unusable_device));
+    ASSERT_TRUE(sock.setup("127.0.0.1", unused_remote_port, unusable_device));
 
     const auto outcome = drive_connect(sock);
 
@@ -592,23 +592,17 @@ TEST(client_connect_error_test, udp_unresolvable_host_open_reports_resolver_fail
                                  << ") instead of EHOSTUNREACH";
 }
 
-TEST(client_connect_error_test, udp_failed_connect_latency_ignores_connect_timeout) {
-    constexpr int short_timeout_ms = 200;
-    constexpr int long_timeout_ms = 2000;
-
+// A UDP connect never touches the network, so its failure latency is only the
+// reconnect delay. There is no connect timeout to charge it: udp_client_socket
+// takes none, which is what keeps the TCP differential test's property from
+// needing a UDP counterpart.
+TEST(client_connect_error_test, udp_failed_connect_costs_only_the_reconnect_delay) {
     udp_client_socket sock;
-    ASSERT_TRUE(sock.setup("127.0.0.1", unused_remote_port, short_timeout_ms, unusable_device));
-    const auto short_run = drive_connect(sock);
-    ASSERT_FALSE(short_run.ok) << "connect bound to a nonexistent device reported success";
+    ASSERT_TRUE(sock.setup("127.0.0.1", unused_remote_port, unusable_device));
 
-    ASSERT_TRUE(sock.setup("127.0.0.1", unused_remote_port, long_timeout_ms, unusable_device));
-    const auto long_run = drive_connect(sock);
-    ASSERT_FALSE(long_run.ok) << "connect bound to a nonexistent device reported success";
+    const auto outcome = drive_connect(sock);
 
-    EXPECT_LT(short_run.elapsed_ms, max_reconnect_delay_ms)
-        << "a connect that failed before touching the network took " << short_run.elapsed_ms << "ms";
-    EXPECT_LT(long_run.elapsed_ms - short_run.elapsed_ms, jitter_slack_ms)
-        << "raising the connect timeout from " << short_timeout_ms << "ms to " << long_timeout_ms << "ms moved failure "
-        << "latency from " << short_run.elapsed_ms << "ms to " << long_run.elapsed_ms
-        << "ms, so a connect that never touched the network is charged the connect timeout";
+    ASSERT_FALSE(outcome.ok) << "connect bound to a nonexistent device reported success";
+    EXPECT_LT(outcome.elapsed_ms, max_reconnect_delay_ms)
+        << "a connect that failed before touching the network took " << outcome.elapsed_ms << "ms";
 }

--- a/lib/everest/io/test/client_connect_error_test.cpp
+++ b/lib/everest/io/test/client_connect_error_test.cpp
@@ -4,6 +4,7 @@
 // Loopback-only fixtures: no test here depends on DNS or on egress.
 
 #include <everest/io/event/unique_fd.hpp>
+#include <everest/io/mdns/mdns_socket.hpp>
 #include <everest/io/tcp/tcp_socket.hpp>
 #include <everest/io/udp/udp_socket.hpp>
 
@@ -24,8 +25,10 @@
 #include <gtest/gtest.h>
 
 using everest::lib::io::event::unique_fd;
+using everest::lib::io::mdns::mdns_socket;
 using everest::lib::io::tcp::tcp_socket;
 using everest::lib::io::udp::udp_client_socket;
+using everest::lib::io::udp::udp_server_socket;
 
 namespace {
 
@@ -43,6 +46,11 @@ constexpr char unusable_device[] = "nosuchdev0";
 
 // Discard port, never contacted: the device bind fails first.
 constexpr std::uint16_t unused_remote_port = 9;
+
+// Let the kernel choose. A server bound to a nonexistent device never reaches
+// bind(), and open_udp_server_socket sets SO_REUSEADDR, so a duplicate bind is
+// not a dependable way to fail one.
+constexpr std::uint16_t kernel_chosen_port = 0;
 
 unique_fd make_loopback_socket(std::uint16_t& bound_port) {
     unique_fd fd{::socket(AF_INET, SOCK_STREAM, 0)};
@@ -141,6 +149,43 @@ private:
     bool m_refused{false};
 };
 
+/// A 127.0.0.1 listen socket that accepts connects: bound to an ephemeral port
+/// and listen()ed with backlog to spare, never accept()ed. The kernel completes
+/// the handshake from the backlog, so a connect to port() succeeds without a
+/// server thread. A throwaway probe connect confirms that, so accepting() means
+/// "connects here succeed". Ephemeral, because concurrent worktrees in this repo
+/// have collided on fixed test ports.
+class accepting_loopback_port {
+public:
+    accepting_loopback_port() {
+        m_listen_fd = make_loopback_socket(m_port);
+        if (not m_listen_fd.is_fd() || ::listen(m_listen_fd, backlog) != 0) {
+            return;
+        }
+        int err = 0;
+        auto probe = start_nonblocking_connect(m_port, err);
+        if (not probe.is_fd()) {
+            return;
+        }
+        m_accepting = connect_completed(probe, probe_wait_ms);
+    }
+
+    bool accepting() const {
+        return m_accepting;
+    }
+    std::uint16_t port() const {
+        return m_port;
+    }
+
+private:
+    // The probe plus one connect per test; the rest is headroom.
+    static constexpr int backlog = 8;
+    static constexpr int probe_wait_ms = 500;
+    unique_fd m_listen_fd;
+    std::uint16_t m_port{0};
+    bool m_accepting{false};
+};
+
 /// A 127.0.0.1 listen socket whose accept queue is deliberately saturated:
 /// listen(fd, 1), never accept, pre-connects issued until one stalls. With the
 /// queue full the kernel stops completing handshakes, so a later connect to
@@ -227,6 +272,21 @@ TEST(client_connect_error_test, tcp_refused_connect_reports_econnrefused) {
                                  << ") instead of ECONNREFUSED";
 }
 
+// open() is the synchronous path and reports through the same get_error(). A
+// refused open must name the refusal, not get_error()'s own probe of a
+// descriptor that was never assigned.
+TEST(client_connect_error_test, tcp_refused_open_reports_econnrefused) {
+    refused_loopback_port refused;
+    ASSERT_TRUE(refused.reserved()) << "could not reserve a closed loopback port that refuses connects";
+
+    tcp_socket sock;
+    ASSERT_FALSE(sock.open("127.0.0.1", refused.port())) << "open of a closed port reported success";
+
+    const int err = sock.get_error();
+    EXPECT_EQ(err, ECONNREFUSED) << "a refused open reported errno " << err << " (" << ::strerror(err)
+                                 << ") instead of ECONNREFUSED";
+}
+
 TEST(client_connect_error_test, tcp_unreachable_peer_connect_reports_etimedout) {
     saturated_loopback_port blocked;
     ASSERT_TRUE(blocked.saturated()) << "could not saturate the loopback accept queue";
@@ -298,6 +358,51 @@ TEST(client_connect_error_test, tcp_timed_out_connect_latency_is_not_doubled) {
         << short_run.elapsed_ms << "ms to " << long_run.elapsed_ms << "ms, so the connect timeout is charged twice";
 }
 
+// A deliberate close() leaves nothing to probe, and get_error() must still say
+// something. Nonzero is the whole contract: zero means "no recorded reason, fall
+// through to probing the descriptor", and generic_error_state treats zero as not
+// on error, so a descriptor-less socket reporting zero would stop the client from
+// reconnecting and present as a hang. The value itself (EBADF from the fallback
+// probe) is an implementation detail and is not asserted.
+TEST(client_connect_error_test, tcp_closed_socket_reports_nonzero_error) {
+    accepting_loopback_port accepting;
+    ASSERT_TRUE(accepting.accepting()) << "could not reserve a loopback port that accepts connects";
+
+    tcp_socket sock;
+    ASSERT_TRUE(sock.open("127.0.0.1", accepting.port())) << "open of an accepting port failed";
+    ASSERT_TRUE(sock.is_open());
+
+    sock.close();
+
+    const int err = sock.get_error();
+    EXPECT_NE(err, 0) << "a closed socket reported 0, which reads as healthy and suppresses the client reset";
+}
+
+// The recorded reason must move with the descriptor. A failed connect records
+// ECONNREFUSED; a later successful open takes ownership of a descriptor and so
+// invalidates that reason. Once the socket is closed again the stale value must
+// not reappear.
+TEST(client_connect_error_test, tcp_successful_open_clears_recorded_connect_error) {
+    refused_loopback_port refused;
+    ASSERT_TRUE(refused.reserved()) << "could not reserve a closed loopback port that refuses connects";
+    accepting_loopback_port accepting;
+    ASSERT_TRUE(accepting.accepting()) << "could not reserve a loopback port that accepts connects";
+
+    tcp_socket sock;
+    ASSERT_TRUE(sock.setup("127.0.0.1", refused.port(), 1000));
+    const auto outcome = drive_connect(sock);
+    ASSERT_FALSE(outcome.ok) << "connect to a closed port reported success";
+    ASSERT_EQ(sock.get_error(), ECONNREFUSED)
+        << "the refused connect was not recorded, so there is nothing to go stale";
+
+    ASSERT_TRUE(sock.open("127.0.0.1", accepting.port())) << "open of an accepting port failed";
+    sock.close();
+
+    const int err = sock.get_error();
+    EXPECT_NE(err, ECONNREFUSED) << "get_error() still reports the ECONNREFUSED of a connect that predates a "
+                                    "successful open, so the recorded reason outlived the descriptor it described";
+}
+
 // udp_client_socket::connect has the same shape and the same two defects. A UDP
 // connect() is a local operation, so it cannot be refused by the peer; binding
 // to a nonexistent device is the deterministic way to fail it.
@@ -318,6 +423,53 @@ TEST(client_connect_error_test, udp_failed_connect_reports_enodev) {
     // std::runtime_error unwind.
     EXPECT_EQ(err, ENODEV) << "a failed connect reported errno " << err << " (" << ::strerror(err)
                            << ") instead of ENODEV";
+}
+
+// The synchronous open_as_client path, reached through udp_client_socket::open.
+// Same claim strength as the async UDP test above: the recorded reason has to be
+// about the failure, not about probing an unassigned descriptor.
+TEST(client_connect_error_test, udp_failed_open_reports_the_failure_reason) {
+    udp_client_socket sock;
+    ASSERT_FALSE(sock.open("127.0.0.1", unused_remote_port, unusable_device))
+        << "open bound to a nonexistent device reported success";
+
+    const int err = sock.get_error();
+    EXPECT_NE(err, EBADF) << "a failed open reported EBADF, which describes get_error()'s own probe of "
+                             "an unassigned descriptor rather than why the open failed";
+    EXPECT_NE(err, 0) << "a failed open left get_error() at 0";
+}
+
+// open_as_server is reached through udp_server_socket::open, which fd_event_client
+// calls from its synchronous init with no handler around it. A throw there escapes
+// into the event loop instead of being reported, so a failing open has to return
+// false and name the reason like every other policy does.
+TEST(client_connect_error_test, udp_server_failed_open_reports_the_failure_reason) {
+    udp_server_socket sock;
+    ASSERT_FALSE(sock.open(kernel_chosen_port, unusable_device))
+        << "open of a server bound to a nonexistent device reported success";
+    EXPECT_FALSE(sock.is_open()) << "a failed open kept a descriptor the caller was told does not exist";
+
+    const int err = sock.get_error();
+    EXPECT_NE(err, EBADF) << "a failed open reported EBADF, which describes get_error()'s own probe of "
+                             "an unassigned descriptor rather than why the open failed";
+    EXPECT_NE(err, 0) << "a failed open left get_error() at 0";
+    // Same device-lookup-before-capability-check path as the client leg, so ENODEV
+    // at any privilege level.
+    EXPECT_EQ(err, ENODEV) << "a failed open reported errno " << err << " (" << ::strerror(err)
+                           << ") instead of ENODEV";
+}
+
+// mdns_socket::open is the third synchronous open on this policy shape and had the
+// same unguarded throw. The interface lookup it fails in raises a plain
+// std::runtime_error with no errno attached, so only the nonzero invariant is
+// claimed here, not a specific value.
+TEST(client_connect_error_test, mdns_failed_open_reports_failure_instead_of_throwing) {
+    mdns_socket sock;
+    ASSERT_FALSE(sock.open(unusable_device)) << "open on a nonexistent interface reported success";
+    EXPECT_FALSE(sock.is_open()) << "a failed open kept a descriptor the caller was told does not exist";
+
+    const int err = sock.get_error();
+    EXPECT_NE(err, 0) << "a failed open left get_error() at 0, which reads as healthy and suppresses the client reset";
 }
 
 TEST(client_connect_error_test, udp_failed_connect_latency_ignores_connect_timeout) {

--- a/lib/everest/io/test/udp_client_v6_test.cpp
+++ b/lib/everest/io/test/udp_client_v6_test.cpp
@@ -84,7 +84,7 @@ private:
 TEST(udp_client_v6_test, connected_roundtrip_over_ipv6_loopback) {
     v6_echo echo;
 
-    udp_client client("::1", echo.port(), 1000);
+    udp_client client("::1", echo.port());
 
     std::atomic<bool> got{false};
     udp_payload received;


### PR DESCRIPTION
## Describe your changes

Four defects on the client connect path. Three of the four ended with a real errno being reported as
`EBADF`, by different routes.

- **The connect errno was discarded.** A refused connect reported `EBADF` (9) instead of
  `ECONNREFUSED` (111), a timeout `EBADF` instead of `ETIMEDOUT` (110). The errno does reach the
  catch site; what lost it was `get_error()` falling back to the pending error of a descriptor that
  was never assigned. It is now captured in the catch block.
- **The reconnect delay was a second copy of the connect timeout.** A refused connect returns in
  about 0 ms and then slept the full 1000 ms timeout before retrying. A 500 ms timeout against a
  saturated backlog cost 1000 ms per attempt. The retry delay is now a separate named value, and the
  tests bound latency rather than asserting an exact sleep.
- **The recorded errno could outlive its descriptor.** Only `setup()` and a successful `connect()`
  invalidated it, so a failed `connect()`, then a successful `open()`, then a deliberate `close()`
  still reported `ECONNREFUSED`. The descriptor and the reason there is no descriptor now move
  together through `adopt()`, `record_connect_failure()` and `discard()`. On `udp_socket_base` the
  descriptor became private, because `mdns_socket` was assigning the inherited protected member
  directly and reaching around every site a per-site clear would have had to cover.
- **`getaddrinfo` failures surfaced as `EBADF` as well.** All four resolver legs threw a bare
  `std::runtime_error`, recorded by the socket-level catch as error 0, landing back on the same
  unassigned-descriptor probe. They now throw `socket_error` carrying `errno` on `EAI_SYSTEM` and
  `EHOSTUNREACH` otherwise, keeping the `gai_strerror` text. A zero `errno` is floored so it cannot
  reproduce the `EBADF` this removes.

Reading `errno` unconditionally on the resolver path would be wrong: after a non-`EAI_SYSTEM` failure
it holds unrelated leftovers (measured 22/`EINVAL` and 90/`EMSGSIZE`), so the mapping is needed for
correctness, not tidiness.

Two gaps stated rather than hidden. The `EAI_SYSTEM` branch and the `open_udp_server_socket` resolver
leg have no forceable failure mode without fault injection, and are marked untested in a comment. The
resolver tests use a 64-octet DNS label rather than an unresolvable hostname, so the file keeps its
no-DNS, no-egress property.

## Issue ticket number and link

N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

---

### Stack

Six PR series, two rooted on `main`. (#2558 and #2559 have merged.)

This PR is rooted on `main` and is blocked by nothing.

- `main`
  - **#2560 `fix/io-connect-errno-and-backoff` (this PR)**
  - #2561 `fix/io-event-handler-truthfulness`
    - #2562 `feat/io-client-tx-tristate`
      - #2563 `feat/io-fd-event-client-handshake-phase`
        - #2564 `feat/io-tls-policies-rebuilt`
      - #2565 `refactor/chargebridge-drop-hand-rolled-tx-gates`
