### PR TITLE
feat(io): event loop driven handshake phase

### DIFF
--- a/lib/everest/io/include/everest/io/event/fd_event_client.hpp
+++ b/lib/everest/io/include/everest/io/event/fd_event_client.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 
 /** \file */
 
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <everest/io/event/event_fd.hpp>
 #include <everest/io/event/fd_event_sync_interface.hpp>
+#include <everest/io/event/timer_fd.hpp>
 #include <everest/io/event/unique_fd.hpp>
 #include <everest/io/socket/socket.hpp>
 #include <everest/io/utilities/event_client_async_policy.hpp>
@@ -20,11 +21,16 @@
 #include <future>
 #include <memory>
 #include <queue>
+#include <string>
 #include <thread>
 #include <type_traits>
 
 namespace everest::lib::io::event {
 class fd_event_handler;
+
+// Opaque: event/fd_event_handler.hpp defines poll_events and includes this header, so including
+// it back would close a cycle.
+enum class poll_events;
 
 /**
  * @enum action_status
@@ -74,6 +80,38 @@ public:
      * @brief Prototype for error_status
      */
     using error_status = std::function<int()>;
+
+    /**
+     * @var handshake_status
+     * @brief Prototype for the query whether the handshake is still pending
+     */
+    using handshake_status = std::function<bool()>;
+
+    /**
+     * @var handshake_events
+     * @brief Prototype for the query which single event the handshake waits for
+     */
+    using handshake_events = std::function<poll_events()>;
+
+    /**
+     * @var handshake_timeout
+     * @brief Prototype for the query how long the handshake may stay pending
+     */
+    using handshake_timeout = std::function<std::chrono::milliseconds()>;
+
+    /**
+     * @var error_text
+     * @brief Prototype for an error description supplied by the client policy
+     */
+    using error_text = std::function<std::string()>;
+
+    /**
+     * @var default_handshake_timeout
+     * @brief Upper bound of a protocol handshake when the client policy states none.
+     * @details Retransmission with a doubling timeout lets a healthy negotiation over a lossy
+     * link take seconds. Past this the peer stopped talking, and the client reports ETIMEDOUT.
+     */
+    static constexpr std::chrono::milliseconds default_handshake_timeout{10000};
 
     /**
      * @var ready_action
@@ -149,9 +187,9 @@ public:
 
     /**
      * @brief Register a function, that is called once the client is ready
-     * @details This callback is performed immediately, if the client is in a ready state
-     *          or the client is ready. The action is persistent and called whenever the client
-     *          is ready after reset.
+     * @details Registration is deferred to the event loop. Called once per connection, so also
+     *          again after a reset, and immediately when the client is already ready. A client
+     *          policy with a handshake phase counts as ready once the handshake is complete.
      * @param[in] item The callback
      */
     void set_on_ready_action(std::function<void()>&& item);
@@ -160,9 +198,18 @@ protected:
     /**
      * @brief Constructor.
      * @details Functionality passed in by functors
+     * @param[in] drive_handshake One handshake step. 'success' to continue, 'fail' on a handshake
+     *            error, 'empty' once the handshake is complete
+     * @param[in] handshake_desired_events The single event the handshake waits for after a step
+     * @param[in] get_handshake_timeout Upper bound of the whole handshake. A non positive value
+     *            selects \ref default_handshake_timeout
+     * @param[in] get_error_string Error description of the client policy. An empty string selects
+     *            the description of the stored error code
      */
     generic_fd_event_client_impl(action const& send_one, action const& receive_one, action const& reset_client,
-                                 error_status const& get_error);
+                                 error_status const& get_error, handshake_status const& handshake_pending,
+                                 action const& drive_handshake, handshake_events const& handshake_desired_events,
+                                 handshake_timeout const& get_handshake_timeout, error_text const& get_error_string);
     ~generic_fd_event_client_impl();
 
     /**
@@ -188,9 +235,95 @@ protected:
     void error_handler();
 
     /**
+     * @brief Perform a single step of the protocol handshake.
+     * @details While the handshake is pending, io events on \p fd are routed here instead of to
+     *          \ref rx_handler / \ref tx_handler. On completion \p fd is monitored for reading
+     *          and the on_ready action is released.
+     * @param[in] fd The file descriptor of the client's socket
+     */
+    void drive_handshake(int fd);
+
+    /**
+     * @brief Monitor \p fd for exactly one of reading or writing.
+     * @details Error and hangup notifications are unconditional and stay untouched.
+     * @param[in] fd The file descriptor
+     * @param[in] desired Anything but reading or writing is rejected: \p fd would end up monitored
+     *            for nothing.
+     * @return True if \p fd is monitored for \p desired afterwards, false otherwise
+     */
+    bool monitor_for(int fd, poll_events desired);
+
+    /**
+     * @brief Mark the connection as failed and report the error of the client policy.
+     */
+    void fail_connection();
+
+    /**
+     * @brief Mark the connection as failed and report \p error_code.
+     * @param[in] error_code The error to report. A 0 is replaced, so the report is never read
+     *            as a cleared error.
+     */
+    void fail_connection(int error_code);
+
+    /**
+     * @brief Mark the connection as failed and report \p error_code described by \p text.
+     * @details For a failure the client itself diagnosed: the client policy would describe an
+     *          error it did not produce.
+     * @param[in] error_code The error to report. A 0 is replaced, so the report is never read
+     *            as a cleared error.
+     * @param[in] text Description of the failure, reported to the error handler
+     */
+    void fail_connection(int error_code, std::string text);
+
+    /**
+     * @brief The description of the pending failure, for the error handler.
+     * @details A description set by \ref fail_connection belongs to that one failure and is
+     *          consumed here. Otherwise the client policy describes the error.
+     * @return The description, empty to select the description of the stored error code
+     */
+    std::string take_error_text();
+
+    /**
+     * @brief Start the handshake deadline, on the first handshake step of a connection.
+     * @details The deadline covers the whole handshake, not a single step. One that cannot be
+     *          armed fails the connection: proceeding would leave the handshake unbounded.
+     * @return True if the deadline is in force, false if the connection was failed
+     */
+    bool start_handshake_deadline();
+
+    void handshake_deadline_expired();
+
+    /**
+     * @brief Disarm the handshake deadline a reset abandons.
+     * @details The generation guard in \ref handshake_deadline_expired already rejects a retired
+     *          expiry; this keeps the invariant local to the reset instead of resting on it alone.
+     */
+    void retire_handshake_deadline();
+
+    /**
+     * @brief Consume the error code of an error or hangup notification on \p fd.
+     * @details Prefers the error of the client policy, then SO_ERROR, then the notification kind
+     *          itself (ENOTCONN for a hangup, EIO otherwise) for a descriptor that is not a
+     *          socket. Never resolves to 0, which would read as a cleared error. Reading SO_ERROR
+     *          clears it, so call this exactly once per connection.
+     * @param[in] fd The file descriptor the notification arrived on
+     * @param[in] kind poll_events::hungup for a hangup, poll_events::error otherwise
+     * @return A nonzero error code
+     */
+    int consume_poll_error(int fd, poll_events kind);
+
+    static poll_events default_desired_events();
+
+    /**
+     * @brief Release the on_ready action, at most once per connection.
+     */
+    void maybe_fire_ready();
+
+    /**
      * @brief Setup io event handling.
      * @details This registers a generic event handler for reading, writing and error handling.
-     *          Errors and reading will be handled continuously, writing on demand.
+     *          Reading is handled continuously, writing on demand. An error or hangup
+     *          notification is terminal and reported once per connection.
      * @param[in] fd Filedescriptor to be monitored.
      */
     void setup_io_event_handler(int fd);
@@ -260,15 +393,28 @@ protected:
     event::event_fd m_io_event_fd;
     event::event_fd m_error_status_event_fd;
     event::event_fd m_connected_event_fd;
+    event::timer_fd m_handshake_timer;
 
     cb_error m_error;
     action m_send_one;
     action m_receive_one;
     action m_reset_client;
     error_status m_get_error;
+    handshake_status m_handshake_pending;
+    action m_drive_handshake;
+    handshake_events m_handshake_desired_events;
+    handshake_timeout m_get_handshake_timeout;
+    error_text m_get_error_string;
+    std::string m_local_error_text;
     util::monitor<client_status_internal> m_client_status;
     ready_action m_on_ready_action;
     std::atomic_uint64_t m_connected_generation{0};
+    bool m_connection_failed{false};
+    // Every connection attempt pre-increments the generation, so 0 cannot match a connection.
+    std::uint64_t m_ready_fired_generation{0};
+    std::uint64_t m_handshake_deadline_generation{0};
+    // 0 means the deadline is registered; nonzero is the errno that stopped it.
+    int m_handshake_deadline_register_error{0};
     /// @endcond
 };
 
@@ -300,6 +446,20 @@ public:
      */
     using ClientPayloadT = typename ClientPolicy::PayloadT;
 
+    // A partial trio would silently disable the handshake and release the on_ready action on a
+    // socket that never negotiated anything.
+    static_assert(utilities::event_client_handshake_policy_v<ClientPolicy> or
+                      utilities::event_client_has_no_handshake_trio_v<ClientPolicy>,
+                  "ClientPolicy must provide all of handshake_complete(), handshake_step() and "
+                  "desired_events(), or none of them");
+
+    // handshake_timeout() bounds the phase the trio implements, so on its own it is read by nothing.
+    static_assert(not utilities::has_member_handshake_timeout_v<ClientPolicy> or
+                      utilities::event_client_handshake_policy_v<ClientPolicy>,
+                  "ClientPolicy provides handshake_timeout() but no handshake to bound: either add "
+                  "handshake_complete(), handshake_step() and desired_events(), or remove "
+                  "handshake_timeout()");
+
     /**
      * @var max_buffered_tx_payloads
      * @brief Upper bound of payloads held in the tx buffer.
@@ -328,18 +488,20 @@ public:
      */
     template <class... ArgsT>
     generic_fd_event_client(utilities::tx_buffering mode, ArgsT... args) :
-        generic_fd_event_client_impl([this]() { return send_one(); }, [this]() { return receive_one(); },
-                                     [this]() { return reset_client(); },
-                                     // A retired handle carries the errno of the peer it served,
-                                     // which is not the errno of the connection replacing it. The
-                                     // EPOLLERR branch reads this without knowing which handle is
-                                     // behind it.
-                                     [this]() { return handle_is_current() ? m_handle->get_error() : 0; }) {
+        generic_fd_event_client_impl(
+            [this]() { return send_one(); }, [this]() { return receive_one(); }, [this]() { return reset_client(); },
+            // A retired handle carries the errno of the peer it served, which is not the errno of
+            // the connection replacing it. The EPOLLERR branch reads this without knowing which
+            // handle is behind it.
+            [this]() { return handle_is_current() ? m_handle->get_error() : 0; },
+            [this]() { return handshake_pending(); }, [this]() { return handshake_step(); },
+            [this]() { return handshake_desired_events(); }, [this]() { return handshake_timeout(); },
+            [this]() { return policy_error_string(); }) {
         m_buffer_tx_before_connect = mode == utilities::tx_buffering::buffer;
         m_async_connect_state = std::make_shared<async_connect_state>();
         register_async_connect_event_handler(&m_async_connect_state->ready_event,
                                              [this]() { process_async_connect_results(); });
-        init<ClientPolicy>(args...);
+        init(args...);
     }
 
     ~generic_fd_event_client() override {
@@ -359,8 +521,9 @@ public:
      * @brief Send data
      * @details This buffers the incoming data and notifies. It will be send as soon as the file descriptor
      * is ready for transmission (POLLOUT / EPOLLOUT). Buffering before the connection is up is opt in,
-     * see \ref utilities::tx_buffering. Must be called from the thread that drives \ref sync: the
-     * buffer is not synchronized.
+     * see \ref utilities::tx_buffering. A handshake phase runs past that window, so a policy with one
+     * buffers across it whatever the mode, and flushes in order once it completes. Must be called from
+     * the thread that drives \ref sync: the buffer is not synchronized.
      * @param[in] payload The data to be transmitted.
      * @return True if the payload was buffered. False if the buffer already holds
      * \ref max_buffered_tx_payloads payloads, if the client is in
@@ -456,55 +619,54 @@ private:
         return state == utilities::connection_state::connected;
     }
 
-    template <class T, class... ArgsT> std::enable_if_t<utilities::event_client_async_policy_v<T>> init(ArgsT... args) {
-        m_open_device = [this, args...]() {
-            auto setup_ok = m_handle->setup(args...);
-            if (setup_ok) {
-                auto connect_generation = m_connect_generation.load();
-                auto state = m_async_connect_state;
-                auto handle = std::move(m_handle);
-                // The usage of a detached thread is intentional to avoid blocking the event_handler.
-                std::thread([state = std::move(state), handle = std::move(handle), connect_generation]() mutable {
-                    bool ok = false;
-                    int fd = -1;
-                    try {
-                        handle->connect([&](bool result_ok, int result_fd) {
-                            ok = result_ok;
-                            fd = result_fd;
-                        });
-                    } catch (...) {
-                        ok = false;
-                        fd = -1;
-                    }
+    template <class... ArgsT> void init(ArgsT... args) {
+        if constexpr (utilities::event_client_async_policy_v<ClientPolicy>) {
+            m_open_device = [this, args...]() {
+                auto setup_ok = m_handle->setup(args...);
+                if (setup_ok) {
+                    auto connect_generation = m_connect_generation.load();
+                    auto state = m_async_connect_state;
+                    auto handle = std::move(m_handle);
+                    // The usage of a detached thread is intentional to avoid blocking the event_handler.
+                    std::thread([state = std::move(state), handle = std::move(handle), connect_generation]() mutable {
+                        bool ok = false;
+                        int fd = -1;
+                        try {
+                            handle->connect([&](bool result_ok, int result_fd) {
+                                ok = result_ok;
+                                fd = result_fd;
+                            });
+                        } catch (...) {
+                            ok = false;
+                            fd = -1;
+                        }
 
-                    if (not state or not state->active.load()) {
-                        return;
-                    }
+                        if (not state or not state->active.load()) {
+                            return;
+                        }
 
-                    auto inserted = state->connect_results.emplace(
-                        async_connect_result{connect_generation, ok, fd, std::move(handle)});
-                    if (inserted != 0) {
-                        state->ready_event.notify();
-                    }
-                }).detach();
-            } else {
+                        auto inserted = state->connect_results.emplace(
+                            async_connect_result{connect_generation, ok, fd, std::move(handle)});
+                        if (inserted != 0) {
+                            state->ready_event.notify();
+                        }
+                    }).detach();
+                } else {
+                    auto generation = m_connect_generation.load();
+                    on_client_ready(generation, false, -1);
+                }
+            };
+            // The initial open has no previous peer, so a payload buffered before this action runs
+            // belongs to the connection it opens.
+            schedule_reset();
+        } else {
+            m_open_device = [this, args...]() {
+                auto result = m_handle->open(args...);
                 auto generation = m_connect_generation.load();
-                on_client_ready(generation, false, -1);
-            }
-        };
-        // The initial open has no previous peer, so a payload buffered before this action runs
-        // belongs to the connection it opens.
-        schedule_reset();
-    }
-
-    template <class T, class... ArgsT>
-    std::enable_if_t<not utilities::event_client_async_policy_v<T>> init(ArgsT... args) {
-        m_open_device = [this, args...]() {
-            auto result = m_handle->open(args...);
-            auto generation = m_connect_generation.load();
-            on_client_ready(generation, result, m_handle->get_fd());
-        };
-        reset_impl();
+                on_client_ready(generation, result, m_handle->get_fd());
+            };
+            reset_impl();
+        }
     }
 
     void schedule_reset() {
@@ -517,6 +679,7 @@ private:
         // reset already flipped the state, but an event dispatched since may have moved it back
         // to connected, which the device opened below has not earned yet.
         reset_connection_state();
+        retire_handshake_deadline();
         reset_client();
         setup_error_event_handler();
         init_device();
@@ -574,6 +737,66 @@ private:
         // handed up; what is dropped is its status, which says nothing about the connection
         // replacing this one.
         return handle_is_current() ? result : action_status::empty;
+    }
+
+    bool handshake_pending() {
+        if constexpr (utilities::event_client_handshake_policy_v<ClientPolicy>) {
+            return m_handle and not m_handle->handshake_complete();
+        } else {
+            return false;
+        }
+    }
+
+    action_status handshake_step() {
+        if constexpr (utilities::event_client_handshake_policy_v<ClientPolicy>) {
+            if (not m_handle) {
+                // 'empty' would read as a completed handshake and release the on_ready action
+                // for a client that does not exist.
+                return action_status::fail;
+            }
+            if (not m_handle->handshake_step()) {
+                return action_status::fail;
+            }
+            if (m_handle->handshake_complete()) {
+                // Payloads queued during the handshake consumed their one-shot tx notification
+                // while its handler declined to monitor writing. Notify again to flush the queue.
+                if (not m_tx_buffer.empty()) {
+                    m_io_event_fd.notify();
+                }
+                return action_status::empty;
+            }
+            return action_status::success;
+        } else {
+            return action_status::empty;
+        }
+    }
+
+    poll_events handshake_desired_events() {
+        if constexpr (utilities::event_client_handshake_policy_v<ClientPolicy>) {
+            if (m_handle) {
+                return m_handle->desired_events();
+            }
+        }
+        // poll_events is only forward declared here, so the fallback is named via the implementation.
+        return default_desired_events();
+    }
+
+    std::chrono::milliseconds handshake_timeout() {
+        if constexpr (utilities::has_member_handshake_timeout_v<ClientPolicy>) {
+            if (m_handle) {
+                return m_handle->handshake_timeout();
+            }
+        }
+        return default_handshake_timeout;
+    }
+
+    std::string policy_error_string() {
+        if constexpr (utilities::has_member_get_error_string_v<ClientPolicy>) {
+            if (m_handle) {
+                return m_handle->get_error_string();
+            }
+        }
+        return {};
     }
 
     action_status reset_client() {
@@ -693,6 +916,26 @@ private:
  *                                    // Return true on success, false otherwise
  *   int get_fd();                    // returns the file discriptor to be monitored
  *   int get_error();                 // return the current error, 0 with no error.
+ *   bool handshake_complete();       // [optional] False while a protocol handshake is outstanding.
+ *   bool handshake_step();           // [optional] One non blocking handshake step. True while it makes
+ *                                    // progress, false on failure. Called once at connect time, before
+ *                                    // any readiness event, because the client owes the first protocol
+ *                                    // message; afterwards only for the event desired_events() asked
+ *                                    // for. A wakeup may be spurious, so a step that cannot progress
+ *                                    // returns true and requests its event again.
+ *   poll_events desired_events();    // [optional] The single event the handshake waits for, queried
+ *                                    // after every step that neither failed nor completed it. Anything
+ *                                    // but reading or writing fails the handshake.
+ *                                    // The three functions above are only used together. Until the
+ *                                    // handshake completes the on_ready action is deferred and payloads
+ *                                    // passed to tx are buffered.
+ *   std::chrono::milliseconds handshake_timeout(); // [optional, rejected without the three functions
+ *                                    // above] Upper bound of the whole handshake, read when it starts.
+ *                                    // A non positive value, or no such function, selects
+ *                                    // generic_fd_event_client_impl::default_handshake_timeout.
+ *   std::string get_error_string();  // [optional] Description of the current error, a const reference
+ *                                    // is fine too. An empty string selects the description of the
+ *                                    // stored error code.
  * };
  * // ClientPolicy owns the file descriptor
  * \endcode

--- a/lib/everest/io/include/everest/io/event/fd_event_handler.hpp
+++ b/lib/everest/io/include/everest/io/event/fd_event_handler.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 
 /** \file */
 
@@ -16,6 +16,7 @@
 #include <functional>
 #include <memory>
 #include <set>
+#include <type_traits>
 
 namespace everest::lib::io::event {
 
@@ -30,6 +31,12 @@ enum class poll_events {
     error = 3,
     hungup = 4,
 };
+
+// event/fd_event_client.hpp declares poll_events opaquely to break the include cycle with this
+// header. That declaration is compatible only while the definition keeps its implicit type.
+static_assert(std::is_same_v<std::underlying_type_t<poll_events>, int>,
+              "poll_events must keep its implicit underlying type: event/fd_event_client.hpp "
+              "declares it without one");
 
 std::set<poll_events> operator|(poll_events lhs, poll_events rhs);
 std::set<poll_events>& operator|(std::set<poll_events>& lhs, poll_events rhs);
@@ -144,7 +151,9 @@ public:
     /**
      * @brief Register an \ref timer_fd for event handling
      * @details Reading from the event happens internally to acknowledge event handling.
-     * If manual handling is necessary use \ref timer_fd filedecriptor directly
+     * If manual handling is necessary use \ref timer_fd filedecriptor directly.
+     * \p handler is not called for an expiry that a rearm or a disarm retired since its poll
+     * batch was harvested: rearming a timer from another handler suppresses its pending tick.
      * @param[in] obj The object to be registerd for event handling
      * @param[in] handler Callback for handling the events on \p obj
      * @return True on success, false otherwise

--- a/lib/everest/io/include/everest/io/utilities/event_client_async_policy.hpp
+++ b/lib/everest/io/include/everest/io/utilities/event_client_async_policy.hpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 
 /** \file */
 
 #pragma once
 
+#include <chrono>
 #include <functional>
+#include <string>
 #include <type_traits>
 
 namespace everest::lib::io::utilities {
@@ -108,5 +110,83 @@ enum class tx_buffering {
     /** Accept while the connection is fresh, hold in the bounded buffer, deliver once it is up. */
     buffer
 };
+
+/**
+ * @brief Primary template for the trait to check if a type T has a member function
+ * 'handshake_complete()' returning something convertible to bool.
+ * @tparam T The type to check.
+ */
+template <typename T, typename V = void> struct has_member_handshake_complete : std::false_type {};
+
+template <typename T>
+struct has_member_handshake_complete<
+    T, std::enable_if_t<std::is_convertible_v<decltype(std::declval<T&>().handshake_complete()), bool>>>
+    : std::true_type {};
+
+template <typename T> inline constexpr bool has_member_handshake_complete_v = has_member_handshake_complete<T>::value;
+
+template <typename T, typename V = void> struct has_member_handshake_step : std::false_type {};
+
+template <typename T>
+struct has_member_handshake_step<
+    T, std::enable_if_t<std::is_convertible_v<decltype(std::declval<T&>().handshake_step()), bool>>> : std::true_type {
+};
+
+template <typename T> inline constexpr bool has_member_handshake_step_v = has_member_handshake_step<T>::value;
+
+/**
+ * @brief Trait for a member function 'desired_events()'.
+ * @details The return type is not constrained: naming event::poll_events here would close a cycle with
+ * event/fd_event_handler.hpp, which includes the event client that consumes this trait.
+ * @tparam T The type to check.
+ */
+template <typename T, typename V = void> struct has_member_desired_events : std::false_type {};
+
+template <typename T>
+struct has_member_desired_events<T, std::void_t<decltype(std::declval<T&>().desired_events())>> : std::true_type {};
+
+template <typename T> inline constexpr bool has_member_desired_events_v = has_member_desired_events<T>::value;
+
+/**
+ * @brief Defines the policy trait for an event client with a protocol handshake phase.
+ * @tparam T The type to check.
+ */
+template <typename T>
+struct event_client_handshake_policy
+    : std::integral_constant<bool, has_member_handshake_complete<T>::value && has_member_handshake_step<T>::value &&
+                                       has_member_desired_events<T>::value> {};
+
+template <typename T> inline constexpr bool event_client_handshake_policy_v = event_client_handshake_policy<T>::value;
+
+/**
+ * @brief True for a type providing none of the three handshake members.
+ * @details The complement of \ref event_client_handshake_policy, which is not its negation: a
+ * type providing only some of the three satisfies neither. 'handshake_timeout()' is not counted
+ * here, it is optional and bounds a handshake the three implement.
+ * @tparam T The type to check.
+ */
+template <typename T>
+inline constexpr bool event_client_has_no_handshake_trio_v =
+    not has_member_handshake_complete_v<T> and not has_member_handshake_step_v<T> and
+    not has_member_desired_events_v<T>;
+
+template <typename T, typename V = void> struct has_member_handshake_timeout : std::false_type {};
+
+template <typename T>
+struct has_member_handshake_timeout<
+    T, std::enable_if_t<
+           std::is_convertible_v<decltype(std::declval<T&>().handshake_timeout()), std::chrono::milliseconds>>>
+    : std::true_type {};
+
+template <typename T> inline constexpr bool has_member_handshake_timeout_v = has_member_handshake_timeout<T>::value;
+
+template <typename T, typename V = void> struct has_member_get_error_string : std::false_type {};
+
+template <typename T>
+struct has_member_get_error_string<
+    T, std::enable_if_t<std::is_convertible_v<decltype(std::declval<T&>().get_error_string()), std::string>>>
+    : std::true_type {};
+
+template <typename T> inline constexpr bool has_member_get_error_string_v = has_member_get_error_string<T>::value;
 
 } // namespace everest::lib::io::utilities

--- a/lib/everest/io/include/everest/io/utilities/generic_error_state.hpp
+++ b/lib/everest/io/include/everest/io/utilities/generic_error_state.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 
 /** \file */
 
@@ -33,8 +33,8 @@ class generic_error_state {
 public:
     /**
      * @var cb_error
-     * @brief Prototype for an on_error handler callback. It receives the current errno
-     * and its string representation
+     * @brief Prototype for an on_error handler callback. It receives the stored error code
+     * and a description of it
      */
     using cb_error = std::function<void(int error, std::string const& msg)>;
     virtual ~generic_error_state() = default;
@@ -99,10 +99,14 @@ protected:
     int current_error() const;
 
     /**
-     * @brief Call the error handler with current errno, if registered.
+     * @brief Call the error handler with the stored error code, if registered.
+     * @details The reported error is never 0. Clearing an error is signaled through
+     *          \ref clear_error_handler instead.
      * @param[in] handler The handler to be called
+     * @param[in] msg Description of the error. An empty string selects the description
+     *            of the stored error code.
      */
-    void call_error_handler(cb_error& handler) const;
+    void call_error_handler(cb_error& handler, std::string const& msg = {}) const;
 
     /**
      * @brief Report a connection up-edge by calling the handler with errno=0 (success)

--- a/lib/everest/io/src/event/fd_event_client.cpp
+++ b/lib/everest/io/src/event/fd_event_client.cpp
@@ -1,15 +1,63 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 
 #include <everest/io/event/fd_event_client.hpp>
 #include <everest/io/event/fd_event_handler.hpp>
 
+#include <cerrno>
+#include <sys/socket.h>
+#include <utility>
+
 namespace everest::lib::io::event {
 
+namespace {
+// Error state 0 means cleared, so a protocol level failure with no errno of its own must
+// not be reported as 0 or the client reports success on a connection it gave up on.
+int genuine_error_code(int error_code) {
+    return error_code != 0 ? error_code : ECONNRESET;
+}
+
+// A local failure with no errno of its own is not a peer reset, so it must not be reported as one.
+int local_error_code(int error_code) {
+    return error_code != 0 ? error_code : EPROTO;
+}
+
+bool is_monitorable(poll_events desired) {
+    return desired == poll_events::read or desired == poll_events::write;
+}
+
+constexpr char unsupported_event_text[]{"handshake policy requested an event that is neither read nor write"};
+constexpr char monitor_failed_text[]{"the connection could not be monitored for the event the handshake waits for"};
+constexpr char deadline_arm_failed_text[]{"handshake deadline could not be armed"};
+constexpr char deadline_register_failed_text[]{"handshake deadline could not be registered"};
+} // namespace
+
 generic_fd_event_client_impl::generic_fd_event_client_impl(action const& send_one, action const& receive_one,
-                                                           action const& reset_client, error_status const& get_error) :
-    m_send_one(send_one), m_receive_one(receive_one), m_reset_client(reset_client), m_get_error(get_error) {
+                                                           action const& reset_client, error_status const& get_error,
+                                                           handshake_status const& handshake_pending,
+                                                           action const& drive_handshake,
+                                                           handshake_events const& handshake_desired_events,
+                                                           handshake_timeout const& get_handshake_timeout,
+                                                           error_text const& get_error_string) :
+    m_send_one(send_one),
+    m_receive_one(receive_one),
+    m_reset_client(reset_client),
+    m_get_error(get_error),
+    m_handshake_pending(handshake_pending),
+    m_drive_handshake(drive_handshake),
+    m_handshake_desired_events(handshake_desired_events),
+    m_get_handshake_timeout(get_handshake_timeout),
+    m_get_error_string(get_error_string) {
     m_event_handler = std::make_unique<event::fd_event_handler>();
+    m_handshake_timer.set_single_shot(true);
+    // Registered once and for all: a timerfd notifies only while it is running.
+    auto const deadline_registered =
+        m_event_handler->register_event_handler(&m_handshake_timer, [this]() { handshake_deadline_expired(); });
+    if (not deadline_registered) {
+        // Read errno before anything else overwrites it.
+        auto const error_code = errno;
+        m_handshake_deadline_register_error = error_code != 0 ? error_code : ENOTSUP;
+    }
 }
 
 generic_fd_event_client_impl::~generic_fd_event_client_impl() {
@@ -41,7 +89,7 @@ bool generic_fd_event_client_impl::setup_error_event_handler() {
         auto const state = current_connection_state();
         if (state == utilities::connection_state::failed) {
             error_handler();
-            call_error_handler(m_error);
+            call_error_handler(m_error, take_error_text());
             return sync_status::error;
         }
         if (state == utilities::connection_state::connected and clear_error_pending()) {
@@ -53,29 +101,43 @@ bool generic_fd_event_client_impl::setup_error_event_handler() {
 
 void generic_fd_event_client_impl::setup_io_event_handler(int fd) {
     using namespace everest::lib::io::event;
+    m_connection_failed = false;
+    // Belongs to the previous connection, so it may not describe a failure of this one.
+    m_local_error_text.clear();
     m_event_handler->register_event_handler(
         fd,
         [this, fd](auto events) {
-            auto success = true;
-            if (events.count(poll_events::error)) {
-                auto error = m_get_error();
-                if (error) {
-                    set_error_status_and_notify(error);
+            // A terminal notification wins over a pending handshake: the connection it would be
+            // negotiated on is gone.
+            if (events.count(poll_events::error) or events.count(poll_events::hungup)) {
+                // Level triggered, so the fd keeps notifying until the queued teardown removes it,
+                // and reading SO_ERROR clears it.
+                if (not m_connection_failed) {
+                    m_connection_failed = true;
+                    auto const kind = events.count(poll_events::error) != 0 ? poll_events::error : poll_events::hungup;
+                    set_error_status_and_notify(consume_poll_error(fd, kind));
                 }
-                success = false;
+                return;
             }
-            if (events.count(poll_events::hungup)) {
-                success = false;
+            if (m_handshake_pending()) {
+                drive_handshake(fd);
+                return;
             }
-            if (success && events.count(poll_events::read)) {
+            auto success = true;
+            if (events.count(poll_events::read)) {
                 success = rx_handler();
             }
-            if (success && events.count(poll_events::write)) {
-                success = tx_handler(fd);
+            if (success and events.count(poll_events::write)) {
+                tx_handler(fd);
             }
         },
         poll_events::read);
     m_event_handler->register_event_handler(&m_io_event_fd, [this, fd](auto) {
+        if (m_handshake_pending()) {
+            // The handshake monitors a single event, so monitoring write here would step it on an
+            // event it never asked for. The queue is flushed once it completes.
+            return;
+        }
         m_event_handler->modify_event_handler(fd, poll_events::write, event_modification::add);
     });
 }
@@ -135,24 +197,166 @@ void generic_fd_event_client_impl::error_handler() {
     add_action([this]() { m_reset_client(); });
 }
 
+void generic_fd_event_client_impl::drive_handshake(int fd) {
+    // Teardown is queued, so events keep arriving until it runs. Never step a dead handshake.
+    if (m_connection_failed) {
+        return;
+    }
+    if (not start_handshake_deadline()) {
+        return;
+    }
+    switch (m_drive_handshake()) {
+    case action_status::success: {
+        auto const desired = m_handshake_desired_events();
+        if (not is_monitorable(desired)) {
+            fail_connection(local_error_code(m_get_error()), unsupported_event_text);
+            return;
+        }
+        if (not monitor_for(fd, desired)) {
+            fail_connection(local_error_code(m_get_error()), monitor_failed_text);
+        }
+        return;
+    }
+    case action_status::empty: {
+        m_handshake_timer.disarm();
+        if (not monitor_for(fd, poll_events::read)) {
+            // A ready client on an unmonitored fd would leave the consumer waiting forever.
+            fail_connection(local_error_code(m_get_error()), monitor_failed_text);
+            return;
+        }
+        maybe_fire_ready();
+        return;
+    }
+    case action_status::fail: {
+        fail_connection();
+        return;
+    }
+    default:
+        fail_connection();
+        return;
+    }
+}
+
+void generic_fd_event_client_impl::fail_connection() {
+    fail_connection(m_get_error());
+}
+
+void generic_fd_event_client_impl::fail_connection(int error_code) {
+    m_connection_failed = true;
+    m_handshake_timer.disarm();
+    set_error_status_and_notify(genuine_error_code(error_code));
+}
+
+void generic_fd_event_client_impl::fail_connection(int error_code, std::string text) {
+    m_local_error_text = std::move(text);
+    fail_connection(error_code);
+}
+
+std::string generic_fd_event_client_impl::take_error_text() {
+    if (not m_local_error_text.empty()) {
+        return std::exchange(m_local_error_text, std::string{});
+    }
+    return m_get_error_string ? m_get_error_string() : std::string{};
+}
+
+bool generic_fd_event_client_impl::start_handshake_deadline() {
+    if (m_handshake_deadline_register_error != 0) {
+        fail_connection(local_error_code(m_handshake_deadline_register_error), deadline_register_failed_text);
+        return false;
+    }
+    auto const generation = m_connected_generation.load();
+    // The bound is on the whole handshake, so later steps keep the deadline the first one armed.
+    if (m_handshake_deadline_generation == generation) {
+        return true;
+    }
+    auto const timeout = m_get_handshake_timeout ? m_get_handshake_timeout() : default_handshake_timeout;
+    // A non positive timeout stops a timerfd, which is the unbounded handshake this guards.
+    if (not m_handshake_timer.set_timeout(timeout > std::chrono::milliseconds::zero() ? timeout
+                                                                                      : default_handshake_timeout)) {
+        // Read errno before anything else overwrites it.
+        auto const error_code = errno;
+        fail_connection(local_error_code(error_code), deadline_arm_failed_text);
+        return false;
+    }
+    // Recorded only once the deadline is in force: no record may claim a bound that never armed.
+    m_handshake_deadline_generation = generation;
+    return true;
+}
+
+void generic_fd_event_client_impl::handshake_deadline_expired() {
+    m_handshake_timer.disarm();
+    // One poll batch can carry both the expiry and the event that finished or replaced the
+    // handshake, so only the pending handshake this deadline was started for may be failed.
+    if (m_connection_failed or m_handshake_deadline_generation != m_connected_generation.load() or
+        not m_handshake_pending()) {
+        return;
+    }
+    fail_connection(ETIMEDOUT);
+}
+
+void generic_fd_event_client_impl::retire_handshake_deadline() {
+    m_handshake_timer.disarm();
+}
+
+int generic_fd_event_client_impl::consume_poll_error(int fd, poll_events kind) {
+    auto error = m_get_error ? m_get_error() : 0;
+    if (error != 0) {
+        return error;
+    }
+    int so_error = 0;
+    socklen_t len = sizeof(so_error);
+    // Consumes the pending socket error. Non sockets (serial, tun/tap) fail and fall through.
+    if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &so_error, &len) == 0 and so_error != 0) {
+        return so_error;
+    }
+    // No code available: a network errno would misdiagnose the serial and tun/tap devices this
+    // client also drives.
+    return kind == poll_events::hungup ? ENOTCONN : EIO;
+}
+
+bool generic_fd_event_client_impl::monitor_for(int fd, poll_events desired) {
+    // Otherwise both would be removed and the fd would be monitored for nothing.
+    if (not is_monitorable(desired)) {
+        return false;
+    }
+    auto read_ok = m_event_handler->modify_event_handler(
+        fd, poll_events::read, desired == poll_events::read ? event_modification::add : event_modification::remove);
+    auto write_ok = m_event_handler->modify_event_handler(
+        fd, poll_events::write, desired == poll_events::write ? event_modification::add : event_modification::remove);
+    return read_ok and write_ok;
+}
+
+poll_events generic_fd_event_client_impl::default_desired_events() {
+    return poll_events::read;
+}
+
 void generic_fd_event_client_impl::prepare_io_event_handler() {
     m_event_handler->register_event_handler(&m_connected_event_fd, [this](auto) {
-        auto client_status = m_client_status.handle();
-        auto generation = m_connected_generation.load();
-        if (client_status->generation != generation) {
+        auto ok = false;
+        auto fd = -1;
+        {
+            // Copy out under the lock only: the handshake setup below runs a policy callback.
+            auto client_status = m_client_status.handle();
+            auto generation = m_connected_generation.load();
+            if (client_status->generation != generation) {
+                return sync_status::ok;
+            }
+            ok = client_status->ok;
+            fd = client_status->fd;
+        }
+
+        auto error_code = m_get_error();
+        set_error_status_and_notify(error_code);
+        if (not ok) {
             return sync_status::ok;
         }
 
-        if (client_status->ok) {
-            auto error_code = m_get_error();
-            set_error_status_and_notify(error_code);
-            setup_io_event_handler(client_status->fd);
-            if (m_on_ready_action) {
-                m_event_handler->add_action(m_on_ready_action);
-            }
+        setup_io_event_handler(fd);
+        if (m_handshake_pending()) {
+            // The client owes the first handshake message, so it cannot wait for readability.
+            drive_handshake(fd);
         } else {
-            auto error_code = m_get_error();
-            set_error_status_and_notify(error_code);
+            maybe_fire_ready();
         }
 
         return sync_status::ok;
@@ -182,11 +386,32 @@ void generic_fd_event_client_impl::register_async_connect_event_handler(event_fd
 }
 
 void generic_fd_event_client_impl::set_on_ready_action(ready_action&& item) {
-    m_on_ready_action = std::move(item);
-    auto client_status = m_client_status.handle();
-    if (client_status->ok) {
-        m_event_handler->add_action(m_on_ready_action);
+    // Assign on the loop thread, where it is read when a connection becomes ready.
+    add_action([this, item = std::move(item)]() mutable {
+        m_on_ready_action = std::move(item);
+        auto connected = false;
+        {
+            auto client_status = m_client_status.handle();
+            connected = client_status->ok;
+        }
+        // A connected transport is not a ready client while its handshake is outstanding, and
+        // the connected status outlives a failure until the queued teardown runs.
+        if (connected and not m_connection_failed and not m_handshake_pending()) {
+            // Explicit registration on a ready connection asks to be called now.
+            m_ready_fired_generation = 0;
+            maybe_fire_ready();
+        }
+    });
+}
+
+void generic_fd_event_client_impl::maybe_fire_ready() {
+    // Recorded per connection, not per monitor change: the record can be cleared before it changes.
+    auto generation = m_connected_generation.load();
+    if (m_ready_fired_generation == generation or not m_on_ready_action) {
+        return;
     }
+    m_ready_fired_generation = generation;
+    m_event_handler->add_action(m_on_ready_action);
 }
 
 } // namespace everest::lib::io::event

--- a/lib/everest/io/src/event/fd_event_handler.cpp
+++ b/lib/everest/io/src/event/fd_event_handler.cpp
@@ -230,8 +230,14 @@ bool fd_event_handler::register_event_handler(timer_fd* fd, event_handler_type c
     auto const registered = register_event_handler(
         raw,
         [handler, fd](event_list const& e) {
-            fd->read();
-            handler(e);
+            // A poll batch is harvested before any of it is dispatched, so a rearm or disarm by an
+            // earlier handler retires an expiry still queued here. timerfd_settime clears the tick
+            // counter, the only identity an expiry carries, so a read of 0 marks it stale.
+            // The event_fd overload keeps its unconditional read: an eventfd is blocking and counts
+            // notifications rather than identifying an arm.
+            if (fd->read() > 0) {
+                handler(e);
+            }
         },
         poll_events::read);
     if (registered) {

--- a/lib/everest/io/src/utilities/generic_error_state.cpp
+++ b/lib/everest/io/src/utilities/generic_error_state.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 #include <everest/io/utilities/generic_error_state.hpp>
+
+#include <cerrno>
 #include <string.h>
 
 namespace everest::lib::io::utilities {
@@ -36,9 +38,12 @@ int generic_error_state::current_error() const {
     return m_current_error;
 }
 
-void generic_error_state::call_error_handler(cb_error& handler) const {
+void generic_error_state::call_error_handler(cb_error& handler, std::string const& msg) const {
     if (handler) {
-        handler(m_current_error, strerror(m_current_error));
+        // The callback must never see 0: consumers branch on 'code != 0', so a 0 report would be
+        // dropped while the state stays failed. Unreachable today, kept as a backstop.
+        auto error = m_current_error != 0 ? m_current_error : ECONNRESET;
+        handler(error, msg.empty() ? std::string{strerror(error)} : msg);
     }
 }
 

--- a/lib/everest/io/test/fd_event_client_async_test.cpp
+++ b/lib/everest/io/test/fd_event_client_async_test.cpp
@@ -3,12 +3,14 @@
 
 #include <everest/io/event/event_fd.hpp>
 #include <everest/io/event/fd_event_client.hpp>
+#include <everest/io/event/fd_event_handler.hpp>
 #include <everest/io/tcp/tcp_client.hpp>
 #include <everest/io/udp/udp_client.hpp>
 #include <everest/io/utilities/event_client_async_policy.hpp>
 #include <everest/io/utilities/generic_error_state.hpp>
 
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <netinet/in.h>
 #include <poll.h>
 #include <sys/socket.h>
@@ -21,10 +23,12 @@
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <functional>
 #include <limits>
 #include <memory>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -37,8 +41,12 @@ using namespace everest::lib::io;
 
 using everest::lib::io::event::event_fd;
 using everest::lib::io::event::fd_event_client;
+using everest::lib::io::event::poll_events;
 using everest::lib::io::event::semaphore_fd;
 using everest::lib::io::utilities::event_client_async_policy_v;
+using everest::lib::io::utilities::event_client_handshake_policy_v;
+using everest::lib::io::utilities::has_member_get_error_string_v;
+using everest::lib::io::utilities::has_member_handshake_timeout_v;
 
 namespace {
 
@@ -595,12 +603,383 @@ char const* state_name(utilities::connection_state state) {
     return "unknown";
 }
 
+static_assert(not event_client_handshake_policy_v<deterministic_async_policy>);
+static_assert(not has_member_get_error_string_v<deterministic_async_policy>);
+
+enum class handshake_step_result {
+    want_read,
+    want_write,
+    want_invalid,
+    complete,
+    fail
+};
+
+class handshake_script {
+public:
+    explicit handshake_script(std::vector<handshake_step_result> steps, int fail_error_code = 0,
+                              std::chrono::milliseconds handshake_timeout = 5s) :
+        m_steps{std::move(steps)}, m_fail_error_code{fail_error_code}, m_handshake_timeout{handshake_timeout} {
+        int fds[2]{-1, -1};
+        if (::socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, fds) == 0) {
+            m_local_fd = fds[0];
+            m_peer_fd = fds[1];
+        }
+    }
+
+    handshake_script(handshake_script const&) = delete;
+    handshake_script& operator=(handshake_script const&) = delete;
+    handshake_script(handshake_script&&) = delete;
+    handshake_script& operator=(handshake_script&&) = delete;
+
+    ~handshake_script() {
+        if (m_local_fd >= 0) {
+            ::close(m_local_fd);
+        }
+        if (m_peer_fd >= 0) {
+            ::close(m_peer_fd);
+        }
+    }
+
+    int local_fd() const {
+        return m_local_fd;
+    }
+
+    int fail_error_code() const {
+        return m_fail_error_code;
+    }
+
+    std::chrono::milliseconds handshake_timeout() const {
+        return m_handshake_timeout;
+    }
+
+    void deliver_peer_record() const {
+        deliver_byte(1);
+    }
+
+    void deliver_byte(char value) const {
+        (void)::send(m_peer_fd, &value, 1, MSG_DONTWAIT);
+    }
+
+    void close_peer() {
+        if (m_peer_fd >= 0) {
+            ::close(m_peer_fd);
+            m_peer_fd = -1;
+        }
+    }
+
+    // Without this a want_read state keeps refiring on the record the step already reacted to.
+    void consume_pending_record() const {
+        char byte{0};
+        (void)::recv(m_local_fd, &byte, 1, MSG_DONTWAIT);
+    }
+
+    handshake_step_result advance() {
+        ++m_step_count;
+        auto const result = m_steps[m_cursor];
+        if (m_cursor + 1 < m_steps.size()) {
+            ++m_cursor;
+        }
+        return result;
+    }
+
+    std::size_t step_count() const {
+        return m_step_count;
+    }
+
+    void register_connect() {
+        ++m_connect_count;
+    }
+
+    std::size_t connect_count() const {
+        return m_connect_count.load();
+    }
+
+    void record_tx(int payload) {
+        m_tx_payloads.push_back(payload);
+    }
+
+    std::vector<int> const& tx_payloads() const {
+        return m_tx_payloads;
+    }
+
+private:
+    std::vector<handshake_step_result> m_steps;
+    int m_fail_error_code{0};
+    std::chrono::milliseconds m_handshake_timeout{5s};
+    std::size_t m_cursor{0};
+    std::size_t m_step_count{0};
+    std::atomic<std::size_t> m_connect_count{0};
+    std::vector<int> m_tx_payloads;
+    int m_local_fd{-1};
+    int m_peer_fd{-1};
+};
+
+class scripted_handshake_policy {
+public:
+    using PayloadT = int;
+
+    scripted_handshake_policy() = default;
+
+    bool setup(std::shared_ptr<handshake_script> script) {
+        m_script = std::move(script);
+        return static_cast<bool>(m_script) and m_script->local_fd() >= 0;
+    }
+
+    void connect(std::function<void(bool, int)> const& cb) {
+        if (not m_script) {
+            cb(false, -1);
+            return;
+        }
+        m_script->register_connect();
+        cb(true, m_script->local_fd());
+    }
+
+    bool handshake_complete() const {
+        return m_complete;
+    }
+
+    bool handshake_step() {
+        if (not m_script) {
+            return false;
+        }
+        m_script->consume_pending_record();
+        switch (m_script->advance()) {
+        case handshake_step_result::want_read:
+            m_desired = poll_events::read;
+            return true;
+        case handshake_step_result::want_write:
+            m_desired = poll_events::write;
+            return true;
+        case handshake_step_result::want_invalid:
+            m_desired = poll_events::priority;
+            return true;
+        case handshake_step_result::complete:
+            m_complete = true;
+            // Poisoned: a completed handshake is monitored for reading, never from this request.
+            m_desired = poll_events::write;
+            return true;
+        case handshake_step_result::fail:
+        default:
+            m_error = m_script->fail_error_code();
+            m_error_string = "scripted handshake failure";
+            return false;
+        }
+    }
+
+    poll_events desired_events() const {
+        return m_desired;
+    }
+
+    std::chrono::milliseconds handshake_timeout() const {
+        return m_script ? m_script->handshake_timeout() : std::chrono::milliseconds{5s};
+    }
+
+    bool tx(PayloadT const& payload) {
+        if (not m_script) {
+            return false;
+        }
+        m_script->record_tx(payload);
+        return true;
+    }
+
+    bool rx(PayloadT& data) {
+        if (not m_script) {
+            return false;
+        }
+        char byte{0};
+        if (::recv(m_script->local_fd(), &byte, 1, MSG_DONTWAIT) != 1) {
+            return false;
+        }
+        data = static_cast<int>(byte);
+        return true;
+    }
+
+    int get_fd() const {
+        return m_script ? m_script->local_fd() : -1;
+    }
+
+    int get_error() const {
+        return m_error;
+    }
+
+    std::string const& get_error_string() const {
+        return m_error_string;
+    }
+
+private:
+    std::shared_ptr<handshake_script> m_script;
+    poll_events m_desired{poll_events::read};
+    bool m_complete{false};
+    int m_error{0};
+    std::string m_error_string;
+};
+
+static_assert(event_client_async_policy_v<scripted_handshake_policy>);
+static_assert(event_client_handshake_policy_v<scripted_handshake_policy>);
+static_assert(has_member_get_error_string_v<scripted_handshake_policy>);
+// The true side of the trait the handshake_timeout() static_assert keys on. Its false side is
+// what that assert lets through, which no compiling translation unit can pin.
+static_assert(has_member_handshake_timeout_v<scripted_handshake_policy>);
+
+class poll_error_script {
+public:
+    explicit poll_error_script(int fd) : m_fd{fd} {
+    }
+
+    poll_error_script(poll_error_script const&) = delete;
+    poll_error_script& operator=(poll_error_script const&) = delete;
+
+    ~poll_error_script() {
+        if (m_fd >= 0) {
+            ::close(m_fd);
+        }
+    }
+
+    int fd() const {
+        return m_fd;
+    }
+
+    void set_policy_error(int code) {
+        m_policy_error.store(code);
+    }
+
+    int policy_error() const {
+        return m_policy_error.load();
+    }
+
+private:
+    int m_fd{-1};
+    std::atomic<int> m_policy_error{0};
+};
+
+class poll_error_policy {
+public:
+    using PayloadT = int;
+
+    poll_error_policy() = default;
+
+    bool setup(std::shared_ptr<poll_error_script> script) {
+        m_script = std::move(script);
+        return static_cast<bool>(m_script) and m_script->fd() >= 0;
+    }
+
+    void connect(std::function<void(bool, int)> const& cb) {
+        if (not m_script) {
+            cb(false, -1);
+            return;
+        }
+        cb(true, m_script->fd());
+    }
+
+    bool tx(PayloadT const&) {
+        return false;
+    }
+
+    bool rx(PayloadT&) {
+        return false;
+    }
+
+    int get_fd() const {
+        return m_script ? m_script->fd() : -1;
+    }
+
+    int get_error() const {
+        return m_script ? m_script->policy_error() : 0;
+    }
+
+private:
+    std::shared_ptr<poll_error_script> m_script;
+};
+
+static_assert(event_client_async_policy_v<poll_error_policy>);
+static_assert(not event_client_handshake_policy_v<poll_error_policy>);
+
+// The port is bound and released so nothing listens on it. poll() does not consume SO_ERROR, so
+// ECONNREFUSED is left unread for the client to resolve.
+int make_refused_tcp_fd() {
+    int probe = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (probe < 0) {
+        return -1;
+    }
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    addr.sin_port = 0;
+    socklen_t addr_len = sizeof(addr);
+    if (::bind(probe, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0 or
+        ::getsockname(probe, reinterpret_cast<sockaddr*>(&addr), &addr_len) != 0) {
+        ::close(probe);
+        return -1;
+    }
+    ::close(probe);
+
+    int fd = ::socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0) {
+        // Something claimed the released port in the meantime.
+        ::close(fd);
+        return -1;
+    }
+    pollfd pfd{fd, POLLOUT, 0};
+    if (::poll(&pfd, 1, 2000) != 1 or (pfd.revents & POLLERR) == 0) {
+        ::close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+int make_hungup_pipe_read_fd() {
+    int fds[2]{-1, -1};
+    if (::pipe2(fds, O_NONBLOCK) != 0) {
+        return -1;
+    }
+    ::close(fds[1]);
+    return fds[0];
+}
+
+int make_errored_pipe_write_fd() {
+    int fds[2]{-1, -1};
+    if (::pipe2(fds, O_NONBLOCK) != 0) {
+        return -1;
+    }
+    ::close(fds[0]);
+    return fds[1];
+}
+
 } // namespace
 
 using deterministic_async_client = fd_event_client<deterministic_async_policy>::type;
 using deterministic_sync_client = fd_event_client<deterministic_sync_policy>::type;
 using rx_capable_sync_client = fd_event_client<rx_capable_sync_policy>::type;
 using faulting_rx_sync_client = fd_event_client<faulting_rx_sync_policy>::type;
+using scripted_handshake_client = fd_event_client<scripted_handshake_policy>::type;
+using poll_error_client = fd_event_client<poll_error_policy>::type;
+
+namespace {
+
+std::string describe_codes(std::vector<int> const& codes) {
+    std::string result;
+    for (auto code : codes) {
+        if (not result.empty()) {
+            result += ", ";
+        }
+        result += std::to_string(code) + " (" + std::strerror(code) + ")";
+    }
+    return result.empty() ? std::string{"none"} : result;
+}
+
+// The handler runs on the loop thread, which is the thread pumping in the tests below.
+template <class Client> void collect_error_codes(Client& client, std::vector<int>& codes) {
+    client.set_error_handler([&codes](int code, std::string const&) {
+        if (code != 0) {
+            codes.push_back(code);
+        }
+    });
+}
+
+} // namespace
 
 // Verify reset and sync do not block when an async connect callback is still
 // pending, protecting against deadlocks in the connect/reset path.
@@ -1476,4 +1855,560 @@ TEST(fd_event_client_error_signal_test, a_failed_read_reports_the_socket_error) 
         << "a read that failed on an established connection reported nothing";
     EXPECT_EQ(codes, (std::vector<int>{0, ECONNRESET})) << "the failed read did not report the socket error";
     EXPECT_TRUE(client.on_error()) << "the client still reports itself up after a failed read";
+}
+
+// Without a handshake phase the client is ready the moment the transport connects, so a
+// registration landing in the publish window and the connected handler would each release.
+TEST(fd_event_client_async_test, ready_action_registered_in_publish_window_fires_once) {
+    auto control = std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{true, 0}});
+    deterministic_async_client client(control);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    control->release(0);
+    ASSERT_TRUE(control->wait_for_attempt_completed(0, 500ms));
+    // Settle without pumping, so the published result is queued but not yet observed.
+    std::this_thread::sleep_for(50ms);
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+
+    pump_for(client, 200ms);
+    EXPECT_EQ(ready_calls.load(), 1) << "on_ready was delivered more than once for one connection";
+}
+
+TEST(fd_event_client_async_test, ready_action_registered_after_ready_fires_immediately) {
+    auto control = std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{true, 0}});
+    deterministic_async_client client(control);
+
+    std::atomic<int> first_calls{0};
+    client.set_on_ready_action([&] { ++first_calls; });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    control->release(0);
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return first_calls.load() >= 1; }));
+
+    std::atomic<int> second_calls{0};
+    client.set_on_ready_action([&] { ++second_calls; });
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return second_calls.load() >= 1; }))
+        << "the late registration was dropped on an already ready connection";
+    pump_for(client, 30ms);
+    EXPECT_EQ(second_calls.load(), 1);
+}
+
+TEST(fd_event_client_handshake_test, first_handshake_step_runs_without_fd_readiness) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read, handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+    pump_for(client, 30ms);
+    EXPECT_EQ(script->step_count(), 1u) << "handshake must not advance without a peer record";
+    EXPECT_EQ(ready_calls.load(), 0);
+
+    script->deliver_peer_record();
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() == 1; }));
+    EXPECT_EQ(script->step_count(), 2u);
+    EXPECT_FALSE(client.on_error());
+}
+
+TEST(fd_event_client_handshake_test, handshake_completing_on_first_step_fires_ready) {
+    auto script =
+        std::make_shared<handshake_script>(std::vector<handshake_step_result>{handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() == 1; }));
+    EXPECT_EQ(script->step_count(), 1u);
+    EXPECT_EQ(script->connect_count(), 1u);
+}
+
+TEST(fd_event_client_handshake_test, on_ready_action_waits_for_handshake_completion) {
+    auto script = std::make_shared<handshake_script>(std::vector<handshake_step_result>{
+        handshake_step_result::want_read, handshake_step_result::want_read, handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+    EXPECT_EQ(ready_calls.load(), 0);
+
+    script->deliver_peer_record();
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 2; }));
+    pump_for(client, 30ms);
+    EXPECT_EQ(ready_calls.load(), 0) << "on_ready fired before the handshake completed";
+
+    script->deliver_peer_record();
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() == 1; }));
+    EXPECT_EQ(script->step_count(), 3u) << "the handshake was stepped for an event it did not ask for";
+}
+
+TEST(fd_event_client_handshake_test, payloads_queued_during_handshake_flush_in_order) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read, handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+    ASSERT_EQ(ready_calls.load(), 0);
+
+    EXPECT_TRUE(client.tx(1));
+    EXPECT_TRUE(client.tx(2));
+    EXPECT_TRUE(client.tx(3));
+    pump_for(client, 30ms);
+    EXPECT_TRUE(script->tx_payloads().empty()) << "payloads must not be written during the handshake";
+    EXPECT_EQ(script->step_count(), 1u) << "a queued payload must not drive a handshake step";
+
+    script->deliver_peer_record();
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return script->tx_payloads().size() == 3; }));
+    EXPECT_EQ(script->tx_payloads(), std::vector<int>({1, 2, 3}));
+    EXPECT_EQ(ready_calls.load(), 1);
+}
+
+TEST(fd_event_client_handshake_test, the_tx_buffer_is_bounded_during_the_handshake) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read, handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+
+    constexpr auto cap = scripted_handshake_client::max_buffered_tx_payloads;
+    std::size_t accepted{0};
+    for (std::size_t i = 0; i < cap + 100; ++i) {
+        if (not client.tx(static_cast<int>(i))) {
+            break;
+        }
+        ++accepted;
+    }
+
+    EXPECT_EQ(accepted, cap) << "the handshake buffered " << accepted << " payloads against a cap of " << cap;
+    EXPECT_FALSE(client.tx(0)) << "the buffer accepted a payload past its cap";
+
+    // tx only notifies: without a loop pass the pending handshake is never asked to hold back.
+    pump_for(client, 100ms);
+    EXPECT_EQ(script->step_count(), 1u) << "a buffered payload stepped the handshake";
+    EXPECT_TRUE(script->tx_payloads().empty()) << "payloads must not be written during the handshake";
+}
+
+// The policy reports errno 0 here (a protocol level failure), so the client has to substitute a
+// code that consumers filtering on 'code != 0' actually see. The cleared-error callback is
+// recorded too: 'error cleared' after a fatal failure passes a dead connection off as healthy.
+TEST(fd_event_client_handshake_test, handshake_failure_reports_one_nonzero_error) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read, handshake_step_result::fail}, 0);
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    std::vector<std::pair<int, std::string>> error_reports;
+    client.set_on_ready_action([&] { ++ready_calls; });
+    client.set_error_handler([&](int code, std::string const& msg) { error_reports.emplace_back(code, msg); });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+
+    // The failing step consumes one, so the fd stays readable and would step a dead handshake.
+    script->deliver_peer_record();
+    script->deliver_peer_record();
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return error_reports.size() >= 2; }));
+    pump_for(client, 50ms);
+
+    ASSERT_EQ(error_reports.size(), 2u);
+    EXPECT_EQ(error_reports[0].first, 0);
+    EXPECT_EQ(error_reports[1].first, ECONNRESET);
+    EXPECT_EQ(error_reports[1].second, "scripted handshake failure");
+    EXPECT_EQ(ready_calls.load(), 0);
+    EXPECT_TRUE(client.on_error());
+}
+
+// A socketpair is always writable, so a want_write state advances with no peer record and a
+// want_read state must not. That only holds if monitoring one event removes the other.
+TEST(fd_event_client_handshake_test, handshake_monitors_write_and_read_exclusively) {
+    auto script = std::make_shared<handshake_script>(std::vector<handshake_step_result>{
+        handshake_step_result::want_write, handshake_step_result::want_read, handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 2; }));
+
+    pump_for(client, 30ms);
+    EXPECT_EQ(script->step_count(), 2u) << "writing is still monitored while the handshake waits for reading";
+    EXPECT_EQ(ready_calls.load(), 0);
+
+    script->deliver_peer_record();
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() == 1; }));
+    EXPECT_EQ(script->step_count(), 3u);
+}
+
+TEST(fd_event_client_handshake_test, ready_action_registered_mid_handshake_waits_for_completion) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read, handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+
+    pump_for(client, 30ms);
+    EXPECT_EQ(ready_calls.load(), 0) << "on_ready fired on a connection whose handshake is still pending";
+
+    script->deliver_peer_record();
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() >= 1; }));
+    pump_for(client, 30ms);
+    EXPECT_EQ(ready_calls.load(), 1) << "on_ready was delivered more than once for one connection";
+}
+
+TEST(fd_event_client_handshake_test, completed_handshake_delivers_application_payloads) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_write, handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    std::atomic<int> rx_calls{0};
+    std::atomic<int> last_payload{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+    client.set_rx_handler([&](int const& payload, auto&) {
+        ++rx_calls;
+        last_payload = payload;
+    });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() == 1; }));
+    ASSERT_EQ(script->step_count(), 2u);
+    ASSERT_EQ(rx_calls.load(), 0);
+
+    script->deliver_byte(7);
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return rx_calls.load() >= 1; }))
+        << "the completed handshake left the connection unmonitored for reading";
+    EXPECT_EQ(last_payload.load(), 7);
+}
+
+TEST(fd_event_client_handshake_test, ready_action_fires_again_after_reset) {
+    auto script =
+        std::make_shared<handshake_script>(std::vector<handshake_step_result>{handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() == 1; }));
+
+    ASSERT_TRUE(client.reset());
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() >= 2; }))
+        << "the ready action stayed set from the previous connection";
+    pump_for(client, 30ms);
+    EXPECT_EQ(ready_calls.load(), 2);
+    EXPECT_GE(script->connect_count(), 2u);
+}
+
+TEST(fd_event_client_handshake_test, unsupported_desired_event_fails_the_handshake) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_invalid}, ECONNREFUSED);
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    std::atomic<int> error_calls{0};
+    int last_code{0};
+    std::string last_message;
+    client.set_on_ready_action([&] { ++ready_calls; });
+    client.set_error_handler([&](int code, std::string const& msg) {
+        if (code != 0) {
+            ++error_calls;
+            last_code = code;
+            last_message = msg;
+        }
+    });
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return error_calls.load() >= 1; }));
+    pump_for(client, 30ms);
+    EXPECT_EQ(error_calls.load(), 1);
+    EXPECT_EQ(last_code, EPROTO) << "a local policy error was reported as " << std::strerror(last_code);
+    EXPECT_EQ(last_message, "handshake policy requested an event that is neither read nor write");
+    EXPECT_EQ(ready_calls.load(), 0);
+    EXPECT_TRUE(client.on_error());
+}
+
+TEST(fd_event_client_handshake_test, handshake_failure_keeps_the_policy_error_code) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read, handshake_step_result::fail},
+        ECONNREFUSED);
+    scripted_handshake_client client(script);
+
+    std::atomic<int> error_calls{0};
+    std::atomic<int> last_code{0};
+    std::string last_message;
+    client.set_error_handler([&](int code, std::string const& msg) {
+        if (code != 0) {
+            ++error_calls;
+            last_code = code;
+            last_message = msg;
+        }
+    });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+    script->deliver_peer_record();
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return error_calls.load() >= 1; }));
+
+    EXPECT_EQ(last_code.load(), ECONNREFUSED);
+    EXPECT_EQ(last_message, "scripted handshake failure");
+}
+
+TEST(fd_event_client_handshake_test, reset_after_handshake_failure_steps_again) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read, handshake_step_result::fail},
+        ECONNREFUSED);
+    scripted_handshake_client client(script);
+
+    std::atomic<int> error_calls{0};
+    client.set_error_handler([&](int code, std::string const&) {
+        if (code != 0) {
+            ++error_calls;
+        }
+    });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+    script->deliver_peer_record();
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return error_calls.load() >= 1; }));
+    auto const steps_before_reset = script->step_count();
+
+    ASSERT_TRUE(client.reset());
+    EXPECT_TRUE(pump_until(client, 500ms,
+                           [&] { return script->connect_count() >= 2 and script->step_count() > steps_before_reset; }));
+    EXPECT_GE(script->connect_count(), 2u);
+    EXPECT_GT(script->step_count(), steps_before_reset) << "the handshake stayed dead across reset";
+}
+
+TEST(fd_event_client_handshake_test, ready_action_registered_after_ready_fires_immediately) {
+    auto script =
+        std::make_shared<handshake_script>(std::vector<handshake_step_result>{handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> first_calls{0};
+    client.set_on_ready_action([&] { ++first_calls; });
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return first_calls.load() == 1; }));
+
+    std::atomic<int> second_calls{0};
+    client.set_on_ready_action([&] { ++second_calls; });
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return second_calls.load() >= 1; }))
+        << "the late registration was dropped on an already ready connection";
+    pump_for(client, 30ms);
+    EXPECT_EQ(second_calls.load(), 1);
+    EXPECT_EQ(first_calls.load(), 1);
+}
+
+// The connected status of a failed connection survives until the queued teardown runs.
+TEST(fd_event_client_handshake_test, ready_action_registered_after_failure_stays_silent) {
+    auto script =
+        std::make_shared<handshake_script>(std::vector<handshake_step_result>{handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() == 1; }));
+
+    // Recorded by the fd handler, which runs before the registration queued below.
+    script->close_peer();
+    std::atomic<int> late_calls{0};
+    client.set_on_ready_action([&] { ++late_calls; });
+
+    pump_for(client, 100ms);
+    EXPECT_EQ(late_calls.load(), 0) << "a failed connection released the ready action";
+    EXPECT_TRUE(client.on_error());
+}
+
+// A peer that connects and then goes silent produces no notification of any kind, so only a
+// deadline turns that into something the consumer can act on.
+TEST(fd_event_client_handshake_test, a_stalled_handshake_fails_on_its_deadline) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read}, 0, 60ms);
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    std::vector<int> codes;
+    client.set_on_ready_action([&] { ++ready_calls; });
+    collect_error_codes(client, codes);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return not codes.empty(); }))
+        << "the stalled handshake was never reported";
+    pump_for(client, 50ms);
+
+    ASSERT_EQ(codes.size(), 1u) << "reported: " << describe_codes(codes);
+    EXPECT_EQ(codes[0], ETIMEDOUT) << "the stalled handshake was reported as " << std::strerror(codes[0]);
+    EXPECT_EQ(ready_calls.load(), 0) << "a client that never negotiated anything was published as ready";
+    EXPECT_EQ(script->step_count(), 1u) << "the handshake was stepped past its deadline";
+    EXPECT_TRUE(client.on_error());
+
+    // A client bounding only its first handshake leaves every reconnect unbounded.
+    ASSERT_TRUE(client.reset());
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return codes.size() >= 2; }))
+        << "the handshake after reset was never bounded, reported: " << describe_codes(codes);
+
+    ASSERT_EQ(codes.size(), 2u) << "reported: " << describe_codes(codes);
+    EXPECT_EQ(codes[1], ETIMEDOUT) << "the stalled handshake after reset was reported as " << std::strerror(codes[1]);
+    EXPECT_EQ(ready_calls.load(), 0) << "a client that never negotiated anything was published as ready";
+}
+
+TEST(fd_event_client_handshake_test, a_dribbling_handshake_fails_on_its_first_deadline) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read, handshake_step_result::want_read,
+                                           handshake_step_result::want_read},
+        0, 200ms);
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    std::vector<int> codes;
+    client.set_on_ready_action([&] { ++ready_calls; });
+    collect_error_codes(client, codes);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+
+    // Stepping every 40ms inside a 200ms bound, for longer than that bound: a deadline restarted
+    // per step would never expire while this runs.
+    auto const stop = std::chrono::steady_clock::now() + 700ms;
+    while (std::chrono::steady_clock::now() < stop and codes.empty()) {
+        script->deliver_peer_record();
+        pump_for(client, 40ms);
+    }
+
+    ASSERT_FALSE(codes.empty()) << "a handshake still stepping was never bounded, after " << script->step_count()
+                                << " steps";
+    ASSERT_EQ(codes.size(), 1u) << "reported: " << describe_codes(codes);
+    EXPECT_EQ(codes[0], ETIMEDOUT) << "the unfinished handshake was reported as " << std::strerror(codes[0]);
+    EXPECT_GT(script->step_count(), 1u) << "the handshake never took a second step, so nothing bounded it";
+    EXPECT_EQ(ready_calls.load(), 0) << "a client that never negotiated anything was published as ready";
+    EXPECT_TRUE(client.on_error());
+}
+
+// The terminal notification arrives on the same descriptor the pending handshake waits on.
+// Handling the handshake first steps a dead connection over and over and reports nothing.
+TEST(fd_event_client_handshake_test, a_peer_drop_during_the_handshake_is_reported_once) {
+    auto script =
+        std::make_shared<handshake_script>(std::vector<handshake_step_result>{handshake_step_result::want_read});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    std::vector<int> codes;
+    client.set_on_ready_action([&] { ++ready_calls; });
+    collect_error_codes(client, codes);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+    auto const steps_before_drop = script->step_count();
+
+    script->close_peer();
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return not codes.empty(); }))
+        << "the peer drop was never reported, the handshake was stepped " << script->step_count() << " times";
+    pump_for(client, 50ms);
+
+    ASSERT_EQ(codes.size(), 1u) << "reported: " << describe_codes(codes);
+    EXPECT_EQ(codes[0], ENOTCONN) << "the dropped peer was reported as " << std::strerror(codes[0]);
+    EXPECT_EQ(script->step_count(), steps_before_drop) << "the handshake was stepped after the peer was gone";
+    EXPECT_EQ(ready_calls.load(), 0) << "a client whose peer dropped mid handshake was published as ready";
+    EXPECT_TRUE(client.on_error());
+}
+
+TEST(fd_event_client_handshake_test, a_completed_handshake_outlives_its_deadline) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::complete}, 0, 60ms);
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    std::vector<int> codes;
+    client.set_on_ready_action([&] { ++ready_calls; });
+    collect_error_codes(client, codes);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() == 1; }));
+    pump_for(client, 250ms);
+
+    EXPECT_TRUE(codes.empty()) << "the deadline of the finished handshake failed the connection: "
+                               << describe_codes(codes);
+    EXPECT_FALSE(client.on_error());
+    EXPECT_EQ(ready_calls.load(), 1);
+}
+
+// A terminal notification is level triggered: the descriptor keeps notifying until the queued
+// teardown removes it. Resolving the code reads SO_ERROR, which consumes it, so a re-dispatch
+// would replace the real reason with the fallback.
+TEST(fd_event_client_poll_error_test, socket_error_is_reported_once_and_not_overwritten) {
+    const int fd = make_refused_tcp_fd();
+    ASSERT_GE(fd, 0) << "could not produce a refused loopback connect";
+    auto script = std::make_shared<poll_error_script>(fd);
+    poll_error_client client(script);
+
+    std::vector<int> codes;
+    collect_error_codes(client, codes);
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return not codes.empty(); }));
+    pump_for(client, 50ms);
+
+    ASSERT_FALSE(codes.empty()) << "the terminal notification was never reported";
+    EXPECT_EQ(codes[0], ECONNREFUSED) << "the socket error was consumed and then reported as "
+                                      << std::strerror(codes[0]);
+    EXPECT_EQ(codes.size(), 1u) << "the terminal notification was reported more than once: " << describe_codes(codes);
+    EXPECT_TRUE(client.on_error());
+}
+
+// Injected from the ready action, which runs after the descriptor is monitored and before the
+// loop can dispatch it, so the connect path itself stays clean.
+TEST(fd_event_client_poll_error_test, policy_error_wins_over_the_socket_error) {
+    const int fd = make_refused_tcp_fd();
+    ASSERT_GE(fd, 0) << "could not produce a refused loopback connect";
+    auto script = std::make_shared<poll_error_script>(fd);
+    poll_error_client client(script);
+
+    std::vector<int> codes;
+    collect_error_codes(client, codes);
+    client.set_on_ready_action([&script] { script->set_policy_error(ETIMEDOUT); });
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return not codes.empty(); }));
+    pump_for(client, 50ms);
+
+    ASSERT_FALSE(codes.empty()) << "the terminal notification was never reported";
+    EXPECT_EQ(codes[0], ETIMEDOUT) << "the policy error was discarded in favor of " << std::strerror(codes[0]);
+    EXPECT_EQ(codes.size(), 1u) << "the terminal notification was reported more than once: " << describe_codes(codes);
+}
+
+// A hangup on something that is not a socket has no code to read back: getsockopt fails on a
+// pipe, a serial line and a tun/tap device alike.
+TEST(fd_event_client_poll_error_test, hangup_without_a_code_reports_not_connected) {
+    const int fd = make_hungup_pipe_read_fd();
+    ASSERT_GE(fd, 0) << "could not produce a hung up pipe";
+    auto script = std::make_shared<poll_error_script>(fd);
+    poll_error_client client(script);
+
+    std::vector<int> codes;
+    collect_error_codes(client, codes);
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return not codes.empty(); }));
+    pump_for(client, 50ms);
+
+    ASSERT_FALSE(codes.empty()) << "the terminal notification was never reported";
+    EXPECT_EQ(codes[0], ENOTCONN) << "a bare hangup was reported as " << std::strerror(codes[0]);
+    EXPECT_EQ(codes.size(), 1u) << "the terminal notification was reported more than once: " << describe_codes(codes);
+}
+
+TEST(fd_event_client_poll_error_test, error_without_a_code_reports_io_failure) {
+    const int fd = make_errored_pipe_write_fd();
+    ASSERT_GE(fd, 0) << "could not produce an errored pipe";
+    auto script = std::make_shared<poll_error_script>(fd);
+    poll_error_client client(script);
+
+    std::vector<int> codes;
+    collect_error_codes(client, codes);
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return not codes.empty(); }));
+    pump_for(client, 50ms);
+
+    ASSERT_FALSE(codes.empty()) << "the terminal notification was never reported";
+    EXPECT_EQ(codes[0], EIO) << "a bare error notification was reported as " << std::strerror(codes[0]);
+    EXPECT_EQ(codes.size(), 1u) << "the terminal notification was reported more than once: " << describe_codes(codes);
 }

--- a/lib/everest/io/test/fd_event_handler_test.cpp
+++ b/lib/everest/io/test/fd_event_handler_test.cpp
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <memory>
+#include <thread>
 #include <type_traits>
 
 #include <unistd.h>
@@ -485,4 +486,72 @@ TEST(fd_event_handler_test, unregistering_a_timer_from_another_handler_reports_f
 
     EXPECT_TRUE(owner.unregister_event_handler(&timer));
     EXPECT_FALSE(owner.is_registered(raw));
+}
+
+TEST(fd_event_handler_test, registered_single_shot_timer_fires_once_with_no_mutation) {
+    fd_event_handler handler;
+    timer_fd timer;
+
+    int timer_fired = 0;
+    ASSERT_TRUE(handler.register_event_handler(&timer, [&]() { ++timer_fired; }));
+
+    timer.set_single_shot(true);
+    ASSERT_TRUE(timer.set_timeout(5ms));
+
+    std::this_thread::sleep_for(20ms);
+    EXPECT_TRUE(handler.poll(0ms));
+
+    EXPECT_EQ(timer_fired, 1);
+}
+
+// One epoll_wait harvests a whole batch before dispatching any of it, so a handler early in the
+// batch can retire a timer whose expiry is already in that same batch. disarm() calls
+// timerfd_settime, which clears the expiration counter, so the dispatch wrapper's read finds
+// nothing and recognizes the harvested expiry as stale.
+// Linux appends to the epoll ready list in the order descriptors become ready. Do not reorder the
+// notify/sleep/poll sequence below: it is what makes the race deterministic instead of racy.
+TEST(fd_event_handler_test, disarming_a_timer_from_another_handler_in_the_same_batch_suppresses_its_dispatch) {
+    fd_event_handler handler;
+    event_fd trigger;
+    timer_fd timer;
+
+    int timer_fired = 0;
+    ASSERT_TRUE(handler.register_event_handler(&trigger, [&]() { timer.disarm(); }));
+    ASSERT_TRUE(handler.register_event_handler(&timer, [&]() { ++timer_fired; }));
+
+    timer.set_single_shot(true);
+    ASSERT_TRUE(timer.set_timeout(5ms));
+
+    // Ready first, so epoll places it ahead of the timer in the batch.
+    trigger.notify();
+    // Ready second: sleep past the timeout.
+    std::this_thread::sleep_for(20ms);
+
+    handler.poll(0ms);
+
+    EXPECT_EQ(timer_fired, 0);
+}
+
+// Same defect via a rearm instead of a disarm: a handler pushes a timer's deadline out from under
+// an expiry that already occurred. set_timeout resets the expiration counter just like disarm().
+TEST(fd_event_handler_test, rearming_a_timer_from_another_handler_in_the_same_batch_suppresses_its_dispatch) {
+    fd_event_handler handler;
+    event_fd trigger;
+    timer_fd timer;
+
+    int timer_fired = 0;
+    ASSERT_TRUE(handler.register_event_handler(&trigger, [&]() { timer.set_timeout(10s); }));
+    ASSERT_TRUE(handler.register_event_handler(&timer, [&]() { ++timer_fired; }));
+
+    timer.set_single_shot(true);
+    ASSERT_TRUE(timer.set_timeout(5ms));
+
+    // Ready first, so epoll places it ahead of the timer in the batch.
+    trigger.notify();
+    // Ready second: sleep past the timeout.
+    std::this_thread::sleep_for(20ms);
+
+    handler.poll(0ms);
+
+    EXPECT_EQ(timer_fired, 0);
 }


### PR DESCRIPTION
## Describe your changes

`generic_fd_event_client` had two states for a connection: not connected, and ready for data. A
protocol that must negotiate before data flows had nowhere to put that negotiation, so it ended up on
its own thread with its own lifetime.

This adds an optional handshake phase between "transport connected" and "ready for data", driven on
the existing event loop. A policy opts in by providing `handshake_step`, `handshake_complete` and
`desired_events`, detected by trait. A policy without them takes exactly the previous path, so
nothing changes for the ten existing clients.

- **The first step runs unsolicited**, as soon as the transport is connected and before any readiness
  event, because the client owes the first protocol message and cannot wait for the descriptor to
  become readable. This is the easiest part of the contract to get wrong. After that the policy is
  stepped only for the single event its `desired_events` asked for.
- **The descriptor is monitored for exactly one of read or write** while a handshake is outstanding,
  never both, because the handshake owns it. Payloads written during that window are queued and
  flushed in order once it completes.
- **A single-shot `timer_fd` bounds the whole handshake**, not each step. Without it,
  `action_status::success` re-armed forever: a peer that completed the TCP connect and then went
  silent left the client in `connected` with `on_error()` reporting false, the ready action never
  fired, `tx()` buffered to its cap and rejected with no diagnostic, and nothing ever called
  `reset()`. Default 10 s; a policy may state its own bound, and a non-positive value falls back to
  the default rather than disarming the timer.
- **A failed arm now fails the connection.** The `set_timeout` result was dropped, so a handshake
  could proceed with no deadline at all, which is the case the timer exists to prevent. Reporting it
  also required an early return, because `maybe_fire_ready()` has no failed-connection guard and
  would otherwise fire ready on the connection the failed arm just killed.
- **A policy carrying `handshake_timeout()` without the trio no longer compiles.** It was silently
  ignored before. `get_error_string` stays independent, and the trio without a timeout still compiles.

Two gaps stated rather than papered over. The expiry path carries a staleness guard so a timer firing
in the same poll batch as the completing event cannot fail a good connection; poll batches have no
defined dispatch order, so the guard is necessary, but it is not reachable from the test harness and
has no test. A failed timer arm is likewise unreachable without fault injection: `timer_fd` takes its
descriptor at construction and exposes no injection seam.

## Issue ticket number and link

N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

---

### Stack

Six PR series, two rooted on `main`. (#2558 and #2559 have merged.)

This PR is 3 above `main`, so 2 PRs (#2561, #2562) must merge before it.

- `main`
  - #2560 `fix/io-connect-errno-and-backoff`
  - #2561 `fix/io-event-handler-truthfulness`
    - #2562 `feat/io-client-tx-tristate`
      - **#2563 `feat/io-fd-event-client-handshake-phase` (this PR)**
        - #2564 `feat/io-tls-policies-rebuilt`
      - #2565 `refactor/chargebridge-drop-hand-rolled-tx-gates`
