### PR TITLE
feat(io): tri-state connection state and bounded tx buffer

### DIFF
--- a/lib/everest/io/README.md
+++ b/lib/everest/io/README.md
@@ -11,3 +11,37 @@ Currently there are clients for
  - TAP
 
 The clients are single threaded and epoll based. Utilities for file descriptor based event handling are provided and used.
+
+## Client tx contract
+
+`fd_event_client::tx()` returns a `bool` and every call site should check it. It rejects once the
+connection has failed, and once `max_buffered_tx_payloads` are already queued, which a peer that
+stops reading reaches on its own. A rejection on a live connection is backpressure, not a failure:
+the connection stays up and everything already accepted is still delivered in order.
+
+Payloads written before the connection is up are **discarded by default**. Holding one across a
+connect replays it onto a connection it was not written for, which delivers a stale value for the
+periodic setpoints and stateful line protocols most consumers carry.
+
+A consumer whose payload survives the delay asks for the buffer, per policy or per instance:
+
+```cpp
+// Per policy: every client built on it buffers unless told otherwise.
+struct my_socket {
+    static constexpr bool buffer_tx_before_connect{true};
+    // ...
+};
+
+// Per instance, overriding the policy default in either direction.
+tcp::tcp_client client(utilities::tx_buffering::buffer, host, port, timeout_ms);
+```
+
+Only a policy that connects asynchronously has a pre-connect window. Asking a synchronous policy to
+buffer is accepted and does nothing.
+
+`reset()` clears the buffer in both modes, so a `true` from `tx()` after a reset always means
+buffered for the connection the reset opens. `reset()` also moves the connection state at call
+time: `on_error()` reports `true` from the call until the reopen.
+
+`tx()` and `reset()` are loop-thread only: call them from the thread that drives `sync()`, or from
+a callback that thread dispatches.

--- a/lib/everest/io/include/everest/io/event/fd_event_client.hpp
+++ b/lib/everest/io/include/everest/io/event/fd_event_client.hpp
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <everest/io/event/event_fd.hpp>
 #include <everest/io/event/fd_event_sync_interface.hpp>
@@ -123,7 +124,25 @@ public:
 
     /**
      * @brief Register an error handler
-     * @details The error handler is called when an error occurs or is cleared
+     * @details The handler is called with the failing errno when a connection attempt or an
+     * established connection fails, and with code 0 exactly once per successful (re)connect.
+     * Code 0 is an up-edge on the connection rather than the clearing of an error the caller
+     * has necessarily seen: a first connect and a reset that never reported a failure both
+     * report it. A read or a write that succeeds while the connection is already up reports
+     * nothing, so ordinary traffic adds no up-edge. A consumer that only wants failures filters
+     * on a nonzero code.
+     *
+     * A nonzero code tears the device down and does not open it again. A consumer that does not
+     * call reset() from this handler is left with a client that has no device.
+     *
+     * One gap the handler cannot be relied on to close: a read or a write that succeeds while the
+     * client is in \ref utilities::connection_state::failed puts the state back to connected and
+     * arms another code 0. Where in the poll pass that success lands decides what the caller sees.
+     * Before this handler observes the failure, the failure is never reported at all. After it,
+     * the teardown it queued still runs while the state has already flipped back, which ends with
+     * the device gone, no reopen, a last signal of code 0, and tx() still accepting into a buffer
+     * nothing drains. A code 0 is therefore a report that a connection came up, not proof that
+     * the client has one.
      * @param[in] handler The callback to be used as error handler
      */
     void set_error_handler(cb_error const& handler);
@@ -282,14 +301,41 @@ public:
     using ClientPayloadT = typename ClientPolicy::PayloadT;
 
     /**
+     * @var max_buffered_tx_payloads
+     * @brief Upper bound of payloads held in the tx buffer.
+     * @details \ref tx rejects once the buffer holds this many payloads. The bound counts
+     * payloads, not bytes, so the memory ceiling is this many times the size of a payload the
+     * caller writes.
+     * For the socket policies, whose \p PayloadT is a `std::vector<std::uint8_t>`, that size is
+     * whatever the caller passes.
+     */
+    static constexpr std::size_t max_buffered_tx_payloads{1024};
+
+    /**
      * @brief Construction of the generic event handler
-     * @details All parameters will be forwarded to the open(...) function of the \p ClientPolicy
+     * @details All parameters will be forwarded to the open(...) function of the \p ClientPolicy.
+     * Pre-connect tx buffering follows \ref utilities::policy_buffers_tx_before_connect.
      */
     template <class... ArgsT>
-    generic_fd_event_client(ArgsT... args) :
+    generic_fd_event_client(ArgsT... args) : generic_fd_event_client(policy_default_tx_buffering, args...) {
+    }
+
+    /**
+     * @brief Construction of the generic event handler, selecting pre-connect tx buffering
+     * @details All parameters following \p mode will be forwarded to the open(...) function of the
+     * \p ClientPolicy. \p mode overrides the policy default in both directions, see \ref tx.
+     * @param[in] mode Whether \ref tx accepts before the connection is up.
+     */
+    template <class... ArgsT>
+    generic_fd_event_client(utilities::tx_buffering mode, ArgsT... args) :
         generic_fd_event_client_impl([this]() { return send_one(); }, [this]() { return receive_one(); },
                                      [this]() { return reset_client(); },
-                                     [this]() { return m_handle ? m_handle->get_error() : 0; }) {
+                                     // A retired handle carries the errno of the peer it served,
+                                     // which is not the errno of the connection replacing it. The
+                                     // EPOLLERR branch reads this without knowing which handle is
+                                     // behind it.
+                                     [this]() { return handle_is_current() ? m_handle->get_error() : 0; }) {
+        m_buffer_tx_before_connect = mode == utilities::tx_buffering::buffer;
         m_async_connect_state = std::make_shared<async_connect_state>();
         register_async_connect_event_handler(&m_async_connect_state->ready_event,
                                              [this]() { process_async_connect_results(); });
@@ -312,12 +358,22 @@ public:
     /**
      * @brief Send data
      * @details This buffers the incoming data and notifies. It will be send as soon as the file descriptor
-     * is ready for transmission (POLLOUT / EPOLLOUT)
+     * is ready for transmission (POLLOUT / EPOLLOUT). Buffering before the connection is up is opt in,
+     * see \ref utilities::tx_buffering. Must be called from the thread that drives \ref sync: the
+     * buffer is not synchronized.
      * @param[in] payload The data to be transmitted.
-     * @return False if client is \ref on_error. False otherwise
+     * @return True if the payload was buffered. False if the buffer already holds
+     * \ref max_buffered_tx_payloads payloads, if the client is in
+     * \ref utilities::connection_state::failed, or if it is in
+     * \ref utilities::connection_state::fresh without \ref utilities::tx_buffering::buffer. A
+     * \p ClientPolicy that connects synchronously has no pre-connect window and rejects in
+     * \ref utilities::connection_state::fresh whatever the mode.
      */
     bool tx(ClientPayloadT const& payload) override {
-        if (on_error()) {
+        if (not connection_accepts_tx()) {
+            return false;
+        }
+        if (m_tx_buffer.size() >= max_buffered_tx_payloads) {
             return false;
         }
         m_tx_buffer.emplace(payload);
@@ -329,12 +385,41 @@ public:
      * @brief Reset the client.
      * @details Use this function to reset the client if on error or any other reason.
      * This destructs the client as defined by \p ClientPolicy and opens it again.
-     * @return True if the client could be successfully created. False otherwise
+     * The connection state moves to \ref utilities::connection_state::fresh and the payloads
+     * buffered for the previous peer are dropped before this returns. Tearing the device down and
+     * opening it again runs as a queued action, and \ref sync polls before it runs its actions:
+     * at the end of the current \ref sync when reset is called from a callback that sync
+     * dispatches, on the next one otherwise.
+     *
+     * A \ref tx in that window follows the mode, see \ref utilities::tx_buffering: a client that
+     * buffers accepts for the connection this reset opens, one that does not rejects until the
+     * reopen has completed. The buffer is cleared in either mode, so a true from \ref tx after
+     * this returns always means buffered for the connection this reset opens.
+     *
+     * The drop is silent: up to \ref max_buffered_tx_payloads payloads that \ref tx accepted are
+     * destroyed here without a count, a callback or a log entry.
+     *
+     * Unread data on the retired connection is lost with it, because tearing the device down
+     * closes its descriptor. A read this poll pass had already queued against the retired handle
+     * is skipped rather than presented as data from the connection this reset opens.
+     *
+     * Shares the threading contract of \ref tx. Must be called from the thread that drives
+     * \ref sync, either directly or from a callback that thread dispatches.
+     * @return Always true. A failed reopen is reported through the error handler, except when the
+     * policy throws while being constructed or opened: the action queue swallows that exception,
+     * so nothing is reported. Constructing it throwing leaves the client without a device; opening
+     * it throwing can leave the handle in place. What is missing either way is
+     * \ref prepare_io_event_handler, so nothing observes the connection and the client never comes
+     * up again.
      */
     bool reset() {
-        auto generation = ++m_connect_generation;
-        set_connected_generation(generation);
-        add_action([this]() { reset_impl(); });
+        // A payload written for the previous peer is stale once another one is opened.
+        m_tx_buffer = {};
+        // Another device is on its way, so the state of the previous connection may not be read
+        // as the state of the new one. Flipping it here rather than in the queued action is what
+        // makes the tx below land in the window this reset opens.
+        reset_connection_state();
+        schedule_reset();
         return true;
     }
 
@@ -357,6 +442,20 @@ public:
     }
 
 private:
+    static constexpr utilities::tx_buffering policy_default_tx_buffering{
+        utilities::policy_buffers_tx_before_connect_v<ClientPolicy> ? utilities::tx_buffering::buffer
+                                                                    : utilities::tx_buffering::discard};
+
+    bool connection_accepts_tx() const {
+        auto const state = current_connection_state();
+        if constexpr (utilities::event_client_async_policy_v<ClientPolicy>) {
+            if (m_buffer_tx_before_connect) {
+                return state != utilities::connection_state::failed;
+            }
+        }
+        return state == utilities::connection_state::connected;
+    }
+
     template <class T, class... ArgsT> std::enable_if_t<utilities::event_client_async_policy_v<T>> init(ArgsT... args) {
         m_open_device = [this, args...]() {
             auto setup_ok = m_handle->setup(args...);
@@ -393,7 +492,9 @@ private:
                 on_client_ready(generation, false, -1);
             }
         };
-        reset();
+        // The initial open has no previous peer, so a payload buffered before this action runs
+        // belongs to the connection it opens.
+        schedule_reset();
     }
 
     template <class T, class... ArgsT>
@@ -406,15 +507,42 @@ private:
         reset_impl();
     }
 
+    void schedule_reset() {
+        auto generation = ++m_connect_generation;
+        set_connected_generation(generation);
+        add_action([this]() { reset_impl(); });
+    }
+
     void reset_impl() {
+        // reset already flipped the state, but an event dispatched since may have moved it back
+        // to connected, which the device opened below has not earned yet.
+        reset_connection_state();
         reset_client();
         setup_error_event_handler();
         init_device();
-        m_tx_buffer = {};
         prepare_io_event_handler();
+        if (not m_tx_buffer.empty()) {
+            // reset_client unregistered the notification, so a payload buffered before it ran has
+            // no pending write event left to arm the new connection with.
+            m_io_event_fd.notify();
+        }
+    }
+
+    // Whether m_handle is the connection the client currently stands for. Generations are bumped
+    // whenever a connection is retired, so a handle that outlives its own generation is the old
+    // peer even while it is still open and still registered. The connection state cannot answer
+    // this: without the guards below a successful read would report code 0 and put a retired
+    // connection back to connected.
+    bool handle_is_current() const {
+        return m_handle != nullptr and m_handle_generation == m_connect_generation.load();
     }
 
     action_status send_one() {
+        // The previous handle stays live and registered for writing until reset_impl runs, so a
+        // buffer filled for the next connection may only be written once that one is up.
+        if (not handle_is_current() or current_connection_state() != utilities::connection_state::connected) {
+            return action_status::empty;
+        }
         if (m_tx_buffer.empty()) {
             return action_status::empty;
         }
@@ -428,12 +556,24 @@ private:
     }
 
     action_status receive_one() {
+        // A reset dispatched earlier in this poll pass has already retired the handle below, so
+        // reading it would hand the consumer one more payload from the peer that reset abandoned.
+        // The read is skipped and that payload is lost with the connection, which is intended:
+        // data from a peer the client has abandoned must not be presented as data from its
+        // replacement.
+        if (not handle_is_current()) {
+            return action_status::empty;
+        }
         auto status = m_handle->rx(m_data);
+        auto result = action_status::fail;
         if (status and m_rx) {
             m_rx(m_data, *this);
-            return action_status::success;
+            result = action_status::success;
         }
-        return action_status::fail;
+        // The callback above may have retired this connection. The read itself was completed and
+        // handed up; what is dropped is its status, which says nothing about the connection
+        // replacing this one.
+        return handle_is_current() ? result : action_status::empty;
     }
 
     action_status reset_client() {
@@ -481,6 +621,7 @@ private:
     }
 
     bool init_device() {
+        m_handle_generation = m_connect_generation.load();
         m_handle = std::make_unique<ClientPolicy>();
         m_open_device();
         return true;
@@ -505,7 +646,12 @@ private:
     std::function<void()> m_open_device;
     std::queue<ClientPayloadT> m_tx_buffer;
     ClientPayloadT m_data;
+    bool m_buffer_tx_before_connect{false};
     std::atomic_uint64_t m_connect_generation{0};
+    // The generation m_handle was opened for. Written and read on the thread that drives sync
+    // only, so it needs no synchronization of its own. Generations start at 1, so the initial
+    // value matches no handle.
+    std::uint64_t m_handle_generation{0};
 };
 
 /**
@@ -521,6 +667,10 @@ private:
  *   // callback = std::function<void(bool success, int filedescriptor)>
  *   using PayloadT = [type of data]  // the type of the payload
  *   ClientPolicy();                  // must be default contructiable
+ *   static constexpr bool buffer_tx_before_connect; // [optional] tx() holds payloads written before the
+ *                                    // connection is up instead of rejecting them. Absent means it does not.
+ *                                    // Read only for a policy that offers setup/connect. Overridable per
+ *                                    // instance, see utilities::tx_buffering
  *   bool open(ArgsT... args);        // Opens the device. Parameters given by fd_event_client's constructor.
  *                                    // Return true on success, false otherwise
  *   bool setup(ArgsT... args);       // [optional] Setup the device. Parameters given by fd_event_client's constructor.

--- a/lib/everest/io/include/everest/io/utilities/event_client_async_policy.hpp
+++ b/lib/everest/io/include/everest/io/utilities/event_client_async_policy.hpp
@@ -57,4 +57,56 @@ struct event_client_async_policy
  */
 template <typename T> inline constexpr bool event_client_async_policy_v = event_client_async_policy<T>::value;
 
+/**
+ * @brief Primary template for the trait to check for the existence of a member
+ * 'buffer_tx_before_connect'.
+ * @tparam T The type to check.
+ */
+template <typename T, typename V = void> struct has_member_buffer_tx_before_connect : std::false_type {};
+
+/**
+ * @brief Specialization of has_member_buffer_tx_before_connect.
+ * This checks for existence and accessibility of a static member 'buffer_tx_before_connect'.
+ * @tparam T The type to check.
+ */
+template <typename T>
+struct has_member_buffer_tx_before_connect<T, std::void_t<decltype(T::buffer_tx_before_connect)>> : std::true_type {};
+
+/**
+ * @brief Primary template for the trait carrying the tx buffering default a policy declares.
+ * A policy that declares no 'buffer_tx_before_connect' does not buffer, see \ref tx_buffering.
+ * @tparam T The type to check.
+ */
+template <typename T, typename V = void> struct policy_buffers_tx_before_connect : std::false_type {};
+
+/**
+ * @brief Specialization of policy_buffers_tx_before_connect for a policy that declares
+ * 'static constexpr bool buffer_tx_before_connect'. It carries the declared value.
+ * @tparam T The type to check.
+ */
+template <typename T>
+struct policy_buffers_tx_before_connect<T, std::enable_if_t<has_member_buffer_tx_before_connect<T>::value>>
+    : std::integral_constant<bool, T::buffer_tx_before_connect> {};
+
+/**
+ * @brief Convenience variable template for the policy_buffers_tx_before_connect trait's value.
+ * @tparam T The type to check.
+ */
+template <typename T>
+inline constexpr bool policy_buffers_tx_before_connect_v = policy_buffers_tx_before_connect<T>::value;
+
+/**
+ * @enum tx_buffering
+ * @brief Whether a client holds payloads written before its connection is up.
+ * @details Selected per instance at construction, defaulting to what the policy declares through
+ * \ref policy_buffers_tx_before_connect. Only a policy that connects asynchronously has a
+ * pre-connect window, see \ref event_client_async_policy.
+ */
+enum class tx_buffering {
+    /** Reject tx() until the connection is up. */
+    discard,
+    /** Accept while the connection is fresh, hold in the bounded buffer, deliver once it is up. */
+    buffer
+};
+
 } // namespace everest::lib::io::utilities

--- a/lib/everest/io/include/everest/io/utilities/generic_error_state.hpp
+++ b/lib/everest/io/include/everest/io/utilities/generic_error_state.hpp
@@ -11,6 +11,21 @@
 namespace everest::lib::io::utilities {
 
 /**
+ * @enum connection_state
+ * @brief The connection state of a client.
+ * @details Separates a client that has not completed a connection attempt yet from one whose
+ * connection attempt failed. \ref generic_error_state::on_error covers both as "not up".
+ */
+enum class connection_state {
+    /** No connection attempt has completed since the device was last opened */
+    fresh,
+    /** Connected and usable */
+    connected,
+    /** A connection attempt or an established connection failed */
+    failed
+};
+
+/**
  * This class bundles some handling logic for <a href="https://man7.org/linux/man-pages/man3/errno.3.html">errno</a>.
  * <br> Its main purpose is the factor out functionality from \ref event::generic_fd_event_client_impl
  */
@@ -27,26 +42,58 @@ public:
 protected:
     /**
      * @brief Update the error state
-     * @details Compares with internal error state and update it.
+     * @details Compares with internal error state and update it. A nonzero code moves the
+     * connection state to \ref connection_state::failed, a zero code to
+     * \ref connection_state::connected. Only \ref reset_connection_state returns to
+     * \ref connection_state::fresh.
+     *
+     * A zero code arriving in any state other than \ref connection_state::connected is an
+     * up-edge on the connection and arms \ref clear_error_pending. Because
+     * \ref connection_state::fresh counts as an up-edge just like
+     * \ref connection_state::failed, a connection that never reported a failure still signals
+     * the one it establishes. Every other call clears \ref clear_error_pending: a nonzero code
+     * because there is no up-edge to report, a zero code in \ref connection_state::connected
+     * because the connection was already up.
      * @param[in] error_code The error state to be set
      * @return False if error status is set, True otherwise
      */
     bool set_error_status(int error_code);
 
     /**
-     * @brief Check if error handling is still needed.
-     * @return True if there is an uncleared error, false otherwise
+     * @brief Check whether a connection up-edge is waiting to be reported.
+     * @details \ref set_error_status rewrites this on every call: a zero code arriving in a state
+     * other than \ref connection_state::connected arms it, every other combination clears it.
+     * \ref clear_error_handler and \ref set_error_cleared clear it as well. Reporting an up-edge
+     * exactly once per successful connect is gated on this.
+     * @return True if an up-edge is pending, false otherwise
      */
     bool clear_error_pending() const;
 
     /**
      * @brief Check the error state
-     * @return True if on error, false otherwise
+     * @details Covers \ref connection_state::fresh and \ref connection_state::failed alike.
+     * @return True if not up, false otherwise
      */
     bool on_error() const;
 
     /**
+     * @brief Check the connection state
+     * @return \ref connection_state::fresh, \ref connection_state::connected or \ref connection_state::failed
+     */
+    connection_state current_connection_state() const;
+
+    /**
+     * @brief Return the connection state to \ref connection_state::fresh
+     * @details To be called when the device is opened again, so a state left over from a previous
+     * connection is not read as the state of the new one. Leaves the current error code untouched,
+     * which is safe because the code is only meaningful in \ref connection_state::failed.
+     */
+    void reset_connection_state();
+
+    /**
      * @brief Get the current error code
+     * @details Only meaningful in \ref connection_state::failed. In
+     * \ref connection_state::fresh the code left over from an earlier connection is still there.
      * @return Current error code
      */
     int current_error() const;
@@ -58,18 +105,21 @@ protected:
     void call_error_handler(cb_error& handler) const;
 
     /**
-     * @brief Call the error handler with errno=0 (success)
+     * @brief Report a connection up-edge by calling the handler with errno=0 (success)
+     * @details Code 0 means the connection is established, not only that a previously reported
+     * error is gone. Disarms \ref clear_error_pending, so an up-edge is reported once per
+     * successful connect.
      * @param[in] handler The handler to be called
      */
     void clear_error_handler(cb_error& handler);
 
     /**
-     * @brief Mark the current error as cleared
+     * @brief Disarm the pending connection up-edge without reporting it
      */
     void set_error_cleared();
 
 private:
-    bool m_on_error{true};
+    connection_state m_connection_state{connection_state::fresh};
     bool m_clear_error_pending{false};
     int m_current_error{0};
 };

--- a/lib/everest/io/src/event/fd_event_client.cpp
+++ b/lib/everest/io/src/event/fd_event_client.cpp
@@ -36,11 +36,15 @@ sync_status generic_fd_event_client_impl::sync_impl(int timeout_ms) {
 
 bool generic_fd_event_client_impl::setup_error_event_handler() {
     return m_event_handler->register_event_handler(&m_error_status_event_fd, [this](auto) {
-        if (on_error()) {
+        // A fresh client has no failure to report and no error to clear, so it stays inert here.
+        // Tearing it down would be unpaired: error_handler does not reopen the device.
+        auto const state = current_connection_state();
+        if (state == utilities::connection_state::failed) {
             error_handler();
             call_error_handler(m_error);
             return sync_status::error;
-        } else if (clear_error_pending()) {
+        }
+        if (state == utilities::connection_state::connected and clear_error_pending()) {
             clear_error_handler(m_error);
         }
         return sync_status::ok;
@@ -92,6 +96,12 @@ bool generic_fd_event_client_impl::set_error_status_and_notify(int error_code) {
 
 bool generic_fd_event_client_impl::rx_handler() {
     auto status = m_receive_one();
+    if (status == action_status::empty) {
+        // The read belongs to a connection that has been retired. Reporting a result on it would
+        // put the state back to connected, or its errno to failed, for the connection replacing
+        // it. Returning false also keeps the write branch of this dispatch shut.
+        return false;
+    }
     auto error_code = status == action_status::success ? 0 : m_get_error();
     auto result = set_error_status_and_notify(error_code);
     return result;

--- a/lib/everest/io/src/utilities/generic_error_state.cpp
+++ b/lib/everest/io/src/utilities/generic_error_state.cpp
@@ -7,10 +7,13 @@ namespace everest::lib::io::utilities {
 
 bool generic_error_state::set_error_status(int error_code) {
     m_current_error = error_code;
-    auto on_error = error_code != 0;
-    m_clear_error_pending = (not on_error) and m_on_error;
-    m_on_error = on_error;
-    return not m_on_error;
+    auto const failed = error_code != 0;
+    // The up-edge, so it reads the previous state and has to be evaluated before the state is
+    // updated. on_error() covers fresh as well as failed, which is what makes a first connect
+    // report code 0 even though no error was ever seen.
+    m_clear_error_pending = (not failed) and on_error();
+    m_connection_state = failed ? connection_state::failed : connection_state::connected;
+    return not failed;
 }
 
 bool generic_error_state::clear_error_pending() const {
@@ -18,7 +21,15 @@ bool generic_error_state::clear_error_pending() const {
 }
 
 bool generic_error_state::on_error() const {
-    return m_on_error;
+    return m_connection_state != connection_state::connected;
+}
+
+connection_state generic_error_state::current_connection_state() const {
+    return m_connection_state;
+}
+
+void generic_error_state::reset_connection_state() {
+    m_connection_state = connection_state::fresh;
 }
 
 int generic_error_state::current_error() const {

--- a/lib/everest/io/test/fd_event_client_async_test.cpp
+++ b/lib/everest/io/test/fd_event_client_async_test.cpp
@@ -3,11 +3,24 @@
 
 #include <everest/io/event/event_fd.hpp>
 #include <everest/io/event/fd_event_client.hpp>
+#include <everest/io/tcp/tcp_client.hpp>
+#include <everest/io/udp/udp_client.hpp>
 #include <everest/io/utilities/event_client_async_policy.hpp>
+#include <everest/io/utilities/generic_error_state.hpp>
 
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <algorithm>
 #include <atomic>
+#include <cerrno>
 #include <chrono>
 #include <condition_variable>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <limits>
 #include <memory>
@@ -24,6 +37,7 @@ using namespace everest::lib::io;
 
 using everest::lib::io::event::event_fd;
 using everest::lib::io::event::fd_event_client;
+using everest::lib::io::event::semaphore_fd;
 using everest::lib::io::utilities::event_client_async_policy_v;
 
 namespace {
@@ -201,22 +215,83 @@ template <class Client> void pump_for(Client& client, std::chrono::milliseconds 
     }
 }
 
+// Stands for "written by a policy that has no connect attempt of its own".
+constexpr std::size_t no_attempt{std::numeric_limits<std::size_t>::max()};
+
+// Records what a policy actually handed to the wire, shared across the policy instances a
+// client creates on every reset.
+struct tx_record {
+    std::vector<int> values;
+    // The connect attempt the policy instance that wrote each value belongs to, so a payload can
+    // be attributed to a peer rather than only to the wire.
+    std::vector<std::size_t> attempts;
+
+    void add(int value, std::size_t attempt) {
+        values.push_back(value);
+        attempts.push_back(attempt);
+    }
+
+    std::vector<std::size_t> attempts_of(int value) const {
+        std::vector<std::size_t> result;
+        for (std::size_t i = 0; i < values.size(); ++i) {
+            if (values[i] == value) {
+                result.push_back(attempts[i]);
+            }
+        }
+        return result;
+    }
+};
+
+// A payload source the test makes readable on demand. The descriptor lives here rather than in
+// the policy, so it survives the policy instances a client replaces on every reset. A semaphore
+// descriptor keeps the counter equal to pending, so a read can never consume more than one push
+// and leave a later read blocking on an empty descriptor.
+struct rx_source {
+    semaphore_fd ready;
+    std::atomic<int> pending{0};
+    int value{0};
+
+    void push(int item) {
+        value = item;
+        ++pending;
+        ready.notify();
+    }
+
+    bool take(int& out) {
+        if (pending.load() <= 0) {
+            return false;
+        }
+        --pending;
+        ready.read();
+        out = value;
+        return true;
+    }
+};
+
 class deterministic_async_policy {
 public:
     using PayloadT = int;
+
+    // Stands in for a payload that survives a replay, so it asks for the pre-connect buffer.
+    static constexpr bool buffer_tx_before_connect{true};
 
     deterministic_async_policy() = default;
     explicit deterministic_async_policy(std::shared_ptr<async_connect_control> control) :
         m_control(std::move(control)) {
     }
     ~deterministic_async_policy() {
-        if (m_control and m_attempt != std::numeric_limits<std::size_t>::max()) {
+        if (m_control and m_attempt != no_attempt) {
             m_control->mark_policy_destroyed(m_attempt);
         }
     }
 
-    bool setup(std::shared_ptr<async_connect_control> control) {
+    // The source is optional. Without one the policy keeps its own descriptor, which never becomes
+    // readable, so a client built without a source behaves exactly as before.
+    bool setup(std::shared_ptr<async_connect_control> control, std::shared_ptr<tx_record> record = nullptr,
+               std::shared_ptr<rx_source> source = nullptr) {
         m_control = std::move(control);
+        m_tx_record = std::move(record);
+        m_source = std::move(source);
         return static_cast<bool>(m_control);
     }
 
@@ -232,12 +307,67 @@ public:
         m_attempt = attempt;
         m_last_error = m_control->error_code(attempt);
         m_control->wait_for_release(attempt);
-        cb(ok, ok ? m_ready_event.get_raw_fd() : -1);
+        cb(ok, ok ? get_fd() : -1);
         m_control->mark_completed(attempt);
     }
 
-    bool tx(PayloadT const&) {
-        return false;
+    bool tx(PayloadT const& payload) {
+        if (not m_tx_record) {
+            return false;
+        }
+        m_tx_record->add(payload, m_attempt);
+        return true;
+    }
+
+    bool rx(PayloadT& data) {
+        return m_source and m_source->take(data);
+    }
+
+    int get_fd() const {
+        return m_source ? m_source->ready.get_raw_fd() : m_ready_event.get_raw_fd();
+    }
+
+    int get_error() const {
+        return m_last_error;
+    }
+
+    // The connect attempt this instance belongs to. A client replaces the instance on every reset,
+    // so this is the identity of the peer a read was served from.
+    std::size_t attempt() const {
+        return m_attempt;
+    }
+
+private:
+    std::shared_ptr<async_connect_control> m_control;
+    std::shared_ptr<tx_record> m_tx_record;
+    std::shared_ptr<rx_source> m_source;
+    event_fd m_ready_event;
+    int m_last_error{0};
+    std::size_t m_attempt{no_attempt};
+};
+
+static_assert(event_client_async_policy_v<deterministic_async_policy>);
+
+// Stands in for the seven aliases that resolve open() synchronously and must keep rejecting
+// until they are up.
+class deterministic_sync_policy {
+public:
+    using PayloadT = int;
+
+    deterministic_sync_policy() = default;
+
+    bool open(std::shared_ptr<tx_record> record) {
+        m_tx_record = std::move(record);
+        return static_cast<bool>(m_tx_record);
+    }
+
+    bool tx(PayloadT const& payload) {
+        if (not m_tx_record) {
+            return false;
+        }
+        // A synchronous policy has no connect attempt to attribute the payload to.
+        m_tx_record->add(payload, no_attempt);
+        return true;
     }
 
     bool rx(PayloadT&) {
@@ -249,21 +379,228 @@ public:
     }
 
     int get_error() const {
-        return m_last_error;
+        return 0;
     }
 
 private:
-    std::shared_ptr<async_connect_control> m_control;
+    std::shared_ptr<tx_record> m_tx_record;
     event_fd m_ready_event;
-    int m_last_error{0};
-    std::size_t m_attempt{std::numeric_limits<std::size_t>::max()};
 };
 
-static_assert(event_client_async_policy_v<deterministic_async_policy>);
+static_assert(not event_client_async_policy_v<deterministic_sync_policy>);
+
+// Synchronous open() plus a working rx, so a reset can be queued in the same poll cycle as a
+// successful receive.
+class rx_capable_sync_policy {
+public:
+    using PayloadT = int;
+
+    rx_capable_sync_policy() = default;
+
+    bool open(std::shared_ptr<tx_record> record, std::shared_ptr<rx_source> source) {
+        m_tx_record = std::move(record);
+        m_source = std::move(source);
+        return static_cast<bool>(m_tx_record) and static_cast<bool>(m_source);
+    }
+
+    bool tx(PayloadT const& payload) {
+        if (not m_tx_record) {
+            return false;
+        }
+        // A synchronous policy has no connect attempt to attribute the payload to.
+        m_tx_record->add(payload, no_attempt);
+        return true;
+    }
+
+    bool rx(PayloadT& data) {
+        return m_source and m_source->take(data);
+    }
+
+    int get_fd() const {
+        return m_source ? m_source->ready.get_raw_fd() : -1;
+    }
+
+    int get_error() const {
+        return 0;
+    }
+
+private:
+    std::shared_ptr<tx_record> m_tx_record;
+    std::shared_ptr<rx_source> m_source;
+};
+
+static_assert(not event_client_async_policy_v<rx_capable_sync_policy>);
+
+// Steers a read that fails on a readable descriptor and the errno the policy then reports for it.
+struct rx_fault_plan {
+    bool rx_fails{false};
+    int error_code{0};
+};
+
+// Synchronous open() whose read can be made to fail while the descriptor is readable, with an
+// errno of the test's choosing. rx_capable_sync_policy cannot express this: its rx only fails on
+// an empty source and its get_error is hardwired to 0, so nothing there reaches the route that
+// turns a dead socket into a reported error.
+class faulting_rx_sync_policy {
+public:
+    using PayloadT = int;
+
+    faulting_rx_sync_policy() = default;
+
+    bool open(std::shared_ptr<rx_source> source, std::shared_ptr<rx_fault_plan> fault) {
+        m_source = std::move(source);
+        m_fault = std::move(fault);
+        return static_cast<bool>(m_source) and static_cast<bool>(m_fault);
+    }
+
+    bool tx(PayloadT const&) {
+        return true;
+    }
+
+    bool rx(PayloadT& data) {
+        int value{0};
+        if (not m_source or not m_source->take(value)) {
+            return false;
+        }
+        // The readiness is taken either way. A socket read that fails has consumed its event too,
+        // so leaving the descriptor readable would spin the poll loop instead.
+        if (m_fault and m_fault->rx_fails) {
+            return false;
+        }
+        data = value;
+        return true;
+    }
+
+    int get_fd() const {
+        return m_source ? m_source->ready.get_raw_fd() : -1;
+    }
+
+    int get_error() const {
+        return m_fault ? m_fault->error_code : 0;
+    }
+
+private:
+    std::shared_ptr<rx_source> m_source;
+    std::shared_ptr<rx_fault_plan> m_fault;
+};
+
+static_assert(not event_client_async_policy_v<faulting_rx_sync_policy>);
+
+// A loopback listener whose accept queue is full. Further connects stay unfinished instead of
+// being refused, and nothing is ever accepted.
+class unreachable_peer {
+public:
+    unreachable_peer() = default;
+    unreachable_peer(unreachable_peer const&) = delete;
+    unreachable_peer& operator=(unreachable_peer const&) = delete;
+
+    ~unreachable_peer() {
+        for (auto fd : m_pending) {
+            ::close(fd);
+        }
+        if (m_listen_fd >= 0) {
+            ::close(m_listen_fd);
+        }
+    }
+
+    bool start() {
+        m_listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+        if (m_listen_fd < 0) {
+            return false;
+        }
+        auto addr = loopback_address(0);
+        if (::bind(m_listen_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+            return false;
+        }
+        if (::listen(m_listen_fd, 1) != 0) {
+            return false;
+        }
+        socklen_t len = sizeof(addr);
+        if (::getsockname(m_listen_fd, reinterpret_cast<sockaddr*>(&addr), &len) != 0) {
+            return false;
+        }
+        m_port = ::ntohs(addr.sin_port);
+
+        for (std::size_t i = 0; i < backlog_fill; ++i) {
+            auto fd = connect_without_waiting();
+            if (fd < 0) {
+                return false;
+            }
+            m_pending.push_back(fd);
+        }
+        return is_saturated();
+    }
+
+    std::uint16_t port() const {
+        return m_port;
+    }
+
+private:
+    static constexpr std::size_t backlog_fill{32};
+    static constexpr int saturation_probe_ms{200};
+
+    static sockaddr_in loopback_address(std::uint16_t port) {
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = ::htonl(INADDR_LOOPBACK);
+        addr.sin_port = ::htons(port);
+        return addr;
+    }
+
+    int connect_without_waiting() const {
+        auto fd = ::socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+        if (fd < 0) {
+            return -1;
+        }
+        auto addr = loopback_address(m_port);
+        if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0 and errno != EINPROGRESS) {
+            ::close(fd);
+            return -1;
+        }
+        return fd;
+    }
+
+    // A saturated queue leaves a fresh connect unfinished for the whole probe window.
+    bool is_saturated() {
+        auto fd = connect_without_waiting();
+        if (fd < 0) {
+            return false;
+        }
+        m_pending.push_back(fd);
+        pollfd item{fd, POLLOUT, 0};
+        return ::poll(&item, 1, saturation_probe_ms) == 0;
+    }
+
+    int m_listen_fd{-1};
+    std::uint16_t m_port{0};
+    std::vector<int> m_pending;
+};
+
+class error_state_probe : public utilities::generic_error_state {
+public:
+    using generic_error_state::current_connection_state;
+    using generic_error_state::on_error;
+    using generic_error_state::set_error_status;
+};
+
+char const* state_name(utilities::connection_state state) {
+    switch (state) {
+    case utilities::connection_state::fresh:
+        return "fresh";
+    case utilities::connection_state::connected:
+        return "connected";
+    case utilities::connection_state::failed:
+        return "failed";
+    }
+    return "unknown";
+}
 
 } // namespace
 
 using deterministic_async_client = fd_event_client<deterministic_async_policy>::type;
+using deterministic_sync_client = fd_event_client<deterministic_sync_policy>::type;
+using rx_capable_sync_client = fd_event_client<rx_capable_sync_policy>::type;
+using faulting_rx_sync_client = fd_event_client<faulting_rx_sync_policy>::type;
 
 // Verify reset and sync do not block when an async connect callback is still
 // pending, protecting against deadlocks in the connect/reset path.
@@ -411,4 +748,732 @@ TEST(fd_event_client_async_test, stale_connected_notification_is_not_observed) {
     EXPECT_EQ(ready_calls.load(), 0);
 
     ASSERT_TRUE(control->wait_for_attempt_completed(1, 300ms));
+}
+
+// A client that has never connected must be distinguishable from one whose connection
+// failed. on_error() keeps covering both as "not up".
+TEST(connection_state_test, a_never_connected_state_is_fresh) {
+    error_state_probe state;
+
+    EXPECT_TRUE(state.on_error());
+    EXPECT_EQ(state.current_connection_state(), utilities::connection_state::fresh)
+        << "a state that never saw a connection attempt reports " << state_name(state.current_connection_state());
+}
+
+TEST(connection_state_test, a_clean_status_reports_connected) {
+    error_state_probe state;
+
+    state.set_error_status(0);
+
+    EXPECT_FALSE(state.on_error());
+    EXPECT_EQ(state.current_connection_state(), utilities::connection_state::connected)
+        << "a state with no pending error reports " << state_name(state.current_connection_state());
+}
+
+TEST(connection_state_test, an_error_status_reports_failed) {
+    error_state_probe state;
+
+    state.set_error_status(ECONNREFUSED);
+
+    EXPECT_TRUE(state.on_error());
+    EXPECT_EQ(state.current_connection_state(), utilities::connection_state::failed)
+        << "a state with a pending error reports " << state_name(state.current_connection_state());
+}
+
+// The live case behind the tri-state: the writer is ready while the async connect is still
+// in flight, so an early payload has to survive instead of being dropped without a
+// diagnostic.
+TEST(fd_event_client_tx_test, tx_while_the_connect_is_pending_is_buffered_and_delivered) {
+    auto control = std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{true, 0}});
+    auto record = std::make_shared<tx_record>();
+    deterministic_async_client client(control, record);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    ASSERT_TRUE(client.on_error()) << "the connect already resolved, so there is no pending window to test";
+
+    EXPECT_TRUE(client.tx(7)) << "a payload sent while the async connect was pending was rejected";
+    EXPECT_TRUE(record->values.empty()) << "a payload was written before the client was up";
+
+    control->release(0);
+    ASSERT_TRUE(control->wait_for_attempt_completed(0, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); }));
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return record->values == std::vector<int>{7}; }))
+        << "the buffered payload was not delivered after the connect completed, " << record->values.size()
+        << " payloads reached the wire";
+}
+
+// The window opens at construction, before the queued connect action has run at all.
+TEST(fd_event_client_tx_test, tx_before_the_first_sync_is_not_silently_dropped) {
+    auto control = std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{true, 0}});
+    auto record = std::make_shared<tx_record>();
+    deterministic_async_client client(control, record);
+
+    EXPECT_TRUE(client.tx(11)) << "a payload sent before the first sync was rejected";
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    control->release(0);
+    ASSERT_TRUE(control->wait_for_attempt_completed(0, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); }));
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return record->values == std::vector<int>{11}; }))
+        << "tx() reported success and the payload never reached the wire, " << record->values.size()
+        << " payloads delivered";
+}
+
+// A failed connect keeps rejecting: there is no peer to buffer for.
+TEST(fd_event_client_tx_test, tx_on_a_failed_client_is_rejected) {
+    auto control = std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{false, ECONNREFUSED}});
+    auto record = std::make_shared<tx_record>();
+    deterministic_async_client client(control, record);
+
+    std::atomic<int> error_calls{0};
+    client.set_error_handler([&](int code, std::string const&) {
+        if (code != 0) {
+            ++error_calls;
+        }
+    });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    control->release(0);
+    ASSERT_TRUE(control->wait_for_attempt_completed(0, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return error_calls.load() == 1; }));
+    ASSERT_TRUE(client.on_error());
+
+    EXPECT_FALSE(client.tx(13)) << "a payload was accepted after the connect failed";
+    EXPECT_TRUE(record->values.empty());
+
+    control->release_all();
+}
+
+// A reset returns the client to fresh, so the buffering window opens on every reconnect and not
+// only on the first attempt. Retrying against a peer that is not up yet is the normal startup
+// path, so a client stuck in failed drops every payload for the rest of its life.
+TEST(fd_event_client_tx_test, a_reset_after_a_failure_buffers_again) {
+    auto control =
+        std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{false, ECONNREFUSED}, {true, 0}});
+    auto record = std::make_shared<tx_record>();
+    deterministic_async_client client(control, record);
+
+    std::atomic<int> error_calls{0};
+    client.set_error_handler([&](int code, std::string const&) {
+        if (code != 0) {
+            ++error_calls;
+        }
+    });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    control->release(0);
+    ASSERT_TRUE(control->wait_for_attempt_completed(0, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return error_calls.load() == 1; }));
+    ASSERT_FALSE(client.tx(23)) << "the failed client accepted a payload, so the reset below proves nothing";
+
+    // Attempt 1 stays pending, so the payload below is written inside the reconnect window.
+    client.reset();
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 2; }));
+    EXPECT_TRUE(client.tx(29)) << "a payload was rejected while the reconnect was still pending";
+    EXPECT_TRUE(record->values.empty()) << "a payload was written before the reconnect completed";
+
+    control->release(1);
+    ASSERT_TRUE(control->wait_for_attempt_completed(1, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); }));
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return record->values == std::vector<int>{29}; }))
+        << "the buffered payload never reached the reconnected peer, " << record->values.size() << " delivered";
+}
+
+// A reset opens another peer, so a payload written for the previous one is stale and may not be
+// replayed onto the new connection.
+TEST(fd_event_client_tx_test, a_reset_discards_what_was_buffered_for_the_previous_peer) {
+    auto control = std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{true, 0}, {true, 0}});
+    auto record = std::make_shared<tx_record>();
+    deterministic_async_client client(control, record);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    ASSERT_TRUE(client.tx(31)) << "the payload under test was not buffered, so the reset below proves nothing";
+
+    client.reset();
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 2; }));
+    control->release_all();
+    ASSERT_TRUE(control->wait_for_attempt_completed(1, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); }));
+
+    // A payload the reconnected client does write proves the wire is live, so a missing 31 is a
+    // discard and not a client that never wrote anything at all.
+    ASSERT_TRUE(client.tx(37));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not record->values.empty(); }))
+        << "the reconnected client never wrote anything";
+    pump_for(client, 100ms);
+    EXPECT_EQ(record->values, std::vector<int>{37}) << "a payload buffered for the previous peer was replayed";
+}
+
+// The reconnect window has to open when reset() returns, not when its queued action runs. A
+// payload written in between belongs to the peer the reset opens, so it may be neither discarded
+// with the old connection nor written to it.
+TEST(fd_event_client_tx_test, a_reset_from_a_connected_client_buffers_for_the_new_peer) {
+    auto control = std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{true, 0}, {true, 0}});
+    auto record = std::make_shared<tx_record>();
+    deterministic_async_client client(control, record);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    control->release(0);
+    ASSERT_TRUE(control->wait_for_attempt_completed(0, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); })) << "the client never came up";
+
+    client.reset();
+    EXPECT_TRUE(client.tx(41)) << "a payload written right after reset() was rejected";
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 2; }));
+    control->release(1);
+    ASSERT_TRUE(control->wait_for_attempt_completed(1, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); }));
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return record->values == std::vector<int>{41}; }))
+        << "the payload written after reset() never reached the wire, " << record->values.size() << " delivered";
+    EXPECT_EQ(record->attempts_of(41), std::vector<std::size_t>{1})
+        << "the payload was written to the peer the reset replaced";
+}
+
+// The old handle is still live and still registered for writing when reset() returns, so the
+// flush path has to stay shut until the new connection is up. Otherwise the very payload the
+// reconnect window accepted is written to the peer it was buffered away from.
+TEST(fd_event_client_tx_test, a_reset_does_not_flush_the_new_payload_to_the_old_peer) {
+    auto control = std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{true, 0}, {true, 0}});
+    auto record = std::make_shared<tx_record>();
+    deterministic_async_client client(control, record);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    control->release(0);
+    ASSERT_TRUE(control->wait_for_attempt_completed(0, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); })) << "the client never came up";
+
+    // One payload out and one still queued leaves the old descriptor registered for writing, so
+    // the next poll pass reaches the flush path before any queued action runs.
+    ASSERT_TRUE(client.tx(51));
+    ASSERT_TRUE(client.tx(53));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return record->values.size() == 1; }));
+    ASSERT_EQ(record->values, std::vector<int>{51});
+
+    client.reset();
+    ASSERT_TRUE(client.tx(59));
+    client.sync(1ms); // The pass where the old descriptor is still writable.
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 2; }));
+    control->release(1);
+    ASSERT_TRUE(control->wait_for_attempt_completed(1, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); }));
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return record->attempts_of(59) == std::vector<std::size_t>{1}; }))
+        << "the payload written after reset() did not reach the new peer exactly once";
+    pump_for(client, 100ms);
+    EXPECT_EQ(record->values, (std::vector<int>{51, 59}))
+        << "a payload buffered for the previous peer was written after the reset";
+}
+
+// The read and the write branch of one descriptor are dispatched in the same pass. A read that
+// succeeds reports the connection as up, which happens after the rx callback has already retired
+// it, so the flush path may not take that report for the identity of the handle it is about to
+// write to.
+TEST(fd_event_client_tx_test, a_reset_from_the_rx_callback_does_not_flush_to_the_old_peer) {
+    auto control = std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{true, 0}, {true, 0}});
+    auto record = std::make_shared<tx_record>();
+    auto source = std::make_shared<rx_source>();
+    deterministic_async_client client(control, record, source);
+
+    std::atomic<int> rx_calls{0};
+    std::atomic<bool> tx_accepted{false};
+    client.set_rx_handler([&](int const&, auto&) {
+        if (++rx_calls == 1) {
+            client.reset();
+            tx_accepted.store(client.tx(73));
+        }
+    });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    control->release(0);
+    ASSERT_TRUE(control->wait_for_attempt_completed(0, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); })) << "the client never came up";
+
+    // Nothing is readable yet, so this pass only arms write interest on the live descriptor. The
+    // payload stays queued and the next pass reports the descriptor readable and writable at once.
+    ASSERT_TRUE(client.tx(71));
+    client.sync(1ms);
+    ASSERT_TRUE(record->values.empty()) << "the queued payload drained before the read pass";
+
+    source->push(5);
+    client.sync(1ms); // The pass that reports read and write together.
+
+    ASSERT_EQ(rx_calls.load(), 1) << "the read under test never reached the callback";
+    ASSERT_TRUE(tx_accepted.load()) << "the payload written from the rx callback was rejected";
+    EXPECT_TRUE(record->attempts_of(73).empty())
+        << "the payload buffered by the rx callback was written to the peer the reset retired";
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 2; }));
+    control->release(1);
+    ASSERT_TRUE(control->wait_for_attempt_completed(1, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); }));
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return record->attempts_of(73) == std::vector<std::size_t>{1}; }))
+        << "the payload did not reach the peer the reset opened exactly once";
+    pump_for(client, 100ms);
+    EXPECT_EQ(record->values, std::vector<int>{73}) << "a payload buffered for the retired peer reached the wire";
+}
+
+// Resetting from inside the error callback and sending straight away is the natural consumer
+// shape for reconnect handling, so the buffering window has to be open by the time the callback
+// returns from reset().
+TEST(fd_event_client_tx_test, a_reset_inside_the_error_callback_accepts_tx_at_once) {
+    auto control =
+        std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{false, ECONNREFUSED}, {true, 0}});
+    auto record = std::make_shared<tx_record>();
+    deterministic_async_client client(control, record);
+
+    std::atomic<int> error_calls{0};
+    std::atomic<bool> tx_accepted{false};
+    client.set_error_handler([&](int code, std::string const&) {
+        if (code == 0) {
+            return;
+        }
+        if (++error_calls == 1) {
+            client.reset();
+            tx_accepted.store(client.tx(61));
+        }
+    });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    control->release(0);
+    ASSERT_TRUE(control->wait_for_attempt_completed(0, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return error_calls.load() == 1; })) << "the connect never failed";
+
+    EXPECT_TRUE(tx_accepted.load()) << "a payload written right after reset() inside the error callback was rejected";
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 2; }));
+    control->release(1);
+    ASSERT_TRUE(control->wait_for_attempt_completed(1, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); }));
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return record->values == std::vector<int>{61}; }))
+        << "the payload never reached the reconnected peer, " << record->values.size() << " delivered";
+    EXPECT_EQ(record->attempts_of(61), std::vector<std::size_t>{1});
+}
+
+// The error status handler and the socket are dispatched in the same poll pass, error status
+// first. A reset issued from the error callback retires the handle before the read branch of that
+// pass runs, so the inbound direction has to close with the outbound one. Otherwise the consumer
+// is handed one more payload from the peer it just abandoned, which a control plane consumer can
+// mistake for a response on the connection it is now waiting on.
+TEST(fd_event_client_rx_test, a_reset_from_the_error_callback_drops_the_retired_peers_read) {
+    // Attempt 0 connects and reports an errno at once, so the pass that registers the socket also
+    // reports the failure. That is what puts the error status event ahead of the socket in the
+    // next batch.
+    auto control =
+        std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{true, ECONNRESET}, {true, 0}});
+    auto record = std::make_shared<tx_record>();
+    auto source = std::make_shared<rx_source>();
+    deterministic_async_client client(control, record, source);
+
+    // Readable before the descriptor joins the poll set, so it is ready the moment the connected
+    // handler registers it, in the same pass that notifies the error status event.
+    source->push(5);
+
+    std::vector<std::size_t> rx_attempts;
+    std::vector<std::size_t> retired_attempts;
+    client.set_error_handler([&](int code, std::string const&) {
+        if (code == 0 or not retired_attempts.empty()) {
+            return;
+        }
+        auto const& handle = client.get_raw_handler();
+        retired_attempts.push_back(handle ? handle->attempt() : no_attempt);
+        client.reset();
+    });
+    client.set_rx_handler([&](int const&, auto&) {
+        auto const& handle = client.get_raw_handler();
+        rx_attempts.push_back(handle ? handle->attempt() : no_attempt);
+    });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    control->release(0);
+    ASSERT_TRUE(control->wait_for_attempt_completed(0, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not retired_attempts.empty(); }))
+        << "the failing connect never reached the error callback";
+    ASSERT_EQ(retired_attempts, std::vector<std::size_t>{0});
+
+    EXPECT_EQ(std::count(rx_attempts.begin(), rx_attempts.end(), std::size_t{0}), 0)
+        << "the rx handler was handed a payload from the peer the error callback retired";
+
+    // The skipped read must not wedge the client: it comes back up and serves reads from the
+    // connection the reset opened. How many reads arrive is not asserted. This double keeps the
+    // descriptor and the pending payload in rx_source, which outlives the policy instances, so the
+    // payload pushed before the reset survives it here. A real socket is closed by the reset and
+    // its unread payload goes with it, so that redelivery is an artifact of the double rather than
+    // a guarantee of the client.
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 2; }));
+    control->release(1);
+    ASSERT_TRUE(control->wait_for_attempt_completed(1, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); })) << "the client never came back up";
+
+    source->push(6);
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not rx_attempts.empty(); }))
+        << "no read reached the rx handler after the reset reopened the client";
+    EXPECT_TRUE(std::all_of(rx_attempts.begin(), rx_attempts.end(), [](std::size_t a) { return a == 1; }))
+        << "a read was attributed to a connection other than the one the reset opened";
+}
+
+// Buffering a peer that never comes up must not grow without limit. tx_attempts is the
+// upper bound the cap has to stay below, not the cap itself.
+TEST(fd_event_client_tx_test, the_tx_buffer_is_bounded_while_the_peer_never_connects) {
+    constexpr std::size_t tx_attempts{100000};
+    auto control = std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{true, 0}});
+    auto record = std::make_shared<tx_record>();
+    deterministic_async_client client(control, record);
+
+    // Attempt 0 is never released, so the peer stays unreachable for the whole test.
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    ASSERT_TRUE(client.on_error());
+
+    std::size_t accepted{0};
+    bool rejected{false};
+    for (std::size_t i = 0; i < tx_attempts; ++i) {
+        if (client.tx(static_cast<int>(i))) {
+            ++accepted;
+            continue;
+        }
+        rejected = true;
+        break;
+    }
+
+    EXPECT_GT(accepted, 0u) << "no payload was buffered while the peer was unreachable";
+    EXPECT_TRUE(rejected) << "the buffer accepted all " << tx_attempts << " payloads, so it is unbounded";
+    EXPECT_TRUE(record->values.empty()) << "payloads reached the wire without a connected peer";
+}
+
+// A reset from the rx callback has to reopen the client just like one issued from outside a
+// callback, so a payload written once that reopen is confirmed reaches the wire.
+TEST(fd_event_client_tx_test, a_reset_from_the_rx_callback_reopens_the_client) {
+    auto record = std::make_shared<tx_record>();
+    auto source = std::make_shared<rx_source>();
+    rx_capable_sync_client client(record, source);
+
+    std::atomic<int> rx_calls{0};
+    client.set_rx_handler([&](int const&, auto&) {
+        if (++rx_calls == 1) {
+            client.reset();
+        }
+    });
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); })) << "the client never came up";
+
+    source->push(3);
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return rx_calls.load() == 1; })) << "the read under test never ran";
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] {
+        return client.get_raw_handler() != nullptr and not client.on_error();
+    })) << "the client never came back up after the reset from the rx callback";
+    EXPECT_TRUE(client.tx(83)) << "a payload was rejected after the reset from the rx callback";
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return record->values == std::vector<int>{83}; }))
+        << "the payload never reached the wire, " << record->values.size() << " payloads delivered";
+}
+
+// Buffering is scoped to async connect policies. A synchronous open() client keeps rejecting
+// until it is up, because replaying a stale control plane payload is worse than dropping it.
+TEST(fd_event_client_tx_test, a_synchronous_client_rejects_tx_before_it_is_up) {
+    auto record = std::make_shared<tx_record>();
+    deterministic_sync_client client(record);
+
+    ASSERT_TRUE(client.on_error()) << "the client reports itself up before its first sync";
+    EXPECT_FALSE(client.tx(17)) << "a synchronous open() client accepted a payload before it was up";
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); }));
+    EXPECT_TRUE(client.tx(19));
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return record->values == std::vector<int>{19}; }))
+        << "the payload sent while up was not delivered, " << record->values.size() << " payloads reached the wire";
+}
+
+// The reconnect window is an async policy feature. A synchronous client is fresh between reset()
+// and the reopen its queued action performs, and fresh rejects, so the window is closed for it.
+TEST(fd_event_client_tx_test, a_synchronous_client_rejects_tx_in_the_reset_window) {
+    auto record = std::make_shared<tx_record>();
+    deterministic_sync_client client(record);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); })) << "the client never came up";
+    ASSERT_TRUE(client.tx(101));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return record->values == std::vector<int>{101}; }));
+
+    client.reset();
+    EXPECT_TRUE(client.on_error()) << "a synchronous client reports itself up inside the reset window";
+    EXPECT_FALSE(client.tx(103)) << "a synchronous client accepted a payload inside the reset window";
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); })) << "the client never came back up";
+    EXPECT_TRUE(client.tx(107)) << "a payload was rejected after the reset completed";
+    EXPECT_TRUE(pump_until(client, 500ms, [&] {
+        return record->values == (std::vector<int>{101, 107});
+    })) << "the payload sent after the reset never reached the wire";
+}
+
+// Buffering is requested, never inherited from a transport that connects asynchronously.
+TEST(fd_event_client_tx_test, a_tcp_client_rejects_tx_while_its_connect_is_pending_by_default) {
+    unreachable_peer peer;
+    ASSERT_TRUE(peer.start()) << "could not saturate a loopback accept queue, "
+                                 "so the connect under test would not stay pending";
+
+    constexpr int connect_timeout_ms{500};
+    tcp::tcp_client client("127.0.0.1", peer.port(), connect_timeout_ms);
+
+    pump_for(client, 100ms);
+    ASSERT_TRUE(client.on_error()) << "the connect resolved against an unreachable peer";
+
+    EXPECT_FALSE(client.tx(std::vector<std::uint8_t>{1, 2, 3}))
+        << "a payload was buffered while the TCP connect was still pending, "
+           "although buffering was never requested";
+}
+
+// A UDP client resolves its connect on the first sync, so its window is everything the caller
+// does between construction and that sync.
+TEST(fd_event_client_tx_test, a_udp_client_rejects_tx_before_its_connect_runs_by_default) {
+    constexpr std::uint16_t unused_remote_port{47500};
+    udp::udp_client client("127.0.0.1", unused_remote_port);
+
+    ASSERT_TRUE(client.on_error()) << "the client reports itself up before its first sync";
+
+    EXPECT_FALSE(client.tx(udp::udp_payload{"early"}))
+        << "a payload was buffered before the UDP connect ran, although buffering was never requested";
+}
+
+TEST(fd_event_client_tx_test, a_tcp_client_asked_to_buffer_accepts_tx_while_its_connect_is_pending) {
+    unreachable_peer peer;
+    ASSERT_TRUE(peer.start()) << "could not saturate a loopback accept queue, "
+                                 "so the connect under test would not stay pending";
+
+    constexpr int connect_timeout_ms{500};
+    tcp::tcp_client client(utilities::tx_buffering::buffer, "127.0.0.1", peer.port(), connect_timeout_ms);
+
+    pump_for(client, 100ms);
+    ASSERT_TRUE(client.on_error()) << "the connect resolved against an unreachable peer";
+
+    EXPECT_TRUE(client.tx(std::vector<std::uint8_t>{1, 2, 3}))
+        << "a payload was rejected while the TCP connect was pending, although buffering was requested";
+}
+
+// Naming discard explicitly rejects just like naming nothing at all.
+TEST(fd_event_client_tx_test, a_tcp_client_asked_to_discard_rejects_tx_while_its_connect_is_pending) {
+    unreachable_peer peer;
+    ASSERT_TRUE(peer.start()) << "could not saturate a loopback accept queue, "
+                                 "so the connect under test would not stay pending";
+
+    constexpr int connect_timeout_ms{500};
+    tcp::tcp_client client(utilities::tx_buffering::discard, "127.0.0.1", peer.port(), connect_timeout_ms);
+
+    pump_for(client, 100ms);
+    ASSERT_TRUE(client.on_error()) << "the connect resolved against an unreachable peer";
+
+    EXPECT_FALSE(client.tx(std::vector<std::uint8_t>{1, 2, 3}))
+        << "a payload was buffered while the TCP connect was pending, although discard was requested";
+}
+
+TEST(fd_event_client_tx_test, an_instance_can_discard_although_its_policy_declares_buffering) {
+    auto control = std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{true, 0}});
+    auto record = std::make_shared<tx_record>();
+    deterministic_async_client client(utilities::tx_buffering::discard, control, record);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    ASSERT_TRUE(client.on_error()) << "the connect already resolved, so there is no pending window to test";
+
+    EXPECT_FALSE(client.tx(41)) << "a payload was buffered while the connect was pending, although the instance "
+                                   "asked to discard and only its policy asked to buffer";
+
+    control->release_all();
+    ASSERT_TRUE(control->wait_for_attempt_completed(0, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); })) << "the client never came up";
+    EXPECT_TRUE(client.tx(43)) << "a payload was rejected once the client was up";
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return record->values == std::vector<int>{43}; }))
+        << "the discarded payload was delivered too, " << record->values.size() << " payloads reached the wire";
+}
+
+// A synchronous policy has no pre-connect window, so asking for the buffer cannot open one.
+TEST(fd_event_client_tx_test, a_synchronous_client_asked_to_buffer_still_rejects_tx_before_it_is_up) {
+    auto record = std::make_shared<tx_record>();
+    deterministic_sync_client client(utilities::tx_buffering::buffer, record);
+
+    ASSERT_TRUE(client.on_error()) << "the client reports itself up before its first sync";
+    EXPECT_FALSE(client.tx(47)) << "a synchronous open() client buffered a payload before it was up, "
+                                   "although it has no pre-connect window to buffer for";
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); })) << "the client never came up";
+    EXPECT_TRUE(client.tx(53)) << "a payload was rejected once the client was up";
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return record->values == std::vector<int>{53}; }))
+        << "the payload sent while up was not delivered, " << record->values.size() << " payloads reached the wire";
+}
+
+// The trait is the declaration side of the default. Absent means off.
+TEST(fd_event_client_tx_test, the_buffering_trait_is_off_unless_a_policy_declares_it) {
+    static_assert(not utilities::policy_buffers_tx_before_connect_v<tcp::tcp_socket>,
+                  "tcp_socket declares no buffer_tx_before_connect, so it must not buffer");
+    static_assert(not utilities::policy_buffers_tx_before_connect_v<deterministic_sync_policy>,
+                  "a policy that declares nothing must not buffer");
+    static_assert(utilities::policy_buffers_tx_before_connect_v<deterministic_async_policy>,
+                  "a policy that declares buffer_tx_before_connect true must buffer");
+
+    EXPECT_FALSE(utilities::policy_buffers_tx_before_connect_v<tcp::tcp_socket>)
+        << "an async transport gained buffering without asking for it";
+    EXPECT_TRUE(utilities::policy_buffers_tx_before_connect_v<deterministic_async_policy>)
+        << "a declared opt in was not read off the policy";
+}
+
+// A completed rx notifies the error status event, which is only observed on the next poll cycle,
+// after a reset queued in the same cycle has already moved the client to fresh. Reading fresh as a
+// failure tears the client down without reopening it, and nothing reaches the wire afterwards.
+TEST(fd_event_client_tx_test, a_reset_racing_a_completed_rx_keeps_the_client_open) {
+    auto record = std::make_shared<tx_record>();
+    auto source = std::make_shared<rx_source>();
+    rx_capable_sync_client client(record, source);
+
+    std::atomic<int> rx_calls{0};
+    client.set_rx_handler([&](int const&, auto&) { ++rx_calls; });
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); })) << "the client never came up";
+    ASSERT_NE(client.get_raw_handler(), nullptr);
+
+    source->push(5);
+    client.reset();
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return rx_calls.load() == 1; })) << "the rx under test never completed";
+    pump_for(client, 100ms);
+
+    EXPECT_NE(client.get_raw_handler(), nullptr) << "the client was torn down and never reopened";
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); }))
+        << "the client never came back up after the reset";
+    EXPECT_TRUE(client.tx(23)) << "a payload was rejected after the reset";
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return record->values == std::vector<int>{23}; }))
+        << "the payload never reached the wire, " << record->values.size() << " payloads delivered";
+}
+
+// Code 0 is an up-edge on the connection, not merely "an error you saw is gone". A client that
+// never reported a failure still signals the connection it just established.
+TEST(fd_event_client_error_signal_test, a_first_successful_connect_reports_code_zero_once) {
+    auto control = std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{true, 0}});
+    deterministic_async_client client(control);
+
+    std::vector<int> codes;
+    client.set_error_handler([&](int code, std::string const&) { codes.push_back(code); });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    control->release(0);
+    ASSERT_TRUE(control->wait_for_attempt_completed(0, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); })) << "the client never came up";
+
+    pump_for(client, 100ms);
+    EXPECT_EQ(codes, std::vector<int>{0})
+        << "a first connect that never failed did not report its up-edge exactly once";
+}
+
+// A reset on a healthy client reports the connection it opens, even though no failure was ever
+// observed on the one it replaced.
+TEST(fd_event_client_error_signal_test, a_clean_reset_reports_code_zero_once_per_reconnect) {
+    auto control = std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{true, 0}, {true, 0}});
+    deterministic_async_client client(control);
+
+    std::vector<int> codes;
+    client.set_error_handler([&](int code, std::string const&) { codes.push_back(code); });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    control->release(0);
+    ASSERT_TRUE(control->wait_for_attempt_completed(0, 500ms));
+    // The status event is only observed on the poll pass after the state moves, so the callback
+    // trails on_error() by one cycle.
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return codes == std::vector<int>{0}; }))
+        << "the first connect did not report its up-edge";
+
+    client.reset();
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 2; }));
+    control->release(1);
+    ASSERT_TRUE(control->wait_for_attempt_completed(1, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); })) << "the client never came back up";
+
+    pump_for(client, 100ms);
+    EXPECT_EQ(codes, (std::vector<int>{0, 0})) << "a clean reset did not report the reconnect exactly once";
+}
+
+// A successful read reports code 0 through the same path a successful connect does. It is not an
+// up-edge on a connection, so interleaving reads with a reset may not add one.
+TEST(fd_event_client_error_signal_test, a_read_interleaved_with_a_reset_reports_one_up_edge_per_connect) {
+    auto control = std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{true, 0}, {true, 0}});
+    auto record = std::make_shared<tx_record>();
+    auto source = std::make_shared<rx_source>();
+    deterministic_async_client client(control, record, source);
+
+    std::vector<int> codes;
+    std::atomic<int> rx_calls{0};
+    client.set_error_handler([&](int code, std::string const&) { codes.push_back(code); });
+    client.set_rx_handler([&](int const&, auto&) {
+        if (++rx_calls == 1) {
+            client.reset();
+            client.tx(89);
+        }
+    });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    control->release(0);
+    ASSERT_TRUE(control->wait_for_attempt_completed(0, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return codes == std::vector<int>{0}; }))
+        << "the first connect did not report its up-edge";
+
+    // Same shape as the flush test: one pass arms write interest, the next reports read and write
+    // together, so the read lands on a connection the callback has already retired.
+    ASSERT_TRUE(client.tx(87));
+    client.sync(1ms);
+    ASSERT_TRUE(record->values.empty()) << "the queued payload drained before the read pass";
+    source->push(5);
+    client.sync(1ms);
+    ASSERT_EQ(rx_calls.load(), 1) << "the read under test never reached the callback";
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 2; }));
+    control->release(1);
+    ASSERT_TRUE(control->wait_for_attempt_completed(1, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); })) << "the client never came back up";
+
+    pump_for(client, 100ms);
+    EXPECT_EQ(codes, (std::vector<int>{0, 0})) << "a successful read added an up-edge of its own";
+}
+
+// The failure the caller has to act on stays visible, and the reconnect that follows is reported
+// once, so a consumer can pair the two.
+TEST(fd_event_client_error_signal_test, a_failure_then_a_reset_reports_the_error_then_code_zero) {
+    auto control =
+        std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{false, ECONNREFUSED}, {true, 0}});
+    deterministic_async_client client(control);
+
+    std::vector<int> codes;
+    client.set_error_handler([&](int code, std::string const&) { codes.push_back(code); });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    control->release(0);
+    ASSERT_TRUE(control->wait_for_attempt_completed(0, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return codes == std::vector<int>{ECONNREFUSED}; }))
+        << "the failed connect did not report its error";
+
+    client.reset();
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 2; }));
+    control->release(1);
+    ASSERT_TRUE(control->wait_for_attempt_completed(1, 500ms));
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return not client.on_error(); })) << "the client never came up";
+
+    pump_for(client, 100ms);
+    EXPECT_EQ(codes, (std::vector<int>{ECONNREFUSED, 0})) << "the reconnect after a failure was not reported once";
+}
+
+// A read that fails on an established connection is the only route that turns a dead socket into a
+// reported errno. Folding the read status into the guard that suppresses a retired handle would
+// report nothing instead, which leaves the client wedged while it still claims to be up.
+TEST(fd_event_client_error_signal_test, a_failed_read_reports_the_socket_error) {
+    auto source = std::make_shared<rx_source>();
+    auto fault = std::make_shared<rx_fault_plan>();
+    faulting_rx_sync_client client(source, fault);
+
+    std::vector<int> codes;
+    client.set_error_handler([&](int code, std::string const&) { codes.push_back(code); });
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return codes == std::vector<int>{0}; }))
+        << "the client never reported its up-edge";
+
+    fault->rx_fails = true;
+    fault->error_code = ECONNRESET;
+    source->push(7);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return codes.size() > 1; }))
+        << "a read that failed on an established connection reported nothing";
+    EXPECT_EQ(codes, (std::vector<int>{0, ECONNRESET})) << "the failed read did not report the socket error";
+    EXPECT_TRUE(client.on_error()) << "the client still reports itself up after a failed read";
 }


### PR DESCRIPTION
## Describe your changes

`generic_error_state` tracked whether a client was up with a single bool, which cannot distinguish
"never connected yet" from "connected and then failed". Those need opposite handling: a payload
written before the first connect resolves is early, the same payload after a failure is
undeliverable. With one bool, both were rejected.

- **`connection_state{fresh, connected, failed}`** replaces the bool. `on_error()` keeps its old
  meaning of "not up", covering `fresh` and `failed`, so existing consumers do not change.
- **`tx()` can buffer during the connect window, but only when asked to.** The bound is
  `max_buffered_tx_payloads`, so an unreachable peer cannot grow the queue without limit, and the
  `bool` return makes a rejected send visible instead of silent. Buffering is **off by default**: a
  policy opts in with `static constexpr bool buffer_tx_before_connect`, and any consumer overrides
  that per instance with a `utilities::tx_buffering` constructor argument. Holding a payload across a
  connect is only correct when its meaning survives the delay, which is false for the periodic
  setpoints and stateful line protocols the in-tree consumers carry: replaying one after a reconnect
  delivers a stale value the peer cannot tell from a fresh one. Deriving that from the transport
  instead would have given every async-connect client replay it never asked for, so the request is
  explicit and the transport trait only decides whether buffering is *available* at all. Policies
  that resolve `open()` synchronously have no pre-connect window and reject until up regardless.
- **A `fresh` client is inert in the error handler.** Introducing a third state made `on_error()`
  true while the stored code was 0, which had never been possible; both chargebridge bridges gate
  their reopen on `if (id not_eq 0)`. Without this, a consumer `reset()` racing a completed I/O left
  the teardown unpaired while the reopen marked the client connected again, so it reported healthy
  forever and accepted into a queue that would never drain.
- **`reset()` applies its state flip at call time.** It sets the state to `fresh` and clears the tx
  buffer synchronously; only the device teardown and reopen stay deferred. This keeps `tx()`'s bool
  truthful across a reset: `true` after `reset()` means buffered for the new connection, not
  discarded with the old one. The clear is unconditional, in both buffering modes.
- **The flush and read paths answer to handle identity, not to connection state.** A user callback
  runs inside the client and can retire the connection mid-dispatch, after which a successful read
  would put the state back to `connected` and let a post-reset payload reach the abandoned peer. Both
  paths now compare a generation stamped when the device is opened, so I/O on a retired handle is
  skipped rather than attributed to its replacement.
- **Error code 0 is an up-edge**, fired exactly once per successful (re)connect, including a first
  connect and a reset that never reported a failure. Documented and pinned; error-only consumers
  filter on a nonzero code. Suppressing the code-0 callback on clean resets would have preserved the
  pre-tri-state observable behavior, but it leaves the callback meaning "an error you may never have
  seen is now gone" and needs its own suppression state machine; the up-edge contract is simpler and
  matches how `can_bridge` already consumes code 0 as its ready signal. Rejecting `tx()` between
  `reset()` and the next `sync()` was also considered and rejected: it breaks the
  reset-inside-error-callback-then-send pattern, which is the natural consumer shape for reconnect
  handling.

Known gap, documented on the error-handler contract rather than fixed here: a read that succeeds
while the client is in `failed` puts the state back to `connected` and arms another code 0, which can
end with the device gone, no reopen, and `tx()` still accepting. It predates this change.

### Consumer-visible changes

Also recorded in `lib/everest/io/README.md` under "Client tx contract", since that outlives the
squash.

1. **`tx()` can now reject on a live connection.** It rejects once `max_buffered_tx_payloads` are
   queued, which a peer that stops reading reaches on its own. This is backpressure, not failure:
   the connection stays up and everything already accepted is still delivered in order. Call sites
   that discard the return turn a stalled peer into silent drops.
2. **`on_error()` is true for the whole reset window.** `reset()` moves the state to `fresh` at call
   time rather than in the queued action, so a consumer polling `on_error()` sees `true` from the
   call until the reopen completes, where it previously stayed `false` until the action ran.
3. **`reset()` is loop-thread only.** It now touches the tx buffer directly, so it carries the same
   threading contract as `tx()`: call it from the thread driving `sync()`, or from a callback that
   thread dispatches. It was previously reachable off-thread via `add_action`.
4. **Pre-connect buffering is opt-in and off by default**, so no existing consumer changes behavior.
   `serial_bridge` keeps dropping during its 1000 ms TCP connect window and the five udp bridges
   keep dropping during theirs, exactly as on `main`. #2565 makes those drops visible in the log
   rather than silent, which was the actual defect. `tls_client_socket` declares the opt-in on
   #2564, keeping the pre-connect buffering `tls_endpoint_base` had before the client moved onto
   `fd_event_client`; without it `TlsE2E.tx_queued_before_handshake_is_flushed_after_ready` fails.

## Issue ticket number and link

N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

---

### Stack

Six PR series, two rooted on `main`. (#2558 and #2559 have merged.)

This PR is 2 above `main`, so 1 PR (#2561) must merge before it.

- `main`
  - #2560 `fix/io-connect-errno-and-backoff`
  - #2561 `fix/io-event-handler-truthfulness`
    - **#2562 `feat/io-client-tx-tristate` (this PR)**
      - #2563 `feat/io-fd-event-client-handshake-phase`
        - #2564 `feat/io-tls-policies-rebuilt`
      - #2565 `refactor/chargebridge-drop-hand-rolled-tx-gates`

