### PR TITLE
fix(io): make event handler registration truthful

### DIFF
--- a/applications/pionix_chargebridge/src/heartbeat_service.cpp
+++ b/applications/pionix_chargebridge/src/heartbeat_service.cpp
@@ -80,21 +80,19 @@ heartbeat_service::~heartbeat_service() {
 }
 
 bool heartbeat_service::register_events(everest::lib::io::event::fd_event_handler& handler) {
-    // clang-format off
-    return
-        handler.register_event_handler(m_udp.get()) &&
-        handler.register_event_handler(&m_heartbeat_timer, [this](auto&) { handle_heartbeat_timer(); }) &&
-        handler.register_event_handler(&m_error_timer, [this](auto&) { handle_error_timer(); });
-    // clang-format on
+    auto result = true;
+    result = handler.register_event_handler(m_udp.get()) && result;
+    result = handler.register_event_handler(&m_heartbeat_timer, [this](auto&) { handle_heartbeat_timer(); }) && result;
+    result = handler.register_event_handler(&m_error_timer, [this](auto&) { handle_error_timer(); }) && result;
+    return result;
 }
 
 bool heartbeat_service::unregister_events(everest::lib::io::event::fd_event_handler& handler) {
-    // clang-format off
-    return
-        handler.unregister_event_handler(m_udp.get()) &&
-        handler.unregister_event_handler(&m_heartbeat_timer) &&
-        handler.unregister_event_handler(&m_error_timer);
-    // clang-format on
+    auto result = true;
+    result = handler.unregister_event_handler(m_udp.get()) && result;
+    result = handler.unregister_event_handler(&m_heartbeat_timer) && result;
+    result = handler.unregister_event_handler(&m_error_timer) && result;
+    return result;
 }
 
 void heartbeat_service::handle_error_timer() {

--- a/lib/everest/io/include/everest/io/event/event_fd.hpp
+++ b/lib/everest/io/include/everest/io/event/event_fd.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "unique_fd.hpp"
+
 #include <cstdint>
 #include <optional>
 
@@ -30,11 +31,12 @@ public:
      */
     virtual ~event_fd_base() = default;
 
+    // fd_event_handler installs a lambda capturing this, so a moved object leaves it reading the old address.
     event_fd_base(const event_fd_base&) = delete;
     event_fd_base& operator=(const event_fd_base&) = delete;
 
-    event_fd_base(event_fd_base&&) = default;
-    event_fd_base& operator=(event_fd_base&&) = default;
+    event_fd_base(event_fd_base&&) = delete;
+    event_fd_base& operator=(event_fd_base&&) = delete;
 
     /**
      * @brief Explicit conversion to file descriptor

--- a/lib/everest/io/include/everest/io/event/fd_event_client.hpp
+++ b/lib/everest/io/include/everest/io/event/fd_event_client.hpp
@@ -51,6 +51,10 @@ struct client_status_internal {
 /**
  * Implements the type independant part of the fd_event_client. This includes all event handling
  * with \ref fd_event_handler. Not to be used on its own.
+ *
+ * Ownership: the client and an outer \ref fd_event_handler may be destroyed in either order, the
+ * registration record holds only a weak reference. Destroy the client on the handler's thread, and
+ * never from a callback that handler is dispatching: it erases that callback while it runs.
  */
 class generic_fd_event_client_impl : public fd_event_sync_interface, protected utilities::generic_error_state {
 public:

--- a/lib/everest/io/include/everest/io/event/fd_event_handler.hpp
+++ b/lib/everest/io/include/everest/io/event/fd_event_handler.hpp
@@ -9,6 +9,7 @@
 #include <everest/io/event/event_fd.hpp>
 #include <everest/io/event/fd_event_client.hpp>
 #include <everest/io/event/fd_event_register_interface.hpp>
+#include <everest/io/event/handler_liveness.hpp>
 #include <everest/util/queue/thread_safe_queue.hpp>
 
 #include <atomic>
@@ -55,6 +56,9 @@ class generic_fd_event_client_impl;
  * be registered together with a list of the events of interest and a callback.
  * This class provides itself a filedescriptor that can be added to other event handlers. This way
  * concerns may be separated and event handlers nested.
+ *
+ * Registration, removal and \ref poll must all run on one thread. \ref add_action is the only
+ * member safe to call from another thread.
  */
 class fd_event_handler {
 public:
@@ -155,7 +159,8 @@ public:
     /**
      * @brief Register a client implementing \ref fd_event_sync_interface for event handling
      * @details On notification from the file descriptor of the client, its sync method is called
-     * If manual handling is necessary use \ref fd_event_client filedescriptor directly
+     * If manual handling is necessary use \ref fd_event_client filedescriptor directly.
+     * The client records this handler and removes its registration when destroyed.
      * @param[in] obj The object to be registerd for event handling
      * @return True on success, false otherwise
      */
@@ -187,16 +192,16 @@ public:
 
     /**
      * @brief Unregister object implementing \ref fd_event_sync_interface from event handling
+     * @details Removes the descriptor recorded at registration time, not the current get_poll_fd.
      * @param[in] obj The object to be removed from event handling
-     * @return True on success, false otherwise
+     * @return True if a registration with this handler was removed, false otherwise
      */
-
     bool unregister_event_handler(fd_event_sync_interface* obj);
 
     /**
      * @brief Unregister timer_fd from event handling
      * @param[in] obj The timer to be removed
-     * @return True on success, false otherwise
+     * @return True if a registration with this handler was removed, false otherwise
      */
     bool unregister_event_handler(timer_fd* obj);
 
@@ -244,6 +249,22 @@ public:
      * @return True on success, false otherwise
      */
     bool remove_event_handler(int fd);
+
+    /**
+     * @brief Check whether a file descriptor has a registered handler
+     * @details Reports the handler map only, so it stays meaningful for an already closed descriptor.
+     * @param[in] fd The file descriptor
+     * @return True if \p fd has a registered handler, false otherwise
+     */
+    bool is_registered(int fd) const;
+
+    /**
+     * @brief The block a registration with this handler is recorded against
+     * @details Cleared in \ref ~fd_event_handler before any member is destroyed. A recorder keeps a
+     * \p std::weak_ptr to it and drops its registration only while the block still names a handler.
+     * @return The liveness block of this handler
+     */
+    std::shared_ptr<handler_liveness> liveness() const;
     /**
      * @}
      */
@@ -315,7 +336,11 @@ private:
      * \return false in case of timeout, true otherwise
      */
     bool poll_impl(int timeout_ms);
+
+    // Not shared_ptr: EventHandlerMap owns the epoll descriptor, and a registrant outliving this
+    // handler must not keep it open.
     std::unique_ptr<EventHandlerMap> m_handlers{nullptr};
+    std::shared_ptr<handler_liveness> m_liveness;
     util::thread_safe_queue<task> task_pool;
     event_fd m_action_event;
 };

--- a/lib/everest/io/include/everest/io/event/fd_event_sync_interface.hpp
+++ b/lib/everest/io/include/everest/io/event/fd_event_sync_interface.hpp
@@ -5,7 +5,11 @@
 
 #pragma once
 
+#include <everest/io/event/registration_record.hpp>
+
 namespace everest::lib::io::event {
+
+class fd_event_handler;
 
 /**
  * @brief Possible outcomes of syncing
@@ -20,11 +24,21 @@ enum class sync_status {
 };
 
 /**
- * Interface for classes implementing default syncing (E/POLLIN only)for fd_event_handler
+ * Interface for classes implementing syncing (E/POLLIN only) for fd_event_handler
  */
 class fd_event_sync_interface {
 public:
-    virtual ~fd_event_sync_interface() = default;
+    fd_event_sync_interface() = default;
+
+    /**
+     * @brief Drops a registration still recorded by \ref register_events
+     */
+    virtual ~fd_event_sync_interface();
+
+    fd_event_sync_interface(fd_event_sync_interface const&) = delete;
+    fd_event_sync_interface& operator=(fd_event_sync_interface const&) = delete;
+    fd_event_sync_interface(fd_event_sync_interface&&) = delete;
+    fd_event_sync_interface& operator=(fd_event_sync_interface&&) = delete;
 
     /**
      * @brief Access to the internal event handler
@@ -40,6 +54,37 @@ public:
      * @return Result of sync operation
      */
     virtual everest::lib::io::event::sync_status sync() = 0;
+
+    /**
+     * @brief Register with an existing event handler
+     * @details Registers \ref get_poll_fd for read (E/POLLIN) and calls \ref sync on notification.
+     * Handler and descriptor are recorded. At most one registration is recorded at a time.
+     * @note Not virtual by design. An override that skipped the recording would leave the handler
+     * calling \ref sync on a destroyed object. Customize \ref get_poll_fd and \ref sync instead, or
+     * implement \ref fd_event_register_interface for a different registration shape.
+     * @param[in] handler The event handler to register with
+     * @return true on success, false otherwise
+     */
+    bool register_events(fd_event_handler& handler);
+
+    /**
+     * @brief Unregister from an existing event handler
+     * @param[in] handler The event handler passed to \ref register_events
+     * @return true if a registration was removed, false otherwise
+     */
+    bool unregister_events(fd_event_handler& handler);
+
+protected:
+    /**
+     * @brief Remove the recorded registration
+     * @details Uses the recorded descriptor instead of \ref get_poll_fd, so it stays callable while
+     * the object is being destroyed. Implementors call it in their destructor.
+     * @return true if a registration was removed, false otherwise
+     */
+    bool unregister_recorded_events();
+
+private:
+    registration_record m_record;
 };
 
 } // namespace everest::lib::io::event

--- a/lib/everest/io/include/everest/io/event/handler_liveness.hpp
+++ b/lib/everest/io/include/everest/io/event/handler_liveness.hpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+/** \file */
+
+#pragma once
+
+namespace everest::lib::io::event {
+
+class fd_event_handler;
+
+/**
+ * @brief Handler-side block a registration is recorded against
+ * @details The handler clears \p handler in its destructor body, before its own members are
+ * destroyed, so a recorder holding a \p std::weak_ptr has no pointer left to dereference after that.
+ * Deliberately includes nothing, so recorders need not depend on fd_event_handler.hpp.
+ */
+struct handler_liveness {
+    fd_event_handler* handler{nullptr};
+};
+
+} // namespace everest::lib::io::event

--- a/lib/everest/io/include/everest/io/event/registration_record.hpp
+++ b/lib/everest/io/include/everest/io/event/registration_record.hpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+/** \file */
+
+#pragma once
+
+#include <everest/io/event/handler_liveness.hpp>
+
+#include <memory>
+
+namespace everest::lib::io::event {
+
+/**
+ * @brief A registration made with an \ref fd_event_handler, remembered by the registrant
+ * @details Holds the handler's \ref handler_liveness block and the registered descriptor, so the
+ * registration can be removed without asking the registrant again and without touching a dead
+ * handler. \ref drop mutates the recording handler's map, so the owner must be destroyed on that
+ * handler's thread (see \ref fd_event_handler).
+ * @note No destructor by design, dropping stays the owner's call: a base class owner must drop
+ * before its derived state is gone, which a destructor at this level would run too late for.
+ */
+class registration_record {
+public:
+    registration_record() = default;
+
+    // A copy would drop a registration its twin still counts on.
+    registration_record(registration_record const&) = delete;
+    registration_record& operator=(registration_record const&) = delete;
+    registration_record(registration_record&&) = delete;
+    registration_record& operator=(registration_record&&) = delete;
+
+    /**
+     * @brief True while the recorded registration still lives in the recording handler's map
+     * @details Asks the map rather than the record alone: a registration dropped by raw
+     * descriptor leaves a record naming a live handler, and that must not block a new one.
+     */
+    bool active() const;
+
+    /**
+     * @brief Remember a registration made with \p handler for \p fd
+     * @param[in] handler The liveness block of the handler the registration was made with
+     * @param[in] fd The registered file descriptor
+     */
+    void record(std::shared_ptr<handler_liveness> handler, int fd);
+
+    /**
+     * @brief Forget the record, removing the registration while the handler is alive
+     * @details The record is cleared before calling out, so re-entry cannot see a half-dropped
+     * state. Touches nothing once the handler is gone.
+     * @return true if a registration was removed, false otherwise
+     */
+    bool drop();
+
+    /**
+     * @brief \ref drop, but only if the record names \p handler
+     * @param[in] handler The liveness block to compare against
+     * @return true if a registration was removed, false otherwise
+     */
+    bool drop_if(std::shared_ptr<handler_liveness> const& handler);
+
+private:
+    std::weak_ptr<handler_liveness> m_handler;
+    int m_fd{-1};
+};
+
+} // namespace everest::lib::io::event

--- a/lib/everest/io/include/everest/io/event/timer_fd.hpp
+++ b/lib/everest/io/include/everest/io/event/timer_fd.hpp
@@ -6,7 +6,11 @@
 #pragma once
 
 #include "unique_fd.hpp"
+#include <everest/io/event/handler_liveness.hpp>
+#include <everest/io/event/registration_record.hpp>
+
 #include <chrono>
+#include <memory>
 
 namespace everest::lib::io::event {
 
@@ -21,6 +25,16 @@ public:
      * @details After construction the timeout is undefined. It must be set manually.
      */
     timer_fd();
+
+    /**
+     * @brief Drops a registration recorded by \ref fd_event_handler
+     */
+    ~timer_fd();
+
+    timer_fd(timer_fd const&) = delete;
+    timer_fd& operator=(timer_fd const&) = delete;
+    timer_fd(timer_fd&&) = delete;
+    timer_fd& operator=(timer_fd&&) = delete;
 
     /**
      * @brief Explicit conversion to file descriptor
@@ -107,9 +121,27 @@ public:
      */
 
 private:
+    friend class fd_event_handler;
+
+    bool has_recorded_registration() const;
+
+    void record_registration(std::shared_ptr<handler_liveness> handler, int fd);
+
+    bool unregister_recorded_events(std::shared_ptr<handler_liveness> const& handler);
+
+    /**
+     * @brief Drop the record, removing the registration while the handler is alive
+     * @details Uses the recorded descriptor instead of \ref get_raw_fd, so this stays callable
+     * while the object is being destroyed.
+     * @see registration_record::drop
+     * @return true if a registration was removed, false otherwise
+     */
+    bool unregister_recorded_events();
+
     unique_fd m_fd;
     long long m_to_ns{0};
     bool m_single_shot{false};
+    registration_record m_record;
 };
 
 } // namespace everest::lib::io::event

--- a/lib/everest/io/src/CMakeLists.txt
+++ b/lib/everest/io/src/CMakeLists.txt
@@ -11,6 +11,8 @@ set_target_properties(everest_io PROPERTIES
 target_sources(everest_io
     PRIVATE
         event/fd_event_handler.cpp
+        event/fd_event_sync_interface.cpp
+        event/registration_record.cpp
         event/unique_fd.cpp
         event/event_fd.cpp
         event/timer_fd.cpp

--- a/lib/everest/io/src/event/fd_event_client.cpp
+++ b/lib/everest/io/src/event/fd_event_client.cpp
@@ -12,7 +12,9 @@ generic_fd_event_client_impl::generic_fd_event_client_impl(action const& send_on
     m_event_handler = std::make_unique<event::fd_event_handler>();
 }
 
-generic_fd_event_client_impl::~generic_fd_event_client_impl() = default;
+generic_fd_event_client_impl::~generic_fd_event_client_impl() {
+    unregister_recorded_events();
+}
 
 int generic_fd_event_client_impl::get_poll_fd() {
     return m_event_handler->get_poll_fd();

--- a/lib/everest/io/src/event/fd_event_handler.cpp
+++ b/lib/everest/io/src/event/fd_event_handler.cpp
@@ -8,6 +8,7 @@
 #include <everest/io/event/timer_fd.hpp>
 #include <everest/io/event/unique_fd.hpp>
 
+#include <algorithm>
 #include <cstdio>
 #include <fcntl.h>
 #include <map>
@@ -92,19 +93,22 @@ public:
         auto result = epoll_ctl(m_epoll_fd, EPOLL_CTL_ADD, fd, &event) == 0;
         if (result) {
             m_event_map[fd] = {std::move(handler), event};
-            m_pollfds.resize(m_pollfds.size() + 1);
+            // Never shrinks, so a handler cannot destroy an entry of the array the running poll
+            // is dispatching. epoll_wait accepts a maxevents larger than the descriptor count.
+            m_pollfds.resize(std::max(m_pollfds.size(), m_event_map.size()));
         }
         return result;
     }
 
     bool remove(int fd) {
-        auto epoll_result = epoll_ctl(m_epoll_fd, EPOLL_CTL_DEL, fd, nullptr);
-        auto handler_result = m_event_map.count(fd);
-        if (handler_result) {
+        auto epoll_removed = epoll_ctl(m_epoll_fd, EPOLL_CTL_DEL, fd, nullptr) == 0;
+        auto handler_removed = m_event_map.count(fd) != 0;
+        if (handler_removed) {
             m_event_map.erase(fd);
-            m_pollfds.resize(m_pollfds.size() - 1);
         }
-        return epoll_result or handler_result;
+        // Closing a descriptor drops it from the epoll set, so EPOLL_CTL_DEL then fails
+        // EBADF on a live registration. Erasing the map entry alone is still a removal.
+        return epoll_removed or handler_removed;
     }
     bool modify_remove(int fd, fd_event_handler::event_list const& events) {
         auto action = [](uint32_t current, fd_event_handler::event_list const& change) {
@@ -133,7 +137,8 @@ public:
         return modify(fd, events, action);
     }
 
-    const auto& get(int fd) const {
+    // A handler may erase its own entry, destroying the std::function the caller is executing.
+    auto get(int fd) const {
         return std::get<fd_event_handler::event_handler_type>(m_event_map.at(fd));
     }
 
@@ -171,19 +176,26 @@ private:
     unique_fd m_epoll_fd;
 };
 
-fd_event_handler::~fd_event_handler() = default;
+// Runs before any member, so every outstanding record is inert before the epoll descriptor closes.
+fd_event_handler::~fd_event_handler() {
+    m_liveness->handler = nullptr;
+}
 
-fd_event_handler::fd_event_handler() {
+fd_event_handler::fd_event_handler() : m_liveness(std::make_shared<handler_liveness>()) {
+    m_liveness->handler = this;
     m_handlers = std::make_unique<EventHandlerMap>();
     register_event_handler(&m_action_event, [](auto&&) {});
+}
+
+std::shared_ptr<handler_liveness> fd_event_handler::liveness() const {
+    return m_liveness;
 }
 
 bool fd_event_handler::register_event_handler(int fd, event_handler_type const& handler, event_list const& events) {
     if (fd == -1 or not handler or m_handlers->exists(fd)) {
         return false;
     }
-    m_handlers->add(fd, handler, events);
-    return true;
+    return m_handlers->add(fd, handler, events);
 }
 
 bool fd_event_handler::register_event_handler(int fd, event_handler_type const& handler, poll_events event) {
@@ -209,17 +221,23 @@ bool fd_event_handler::register_event_handler(event_fd* fd, event_handler_simple
 }
 
 bool fd_event_handler::register_event_handler(timer_fd* fd, event_handler_type const& handler) {
-    if (not fd) {
+    // One record per object. A second registration would leave the first unrecorded and therefore
+    // unremovable.
+    if (not fd or fd->has_recorded_registration()) {
         return false;
     }
     auto raw = fd->get_raw_fd();
-    return register_event_handler(
+    auto const registered = register_event_handler(
         raw,
         [handler, fd](event_list const& e) {
             fd->read();
             handler(e);
         },
         poll_events::read);
+    if (registered) {
+        fd->record_registration(m_liveness, raw);
+    }
+    return registered;
 }
 
 bool fd_event_handler::register_event_handler(timer_fd* fd, event_handler_simple_type const& handler) {
@@ -230,9 +248,7 @@ bool fd_event_handler::register_event_handler(fd_event_sync_interface* obj) {
     if (not obj) {
         return false;
     }
-    auto raw = obj->get_poll_fd();
-    return register_event_handler(
-        raw, [obj](event_list const&) { obj->sync(); }, poll_events::read);
+    return obj->register_events(*this);
 }
 
 bool fd_event_handler::register_event_handler(fd_event_register_interface* obj) {
@@ -267,14 +283,14 @@ bool fd_event_handler::unregister_event_handler(fd_event_sync_interface* obj) {
     if (not obj) {
         return false;
     }
-    return remove_event_handler(obj->get_poll_fd());
+    return obj->unregister_events(*this);
 }
 
 bool fd_event_handler::unregister_event_handler(timer_fd* obj) {
     if (not obj) {
         return false;
     }
-    return remove_event_handler(obj->get_raw_fd());
+    return obj->unregister_recorded_events(m_liveness);
 }
 
 bool fd_event_handler::unregister_event_handler(event_fd* obj) {
@@ -318,6 +334,13 @@ bool fd_event_handler::remove_event_handler(int fd) {
     return m_handlers->remove(fd);
 }
 
+bool fd_event_handler::is_registered(int fd) const {
+    if (fd == -1) {
+        return false;
+    }
+    return m_handlers->exists(fd);
+}
+
 void fd_event_handler::poll() {
     poll_impl(-1);
 }
@@ -328,8 +351,14 @@ bool fd_event_handler::poll_impl(int timeout_ms) {
 
     if (status > 0) {
         for (int i = 0; i < status; ++i) {
-            auto& item = pollfds[i];
-            m_handlers->get(item.data.fd)(bitmask_to_poll_events(item.events));
+            auto const item = pollfds[i];
+            // A handler may unregister any descriptor, including one later in this batch.
+            // Such an entry has no handler left to call and must not be dispatched.
+            if (not m_handlers->exists(item.data.fd)) {
+                continue;
+            }
+            auto const handler = m_handlers->get(item.data.fd);
+            handler(bitmask_to_poll_events(item.events));
         }
         return true;
     }

--- a/lib/everest/io/src/event/fd_event_sync_interface.cpp
+++ b/lib/everest/io/src/event/fd_event_sync_interface.cpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/event/fd_event_sync_interface.hpp>
+
+#include <everest/io/event/fd_event_handler.hpp>
+
+namespace everest::lib::io::event {
+
+fd_event_sync_interface::~fd_event_sync_interface() {
+    unregister_recorded_events();
+}
+
+bool fd_event_sync_interface::register_events(fd_event_handler& handler) {
+    if (m_record.active()) {
+        return false;
+    }
+    auto const fd = get_poll_fd();
+    auto const registered = handler.register_event_handler(
+        fd, [this](fd_event_handler::event_list const&) { sync(); }, poll_events::read);
+    if (registered) {
+        m_record.record(handler.liveness(), fd);
+    }
+    return registered;
+}
+
+bool fd_event_sync_interface::unregister_events(fd_event_handler& handler) {
+    return m_record.drop_if(handler.liveness());
+}
+
+bool fd_event_sync_interface::unregister_recorded_events() {
+    return m_record.drop();
+}
+
+} // namespace everest::lib::io::event

--- a/lib/everest/io/src/event/registration_record.cpp
+++ b/lib/everest/io/src/event/registration_record.cpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/event/registration_record.hpp>
+
+#include <everest/io/event/fd_event_handler.hpp>
+
+#include <utility>
+
+namespace everest::lib::io::event {
+
+bool registration_record::active() const {
+    auto const live = m_handler.lock();
+    return live and live->handler and live->handler->is_registered(m_fd);
+}
+
+void registration_record::record(std::shared_ptr<handler_liveness> handler, int fd) {
+    m_handler = std::move(handler);
+    m_fd = fd;
+}
+
+bool registration_record::drop() {
+    auto const live = m_handler.lock();
+    auto const fd = std::exchange(m_fd, -1);
+    m_handler.reset();
+    return live and live->handler and live->handler->remove_event_handler(fd);
+}
+
+bool registration_record::drop_if(std::shared_ptr<handler_liveness> const& handler) {
+    if (m_handler.lock() != handler) {
+        return false;
+    }
+    return drop();
+}
+
+} // namespace everest::lib::io::event

--- a/lib/everest/io/src/event/timer_fd.cpp
+++ b/lib/everest/io/src/event/timer_fd.cpp
@@ -6,6 +6,7 @@
 #include <stdexcept>
 #include <sys/timerfd.h>
 #include <unistd.h>
+#include <utility>
 
 namespace everest::lib::io::event {
 
@@ -13,6 +14,11 @@ timer_fd::timer_fd() : m_fd(::timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK)) {
     if (m_fd == -1) {
         throw std::runtime_error("failed to create an timerfd");
     }
+}
+
+// Runs before m_fd is destroyed, so the recorded descriptor is still the one the handler holds.
+timer_fd::~timer_fd() {
+    unregister_recorded_events();
 }
 
 timer_fd::operator int() const {
@@ -70,6 +76,22 @@ bool timer_fd::set_timeout_ns(long long to) {
     }
 
     return ::timerfd_settime(m_fd, 0, &timer, nullptr) == 0;
+}
+
+bool timer_fd::has_recorded_registration() const {
+    return m_record.active();
+}
+
+void timer_fd::record_registration(std::shared_ptr<handler_liveness> handler, int fd) {
+    m_record.record(std::move(handler), fd);
+}
+
+bool timer_fd::unregister_recorded_events(std::shared_ptr<handler_liveness> const& handler) {
+    return m_record.drop_if(handler);
+}
+
+bool timer_fd::unregister_recorded_events() {
+    return m_record.drop();
 }
 
 } // namespace everest::lib::io::event

--- a/lib/everest/io/src/mqtt/mqtt_client.cpp
+++ b/lib/everest/io/src/mqtt/mqtt_client.cpp
@@ -29,6 +29,7 @@ std::string mqtt_client::get_client_id() const {
 }
 
 mqtt_client::~mqtt_client() {
+    unregister_recorded_events();
     // This fixes late adding actions to the event_handler
     mosquitto_cpp::set_callback_disconnect_impl([](auto&, auto, auto const&) {});
 }

--- a/lib/everest/io/test/CMakeLists.txt
+++ b/lib/everest/io/test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(everest_io_tests
   udp_dualstack_server_socket_test.cpp
   fd_event_client_async_test.cpp
   client_connect_error_test.cpp
+  fd_event_handler_test.cpp
 )
 
 target_link_libraries(everest_io_tests

--- a/lib/everest/io/test/fd_event_handler_test.cpp
+++ b/lib/everest/io/test/fd_event_handler_test.cpp
@@ -1,0 +1,488 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/event/event_fd.hpp>
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/event/fd_event_sync_interface.hpp>
+#include <everest/io/event/timer_fd.hpp>
+
+#include <chrono>
+#include <cstdlib>
+#include <memory>
+#include <type_traits>
+
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+using everest::lib::io::event::event_fd;
+using everest::lib::io::event::fd_event_handler;
+using everest::lib::io::event::fd_event_sync_interface;
+using everest::lib::io::event::poll_events;
+using everest::lib::io::event::sync_status;
+using everest::lib::io::event::timer_fd;
+
+namespace {
+
+class minimal_sync_client : public fd_event_sync_interface {
+public:
+    int get_poll_fd() override {
+        return m_event.get_raw_fd();
+    }
+
+    sync_status sync() override {
+        m_event.read();
+        return sync_status::ok;
+    }
+
+private:
+    event_fd m_event;
+};
+
+struct closure_lifetime {
+    int next{0};
+    void const* running{nullptr};
+    int callback_finished{-1};
+    int closure_destroyed{-1};
+};
+
+/// std::function copies the closure, so only the probe the running callback claimed may record.
+class destruction_probe {
+public:
+    explicit destruction_probe(closure_lifetime& order) : m_order(&order) {
+    }
+
+    destruction_probe(destruction_probe const&) = default;
+    destruction_probe& operator=(destruction_probe const&) = default;
+
+    ~destruction_probe() {
+        if (m_order->running == this) {
+            m_order->closure_destroyed = ++m_order->next;
+        }
+    }
+
+private:
+    closure_lifetime* m_order;
+};
+
+/// On the callback's stack, not in the closure, so it records completion after the closure dies.
+class completion_marker {
+public:
+    explicit completion_marker(closure_lifetime& order) : m_order(&order) {
+    }
+
+    completion_marker(completion_marker const&) = delete;
+    completion_marker& operator=(completion_marker const&) = delete;
+
+    ~completion_marker() {
+        m_order->callback_finished = ++m_order->next;
+    }
+
+private:
+    closure_lifetime* m_order;
+};
+
+/// Regular files are not pollable, so epoll_ctl rejects them with EPERM.
+int open_unpollable_fd() {
+    char path[] = "/tmp/everest_io_fd_event_handler_XXXXXX";
+    auto const raw = ::mkstemp(path);
+    if (raw != -1) {
+        ::unlink(path);
+    }
+    return raw;
+}
+
+} // namespace
+
+TEST(fd_event_handler_test, sync_interface_cannot_be_copied_or_moved) {
+    EXPECT_FALSE(std::is_copy_constructible_v<minimal_sync_client>);
+    EXPECT_FALSE(std::is_copy_assignable_v<minimal_sync_client>);
+    EXPECT_FALSE(std::is_move_constructible_v<minimal_sync_client>);
+    EXPECT_FALSE(std::is_move_assignable_v<minimal_sync_client>);
+}
+
+TEST(fd_event_handler_test, destroying_sync_client_drops_its_map_entry) {
+    fd_event_handler handler;
+    int raw = -1;
+
+    {
+        minimal_sync_client client;
+        raw = client.get_poll_fd();
+        ASSERT_NE(raw, -1);
+        ASSERT_TRUE(handler.register_event_handler(&client));
+        ASSERT_TRUE(handler.is_registered(raw));
+    }
+
+    EXPECT_FALSE(handler.is_registered(raw));
+}
+
+TEST(fd_event_handler_test, unregister_reports_false_for_an_unknown_fd) {
+    fd_event_handler handler;
+
+    auto probe = std::make_unique<event_fd>();
+    auto const raw = probe->get_raw_fd();
+    ASSERT_TRUE(handler.register_event_handler(
+        raw, [](fd_event_handler::event_list const&) {}, poll_events::read));
+
+    probe.reset();
+    EXPECT_TRUE(handler.unregister_event_handler(raw));
+    ASSERT_FALSE(handler.is_registered(raw));
+
+    EXPECT_FALSE(handler.unregister_event_handler(raw));
+}
+
+TEST(fd_event_handler_test, register_reports_false_when_epoll_add_fails) {
+    fd_event_handler handler;
+
+    auto const raw = open_unpollable_fd();
+    ASSERT_NE(raw, -1);
+
+    EXPECT_FALSE(handler.register_event_handler(
+        raw, [](fd_event_handler::event_list const&) {}, poll_events::read));
+    EXPECT_FALSE(handler.is_registered(raw));
+
+    ::close(raw);
+}
+
+TEST(fd_event_handler_test, poll_keeps_the_batch_across_a_registration_exchange) {
+    fd_event_handler handler;
+
+    event_fd churn;
+    event_fd doomed;
+    event_fd replacement;
+    event_fd victim;
+
+    auto const doomed_raw = doomed.get_raw_fd();
+
+    int victim_calls = 0;
+
+    ASSERT_TRUE(handler.register_event_handler(&churn, [&](fd_event_handler::event_list const&) {
+        handler.unregister_event_handler(doomed_raw);
+        handler.register_event_handler(
+            replacement.get_raw_fd(), [](fd_event_handler::event_list const&) {}, poll_events::read);
+    }));
+    ASSERT_TRUE(handler.register_event_handler(&doomed, [](fd_event_handler::event_list const&) {}));
+    ASSERT_TRUE(handler.register_event_handler(&victim, [&](fd_event_handler::event_list const&) { ++victim_calls; }));
+
+    // Every descriptor must be ready, the action event included, so the batch spans the whole array.
+    handler.add_action([]() {});
+    churn.notify();
+    doomed.notify();
+    victim.notify();
+
+    handler.poll(100ms);
+
+    EXPECT_EQ(victim_calls, 1);
+}
+
+TEST(fd_event_handler_test, poll_survives_unregistration_from_within_a_handler) {
+    fd_event_handler handler;
+
+    event_fd first;
+    event_fd second;
+    event_fd idle;
+
+    auto const first_raw = first.get_raw_fd();
+    auto const second_raw = second.get_raw_fd();
+
+    int first_calls = 0;
+    int second_calls = 0;
+
+    ASSERT_TRUE(handler.register_event_handler(
+        first_raw,
+        [&](fd_event_handler::event_list const&) {
+            ++first_calls;
+            first.read();
+            handler.unregister_event_handler(second_raw);
+        },
+        poll_events::read));
+    ASSERT_TRUE(handler.register_event_handler(
+        second_raw,
+        [&](fd_event_handler::event_list const&) {
+            ++second_calls;
+            second.read();
+            handler.unregister_event_handler(first_raw);
+        },
+        poll_events::read));
+    ASSERT_TRUE(handler.register_event_handler(
+        idle.get_raw_fd(), [](fd_event_handler::event_list const&) {}, poll_events::read));
+
+    first.notify();
+    second.notify();
+
+    EXPECT_NO_THROW(handler.poll(100ms));
+
+    // Batch order is unspecified, so whichever handler runs first unregisters the other.
+    EXPECT_EQ(first_calls + second_calls, 1);
+}
+
+// Unregistering the running descriptor destroys the std::function the dispatch loop is executing.
+TEST(fd_event_handler_test, callback_may_unregister_its_own_fd) {
+    fd_event_handler handler;
+
+    event_fd self;
+    auto const raw = self.get_raw_fd();
+
+    int calls = 0;
+    closure_lifetime order;
+
+    ASSERT_TRUE(handler.register_event_handler(
+        raw,
+        [&, probe = destruction_probe(order)](fd_event_handler::event_list const&) {
+            completion_marker done{order};
+            order.running = &probe;
+            ++calls;
+            self.read();
+            handler.unregister_event_handler(raw);
+        },
+        poll_events::read));
+
+    self.notify();
+
+    EXPECT_NO_THROW(handler.poll(100ms));
+
+    EXPECT_EQ(calls, 1);
+    EXPECT_FALSE(handler.is_registered(raw));
+
+    ASSERT_NE(order.callback_finished, -1);
+    ASSERT_NE(order.closure_destroyed, -1);
+    EXPECT_LT(order.callback_finished, order.closure_destroyed);
+}
+
+TEST(fd_event_handler_test, sync_client_outliving_its_handler_is_inert) {
+    fd_event_handler unrelated;
+    minimal_sync_client client;
+
+    {
+        fd_event_handler handler;
+        ASSERT_TRUE(handler.register_event_handler(&client));
+        ASSERT_TRUE(handler.is_registered(client.get_poll_fd()));
+    }
+
+    EXPECT_FALSE(client.unregister_events(unrelated));
+    EXPECT_FALSE(unrelated.is_registered(client.get_poll_fd()));
+
+    EXPECT_TRUE(unrelated.register_event_handler(&client));
+    EXPECT_TRUE(unrelated.is_registered(client.get_poll_fd()));
+}
+
+TEST(fd_event_handler_test, either_destruction_order_of_handler_and_client_is_safe) {
+    {
+        minimal_sync_client client;
+        fd_event_handler handler;
+        ASSERT_TRUE(handler.register_event_handler(&client));
+        ASSERT_TRUE(handler.is_registered(client.get_poll_fd()));
+    }
+
+    {
+        fd_event_handler handler;
+        int raw = -1;
+        {
+            minimal_sync_client client;
+            raw = client.get_poll_fd();
+            ASSERT_TRUE(handler.register_event_handler(&client));
+            ASSERT_TRUE(handler.is_registered(raw));
+        }
+        EXPECT_FALSE(handler.is_registered(raw));
+    }
+}
+
+TEST(fd_event_handler_test, sync_client_can_register_again_after_unregistering) {
+    fd_event_handler handler;
+    minimal_sync_client client;
+    auto const raw = client.get_poll_fd();
+
+    ASSERT_TRUE(handler.register_event_handler(&client));
+    ASSERT_TRUE(handler.is_registered(raw));
+
+    ASSERT_TRUE(handler.unregister_event_handler(&client));
+    ASSERT_FALSE(handler.is_registered(raw));
+
+    ASSERT_TRUE(handler.register_event_handler(&client));
+    EXPECT_TRUE(handler.is_registered(raw));
+
+    EXPECT_TRUE(handler.unregister_event_handler(&client));
+    EXPECT_FALSE(handler.is_registered(raw));
+}
+
+TEST(fd_event_handler_test, register_events_refuses_a_second_registration) {
+    fd_event_handler first;
+    fd_event_handler second;
+    minimal_sync_client client;
+    auto const raw = client.get_poll_fd();
+
+    ASSERT_TRUE(first.register_event_handler(&client));
+
+    EXPECT_FALSE(first.register_event_handler(&client));
+    EXPECT_FALSE(second.register_event_handler(&client));
+    EXPECT_FALSE(second.is_registered(raw));
+    EXPECT_TRUE(first.is_registered(raw));
+}
+
+TEST(fd_event_handler_test, handler_self_registration_survives_destruction) {
+    {
+        fd_event_handler handler;
+        handler.add_action([]() {});
+        EXPECT_TRUE(handler.poll(100ms));
+        handler.run_actions();
+    }
+
+    // A fresh handler recycles the descriptor numbers of the destroyed one and must start empty.
+    fd_event_handler reused;
+    EXPECT_FALSE(reused.poll(100ms));
+}
+
+TEST(fd_event_handler_test, timer_and_event_cannot_be_copied_or_moved) {
+    EXPECT_FALSE(std::is_copy_constructible_v<timer_fd>);
+    EXPECT_FALSE(std::is_copy_assignable_v<timer_fd>);
+    EXPECT_FALSE(std::is_move_constructible_v<timer_fd>);
+    EXPECT_FALSE(std::is_move_assignable_v<timer_fd>);
+
+    EXPECT_FALSE(std::is_copy_constructible_v<event_fd>);
+    EXPECT_FALSE(std::is_copy_assignable_v<event_fd>);
+    EXPECT_FALSE(std::is_move_constructible_v<event_fd>);
+    EXPECT_FALSE(std::is_move_assignable_v<event_fd>);
+}
+
+TEST(fd_event_handler_test, registered_timer_fires_and_is_acknowledged) {
+    fd_event_handler handler;
+    timer_fd timer;
+
+    int calls = 0;
+    ASSERT_TRUE(handler.register_event_handler(&timer, [&]() { ++calls; }));
+
+    timer.set_single_shot(true);
+    ASSERT_TRUE(timer.set_timeout_ms(1));
+
+    EXPECT_TRUE(handler.poll(100ms));
+    EXPECT_EQ(calls, 1);
+
+    EXPECT_FALSE(handler.poll(100ms));
+}
+
+TEST(fd_event_handler_test, destroying_registered_timer_drops_its_map_entry) {
+    fd_event_handler handler;
+    int raw = -1;
+
+    {
+        timer_fd timer;
+        raw = timer.get_raw_fd();
+        ASSERT_NE(raw, -1);
+        ASSERT_TRUE(handler.register_event_handler(&timer, []() {}));
+        ASSERT_TRUE(handler.is_registered(raw));
+    }
+
+    EXPECT_FALSE(handler.is_registered(raw));
+}
+
+TEST(fd_event_handler_test, timer_outliving_its_handler_is_inert) {
+    fd_event_handler unrelated;
+    timer_fd timer;
+    auto const raw = timer.get_raw_fd();
+
+    {
+        fd_event_handler handler;
+        ASSERT_TRUE(handler.register_event_handler(&timer, []() {}));
+        ASSERT_TRUE(handler.is_registered(raw));
+    }
+
+    EXPECT_FALSE(unrelated.unregister_event_handler(&timer));
+    EXPECT_FALSE(unrelated.is_registered(raw));
+
+    EXPECT_TRUE(unrelated.register_event_handler(&timer, []() {}));
+    EXPECT_TRUE(unrelated.is_registered(raw));
+}
+
+// Behavior change: one descriptor in two epoll sets used to be legal, the second is now refused.
+TEST(fd_event_handler_test, register_event_handler_refuses_a_second_timer_registration) {
+    fd_event_handler first;
+    fd_event_handler second;
+    timer_fd timer;
+    auto const raw = timer.get_raw_fd();
+
+    ASSERT_TRUE(first.register_event_handler(&timer, []() {}));
+
+    EXPECT_FALSE(second.register_event_handler(&timer, []() {}));
+    EXPECT_FALSE(second.is_registered(raw));
+    EXPECT_TRUE(first.is_registered(raw));
+
+    // Twice on the same handler was already refused by the descriptor guard.
+    EXPECT_FALSE(first.register_event_handler(&timer, []() {}));
+    EXPECT_TRUE(first.is_registered(raw));
+}
+
+TEST(fd_event_handler_test, timer_can_register_again_after_unregistering) {
+    fd_event_handler handler;
+    timer_fd timer;
+    auto const raw = timer.get_raw_fd();
+
+    ASSERT_TRUE(handler.register_event_handler(&timer, []() {}));
+    ASSERT_TRUE(handler.unregister_event_handler(&timer));
+    ASSERT_FALSE(handler.is_registered(raw));
+
+    ASSERT_TRUE(handler.register_event_handler(&timer, []() {}));
+    EXPECT_TRUE(handler.is_registered(raw));
+
+    EXPECT_TRUE(handler.unregister_event_handler(&timer));
+    EXPECT_FALSE(handler.is_registered(raw));
+
+    EXPECT_FALSE(handler.unregister_event_handler(&timer));
+}
+
+// event_fd records nothing, so this pins the descriptor guard alone.
+TEST(fd_event_handler_test, registering_again_after_removal_by_descriptor_succeeds) {
+    fd_event_handler handler;
+    event_fd event;
+    auto const raw = event.get_raw_fd();
+
+    ASSERT_TRUE(handler.register_event_handler(&event, []() {}));
+    ASSERT_TRUE(handler.unregister_event_handler(raw));
+    ASSERT_FALSE(handler.is_registered(raw));
+
+    EXPECT_TRUE(handler.register_event_handler(&event, []() {}));
+    EXPECT_TRUE(handler.is_registered(raw));
+}
+
+// A record is honored only while the handler's map still holds the recorded descriptor.
+TEST(fd_event_handler_test, registering_a_timer_again_after_removal_by_descriptor_succeeds) {
+    fd_event_handler handler;
+    timer_fd timer;
+    auto const raw = timer.get_raw_fd();
+
+    ASSERT_TRUE(handler.register_event_handler(&timer, []() {}));
+    ASSERT_TRUE(handler.remove_event_handler(raw));
+    ASSERT_FALSE(handler.is_registered(raw));
+
+    EXPECT_TRUE(handler.register_event_handler(&timer, []() {}));
+    EXPECT_TRUE(handler.is_registered(raw));
+}
+
+TEST(fd_event_handler_test, registering_a_sync_client_again_after_removal_by_descriptor_succeeds) {
+    fd_event_handler handler;
+    minimal_sync_client client;
+    auto const raw = client.get_poll_fd();
+
+    ASSERT_TRUE(handler.register_event_handler(&client));
+    ASSERT_TRUE(handler.remove_event_handler(raw));
+    ASSERT_FALSE(handler.is_registered(raw));
+
+    EXPECT_TRUE(handler.register_event_handler(&client));
+    EXPECT_TRUE(handler.is_registered(raw));
+}
+
+TEST(fd_event_handler_test, unregistering_a_timer_from_another_handler_reports_false) {
+    fd_event_handler owner;
+    fd_event_handler other;
+    timer_fd timer;
+    auto const raw = timer.get_raw_fd();
+
+    ASSERT_TRUE(owner.register_event_handler(&timer, []() {}));
+
+    EXPECT_FALSE(other.unregister_event_handler(&timer));
+    EXPECT_TRUE(owner.is_registered(raw));
+
+    EXPECT_TRUE(owner.unregister_event_handler(&timer));
+    EXPECT_FALSE(owner.is_registered(raw));
+}

--- a/modules/EnergyManagement/EEBUS/EebusConnectionHandler.cpp
+++ b/modules/EnergyManagement/EEBUS/EebusConnectionHandler.cpp
@@ -29,6 +29,7 @@ int EebusConnectionHandler::get_poll_fd() {
 }
 
 EebusConnectionHandler::~EebusConnectionHandler() {
+    unregister_recorded_events();
     stop();
 }
 


### PR DESCRIPTION
## Describe your changes

`fd_event_handler`'s registration calls could report success after `epoll_ctl` had failed, so a
caller had no way to tell a live registration from a dead one. This makes those results honest and
gives `fd_event_sync_interface` ownership of the registration it creates.

- **Truthful results.** `register_event_handler` and `unregister_event_handler` now report the
  `epoll_ctl` outcome, not just whether the bookkeeping succeeded. Call sites that already checked
  start seeing real failures, which is the point. `pionix_chargebridge` is the one that checks, so
  wiring mistakes that used to pass silently now surface at startup.
- **`is_registered(fd)`** is added, because a bool return cannot answer whether a descriptor is still
  in the handler.
- **The interface drops its own registration.** An implementor destroyed while still registered left
  its entry in the map. The stale callback cannot fire for the nested-handler case (destruction
  closes the nested epoll descriptor and the kernel drops it), so this is a leak rather than a use
  after free. The real failure is descriptor recycling: a later registration that receives the same
  number is rejected because the map still holds the old entry, failing far from its cause. The
  interface now records the handler and descriptor and unregisters in its own destructor, using the
  recorded number rather than calling the pure-virtual `get_poll_fd()` on an object being destroyed.
  Copy and move are deleted, since a recorded registration has exactly one owner.
- **`register_events` and `unregister_events` are no longer virtual.** Nothing overrides them, and an
  override that skipped the recording would leave the handler calling `sync()` on a destroyed object,
  a use after free rather than a leak. Consumers needing a different registration shape (several
  descriptors, write events) implement `fd_event_register_interface`, whose equivalents stay pure
  virtual.
- **Lifetime documentation corrected.** It claimed the outer handler must outlive the client. It need
  not: the record holds a `std::weak_ptr`, so the destructor skips its unregister step once the
  handler is gone, and both destruction orders are covered by tests. The constraint that does hold is
  now stated instead: while the handler is alive that step removes the client's entry from the
  handler's map, so the client must be destroyed on the handler's thread.

## Issue ticket number and link

N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

---

### Stack

Six PR series, two rooted on `main`. (#2558 and #2559 have merged.)

This PR is rooted on `main` and is blocked by nothing.

- `main`
  - #2560 `fix/io-connect-errno-and-backoff`
  - **#2561 `fix/io-event-handler-truthfulness` (this PR)**
    - #2562 `feat/io-client-tx-tristate`
      - #2563 `feat/io-fd-event-client-handshake-phase`
        - #2564 `feat/io-tls-policies-rebuilt`
      - #2565 `refactor/chargebridge-drop-hand-rolled-tx-gates`
