### PR TITLE
feat(io/tls): event loop driven TLS client and server

### DIFF
--- a/lib/everest/io/BUILD.bazel
+++ b/lib/everest/io/BUILD.bazel
@@ -43,6 +43,7 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = [
+        "//lib/everest/tls",
         "//lib/everest/util",
         "@mosquitto",
     ],

--- a/lib/everest/io/README.md
+++ b/lib/everest/io/README.md
@@ -9,8 +9,9 @@ Currently there are clients for
  - PTY
  - TCP
  - TAP
+ - TLS (enabled via `EVEREST_IO_ENABLE_TLS=ON`, default ON)
 
-The clients are single threaded and epoll based. Utilities for file descriptor based event handling are provided and used.
+The clients are driven from a single event loop and are epoll based; the async connect path uses a short-lived detached thread for the blocking connect. Utilities for file descriptor based event handling are provided and used.
 
 ## Client tx contract
 
@@ -45,3 +46,80 @@ time: `on_error()` reports `true` from the call until the reopen.
 
 `tx()` and `reset()` are loop-thread only: call them from the thread that drives `sync()`, or from
 a callback that thread dispatches.
+## TLS
+
+Drives the libtls (`everest::tls`) `Server` and `Client` through the same
+`fd_event_handler` pattern as the other clients. Disable with
+`-DEVEREST_IO_ENABLE_TLS=OFF` when libtls / OpenSSL are unavailable.
+
+### Server side
+
+`tls_listener` owns the listen socket and an embedded `tls::Server`. For each
+accepted connection it yields a `std::unique_ptr<tls::tls_server>` to the accept
+callback. Register it on the same `fd_event_handler` with
+`register_event_handler(conn.get())`, which makes the loop drive the handshake and
+rx/tx, and keep it alive for the connection's lifetime.
+
+Dropping the `unique_ptr` tears the connection down and unregisters its fds.
+
+`tls_server::tx()` buffers and returns a `bool`. Check it: a rejection is
+backpressure, not a failure, but ignoring it turns a stalled peer into silently
+dropped payloads.
+
+`tls_listener::set_error_handler` is the only way to observe a failed accept, and
+is never called with code `0`. Descriptor exhaustion is reported as `EMFILE` or
+`ENFILE` and costs the queued connection; serving resumes by itself once
+descriptors are available.
+
+### Client side
+
+`tls_client` is an alias for `event::fd_event_client<tls_client_socket>::type`,
+not a class. `tls_client_interface` names the second parameter of the rx callback
+without naming the concrete type.
+
+The client is an `fd_event_sync_interface` nesting its own `fd_event_handler`:
+`register_event_handler(&client)` resolves to the sync-interface overload, and the
+outer handler polls `get_poll_fd()` and calls `sync()`. Only the blocking TCP
+connect runs off-loop, on the generic client's short-lived detached thread; the TLS
+handshake is driven loop-side through the handshake trait of `tls_client_socket`, so
+user code wires no handshake hooks or `desired_events`.
+
+`unregister_event_handler(&client)` is the explicit way to leave the handler, but
+the destructor drops the registration anyway.
+
+What is required is the ordering. The `fd_event_handler` **must outlive** every
+endpoint registered on it, client and server alike, because the endpoint's
+destructor reaches into the handler to unregister. Declare the handler first, so it
+is destroyed last.
+
+`tx()` accepts payloads from the start: those queued before the connect completes
+and during the handshake are held and flushed in order once the connection is up
+(`tls_client_socket` declares `buffer_tx_before_connect`, see "Client tx contract"
+above). The on-ready action signals there is a connection to send on.
+
+A connect or handshake that keeps failing goes inert: the error handler fires and
+the client tears down, but it does not reconnect on its own, only a consumer
+`reset()` reopens it. The error callback also reports a cleared error as code `0`,
+so gate consumer logic on `err != 0`.
+
+A DNS `host_for_sni` is sent in the TLS SNI extension, an IP literal is not (RFC
+6066). `tls.verify_subject_name = true` additionally pins the peer certificate to
+`host_for_sni` (a DNS name via RFC-6125 SAN/CN matching, an IP literal via IP-SAN
+matching), not to the TCP connect target. Pinning is only enforced when
+`tls.verify_server` is also true; with an IP-literal target and no matching SAN,
+leave `verify_subject_name` at its default `false`.
+
+### Threading and signals
+
+`tx()` wakes the loop through an internal `event_fd`. Its queue is not
+synchronized, so call `tx()` only from the loop thread (the rx handler or the
+on-ready action), never from another thread.
+
+OpenSSL drives its socket BIO through `write()` without `MSG_NOSIGNAL`, so a write
+to a peer-reset connection raises `SIGPIPE`. Processes using this layer must
+install `signal(SIGPIPE, SIG_IGN)` or a peer reset during `tx()` aborts the
+process.
+
+Example binaries in `lib/everest/io/examples/`:
+ - `test_tls_server`: `tls_listener` + `tls_server` echo demo
+ - `test_tls_client`: event-loop-driven `tls_client` demo

--- a/lib/everest/io/examples/CMakeLists.txt
+++ b/lib/everest/io/examples/CMakeLists.txt
@@ -99,6 +99,22 @@ target_compile_features(test_udp_unconnected_client PUBLIC cxx_std_17)
 target_compile_options(test_udp_unconnected_client PRIVATE -fsanitize=address -g)
 target_link_options(test_udp_unconnected_client PRIVATE -static-libasan -fsanitize=address)
 
+###
+
+if(EVEREST_IO_ENABLE_TLS)
+    add_executable(test_tls_server test_tls_server.cpp)
+    target_link_libraries(test_tls_server PRIVATE everest::io)
+    target_compile_features(test_tls_server PUBLIC cxx_std_17)
+    target_compile_options(test_tls_server PRIVATE -fsanitize=address -g)
+    target_link_options(test_tls_server PRIVATE -static-libasan -fsanitize=address)
+
+    add_executable(test_tls_client test_tls_client.cpp)
+    target_link_libraries(test_tls_client PRIVATE everest::io)
+    target_compile_features(test_tls_client PUBLIC cxx_std_17)
+    target_compile_options(test_tls_client PRIVATE -fsanitize=address -g)
+    target_link_options(test_tls_client PRIVATE -static-libasan -fsanitize=address)
+endif()
+
 
 
 

--- a/lib/everest/io/examples/test_tls_client.cpp
+++ b/lib/everest/io/examples/test_tls_client.cpp
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/event/timer_fd.hpp>
+#include <everest/io/tls/tls_client.hpp>
+#include <everest/io/tls/tls_client_config.hpp>
+
+#include <atomic>
+#include <csignal>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <string>
+
+using namespace everest::lib::io::tls;
+using namespace everest::lib::io::event;
+
+using payload_t = tls_client_socket::PayloadT;
+
+int main(int argc, char* argv[]) {
+    std::cout << "TLS echo client example" << std::endl;
+
+    // OpenSSL writes without MSG_NOSIGNAL, so a write to a peer-reset connection raises
+    // SIGPIPE. Every process using this layer must ignore it.
+    std::signal(SIGPIPE, SIG_IGN);
+
+    std::string host = "127.0.0.1";
+    std::uint16_t port = 8443;
+    std::string trust_anchor = "server_root_cert.pem";
+
+    if (argc == 4) {
+        host = argv[1];
+        try {
+            auto tmp = std::stoul(argv[2]);
+            if (tmp > 65535u) {
+                throw std::invalid_argument("port out of range");
+            }
+            port = static_cast<std::uint16_t>(tmp);
+        } catch (...) {
+            std::cerr << "ERROR: invalid port '" << argv[2] << "'" << std::endl;
+            return 1;
+        }
+        trust_anchor = argv[3];
+    } else if (argc != 1) {
+        std::cout << "USAGE: test_tls_client [host port trust_anchor.pem]" << std::endl;
+        std::cout << "  Defaults: 127.0.0.1 8443 server_root_cert.pem" << std::endl;
+        return 1;
+    }
+
+    tls_client_socket::Config cfg{};
+    cfg.tls.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    cfg.tls.ciphersuites = "";
+    cfg.tls.verify_locations_file = trust_anchor;
+    cfg.tls.io_timeout_ms = 5000;
+    cfg.tls.verify_server = true;
+    cfg.host_for_sni = host;
+
+    std::cout << "Connecting to " << host << ":" << port << " ..." << std::endl;
+
+    fd_event_handler ev_handler;
+    tls_client client(cfg, host, port, 5000);
+
+    std::atomic<bool> running{true};
+    int replies_received = 0;
+    const int expected_replies = 3;
+
+    client.set_error_handler([&running](int err, std::string const& msg) {
+        if (err != 0) {
+            std::cerr << "ERROR (" << err << "): " << msg << std::endl;
+            running = false;
+        }
+    });
+
+    client.set_rx_handler(
+        [&replies_received, &running, expected_replies](payload_t const& payload, tls_client_interface&) {
+            ++replies_received;
+            std::cout << "Reply (" << payload.size() << " bytes): " << std::string(payload.begin(), payload.end());
+            if (replies_received >= expected_replies) {
+                running = false;
+            }
+        });
+
+    client.set_on_ready_action([&client]() {
+        std::cout << "Handshake complete. Sending messages..." << std::endl;
+        for (const char* text : {"hello tls\n", "second message\n", "goodbye\n"}) {
+            payload_t msg(text, text + std::strlen(text));
+            client.tx(msg);
+        }
+    });
+
+    ev_handler.register_event_handler(&client);
+    ev_handler.run(running);
+
+    // The explicit path out of the handler. ev_handler is declared before the client, so it
+    // outlives it and the client's destructor would drop the registration anyway.
+    ev_handler.unregister_event_handler(&client);
+
+    std::cout << "Done." << std::endl;
+    return 0;
+}

--- a/lib/everest/io/examples/test_tls_server.cpp
+++ b/lib/everest/io/examples/test_tls_server.cpp
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tls/tls_listener.hpp>
+#include <everest/io/tls/tls_listener_config.hpp>
+#include <everest/io/tls/tls_server.hpp>
+#include <everest/io/tls/tls_server_socket.hpp>
+
+#include <atomic>
+#include <csignal>
+#include <cstdint>
+#include <deque>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using namespace everest::lib::io::tls;
+using namespace everest::lib::io::event;
+
+int main(int argc, char* argv[]) {
+    std::cout << "TLS echo server example" << std::endl;
+
+    // OpenSSL writes without MSG_NOSIGNAL, so a write to a peer-reset connection raises
+    // SIGPIPE. Every process using this layer must ignore it.
+    std::signal(SIGPIPE, SIG_IGN);
+
+    std::uint16_t bind_port = 8443;
+    std::string cert_chain = "server_chain.pem";
+    std::string private_key = "server_priv.pem";
+    std::string trust_anchor = "server_root_cert.pem";
+
+    if (argc == 5) {
+        try {
+            auto tmp = std::stoul(argv[1]);
+            if (tmp > 65535u) {
+                throw std::invalid_argument("port out of range");
+            }
+            bind_port = static_cast<std::uint16_t>(tmp);
+        } catch (...) {
+            std::cerr << "ERROR: invalid port '" << argv[1] << "'" << std::endl;
+            return 1;
+        }
+        cert_chain = argv[2];
+        private_key = argv[3];
+        trust_anchor = argv[4];
+    } else if (argc != 1) {
+        std::cout << "USAGE: test_tls_server [port cert_chain.pem key.pem trust_anchor.pem]" << std::endl;
+        std::cout << "  Defaults: 8443 server_chain.pem server_priv.pem server_root_cert.pem" << std::endl;
+        return 1;
+    }
+
+    tls_listener::Config lcfg;
+    auto& chain = lcfg.tls.chains.emplace_back();
+    chain.certificate_chain_file = cert_chain.c_str();
+    chain.private_key_file = private_key.c_str();
+    chain.trust_anchor_file = trust_anchor.c_str();
+    lcfg.tls.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    lcfg.tls.ciphersuites = "";
+    lcfg.tls.verify_client = false;
+    lcfg.tls.io_timeout_ms = 1000;
+    lcfg.bind_addr = "127.0.0.1";
+    lcfg.bind_port = bind_port;
+
+    fd_event_handler ev_handler;
+    tls_listener listener(std::move(lcfg));
+
+    std::cout << "Listener will accept on 127.0.0.1:" << listener.listen_port() << " once the event loop runs"
+              << std::endl;
+
+    // Keeps the accepted connections alive for the lifetime of the loop.
+    std::deque<std::unique_ptr<tls_server>> connections;
+
+    listener.set_accept_callback([&ev_handler, &connections](std::unique_ptr<tls_server> conn,
+                                                             std::string const& peer_ip, std::uint16_t peer_port) {
+        std::cout << "Accepted from " << peer_ip << ":" << peer_port << std::endl;
+        conn->set_rx_handler([](tls_server_socket::PayloadT const& payload, auto& self) {
+            std::cout << "RX (" << payload.size() << " bytes): " << std::string(payload.begin(), payload.end())
+                      << std::flush;
+            self.tx(payload);
+        });
+        ev_handler.register_event_handler(conn.get());
+        connections.push_back(std::move(conn));
+    });
+
+    ev_handler.register_event_handler(&listener);
+
+    std::atomic<bool> running{true};
+    ev_handler.run(running);
+
+    // Each tls_server destructor unregisters itself and closes its TLS connection.
+    connections.clear();
+    return 0;
+}

--- a/lib/everest/io/include/everest/io/event/fd_event_client.hpp
+++ b/lib/everest/io/include/everest/io/event/fd_event_client.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 
 /** \file */
 
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <everest/io/event/event_fd.hpp>
 #include <everest/io/event/fd_event_sync_interface.hpp>
+#include <everest/io/event/timer_fd.hpp>
 #include <everest/io/event/unique_fd.hpp>
 #include <everest/io/socket/socket.hpp>
 #include <everest/io/utilities/event_client_async_policy.hpp>
@@ -20,11 +21,16 @@
 #include <future>
 #include <memory>
 #include <queue>
+#include <string>
 #include <thread>
 #include <type_traits>
 
 namespace everest::lib::io::event {
 class fd_event_handler;
+
+// Opaque: event/fd_event_handler.hpp defines poll_events and includes this header, so including
+// it back would close a cycle.
+enum class poll_events;
 
 /**
  * @enum action_status
@@ -74,6 +80,38 @@ public:
      * @brief Prototype for error_status
      */
     using error_status = std::function<int()>;
+
+    /**
+     * @var handshake_status
+     * @brief Prototype for the query whether the handshake is still pending
+     */
+    using handshake_status = std::function<bool()>;
+
+    /**
+     * @var handshake_events
+     * @brief Prototype for the query which single event the handshake waits for
+     */
+    using handshake_events = std::function<poll_events()>;
+
+    /**
+     * @var handshake_timeout
+     * @brief Prototype for the query how long the handshake may stay pending
+     */
+    using handshake_timeout = std::function<std::chrono::milliseconds()>;
+
+    /**
+     * @var error_text
+     * @brief Prototype for an error description supplied by the client policy
+     */
+    using error_text = std::function<std::string()>;
+
+    /**
+     * @var default_handshake_timeout
+     * @brief Upper bound of a protocol handshake when the client policy states none.
+     * @details Retransmission with a doubling timeout lets a healthy negotiation over a lossy
+     * link take seconds. Past this the peer stopped talking, and the client reports ETIMEDOUT.
+     */
+    static constexpr std::chrono::milliseconds default_handshake_timeout{10000};
 
     /**
      * @var ready_action
@@ -149,9 +187,9 @@ public:
 
     /**
      * @brief Register a function, that is called once the client is ready
-     * @details This callback is performed immediately, if the client is in a ready state
-     *          or the client is ready. The action is persistent and called whenever the client
-     *          is ready after reset.
+     * @details Registration is deferred to the event loop. Called once per connection, so also
+     *          again after a reset, and immediately when the client is already ready. A client
+     *          policy with a handshake phase counts as ready once the handshake is complete.
      * @param[in] item The callback
      */
     void set_on_ready_action(std::function<void()>&& item);
@@ -160,9 +198,18 @@ protected:
     /**
      * @brief Constructor.
      * @details Functionality passed in by functors
+     * @param[in] drive_handshake One handshake step. 'success' to continue, 'fail' on a handshake
+     *            error, 'empty' once the handshake is complete
+     * @param[in] handshake_desired_events The single event the handshake waits for after a step
+     * @param[in] get_handshake_timeout Upper bound of the whole handshake. A non positive value
+     *            selects \ref default_handshake_timeout
+     * @param[in] get_error_string Error description of the client policy. An empty string selects
+     *            the description of the stored error code
      */
     generic_fd_event_client_impl(action const& send_one, action const& receive_one, action const& reset_client,
-                                 error_status const& get_error);
+                                 error_status const& get_error, handshake_status const& handshake_pending,
+                                 action const& drive_handshake, handshake_events const& handshake_desired_events,
+                                 handshake_timeout const& get_handshake_timeout, error_text const& get_error_string);
     ~generic_fd_event_client_impl();
 
     /**
@@ -188,9 +235,95 @@ protected:
     void error_handler();
 
     /**
+     * @brief Perform a single step of the protocol handshake.
+     * @details While the handshake is pending, io events on \p fd are routed here instead of to
+     *          \ref rx_handler / \ref tx_handler. On completion \p fd is monitored for reading
+     *          and the on_ready action is released.
+     * @param[in] fd The file descriptor of the client's socket
+     */
+    void drive_handshake(int fd);
+
+    /**
+     * @brief Monitor \p fd for exactly one of reading or writing.
+     * @details Error and hangup notifications are unconditional and stay untouched.
+     * @param[in] fd The file descriptor
+     * @param[in] desired Anything but reading or writing is rejected: \p fd would end up monitored
+     *            for nothing.
+     * @return True if \p fd is monitored for \p desired afterwards, false otherwise
+     */
+    bool monitor_for(int fd, poll_events desired);
+
+    /**
+     * @brief Mark the connection as failed and report the error of the client policy.
+     */
+    void fail_connection();
+
+    /**
+     * @brief Mark the connection as failed and report \p error_code.
+     * @param[in] error_code The error to report. A 0 is replaced, so the report is never read
+     *            as a cleared error.
+     */
+    void fail_connection(int error_code);
+
+    /**
+     * @brief Mark the connection as failed and report \p error_code described by \p text.
+     * @details For a failure the client itself diagnosed: the client policy would describe an
+     *          error it did not produce.
+     * @param[in] error_code The error to report. A 0 is replaced, so the report is never read
+     *            as a cleared error.
+     * @param[in] text Description of the failure, reported to the error handler
+     */
+    void fail_connection(int error_code, std::string text);
+
+    /**
+     * @brief The description of the pending failure, for the error handler.
+     * @details A description set by \ref fail_connection belongs to that one failure and is
+     *          consumed here. Otherwise the client policy describes the error.
+     * @return The description, empty to select the description of the stored error code
+     */
+    std::string take_error_text();
+
+    /**
+     * @brief Start the handshake deadline, on the first handshake step of a connection.
+     * @details The deadline covers the whole handshake, not a single step. One that cannot be
+     *          armed fails the connection: proceeding would leave the handshake unbounded.
+     * @return True if the deadline is in force, false if the connection was failed
+     */
+    bool start_handshake_deadline();
+
+    void handshake_deadline_expired();
+
+    /**
+     * @brief Disarm the handshake deadline a reset abandons.
+     * @details The generation guard in \ref handshake_deadline_expired already rejects a retired
+     *          expiry; this keeps the invariant local to the reset instead of resting on it alone.
+     */
+    void retire_handshake_deadline();
+
+    /**
+     * @brief Consume the error code of an error or hangup notification on \p fd.
+     * @details Prefers the error of the client policy, then SO_ERROR, then the notification kind
+     *          itself (ENOTCONN for a hangup, EIO otherwise) for a descriptor that is not a
+     *          socket. Never resolves to 0, which would read as a cleared error. Reading SO_ERROR
+     *          clears it, so call this exactly once per connection.
+     * @param[in] fd The file descriptor the notification arrived on
+     * @param[in] kind poll_events::hungup for a hangup, poll_events::error otherwise
+     * @return A nonzero error code
+     */
+    int consume_poll_error(int fd, poll_events kind);
+
+    static poll_events default_desired_events();
+
+    /**
+     * @brief Release the on_ready action, at most once per connection.
+     */
+    void maybe_fire_ready();
+
+    /**
      * @brief Setup io event handling.
      * @details This registers a generic event handler for reading, writing and error handling.
-     *          Errors and reading will be handled continuously, writing on demand.
+     *          Reading is handled continuously, writing on demand. An error or hangup
+     *          notification is terminal and reported once per connection.
      * @param[in] fd Filedescriptor to be monitored.
      */
     void setup_io_event_handler(int fd);
@@ -260,15 +393,28 @@ protected:
     event::event_fd m_io_event_fd;
     event::event_fd m_error_status_event_fd;
     event::event_fd m_connected_event_fd;
+    event::timer_fd m_handshake_timer;
 
     cb_error m_error;
     action m_send_one;
     action m_receive_one;
     action m_reset_client;
     error_status m_get_error;
+    handshake_status m_handshake_pending;
+    action m_drive_handshake;
+    handshake_events m_handshake_desired_events;
+    handshake_timeout m_get_handshake_timeout;
+    error_text m_get_error_string;
+    std::string m_local_error_text;
     util::monitor<client_status_internal> m_client_status;
     ready_action m_on_ready_action;
     std::atomic_uint64_t m_connected_generation{0};
+    bool m_connection_failed{false};
+    // Every connection attempt pre-increments the generation, so 0 cannot match a connection.
+    std::uint64_t m_ready_fired_generation{0};
+    std::uint64_t m_handshake_deadline_generation{0};
+    // 0 means the deadline is registered; nonzero is the errno that stopped it.
+    int m_handshake_deadline_register_error{0};
     /// @endcond
 };
 
@@ -300,6 +446,20 @@ public:
      */
     using ClientPayloadT = typename ClientPolicy::PayloadT;
 
+    // A partial trio would silently disable the handshake and release the on_ready action on a
+    // socket that never negotiated anything.
+    static_assert(utilities::event_client_handshake_policy_v<ClientPolicy> or
+                      utilities::event_client_has_no_handshake_trio_v<ClientPolicy>,
+                  "ClientPolicy must provide all of handshake_complete(), handshake_step() and "
+                  "desired_events(), or none of them");
+
+    // handshake_timeout() bounds the phase the trio implements, so on its own it is read by nothing.
+    static_assert(not utilities::has_member_handshake_timeout_v<ClientPolicy> or
+                      utilities::event_client_handshake_policy_v<ClientPolicy>,
+                  "ClientPolicy provides handshake_timeout() but no handshake to bound: either add "
+                  "handshake_complete(), handshake_step() and desired_events(), or remove "
+                  "handshake_timeout()");
+
     /**
      * @var max_buffered_tx_payloads
      * @brief Upper bound of payloads held in the tx buffer.
@@ -328,18 +488,20 @@ public:
      */
     template <class... ArgsT>
     generic_fd_event_client(utilities::tx_buffering mode, ArgsT... args) :
-        generic_fd_event_client_impl([this]() { return send_one(); }, [this]() { return receive_one(); },
-                                     [this]() { return reset_client(); },
-                                     // A retired handle carries the errno of the peer it served,
-                                     // which is not the errno of the connection replacing it. The
-                                     // EPOLLERR branch reads this without knowing which handle is
-                                     // behind it.
-                                     [this]() { return handle_is_current() ? m_handle->get_error() : 0; }) {
+        generic_fd_event_client_impl(
+            [this]() { return send_one(); }, [this]() { return receive_one(); }, [this]() { return reset_client(); },
+            // A retired handle carries the errno of the peer it served, which is not the errno of
+            // the connection replacing it. The EPOLLERR branch reads this without knowing which
+            // handle is behind it.
+            [this]() { return handle_is_current() ? m_handle->get_error() : 0; },
+            [this]() { return handshake_pending(); }, [this]() { return handshake_step(); },
+            [this]() { return handshake_desired_events(); }, [this]() { return handshake_timeout(); },
+            [this]() { return policy_error_string(); }) {
         m_buffer_tx_before_connect = mode == utilities::tx_buffering::buffer;
         m_async_connect_state = std::make_shared<async_connect_state>();
         register_async_connect_event_handler(&m_async_connect_state->ready_event,
                                              [this]() { process_async_connect_results(); });
-        init<ClientPolicy>(args...);
+        init(args...);
     }
 
     ~generic_fd_event_client() override {
@@ -359,8 +521,9 @@ public:
      * @brief Send data
      * @details This buffers the incoming data and notifies. It will be send as soon as the file descriptor
      * is ready for transmission (POLLOUT / EPOLLOUT). Buffering before the connection is up is opt in,
-     * see \ref utilities::tx_buffering. Must be called from the thread that drives \ref sync: the
-     * buffer is not synchronized.
+     * see \ref utilities::tx_buffering. A handshake phase runs past that window, so a policy with one
+     * buffers across it whatever the mode, and flushes in order once it completes. Must be called from
+     * the thread that drives \ref sync: the buffer is not synchronized.
      * @param[in] payload The data to be transmitted.
      * @return True if the payload was buffered. False if the buffer already holds
      * \ref max_buffered_tx_payloads payloads, if the client is in
@@ -456,55 +619,54 @@ private:
         return state == utilities::connection_state::connected;
     }
 
-    template <class T, class... ArgsT> std::enable_if_t<utilities::event_client_async_policy_v<T>> init(ArgsT... args) {
-        m_open_device = [this, args...]() {
-            auto setup_ok = m_handle->setup(args...);
-            if (setup_ok) {
-                auto connect_generation = m_connect_generation.load();
-                auto state = m_async_connect_state;
-                auto handle = std::move(m_handle);
-                // The usage of a detached thread is intentional to avoid blocking the event_handler.
-                std::thread([state = std::move(state), handle = std::move(handle), connect_generation]() mutable {
-                    bool ok = false;
-                    int fd = -1;
-                    try {
-                        handle->connect([&](bool result_ok, int result_fd) {
-                            ok = result_ok;
-                            fd = result_fd;
-                        });
-                    } catch (...) {
-                        ok = false;
-                        fd = -1;
-                    }
+    template <class... ArgsT> void init(ArgsT... args) {
+        if constexpr (utilities::event_client_async_policy_v<ClientPolicy>) {
+            m_open_device = [this, args...]() {
+                auto setup_ok = m_handle->setup(args...);
+                if (setup_ok) {
+                    auto connect_generation = m_connect_generation.load();
+                    auto state = m_async_connect_state;
+                    auto handle = std::move(m_handle);
+                    // The usage of a detached thread is intentional to avoid blocking the event_handler.
+                    std::thread([state = std::move(state), handle = std::move(handle), connect_generation]() mutable {
+                        bool ok = false;
+                        int fd = -1;
+                        try {
+                            handle->connect([&](bool result_ok, int result_fd) {
+                                ok = result_ok;
+                                fd = result_fd;
+                            });
+                        } catch (...) {
+                            ok = false;
+                            fd = -1;
+                        }
 
-                    if (not state or not state->active.load()) {
-                        return;
-                    }
+                        if (not state or not state->active.load()) {
+                            return;
+                        }
 
-                    auto inserted = state->connect_results.emplace(
-                        async_connect_result{connect_generation, ok, fd, std::move(handle)});
-                    if (inserted != 0) {
-                        state->ready_event.notify();
-                    }
-                }).detach();
-            } else {
+                        auto inserted = state->connect_results.emplace(
+                            async_connect_result{connect_generation, ok, fd, std::move(handle)});
+                        if (inserted != 0) {
+                            state->ready_event.notify();
+                        }
+                    }).detach();
+                } else {
+                    auto generation = m_connect_generation.load();
+                    on_client_ready(generation, false, -1);
+                }
+            };
+            // The initial open has no previous peer, so a payload buffered before this action runs
+            // belongs to the connection it opens.
+            schedule_reset();
+        } else {
+            m_open_device = [this, args...]() {
+                auto result = m_handle->open(args...);
                 auto generation = m_connect_generation.load();
-                on_client_ready(generation, false, -1);
-            }
-        };
-        // The initial open has no previous peer, so a payload buffered before this action runs
-        // belongs to the connection it opens.
-        schedule_reset();
-    }
-
-    template <class T, class... ArgsT>
-    std::enable_if_t<not utilities::event_client_async_policy_v<T>> init(ArgsT... args) {
-        m_open_device = [this, args...]() {
-            auto result = m_handle->open(args...);
-            auto generation = m_connect_generation.load();
-            on_client_ready(generation, result, m_handle->get_fd());
-        };
-        reset_impl();
+                on_client_ready(generation, result, m_handle->get_fd());
+            };
+            reset_impl();
+        }
     }
 
     void schedule_reset() {
@@ -517,6 +679,7 @@ private:
         // reset already flipped the state, but an event dispatched since may have moved it back
         // to connected, which the device opened below has not earned yet.
         reset_connection_state();
+        retire_handshake_deadline();
         reset_client();
         setup_error_event_handler();
         init_device();
@@ -574,6 +737,66 @@ private:
         // handed up; what is dropped is its status, which says nothing about the connection
         // replacing this one.
         return handle_is_current() ? result : action_status::empty;
+    }
+
+    bool handshake_pending() {
+        if constexpr (utilities::event_client_handshake_policy_v<ClientPolicy>) {
+            return m_handle and not m_handle->handshake_complete();
+        } else {
+            return false;
+        }
+    }
+
+    action_status handshake_step() {
+        if constexpr (utilities::event_client_handshake_policy_v<ClientPolicy>) {
+            if (not m_handle) {
+                // 'empty' would read as a completed handshake and release the on_ready action
+                // for a client that does not exist.
+                return action_status::fail;
+            }
+            if (not m_handle->handshake_step()) {
+                return action_status::fail;
+            }
+            if (m_handle->handshake_complete()) {
+                // Payloads queued during the handshake consumed their one-shot tx notification
+                // while its handler declined to monitor writing. Notify again to flush the queue.
+                if (not m_tx_buffer.empty()) {
+                    m_io_event_fd.notify();
+                }
+                return action_status::empty;
+            }
+            return action_status::success;
+        } else {
+            return action_status::empty;
+        }
+    }
+
+    poll_events handshake_desired_events() {
+        if constexpr (utilities::event_client_handshake_policy_v<ClientPolicy>) {
+            if (m_handle) {
+                return m_handle->desired_events();
+            }
+        }
+        // poll_events is only forward declared here, so the fallback is named via the implementation.
+        return default_desired_events();
+    }
+
+    std::chrono::milliseconds handshake_timeout() {
+        if constexpr (utilities::has_member_handshake_timeout_v<ClientPolicy>) {
+            if (m_handle) {
+                return m_handle->handshake_timeout();
+            }
+        }
+        return default_handshake_timeout;
+    }
+
+    std::string policy_error_string() {
+        if constexpr (utilities::has_member_get_error_string_v<ClientPolicy>) {
+            if (m_handle) {
+                return m_handle->get_error_string();
+            }
+        }
+        return {};
     }
 
     action_status reset_client() {
@@ -693,6 +916,26 @@ private:
  *                                    // Return true on success, false otherwise
  *   int get_fd();                    // returns the file discriptor to be monitored
  *   int get_error();                 // return the current error, 0 with no error.
+ *   bool handshake_complete();       // [optional] False while a protocol handshake is outstanding.
+ *   bool handshake_step();           // [optional] One non blocking handshake step. True while it makes
+ *                                    // progress, false on failure. Called once at connect time, before
+ *                                    // any readiness event, because the client owes the first protocol
+ *                                    // message; afterwards only for the event desired_events() asked
+ *                                    // for. A wakeup may be spurious, so a step that cannot progress
+ *                                    // returns true and requests its event again.
+ *   poll_events desired_events();    // [optional] The single event the handshake waits for, queried
+ *                                    // after every step that neither failed nor completed it. Anything
+ *                                    // but reading or writing fails the handshake.
+ *                                    // The three functions above are only used together. Until the
+ *                                    // handshake completes the on_ready action is deferred and payloads
+ *                                    // passed to tx are buffered.
+ *   std::chrono::milliseconds handshake_timeout(); // [optional, rejected without the three functions
+ *                                    // above] Upper bound of the whole handshake, read when it starts.
+ *                                    // A non positive value, or no such function, selects
+ *                                    // generic_fd_event_client_impl::default_handshake_timeout.
+ *   std::string get_error_string();  // [optional] Description of the current error, a const reference
+ *                                    // is fine too. An empty string selects the description of the
+ *                                    // stored error code.
  * };
  * // ClientPolicy owns the file descriptor
  * \endcode

--- a/lib/everest/io/include/everest/io/event/fd_event_handler.hpp
+++ b/lib/everest/io/include/everest/io/event/fd_event_handler.hpp
@@ -32,11 +32,12 @@ enum class poll_events {
     hungup = 4,
 };
 
-// event/fd_event_client.hpp declares poll_events opaquely to break the include cycle with this
-// header. That declaration is compatible only while the definition keeps its implicit type.
+// event/fd_event_client.hpp and socket/socket.hpp declare poll_events opaquely to break the
+// include cycle with this header. Those declarations are compatible only while the definition
+// keeps its implicit type.
 static_assert(std::is_same_v<std::underlying_type_t<poll_events>, int>,
-              "poll_events must keep its implicit underlying type: event/fd_event_client.hpp "
-              "declares it without one");
+              "poll_events must keep its implicit underlying type: event/fd_event_client.hpp and "
+              "socket/socket.hpp declare it without one");
 
 std::set<poll_events> operator|(poll_events lhs, poll_events rhs);
 std::set<poll_events>& operator|(std::set<poll_events>& lhs, poll_events rhs);

--- a/lib/everest/io/include/everest/io/event/fd_event_handler.hpp
+++ b/lib/everest/io/include/everest/io/event/fd_event_handler.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 
 /** \file */
 
@@ -16,6 +16,7 @@
 #include <functional>
 #include <memory>
 #include <set>
+#include <type_traits>
 
 namespace everest::lib::io::event {
 
@@ -30,6 +31,12 @@ enum class poll_events {
     error = 3,
     hungup = 4,
 };
+
+// event/fd_event_client.hpp declares poll_events opaquely to break the include cycle with this
+// header. That declaration is compatible only while the definition keeps its implicit type.
+static_assert(std::is_same_v<std::underlying_type_t<poll_events>, int>,
+              "poll_events must keep its implicit underlying type: event/fd_event_client.hpp "
+              "declares it without one");
 
 std::set<poll_events> operator|(poll_events lhs, poll_events rhs);
 std::set<poll_events>& operator|(std::set<poll_events>& lhs, poll_events rhs);
@@ -144,7 +151,9 @@ public:
     /**
      * @brief Register an \ref timer_fd for event handling
      * @details Reading from the event happens internally to acknowledge event handling.
-     * If manual handling is necessary use \ref timer_fd filedecriptor directly
+     * If manual handling is necessary use \ref timer_fd filedecriptor directly.
+     * \p handler is not called for an expiry that a rearm or a disarm retired since its poll
+     * batch was harvested: rearming a timer from another handler suppresses its pending tick.
      * @param[in] obj The object to be registerd for event handling
      * @param[in] handler Callback for handling the events on \p obj
      * @return True on success, false otherwise

--- a/lib/everest/io/include/everest/io/socket/socket.hpp
+++ b/lib/everest/io/include/everest/io/socket/socket.hpp
@@ -13,6 +13,13 @@
 #include <everest/io/event/unique_fd.hpp>
 #include <everest/io/udp/endpoint.hpp>
 
+namespace everest::lib::io::event {
+// Declared opaquely, and without an underlying type, to keep this header out of an include cycle:
+// event/fd_event_handler.hpp defines poll_events with its implicit type and
+// event/fd_event_client.hpp already includes this header.
+enum class poll_events;
+} // namespace everest::lib::io::event
+
 namespace everest::lib::io::socket {
 
 /**
@@ -178,6 +185,18 @@ event::unique_fd open_tcp_socket_with_timeout(const std::string& host, std::uint
                                               const std::string& device = {});
 
 /**
+ * @brief Open a TCP socket in server mode (bound and listening).
+ * @details Non-blocking, close-on-exec, with SO_REUSEADDR and SO_REUSEPORT set. The family is
+ * AF_INET6 when @p ipv6_only is set or @p bind_addr contains a ':', otherwise AF_INET.
+ * @param[in] bind_addr Numeric bind address (e.g. "0.0.0.0", "127.0.0.1", "::", "::1").
+ * @param[in] port The port to listen on (0 for an ephemeral port).
+ * @param[in] ipv6_only When true, force an IPv6 socket and set IPV6_V6ONLY.
+ * @return The managed file descriptor of the listening socket.
+ * @throws std::runtime_error if any step (socket, setsockopt, inet_pton, bind, listen) fails.
+ */
+event::unique_fd open_tcp_server_socket(std::string const& bind_addr, std::uint16_t port, bool ipv6_only);
+
+/**
  * @brief Bind a socket to a specific network interface.
  * @details Tries SO_BINDTODEVICE first (needs CAP_NET_RAW). On EPERM/EACCES, falls back to:
  *   - IP_UNICAST_IF (AF_INET) or IPV6_UNICAST_IF (AF_INET6) to restrict the outgoing
@@ -282,6 +301,16 @@ void set_socket_send_buffer_to_min(int fd);
  * @return Description
  */
 int get_pending_error(int fd);
+
+/**
+ * @brief Resolve the error behind an error or hangup notification on a descriptor
+ * @details Reads <a href="https://man7.org/linux/man-pages/man7/socket.7.html">SO_ERROR</a>, which
+ * clears it, so only the first call for a given failure can answer with the real code. Descriptors
+ * that are not sockets (pty, tun/tap) fail getsockopt outright and resolve to @p fallback, or, when
+ * that is 0, to a code derived from @p kind: ENOTCONN for a hangup, EIO for an error.
+ * @return A nonzero error code
+ */
+int consume_poll_error(int fd, event::poll_events kind, int fallback);
 
 /**
  * @brief Checks if a TCP socket is still connected and operational without consuming any incoming data.

--- a/lib/everest/io/include/everest/io/tcp/tcp_socket.hpp
+++ b/lib/everest/io/include/everest/io/tcp/tcp_socket.hpp
@@ -113,6 +113,15 @@ public:
     void close();
 
     /**
+     * @brief Surrender ownership of the file descriptor without closing it.
+     * @details After this the socket holds no fd; close()/destruction become no-ops.
+     *          Used when another owner (e.g. a TLS BIO created with BIO_CLOSE) takes
+     *          over the fd's lifetime.
+     * @return The previously owned file descriptor (NO_DESCRIPTOR_SENTINEL if none).
+     */
+    int release();
+
+    /**
      * @brief Enable KEEPALIVE for the connection
      * @param[in] count  The maximum number of keepalive probes TCP should send
      *                   before dropping the connection.

--- a/lib/everest/io/include/everest/io/tls/detail/tls_result_from_libtls.hpp
+++ b/lib/everest/io/include/everest/io/tls/detail/tls_result_from_libtls.hpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+#include <everest/io/tls/tls_result.hpp>
+#include <everest/tls/tls.hpp>
+
+namespace everest::lib::io::tls::detail {
+
+inline io_result to_io_result(::tls::Connection::result_t r) {
+    using result_t = ::tls::Connection::result_t;
+    switch (r) {
+    case result_t::success:
+        return io_result::success;
+    case result_t::want_read:
+        return io_result::want_read;
+    case result_t::want_write:
+        return io_result::want_write;
+    case result_t::closed:
+        return io_result::closed;
+    case result_t::timeout:
+        return io_result::timeout;
+    }
+    return io_result::failed;
+}
+
+} // namespace everest::lib::io::tls::detail

--- a/lib/everest/io/include/everest/io/tls/tls_client.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_client.hpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+/** \file */
+
+#pragma once
+#include <everest/io/event/fd_event_client.hpp>
+#include <everest/io/tls/tls_client_socket.hpp>
+
+namespace everest::lib::io::tls {
+
+/**
+ * @var tls_client
+ * @brief Event-loop-driven TLS client.
+ * @details Register it with an \ref event::fd_event_handler to drive it. Constructor arguments are
+ *          forwarded to tls_client_socket::setup(cfg, host, port, timeout_ms). The TLS handshake
+ *          runs on the loop, only the TCP connect runs on the async policy's detached thread.
+ *          Payloads passed to tx() before the connect completes and during the handshake are
+ *          buffered and flushed in order once it completes. The outer handler must outlive the
+ *          client, whose destructor unregisters from it.
+ */
+using tls_client = event::fd_event_client<tls_client_socket>::type;
+
+/**
+ * @var tls_client_interface
+ * @brief The client as seen by its RX callback.
+ */
+using tls_client_interface = event::fd_event_client<tls_client_socket>::interface;
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_client_config.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_client_config.hpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+#include <everest/io/tls/tls_client_socket.hpp>
+#include <everest/tls/tls.hpp>
+
+#include <cstdint>
+#include <string>
+
+// Owning mirror of ::tls::Client::config_t. The generic client copies this Config at construction
+// and replays setup() on the first poll and on every reconnect, so it must not carry raw pointers
+// into caller memory. ::tls::ConfigItem keeps its own copy and preserves libtls's distinction
+// between unset (nullptr) and empty (""). setup() materializes a ::tls::Client::config_t from
+// these fields for the duration of ::tls::Client::init(), which copies what it needs.
+struct everest::lib::io::tls::tls_client_socket::Config {
+    struct tls_config {
+        ::tls::ConfigItem cipher_list{nullptr};                  //!< unset means use default
+        ::tls::ConfigItem ciphersuites{nullptr};                 //!< unset means use default, "" disables TLS 1.3
+        ::tls::ConfigItem certificate_chain_file{nullptr};       //!< client certificate and intermediate CAs
+        ::tls::ConfigItem private_key_file{nullptr};             //!< private key for client certificate
+        ::tls::ConfigItem private_key_password{nullptr};         //!< optional password for private key
+        ::tls::ConfigItem verify_locations_file{nullptr};        //!< PEM trust anchors for server certificate
+        ::tls::ConfigItem verify_locations_path{nullptr};        //!< for server certificate
+        ::tls::Client::trusted_ca_keys_t trusted_ca_keys_data{}; //!< trusted CA keys configuration data
+        std::int32_t io_timeout_ms{-1};                          //!< socket timeout in milliseconds
+        int min_proto_version{0};                                //!< 0 means use default
+        bool verify_server{true};                                //!< verify the server certificate
+        bool verify_subject_name{false};                         //!< pin the peer certificate to host_for_sni
+        bool status_request{false};                              //!< status request extension in the client hello
+        bool status_request_v2{false};                           //!< status request v2 extension in the client hello
+        bool trusted_ca_keys{false};                             //!< trusted ca keys extension in the client hello
+    };
+    tls_config tls{};
+    std::string host_for_sni;
+};

--- a/lib/everest/io/include/everest/io/tls/tls_client_socket.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_client_socket.hpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+#include <everest/io/tcp/tcp_socket.hpp>
+#include <everest/io/tls/tls_socket_base.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace tls {
+class Client;
+class ClientConnection;
+} // namespace tls
+
+namespace everest::lib::io::tls {
+
+// TLS client connection policy: async TCP connect + handshake via setup()/connect(). Shared
+// tx/rx/handshake logic lives in tls_socket_base, this class adds the connect machinery and the
+// TCP-aware get_fd()/get_error()/close() overrides.
+class tls_client_socket : public tls_socket_base<tls_client_socket> {
+public:
+    static constexpr bool buffer_tx_before_connect{true};
+
+    // Defined in tls_client_config.hpp.
+    struct Config;
+
+    tls_client_socket() = default;
+    tls_client_socket(tls_client_socket const&) = delete;
+    tls_client_socket(tls_client_socket&&) = default;
+    tls_client_socket& operator=(tls_client_socket const&) = delete;
+    tls_client_socket& operator=(tls_client_socket&&) = default;
+    // Closes the TLS session. The event client destroys the policy to tear a connection down and
+    // never calls close(), so without this the peer sees a truncated stream.
+    ~tls_client_socket();
+
+    // Build the SSL_CTX and record the TCP connect parameters. Starts no connect itself, so it
+    // returns quickly. Must be followed by connect(), which does the blocking work.
+    bool setup(Config cfg, std::string const& remote_host, std::uint16_t remote_port, int timeout_ms);
+
+    // Wrap the connected fd, without handshaking: the loop drives that. Runs on the
+    // fd_event_client connect thread.
+    void connect(std::function<void(bool, int)> const& cb);
+
+    // The TLS connection fd once handshaking, the TCP fd otherwise, -1 if neither.
+    int get_fd() const;
+    int get_error() const;
+    void close();
+
+    // tls_socket_base hooks (public so the base can call them without friendship).
+    ::tls::Connection* connection() const;
+    io_result step_handshake(); // one non-blocking connect(0)
+    void reset_connection();
+
+protected:
+    // Protected so a unit-test subclass can confirm ownership was surrendered to the TLS
+    // connection's BIO (no double-close).
+    tcp::tcp_socket m_tcp{};
+
+private:
+    std::string m_host_for_sni{};
+    std::unique_ptr<::tls::Client> m_client{};
+    std::unique_ptr<::tls::ClientConnection> m_conn{};
+};
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_endpoint_base.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_endpoint_base.hpp
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+#include <everest/io/event/event_fd.hpp>
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/event/fd_event_register_interface.hpp>
+#include <everest/io/event/timer_fd.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <queue>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace everest::lib::io::tls {
+
+// Base for the loop-driven TLS server endpoints. Wires one accepted TLS connection onto an
+// fd_event_handler and drives the handshake inside its own dispatch lambda, so the shared handler
+// never sees handshake state. Derived supplies start() (monitor the accepted fd) and stop().
+// The client side instead is an fd_event_client over tls_client_socket, with its own nested handler
+// and connect thread. The socket is owned by value, so its get_fd()/get_error()/close() resolve
+// statically, with no virtual dispatch on the rx/tx path.
+// Member definitions live in tls_endpoint_base_impl.hpp.
+template <class Socket> class tls_endpoint_base : public event::fd_event_register_interface {
+public:
+    using PayloadT = std::vector<std::uint8_t>;
+    // Passes the endpoint itself, so an rx handler can tx() without naming the derived type.
+    using cb_rx = std::function<void(PayloadT const&, tls_endpoint_base<Socket>&)>;
+
+    /**
+     * @var max_buffered_tx_payloads
+     * @brief Upper bound of payloads held in the tx buffer, past which \ref tx rejects.
+     * @details Counts payloads, not bytes, so the ceiling scales with the size the caller writes.
+     */
+    static constexpr std::size_t max_buffered_tx_payloads{1024};
+
+    /**
+     * @var default_handshake_timeout
+     * @brief Upper bound of the accept handshake, matching the client's bound in
+     * generic_fd_event_client_impl. Past this the peer stopped talking and the endpoint fails
+     * with ETIMEDOUT.
+     */
+    static constexpr std::chrono::milliseconds default_handshake_timeout{10000};
+
+    ~tls_endpoint_base() override = default;
+
+    // Runs inside the connection dispatch, which keeps reading members after it returns, so it may
+    // not destroy the endpoint. The error handler is the callback for that.
+    void set_rx_handler(cb_rx handler) {
+        m_rx = std::move(handler);
+    }
+
+    // Enqueue a payload and add POLLOUT; payloads enqueued during the handshake are flushed once it
+    // completes. Rejects after the endpoint errored and at max_buffered_tx_payloads, which a peer
+    // that stops reading reaches on its own. A rejection is backpressure, not a failure: the
+    // connection stays live and everything already accepted is still delivered. Loop thread only,
+    // the queue is not synchronized.
+    bool tx(PayloadT const& payload);
+
+    // Fired once, after the accept handshake completes, from run_actions(). Safe to destroy the
+    // endpoint from, same as the error handler.
+    void set_on_ready_action(std::function<void()> action) {
+        m_on_ready = std::move(action);
+    }
+
+    // Fired once per connection with a nonzero code, from run_actions() rather than from the
+    // dispatch that failed, so the callback may destroy the endpoint. That is the documented way to
+    // retire a tls_server, which never reconnects. The report is queued behind the fd teardown, and
+    // is lost if the handler dies before it drains.
+    void set_error_handler(std::function<void(int, std::string const&)> handler) {
+        m_error = std::move(handler);
+    }
+
+    // Bound on the whole accept handshake. Effective only before registration, the deadline arms
+    // when the connection fd registers. A non-positive value selects default_handshake_timeout.
+    void set_handshake_timeout(std::chrono::milliseconds timeout) {
+        m_handshake_timeout = timeout > std::chrono::milliseconds::zero() ? timeout : default_handshake_timeout;
+    }
+
+    bool register_events(event::fd_event_handler& handler) override;
+
+    bool unregister_events(event::fd_event_handler& handler) override;
+
+protected:
+    virtual bool start(event::fd_event_handler& handler) = 0;
+    virtual void stop() = 0;
+
+    bool register_connection_fd(event::fd_event_handler& handler, int fd, event::poll_events initial);
+
+    void drive_handshake(int fd);
+
+    void flush_rx(int fd);
+
+    void flush_tx(int fd);
+
+    // Whose would-block m_desired describes; the socket reports one desired event for both
+    // directions. `none` means nothing blocked, so m_desired is the idle need and not a wait:
+    // reading a completed send as a parked one drops POLLOUT with the queue still to go.
+    enum class direction : std::uint8_t {
+        receive,
+        send,
+        none
+    };
+
+    // Invariant: read off implies write on, so the descriptor is never left unmonitored.
+    bool route_desired_events(int fd, direction blocked);
+
+    void maybe_fire_ready();
+
+    // Error code for an EPOLLERR/EPOLLHUP dispatch. The socket's own error wins; a 0 there is a live
+    // connection that has not yet failed a TLS op, e.g. a peer RST after the handshake. Never
+    // resolves to 0. Reading SO_ERROR clears it, so fail()'s idempotence keeps this to one call.
+    int consume_poll_error(int fd);
+
+    // Idempotent within a connection. Safe from inside a dispatch: the fd teardown and the error
+    // report are both deferred, in that order.
+    void fail(int error_code);
+
+    // Same, with a text that the socket's own error state cannot describe.
+    void fail(int error_code, std::string const& error_text);
+
+    void retire_handshake_deadline();
+
+    // Monitor the connection fd for exactly one of read/write. False means the fd is not monitored for
+    // anything, which no caller may treat as success.
+    bool monitor_for(int fd, event::poll_events desired);
+
+    // The cache is answered only while the registration still exists, so an unchanged mask cannot
+    // report success on a descriptor nothing monitors.
+    bool apply_monitoring(int fd, bool read, bool write);
+
+    Socket m_socket;
+    event::fd_event_handler* m_handler{nullptr};
+    event::event_fd m_tx_notify;
+    std::queue<PayloadT> m_tx_buffer;
+    cb_rx m_rx;
+    std::function<void()> m_on_ready;
+    std::function<void(int, std::string const&)> m_error;
+    bool m_ready_fired{false};
+    bool m_errored{false};
+    int m_fd{-1};
+    // What the handler currently monitors on m_fd. Written by apply_monitoring and by the seed in
+    // register_connection_fd, nowhere else.
+    bool m_monitored_read{false};
+    bool m_monitored_write{false};
+    event::timer_fd m_handshake_timer;
+    std::chrono::milliseconds m_handshake_timeout{default_handshake_timeout};
+    // One poll batch can carry both the expiry and the event that completes the handshake, and the
+    // batch is harvested before dispatch, so the expiry handler needs this beyond the disarm.
+    bool m_handshake_deadline_active{false};
+
+private:
+    PayloadT m_rx_data;
+};
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_endpoint_base_impl.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_endpoint_base_impl.hpp
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+#include <everest/io/socket/socket.hpp>
+#include <everest/io/tls/tls_endpoint_base.hpp>
+
+#include <cerrno>
+#include <utility>
+
+// Member definitions of tls_endpoint_base. Include to instantiate the base for a Socket of your own.
+
+namespace everest::lib::io::tls {
+
+template <class Socket> bool tls_endpoint_base<Socket>::tx(PayloadT const& payload) {
+    if (m_errored || m_tx_buffer.size() >= max_buffered_tx_payloads) {
+        return false;
+    }
+    m_tx_buffer.push(payload);
+    m_tx_notify.notify();
+    return true;
+}
+
+template <class Socket> bool tls_endpoint_base<Socket>::register_events(event::fd_event_handler& handler) {
+    if (m_handler != nullptr) {
+        return false;
+    }
+    m_handler = &handler;
+    auto result = handler.register_event_handler(&m_tx_notify, [this]() {
+        // One-shot and already drained: nothing would retry a failed request.
+        if (m_fd >= 0 and not apply_monitoring(m_fd, m_monitored_read, true)) {
+            fail(EPROTO);
+        }
+    });
+    m_handshake_timer.set_single_shot(true);
+    // Registered before start(): the deadline arms inside register_connection_fd.
+    result = handler.register_event_handler(&m_handshake_timer, [this]() {
+        // A disarm in this batch already retired the expiry via the tick
+        // counter; the flag covers a completion dispatched after it.
+        if (not m_handshake_deadline_active) {
+            return;
+        }
+        fail(ETIMEDOUT, "handshake deadline expired");
+    }) and result;
+    auto started = start(handler);
+    return result and started;
+}
+
+template <class Socket> bool tls_endpoint_base<Socket>::unregister_events(event::fd_event_handler& handler) {
+    auto result = true;
+    if (m_fd >= 0) {
+        result = handler.remove_event_handler(m_fd) && result;
+        m_fd = -1;
+    }
+    result = handler.unregister_event_handler(&m_tx_notify) && result;
+    retire_handshake_deadline();
+    result = handler.unregister_event_handler(&m_handshake_timer) && result;
+    stop();
+    m_handler = nullptr;
+    return result;
+}
+
+template <class Socket>
+bool tls_endpoint_base<Socket>::register_connection_fd(event::fd_event_handler& handler, int fd,
+                                                       event::poll_events initial) {
+    m_fd = fd;
+    m_monitored_read = false;
+    m_monitored_write = false;
+    const auto registered = handler.register_event_handler(
+        fd,
+        [this, fd](auto events) {
+            using namespace event;
+            if (events.count(poll_events::error) || events.count(poll_events::hungup)) {
+                fail(consume_poll_error(fd));
+                return;
+            }
+            if (not m_socket.handshake_complete()) {
+                drive_handshake(fd);
+                return;
+            }
+            if (events.count(poll_events::read)) {
+                flush_rx(fd);
+            }
+            if (not m_errored and events.count(poll_events::write)) {
+                flush_tx(fd);
+            }
+        },
+        initial);
+    if (registered) {
+        m_monitored_read = initial == event::poll_events::read;
+        m_monitored_write = initial == event::poll_events::write;
+        // The bound covers the whole handshake: a peer may connect and never send a byte, which
+        // generates no event at all, so only a timer can retire the endpoint.
+        if (not m_handshake_timer.set_timeout(m_handshake_timeout)) {
+            fail(EPROTO, "handshake deadline could not be armed");
+            return false;
+        }
+        m_handshake_deadline_active = true;
+    }
+    return registered;
+}
+
+template <class Socket> void tls_endpoint_base<Socket>::drive_handshake(int fd) {
+    if (not m_socket.handshake_step()) {
+        fail(m_socket.get_error());
+        return;
+    }
+    if (m_socket.handshake_complete()) {
+        retire_handshake_deadline();
+        if (not monitor_for(fd, event::poll_events::read)) {
+            fail(EPROTO);
+            return;
+        }
+        maybe_fire_ready();
+        // Payloads queued during the handshake spent their notify while write was unmonitored.
+        if (not m_tx_buffer.empty()) {
+            m_tx_notify.notify();
+        }
+        return;
+    }
+    if (not monitor_for(fd, m_socket.desired_events())) {
+        fail(EPROTO);
+    }
+}
+
+template <class Socket> void tls_endpoint_base<Socket>::flush_rx(int fd) {
+    auto blocked = direction::receive;
+    if (m_socket.rx(m_rx_data)) {
+        if (m_rx) {
+            m_rx(m_rx_data, *this);
+        }
+        blocked = direction::none;
+    } else if (not m_socket.is_open()) {
+        fail(m_socket.get_error());
+        return;
+    }
+    // The rx handler may have failed the endpoint, whose fd is already queued for teardown.
+    if (not m_errored and not route_desired_events(fd, blocked)) {
+        fail(EPROTO);
+    }
+}
+
+// Every outcome routes: a success moves the socket's need back to read, and a stale mask from an
+// earlier would-block would keep POLLIN dropped.
+template <class Socket> void tls_endpoint_base<Socket>::flush_tx(int fd) {
+    auto blocked = direction::none;
+    if (not m_tx_buffer.empty()) {
+        auto& front = m_tx_buffer.front();
+        if (m_socket.tx(front)) {
+            m_tx_buffer.pop();
+        } else if (not m_socket.is_open()) {
+            fail(m_socket.get_error());
+            return;
+        } else {
+            blocked = direction::send;
+        }
+    }
+    if (not route_desired_events(fd, blocked)) {
+        fail(EPROTO);
+    }
+}
+
+// Read is dropped only for a receive waiting on writability: leaving it on re-drives that receive
+// every tick. A send waiting on writability is only a full kernel buffer, so dropping read there
+// deadlocks. Write stays off on an idle queue, which would spin the loop on an always-writable fd.
+template <class Socket> bool tls_endpoint_base<Socket>::route_desired_events(int fd, direction blocked) {
+    const auto wants_write = m_socket.desired_events() == event::poll_events::write;
+    const auto rx_wants_write = blocked == direction::receive and wants_write;
+    const auto monitor_read = not rx_wants_write;
+    const auto monitor_write =
+        rx_wants_write or (not m_tx_buffer.empty() and not(blocked == direction::send and not wants_write));
+    // Unreachable today: both callers turn a false into fail(EPROTO), so an fd monitored for
+    // nothing is loud instead of frozen.
+    if (not monitor_read and not monitor_write) {
+        return false;
+    }
+    return apply_monitoring(fd, monitor_read, monitor_write);
+}
+
+template <class Socket> void tls_endpoint_base<Socket>::maybe_fire_ready() {
+    if (m_ready_fired || not m_on_ready) {
+        return;
+    }
+    m_ready_fired = true;
+    if (m_handler != nullptr) {
+        m_handler->add_action(m_on_ready);
+    }
+}
+
+template <class Socket> int tls_endpoint_base<Socket>::consume_poll_error(int fd) {
+    int err = m_socket.get_error();
+    if (err != 0) {
+        return err;
+    }
+    // Always a real socket here, so the notification kind cannot improve on ECONNRESET.
+    return socket::consume_poll_error(fd, event::poll_events::error, ECONNRESET);
+}
+
+// A synchronous removal would destroy the executing std::function and resize pollfds mid-iteration.
+template <class Socket> void tls_endpoint_base<Socket>::fail(int error_code) {
+    fail(error_code, m_socket.get_error_string());
+}
+
+template <class Socket> void tls_endpoint_base<Socket>::fail(int error_code, std::string const& error_text) {
+    if (m_errored) {
+        return;
+    }
+    retire_handshake_deadline();
+    // The error callback never sees 0: callers branch on it, so a 0 leaves a dead endpoint silent.
+    if (error_code == 0) {
+        error_code = ECONNRESET;
+    }
+    m_errored = true;
+    if (m_fd >= 0 && m_handler != nullptr) {
+        // Remove before close, both deferred: a synchronous close lets an accept recycle the fd
+        // number and strand the pending remove-by-number.
+        auto close_conn = m_socket.release_closer();
+        m_handler->add_action([handler = m_handler, fd = m_fd, close_conn = std::move(close_conn)]() mutable {
+            handler->remove_event_handler(fd);
+            close_conn();
+        });
+        m_fd = -1;
+    } else {
+        // Nothing is dispatching, so close synchronously. m_fd stays: apply_monitoring fails
+        // without a handler regardless.
+        m_socket.close();
+    }
+    if (not m_error) {
+        return;
+    }
+    if (m_handler == nullptr) {
+        // Unreachable by construction: every fail() path runs from a registration this endpoint
+        // owns, and register_events sets m_handler before start(). A derived class that makes it
+        // reachable inherits a synchronous report, without the guarantee below.
+        m_error(error_code, error_text);
+        return;
+    }
+    // Queued after the teardown and holding no `this`, so the callback may destroy the endpoint.
+    m_handler->add_action([report = m_error, error_code, text = error_text]() { report(error_code, text); });
+}
+
+template <class Socket> void tls_endpoint_base<Socket>::retire_handshake_deadline() {
+    m_handshake_deadline_active = false;
+    m_handshake_timer.disarm();
+}
+
+template <class Socket> bool tls_endpoint_base<Socket>::monitor_for(int fd, event::poll_events desired) {
+    return apply_monitoring(fd, desired == event::poll_events::read, desired == event::poll_events::write);
+}
+
+template <class Socket> bool tls_endpoint_base<Socket>::apply_monitoring(int fd, bool read, bool write) {
+    if (m_handler == nullptr) {
+        return false;
+    }
+    const auto cached = fd == m_fd and m_handler->is_registered(fd);
+    auto apply = [&](event::poll_events which, bool want, bool& state) {
+        if (cached and state == want) {
+            return true;
+        }
+        const auto ok = m_handler->modify_event_handler(
+            fd, which, want ? event::event_modification::add : event::event_modification::remove);
+        if (ok and cached) {
+            state = want;
+        }
+        return ok;
+    };
+    const auto read_ok = apply(event::poll_events::read, read, m_monitored_read);
+    const auto write_ok = apply(event::poll_events::write, write, m_monitored_write);
+    return read_ok and write_ok;
+}
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_listener.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_listener.hpp
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+#include <everest/io/event/fd_event_sync_interface.hpp>
+#include <everest/io/event/unique_fd.hpp>
+#include <everest/io/tls/tls_server.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
+// Opaque: libtls stays out of the public headers, see tls_socket_base.hpp.
+namespace tls {
+class Server;
+}
+
+namespace everest::lib::io::tls {
+
+// Listening TLS socket. Owns a ::tls::Server and a non-blocking listen fd, register it with an
+// fd_event_handler to drive accept events on the loop. Each accepted connection is wrapped in a
+// tls_server and handed to the accept callback, which takes ownership of the unique_ptr.
+class tls_listener : public event::fd_event_sync_interface {
+public:
+    // Defined in tls_listener_config.hpp.
+    struct Config;
+
+    using accept_cb =
+        std::function<void(std::unique_ptr<tls_server> conn, std::string peer_ip, std::uint16_t peer_port)>;
+    using error_cb = std::function<void(int, std::string const&)>;
+
+    // Creates a non-blocking listen socket and builds the SSL_CTX. Throws
+    // std::runtime_error on a system-call or libtls init failure.
+    explicit tls_listener(Config cfg);
+
+    tls_listener(tls_listener const&) = delete;
+    tls_listener(tls_listener&&) = delete;
+    tls_listener& operator=(tls_listener const&) = delete;
+    tls_listener& operator=(tls_listener&&) = delete;
+
+    // Out of line: the unique_ptr needs ::tls::Server complete.
+    ~tls_listener() override;
+
+    // Fires synchronously inside sync(), before the handshake: the receiver attaches an rx handler
+    // and registers the connection so the loop drives the handshake.
+    void set_accept_callback(accept_cb cb) {
+        m_cb = std::move(cb);
+    }
+
+    // The only way to observe a failed accept: sync()'s status is discarded by the sync-interface
+    // registration, so a listener that accepts nothing is otherwise indistinguishable from an idle
+    // one. Never called with code 0.
+    void set_error_handler(error_cb cb) {
+        m_error = std::move(cb);
+    }
+
+    int get_poll_fd() override {
+        return static_cast<int>(m_listen_fd);
+    }
+
+    event::sync_status sync() override;
+
+    // Resolved after bind, so this is where an ephemeral bind_port lands.
+    std::uint16_t listen_port() const {
+        return m_listen_port;
+    }
+
+private:
+    // Spend the reserved descriptor to accept and immediately drop one queued connection. Under
+    // descriptor exhaustion the connection stays queued and the listen fd stays readable, so
+    // returning without draining it would spin the loop on every poll.
+    void shed_queued_connection(int accept_errno);
+    void report_error(int code, std::string const& what);
+
+    std::unique_ptr<::tls::Server> m_server;
+    event::unique_fd m_listen_fd;
+    // Held open only so it can be released to make room for the shed above.
+    event::unique_fd m_reserve_fd;
+    std::uint16_t m_listen_port{0};
+    accept_cb m_cb;
+    error_cb m_error;
+};
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_listener_config.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_listener_config.hpp
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+#include <everest/io/tls/tls_listener.hpp>
+#include <everest/tls/tls.hpp>
+
+#include <cstdint>
+#include <string>
+
+// Split out of tls_listener.hpp to keep that header libtls-free.
+struct everest::lib::io::tls::tls_listener::Config {
+    ::tls::Server::config_t tls{}; // chains, ciphers, verify mode etc.
+    std::string bind_addr;
+    std::uint16_t bind_port{0}; // 0 selects an ephemeral port
+    bool ipv6_only{false};      // when true, AF_INET6 + IPV6_V6ONLY=1
+};

--- a/lib/everest/io/include/everest/io/tls/tls_result.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_result.hpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <cerrno>
+
+namespace everest::lib::io::tls {
+
+// Not ::tls::Connection::result_t: that type is nested, so it cannot be forward declared.
+enum class io_result {
+    success,
+    want_read,
+    want_write,
+    closed,
+    timeout,
+    failed,
+};
+
+// Map a terminal TLS result to an errno-style code, so get_error() reports a POSIX error, not -1.
+inline int errno_from_result(io_result r) {
+    switch (r) {
+    case io_result::closed:
+        return ECONNRESET;
+    case io_result::timeout:
+        return ETIMEDOUT;
+    default:
+        return EPROTO;
+    }
+}
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_server.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_server.hpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tls/tls_endpoint_base.hpp>
+#include <everest/io/tls/tls_server_socket.hpp>
+
+#include <memory>
+
+// Opaque: libtls stays out of the public headers, see tls_socket_base.hpp.
+namespace tls {
+class ServerConnection;
+}
+
+namespace everest::lib::io::tls {
+
+// Event-loop-driven TLS server connection: register it with an fd_event_handler to drive it. The
+// accept handshake runs on the loop, kicked by the incoming ClientHello, so no worker thread is
+// needed.
+//
+// Single-use: wraps exactly one accepted connection and never reconnects, since an accepted
+// connection cannot be replayed. On disconnect or error the owner must drop the unique_ptr.
+class tls_server : public tls_endpoint_base<tls_server_socket> {
+public:
+    explicit tls_server(std::unique_ptr<::tls::ServerConnection> conn);
+
+    tls_server(tls_server const&) = delete;
+    tls_server(tls_server&&) = delete;
+    tls_server& operator=(tls_server const&) = delete;
+    tls_server& operator=(tls_server&&) = delete;
+    ~tls_server() override;
+
+private:
+    bool start(event::fd_event_handler& handler) override;
+    void stop() override;
+};
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_server_socket.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_server_socket.hpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+#include <everest/io/tls/tls_socket_base.hpp>
+
+#include <functional>
+#include <memory>
+
+// Opaque: libtls stays out of the public headers, see tls_socket_base.hpp.
+namespace tls {
+class ServerConnection;
+}
+
+namespace everest::lib::io::tls {
+
+// TLS server connection policy. The accepted connection is injected once via open(), the event
+// loop then drives accept(0) until handshake_complete(), then tx()/rx(). Shared logic lives in
+// tls_socket_base.
+class tls_server_socket : public tls_socket_base<tls_server_socket> {
+public:
+    tls_server_socket() = default;
+
+    // False when conn is null.
+    bool open(std::unique_ptr<::tls::ServerConnection> conn);
+
+    tls_server_socket(tls_server_socket const&) = delete;
+    tls_server_socket& operator=(tls_server_socket const&) = delete;
+
+    // Out of line: the unique_ptr needs ::tls::ServerConnection complete.
+    tls_server_socket(tls_server_socket&&) noexcept;
+    tls_server_socket& operator=(tls_server_socket&&) noexcept;
+    ~tls_server_socket();
+
+    // tls_socket_base hooks (public so the base can call them without friendship).
+    ::tls::Connection* connection() const;
+    io_result step_handshake(); // one non-blocking accept(0)
+    void reset_connection();
+
+    // Hand the connection, the fd's BIO_CLOSE owner, to a closer so the fd stays open until the
+    // closer runs. Used to defer the close past the handler removal. No TLS shutdown, the
+    // connection has faulted.
+    std::function<void()> release_closer();
+
+private:
+    std::unique_ptr<::tls::ServerConnection> m_conn;
+};
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_socket_base.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_socket_base.hpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#pragma once
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tls/tls_result.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// Opaque: including everest/tls/tls.hpp instead would chain libtls, and with it the OpenSSL
+// headers, into every consumer.
+namespace tls {
+class Connection;
+}
+
+namespace everest::lib::io::tls {
+
+// Shared fd_event_client policy logic for the TLS client and server sockets.
+// Derived (client/server) provides three public hooks the base calls:
+//   ::tls::Connection* connection() const;
+//   io_result step_handshake();
+//   void reset_connection();
+// Member definitions live in tls_socket_base_impl.hpp.
+template <class Derived> class tls_socket_base {
+public:
+    using PayloadT = std::vector<std::uint8_t>;
+
+    bool handshake_step();
+
+    bool handshake_complete() const {
+        return m_handshake_done;
+    }
+
+    bool tx(PayloadT& payload);
+
+    // Invariant: a false return from want_read/want_write must leave the error state untouched. The
+    // event client maps every false rx() to action_status::fail and reports get_error(), so an error
+    // recorded for a clean would-block would surface a spurious failure on every idle wakeup.
+    bool rx(PayloadT& buffer);
+
+    bool is_open() const;
+
+    int get_fd() const;
+
+    int get_error() const {
+        return m_last_error;
+    }
+
+    // OpenSSL error text captured at the last failure, empty when none was reported.
+    const std::string& get_error_string() const {
+        return m_last_error_text;
+    }
+
+    void close();
+
+    event::poll_events desired_events() const {
+        return m_desired;
+    }
+
+protected:
+    static constexpr std::size_t c_read_chunk_size = 4096;
+
+    Derived& self() {
+        return static_cast<Derived&>(*this);
+    }
+    Derived const& self() const {
+        return static_cast<Derived const&>(*this);
+    }
+
+    void reset_error_state() {
+        m_last_error = 0;
+        m_last_error_text.clear();
+        m_failed = false;
+    }
+
+    event::poll_events m_desired{event::poll_events::read};
+    int m_last_error{0};
+    std::string m_last_error_text;
+    bool m_handshake_done{false};
+    // Set on a terminal TLS result. The Connection stays alive (its fd stays open) until the
+    // endpoint's fail() defers the close, is_open() reports closed so the endpoint routes there.
+    bool m_failed{false};
+};
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_socket_base_impl.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_socket_base_impl.hpp
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+#include <everest/io/tls/detail/tls_result_from_libtls.hpp>
+#include <everest/io/tls/tls_socket_base.hpp>
+#include <everest/tls/tls.hpp>
+
+// Member definitions of tls_socket_base. Include to instantiate the base for a Derived of your own.
+
+namespace everest::lib::io::tls {
+
+template <class Derived> bool tls_socket_base<Derived>::handshake_step() {
+    auto* c = self().connection();
+    if (c == nullptr || m_handshake_done) {
+        return false;
+    }
+    const auto res = self().step_handshake();
+    switch (res) {
+    case io_result::success:
+        m_handshake_done = true;
+        m_desired = event::poll_events::read;
+        return true;
+    case io_result::want_read:
+        m_desired = event::poll_events::read;
+        return true;
+    case io_result::want_write:
+        m_desired = event::poll_events::write;
+        return true;
+    default:
+        m_last_error = errno_from_result(res);
+        m_last_error_text = c->last_error();
+        // The connection stays alive: the endpoint's fail() defers the close, keeping the fd reserved.
+        m_failed = true;
+        return false;
+    }
+}
+
+template <class Derived> bool tls_socket_base<Derived>::tx(PayloadT& payload) {
+    if (payload.empty()) {
+        return true;
+    }
+    auto* c = self().connection();
+    if (c == nullptr) {
+        return false;
+    }
+    std::size_t written = 0;
+    const auto res =
+        detail::to_io_result(c->write(reinterpret_cast<std::byte const*>(payload.data()), payload.size(), written, 0));
+    switch (res) {
+    case io_result::success:
+        payload.erase(payload.begin(), payload.begin() + static_cast<std::ptrdiff_t>(written));
+        // A want_write then a success must drop back to read, or desired_events() strands the rx side.
+        m_desired = payload.empty() ? event::poll_events::read : event::poll_events::write;
+        return payload.empty();
+    // SSL_MODE_ENABLE_PARTIAL_WRITE is off: a would-block accepts nothing and must retry the same buffer.
+    case io_result::want_read:
+        m_desired = event::poll_events::read;
+        return false;
+    case io_result::want_write:
+        m_desired = event::poll_events::write;
+        return false;
+    default:
+        m_last_error = errno_from_result(res);
+        m_last_error_text = c->last_error();
+        m_failed = true;
+        return false;
+    }
+}
+
+template <class Derived> bool tls_socket_base<Derived>::rx(PayloadT& buffer) {
+    auto* c = self().connection();
+    if (c == nullptr) {
+        return false;
+    }
+    std::byte tmp[c_read_chunk_size];
+    std::size_t n = 0;
+    const auto res = detail::to_io_result(c->read(tmp, sizeof tmp, n, 0));
+    buffer.clear();
+    switch (res) {
+    case io_result::success:
+        buffer.assign(reinterpret_cast<std::uint8_t*>(tmp), reinterpret_cast<std::uint8_t*>(tmp) + n);
+        // A decrypted record's remainder sits in the record layer, not the socket: readability never returns.
+        while (self().connection() != nullptr && self().connection()->has_pending()) {
+            std::size_t more = 0;
+            const auto next = detail::to_io_result(self().connection()->read(tmp, sizeof tmp, more, 0));
+            if (next != io_result::success || more == 0) {
+                break;
+            }
+            buffer.insert(buffer.end(), reinterpret_cast<std::uint8_t*>(tmp),
+                          reinterpret_cast<std::uint8_t*>(tmp) + more);
+        }
+        m_desired = event::poll_events::read;
+        return not buffer.empty();
+    case io_result::want_read:
+        m_desired = event::poll_events::read;
+        return false;
+    case io_result::want_write:
+        m_desired = event::poll_events::write;
+        return false;
+    default:
+        m_last_error = errno_from_result(res);
+        m_last_error_text = c->last_error();
+        m_failed = true;
+        return false;
+    }
+}
+
+template <class Derived> bool tls_socket_base<Derived>::is_open() const {
+    return not m_failed and self().connection() != nullptr;
+}
+
+template <class Derived> int tls_socket_base<Derived>::get_fd() const {
+    auto* c = self().connection();
+    return c != nullptr ? c->socket() : -1;
+}
+
+template <class Derived> void tls_socket_base<Derived>::close() {
+    if (auto* c = self().connection()) {
+        c->shutdown(0);
+    }
+    self().reset_connection();
+    m_desired = event::poll_events::read;
+    m_handshake_done = false;
+    m_failed = false;
+    m_last_error_text.clear();
+}
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/utilities/event_client_async_policy.hpp
+++ b/lib/everest/io/include/everest/io/utilities/event_client_async_policy.hpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 
 /** \file */
 
 #pragma once
 
+#include <chrono>
 #include <functional>
+#include <string>
 #include <type_traits>
 
 namespace everest::lib::io::utilities {
@@ -108,5 +110,83 @@ enum class tx_buffering {
     /** Accept while the connection is fresh, hold in the bounded buffer, deliver once it is up. */
     buffer
 };
+
+/**
+ * @brief Primary template for the trait to check if a type T has a member function
+ * 'handshake_complete()' returning something convertible to bool.
+ * @tparam T The type to check.
+ */
+template <typename T, typename V = void> struct has_member_handshake_complete : std::false_type {};
+
+template <typename T>
+struct has_member_handshake_complete<
+    T, std::enable_if_t<std::is_convertible_v<decltype(std::declval<T&>().handshake_complete()), bool>>>
+    : std::true_type {};
+
+template <typename T> inline constexpr bool has_member_handshake_complete_v = has_member_handshake_complete<T>::value;
+
+template <typename T, typename V = void> struct has_member_handshake_step : std::false_type {};
+
+template <typename T>
+struct has_member_handshake_step<
+    T, std::enable_if_t<std::is_convertible_v<decltype(std::declval<T&>().handshake_step()), bool>>> : std::true_type {
+};
+
+template <typename T> inline constexpr bool has_member_handshake_step_v = has_member_handshake_step<T>::value;
+
+/**
+ * @brief Trait for a member function 'desired_events()'.
+ * @details The return type is not constrained: naming event::poll_events here would close a cycle with
+ * event/fd_event_handler.hpp, which includes the event client that consumes this trait.
+ * @tparam T The type to check.
+ */
+template <typename T, typename V = void> struct has_member_desired_events : std::false_type {};
+
+template <typename T>
+struct has_member_desired_events<T, std::void_t<decltype(std::declval<T&>().desired_events())>> : std::true_type {};
+
+template <typename T> inline constexpr bool has_member_desired_events_v = has_member_desired_events<T>::value;
+
+/**
+ * @brief Defines the policy trait for an event client with a protocol handshake phase.
+ * @tparam T The type to check.
+ */
+template <typename T>
+struct event_client_handshake_policy
+    : std::integral_constant<bool, has_member_handshake_complete<T>::value && has_member_handshake_step<T>::value &&
+                                       has_member_desired_events<T>::value> {};
+
+template <typename T> inline constexpr bool event_client_handshake_policy_v = event_client_handshake_policy<T>::value;
+
+/**
+ * @brief True for a type providing none of the three handshake members.
+ * @details The complement of \ref event_client_handshake_policy, which is not its negation: a
+ * type providing only some of the three satisfies neither. 'handshake_timeout()' is not counted
+ * here, it is optional and bounds a handshake the three implement.
+ * @tparam T The type to check.
+ */
+template <typename T>
+inline constexpr bool event_client_has_no_handshake_trio_v =
+    not has_member_handshake_complete_v<T> and not has_member_handshake_step_v<T> and
+    not has_member_desired_events_v<T>;
+
+template <typename T, typename V = void> struct has_member_handshake_timeout : std::false_type {};
+
+template <typename T>
+struct has_member_handshake_timeout<
+    T, std::enable_if_t<
+           std::is_convertible_v<decltype(std::declval<T&>().handshake_timeout()), std::chrono::milliseconds>>>
+    : std::true_type {};
+
+template <typename T> inline constexpr bool has_member_handshake_timeout_v = has_member_handshake_timeout<T>::value;
+
+template <typename T, typename V = void> struct has_member_get_error_string : std::false_type {};
+
+template <typename T>
+struct has_member_get_error_string<
+    T, std::enable_if_t<std::is_convertible_v<decltype(std::declval<T&>().get_error_string()), std::string>>>
+    : std::true_type {};
+
+template <typename T> inline constexpr bool has_member_get_error_string_v = has_member_get_error_string<T>::value;
 
 } // namespace everest::lib::io::utilities

--- a/lib/everest/io/include/everest/io/utilities/generic_error_state.hpp
+++ b/lib/everest/io/include/everest/io/utilities/generic_error_state.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 
 /** \file */
 
@@ -33,8 +33,8 @@ class generic_error_state {
 public:
     /**
      * @var cb_error
-     * @brief Prototype for an on_error handler callback. It receives the current errno
-     * and its string representation
+     * @brief Prototype for an on_error handler callback. It receives the stored error code
+     * and a description of it
      */
     using cb_error = std::function<void(int error, std::string const& msg)>;
     virtual ~generic_error_state() = default;
@@ -99,10 +99,14 @@ protected:
     int current_error() const;
 
     /**
-     * @brief Call the error handler with current errno, if registered.
+     * @brief Call the error handler with the stored error code, if registered.
+     * @details The reported error is never 0. Clearing an error is signaled through
+     *          \ref clear_error_handler instead.
      * @param[in] handler The handler to be called
+     * @param[in] msg Description of the error. An empty string selects the description
+     *            of the stored error code.
      */
-    void call_error_handler(cb_error& handler) const;
+    void call_error_handler(cb_error& handler, std::string const& msg = {}) const;
 
     /**
      * @brief Report a connection up-edge by calling the handler with errno=0 (success)

--- a/lib/everest/io/src/CMakeLists.txt
+++ b/lib/everest/io/src/CMakeLists.txt
@@ -125,17 +125,56 @@ install(TARGETS everest_io
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
+# The tls headers are excluded unconditionally: they include libtls headers, and libtls is
+# reachable only through BUILD_INTERFACE below, so an installed consumer could not compile
+# them. Shipping them would offer an interface that cannot be used.
 if(EVEREST_IO_WITH_MQTT)
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../include/everest
         DESTINATION include
         FILES_MATCHING PATTERN "*.hpp"
+        PATTERN "tls" EXCLUDE
     )
 else()
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../include/everest
         DESTINATION include
         FILES_MATCHING PATTERN "*.hpp"
         PATTERN "mqtt" EXCLUDE
+        PATTERN "tls" EXCLUDE
     )
+endif()
+
+option(EVEREST_IO_ENABLE_TLS "Build TLS client/server adapters in everest_io (requires everest::tls)" ON)
+
+if(EVEREST_IO_ENABLE_TLS)
+    target_sources(everest_io
+        PRIVATE
+            tls/tls_socket_base.cpp
+            tls/tls_endpoint_base.cpp
+            tls/tls_server_socket.cpp
+            tls/tls_server.cpp
+            tls/tls_listener.cpp
+            tls/tls_client_socket.cpp
+    )
+    target_link_libraries(everest_io PRIVATE $<BUILD_INTERFACE:tls>)
+    # libtls is not installed as part of everest-core's export set, so its
+    # public include directories are propagated to in-tree consumers only via
+    # BUILD_INTERFACE. Mirrors libtls's own PUBLIC include directories.
+    target_include_directories(everest_io
+        PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/everest/tls>
+            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/everest/tls/include>
+    )
+
+    # No everest_io link: its BUILD_INTERFACE carries the libtls includes above, which would make
+    # the guard vacuous.
+    add_library(everest_io_tls_header_guard OBJECT tls/tls_public_header_guard.cpp)
+    target_include_directories(everest_io_tls_header_guard
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/../include
+    )
+    target_link_libraries(everest_io_tls_header_guard PRIVATE $<BUILD_INTERFACE:everest_util>)
+    target_compile_features(everest_io_tls_header_guard PRIVATE cxx_std_17)
+    add_dependencies(everest_io everest_io_tls_header_guard)
 endif()
 
 if(DISABLE_EDM)

--- a/lib/everest/io/src/event/fd_event_client.cpp
+++ b/lib/everest/io/src/event/fd_event_client.cpp
@@ -3,9 +3,9 @@
 
 #include <everest/io/event/fd_event_client.hpp>
 #include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/socket/socket.hpp>
 
 #include <cerrno>
-#include <sys/socket.h>
 #include <utility>
 
 namespace everest::lib::io::event {
@@ -303,15 +303,10 @@ int generic_fd_event_client_impl::consume_poll_error(int fd, poll_events kind) {
     if (error != 0) {
         return error;
     }
-    int so_error = 0;
-    socklen_t len = sizeof(so_error);
-    // Consumes the pending socket error. Non sockets (serial, tun/tap) fail and fall through.
-    if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &so_error, &len) == 0 and so_error != 0) {
-        return so_error;
-    }
-    // No code available: a network errno would misdiagnose the serial and tun/tap devices this
-    // client also drives.
-    return kind == poll_events::hungup ? ENOTCONN : EIO;
+    // With no code to read back, the fallback describes the notification rather than naming a
+    // cause: this client also drives serial lines and tun/tap devices, where ECONNRESET would
+    // invent a peer that reset nothing.
+    return socket::consume_poll_error(fd, kind, kind == poll_events::hungup ? ENOTCONN : EIO);
 }
 
 bool generic_fd_event_client_impl::monitor_for(int fd, poll_events desired) {

--- a/lib/everest/io/src/event/fd_event_client.cpp
+++ b/lib/everest/io/src/event/fd_event_client.cpp
@@ -1,15 +1,63 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 
 #include <everest/io/event/fd_event_client.hpp>
 #include <everest/io/event/fd_event_handler.hpp>
 
+#include <cerrno>
+#include <sys/socket.h>
+#include <utility>
+
 namespace everest::lib::io::event {
 
+namespace {
+// Error state 0 means cleared, so a protocol level failure with no errno of its own must
+// not be reported as 0 or the client reports success on a connection it gave up on.
+int genuine_error_code(int error_code) {
+    return error_code != 0 ? error_code : ECONNRESET;
+}
+
+// A local failure with no errno of its own is not a peer reset, so it must not be reported as one.
+int local_error_code(int error_code) {
+    return error_code != 0 ? error_code : EPROTO;
+}
+
+bool is_monitorable(poll_events desired) {
+    return desired == poll_events::read or desired == poll_events::write;
+}
+
+constexpr char unsupported_event_text[]{"handshake policy requested an event that is neither read nor write"};
+constexpr char monitor_failed_text[]{"the connection could not be monitored for the event the handshake waits for"};
+constexpr char deadline_arm_failed_text[]{"handshake deadline could not be armed"};
+constexpr char deadline_register_failed_text[]{"handshake deadline could not be registered"};
+} // namespace
+
 generic_fd_event_client_impl::generic_fd_event_client_impl(action const& send_one, action const& receive_one,
-                                                           action const& reset_client, error_status const& get_error) :
-    m_send_one(send_one), m_receive_one(receive_one), m_reset_client(reset_client), m_get_error(get_error) {
+                                                           action const& reset_client, error_status const& get_error,
+                                                           handshake_status const& handshake_pending,
+                                                           action const& drive_handshake,
+                                                           handshake_events const& handshake_desired_events,
+                                                           handshake_timeout const& get_handshake_timeout,
+                                                           error_text const& get_error_string) :
+    m_send_one(send_one),
+    m_receive_one(receive_one),
+    m_reset_client(reset_client),
+    m_get_error(get_error),
+    m_handshake_pending(handshake_pending),
+    m_drive_handshake(drive_handshake),
+    m_handshake_desired_events(handshake_desired_events),
+    m_get_handshake_timeout(get_handshake_timeout),
+    m_get_error_string(get_error_string) {
     m_event_handler = std::make_unique<event::fd_event_handler>();
+    m_handshake_timer.set_single_shot(true);
+    // Registered once and for all: a timerfd notifies only while it is running.
+    auto const deadline_registered =
+        m_event_handler->register_event_handler(&m_handshake_timer, [this]() { handshake_deadline_expired(); });
+    if (not deadline_registered) {
+        // Read errno before anything else overwrites it.
+        auto const error_code = errno;
+        m_handshake_deadline_register_error = error_code != 0 ? error_code : ENOTSUP;
+    }
 }
 
 generic_fd_event_client_impl::~generic_fd_event_client_impl() {
@@ -41,7 +89,7 @@ bool generic_fd_event_client_impl::setup_error_event_handler() {
         auto const state = current_connection_state();
         if (state == utilities::connection_state::failed) {
             error_handler();
-            call_error_handler(m_error);
+            call_error_handler(m_error, take_error_text());
             return sync_status::error;
         }
         if (state == utilities::connection_state::connected and clear_error_pending()) {
@@ -53,29 +101,43 @@ bool generic_fd_event_client_impl::setup_error_event_handler() {
 
 void generic_fd_event_client_impl::setup_io_event_handler(int fd) {
     using namespace everest::lib::io::event;
+    m_connection_failed = false;
+    // Belongs to the previous connection, so it may not describe a failure of this one.
+    m_local_error_text.clear();
     m_event_handler->register_event_handler(
         fd,
         [this, fd](auto events) {
-            auto success = true;
-            if (events.count(poll_events::error)) {
-                auto error = m_get_error();
-                if (error) {
-                    set_error_status_and_notify(error);
+            // A terminal notification wins over a pending handshake: the connection it would be
+            // negotiated on is gone.
+            if (events.count(poll_events::error) or events.count(poll_events::hungup)) {
+                // Level triggered, so the fd keeps notifying until the queued teardown removes it,
+                // and reading SO_ERROR clears it.
+                if (not m_connection_failed) {
+                    m_connection_failed = true;
+                    auto const kind = events.count(poll_events::error) != 0 ? poll_events::error : poll_events::hungup;
+                    set_error_status_and_notify(consume_poll_error(fd, kind));
                 }
-                success = false;
+                return;
             }
-            if (events.count(poll_events::hungup)) {
-                success = false;
+            if (m_handshake_pending()) {
+                drive_handshake(fd);
+                return;
             }
-            if (success && events.count(poll_events::read)) {
+            auto success = true;
+            if (events.count(poll_events::read)) {
                 success = rx_handler();
             }
-            if (success && events.count(poll_events::write)) {
-                success = tx_handler(fd);
+            if (success and events.count(poll_events::write)) {
+                tx_handler(fd);
             }
         },
         poll_events::read);
     m_event_handler->register_event_handler(&m_io_event_fd, [this, fd](auto) {
+        if (m_handshake_pending()) {
+            // The handshake monitors a single event, so monitoring write here would step it on an
+            // event it never asked for. The queue is flushed once it completes.
+            return;
+        }
         m_event_handler->modify_event_handler(fd, poll_events::write, event_modification::add);
     });
 }
@@ -135,24 +197,166 @@ void generic_fd_event_client_impl::error_handler() {
     add_action([this]() { m_reset_client(); });
 }
 
+void generic_fd_event_client_impl::drive_handshake(int fd) {
+    // Teardown is queued, so events keep arriving until it runs. Never step a dead handshake.
+    if (m_connection_failed) {
+        return;
+    }
+    if (not start_handshake_deadline()) {
+        return;
+    }
+    switch (m_drive_handshake()) {
+    case action_status::success: {
+        auto const desired = m_handshake_desired_events();
+        if (not is_monitorable(desired)) {
+            fail_connection(local_error_code(m_get_error()), unsupported_event_text);
+            return;
+        }
+        if (not monitor_for(fd, desired)) {
+            fail_connection(local_error_code(m_get_error()), monitor_failed_text);
+        }
+        return;
+    }
+    case action_status::empty: {
+        m_handshake_timer.disarm();
+        if (not monitor_for(fd, poll_events::read)) {
+            // A ready client on an unmonitored fd would leave the consumer waiting forever.
+            fail_connection(local_error_code(m_get_error()), monitor_failed_text);
+            return;
+        }
+        maybe_fire_ready();
+        return;
+    }
+    case action_status::fail: {
+        fail_connection();
+        return;
+    }
+    default:
+        fail_connection();
+        return;
+    }
+}
+
+void generic_fd_event_client_impl::fail_connection() {
+    fail_connection(m_get_error());
+}
+
+void generic_fd_event_client_impl::fail_connection(int error_code) {
+    m_connection_failed = true;
+    m_handshake_timer.disarm();
+    set_error_status_and_notify(genuine_error_code(error_code));
+}
+
+void generic_fd_event_client_impl::fail_connection(int error_code, std::string text) {
+    m_local_error_text = std::move(text);
+    fail_connection(error_code);
+}
+
+std::string generic_fd_event_client_impl::take_error_text() {
+    if (not m_local_error_text.empty()) {
+        return std::exchange(m_local_error_text, std::string{});
+    }
+    return m_get_error_string ? m_get_error_string() : std::string{};
+}
+
+bool generic_fd_event_client_impl::start_handshake_deadline() {
+    if (m_handshake_deadline_register_error != 0) {
+        fail_connection(local_error_code(m_handshake_deadline_register_error), deadline_register_failed_text);
+        return false;
+    }
+    auto const generation = m_connected_generation.load();
+    // The bound is on the whole handshake, so later steps keep the deadline the first one armed.
+    if (m_handshake_deadline_generation == generation) {
+        return true;
+    }
+    auto const timeout = m_get_handshake_timeout ? m_get_handshake_timeout() : default_handshake_timeout;
+    // A non positive timeout stops a timerfd, which is the unbounded handshake this guards.
+    if (not m_handshake_timer.set_timeout(timeout > std::chrono::milliseconds::zero() ? timeout
+                                                                                      : default_handshake_timeout)) {
+        // Read errno before anything else overwrites it.
+        auto const error_code = errno;
+        fail_connection(local_error_code(error_code), deadline_arm_failed_text);
+        return false;
+    }
+    // Recorded only once the deadline is in force: no record may claim a bound that never armed.
+    m_handshake_deadline_generation = generation;
+    return true;
+}
+
+void generic_fd_event_client_impl::handshake_deadline_expired() {
+    m_handshake_timer.disarm();
+    // One poll batch can carry both the expiry and the event that finished or replaced the
+    // handshake, so only the pending handshake this deadline was started for may be failed.
+    if (m_connection_failed or m_handshake_deadline_generation != m_connected_generation.load() or
+        not m_handshake_pending()) {
+        return;
+    }
+    fail_connection(ETIMEDOUT);
+}
+
+void generic_fd_event_client_impl::retire_handshake_deadline() {
+    m_handshake_timer.disarm();
+}
+
+int generic_fd_event_client_impl::consume_poll_error(int fd, poll_events kind) {
+    auto error = m_get_error ? m_get_error() : 0;
+    if (error != 0) {
+        return error;
+    }
+    int so_error = 0;
+    socklen_t len = sizeof(so_error);
+    // Consumes the pending socket error. Non sockets (serial, tun/tap) fail and fall through.
+    if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &so_error, &len) == 0 and so_error != 0) {
+        return so_error;
+    }
+    // No code available: a network errno would misdiagnose the serial and tun/tap devices this
+    // client also drives.
+    return kind == poll_events::hungup ? ENOTCONN : EIO;
+}
+
+bool generic_fd_event_client_impl::monitor_for(int fd, poll_events desired) {
+    // Otherwise both would be removed and the fd would be monitored for nothing.
+    if (not is_monitorable(desired)) {
+        return false;
+    }
+    auto read_ok = m_event_handler->modify_event_handler(
+        fd, poll_events::read, desired == poll_events::read ? event_modification::add : event_modification::remove);
+    auto write_ok = m_event_handler->modify_event_handler(
+        fd, poll_events::write, desired == poll_events::write ? event_modification::add : event_modification::remove);
+    return read_ok and write_ok;
+}
+
+poll_events generic_fd_event_client_impl::default_desired_events() {
+    return poll_events::read;
+}
+
 void generic_fd_event_client_impl::prepare_io_event_handler() {
     m_event_handler->register_event_handler(&m_connected_event_fd, [this](auto) {
-        auto client_status = m_client_status.handle();
-        auto generation = m_connected_generation.load();
-        if (client_status->generation != generation) {
+        auto ok = false;
+        auto fd = -1;
+        {
+            // Copy out under the lock only: the handshake setup below runs a policy callback.
+            auto client_status = m_client_status.handle();
+            auto generation = m_connected_generation.load();
+            if (client_status->generation != generation) {
+                return sync_status::ok;
+            }
+            ok = client_status->ok;
+            fd = client_status->fd;
+        }
+
+        auto error_code = m_get_error();
+        set_error_status_and_notify(error_code);
+        if (not ok) {
             return sync_status::ok;
         }
 
-        if (client_status->ok) {
-            auto error_code = m_get_error();
-            set_error_status_and_notify(error_code);
-            setup_io_event_handler(client_status->fd);
-            if (m_on_ready_action) {
-                m_event_handler->add_action(m_on_ready_action);
-            }
+        setup_io_event_handler(fd);
+        if (m_handshake_pending()) {
+            // The client owes the first handshake message, so it cannot wait for readability.
+            drive_handshake(fd);
         } else {
-            auto error_code = m_get_error();
-            set_error_status_and_notify(error_code);
+            maybe_fire_ready();
         }
 
         return sync_status::ok;
@@ -182,11 +386,32 @@ void generic_fd_event_client_impl::register_async_connect_event_handler(event_fd
 }
 
 void generic_fd_event_client_impl::set_on_ready_action(ready_action&& item) {
-    m_on_ready_action = std::move(item);
-    auto client_status = m_client_status.handle();
-    if (client_status->ok) {
-        m_event_handler->add_action(m_on_ready_action);
+    // Assign on the loop thread, where it is read when a connection becomes ready.
+    add_action([this, item = std::move(item)]() mutable {
+        m_on_ready_action = std::move(item);
+        auto connected = false;
+        {
+            auto client_status = m_client_status.handle();
+            connected = client_status->ok;
+        }
+        // A connected transport is not a ready client while its handshake is outstanding, and
+        // the connected status outlives a failure until the queued teardown runs.
+        if (connected and not m_connection_failed and not m_handshake_pending()) {
+            // Explicit registration on a ready connection asks to be called now.
+            m_ready_fired_generation = 0;
+            maybe_fire_ready();
+        }
+    });
+}
+
+void generic_fd_event_client_impl::maybe_fire_ready() {
+    // Recorded per connection, not per monitor change: the record can be cleared before it changes.
+    auto generation = m_connected_generation.load();
+    if (m_ready_fired_generation == generation or not m_on_ready_action) {
+        return;
     }
+    m_ready_fired_generation = generation;
+    m_event_handler->add_action(m_on_ready_action);
 }
 
 } // namespace everest::lib::io::event

--- a/lib/everest/io/src/event/fd_event_handler.cpp
+++ b/lib/everest/io/src/event/fd_event_handler.cpp
@@ -230,8 +230,14 @@ bool fd_event_handler::register_event_handler(timer_fd* fd, event_handler_type c
     auto const registered = register_event_handler(
         raw,
         [handler, fd](event_list const& e) {
-            fd->read();
-            handler(e);
+            // A poll batch is harvested before any of it is dispatched, so a rearm or disarm by an
+            // earlier handler retires an expiry still queued here. timerfd_settime clears the tick
+            // counter, the only identity an expiry carries, so a read of 0 marks it stale.
+            // The event_fd overload keeps its unconditional read: an eventfd is blocking and counts
+            // notifications rather than identifying an arm.
+            if (fd->read() > 0) {
+                handler(e);
+            }
         },
         poll_events::read);
     if (registered) {

--- a/lib/everest/io/src/socket/socket.cpp
+++ b/lib/everest/io/src/socket/socket.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <arpa/inet.h>
 #include <asm-generic/socket.h>
+#include <cerrno>
 #include <chrono>
 #include <cstring>
 #include <fcntl.h>
@@ -23,6 +24,9 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+// Nothing includes this translation unit, so the complete poll_events is available here where
+// socket/socket.hpp can only declare it opaquely.
+#include <everest/io/event/fd_event_handler.hpp>
 #include <everest/io/event/unique_fd.hpp>
 #include <everest/io/mdns/mdns.hpp>
 #include <everest/io/socket/socket.hpp>
@@ -412,6 +416,66 @@ event::unique_fd open_tcp_socket(const std::string& host, std::uint16_t port, co
     throw std::runtime_error(std::string("Could not open a socket for ") + host + ":" + std::to_string(port));
 }
 
+event::unique_fd open_tcp_server_socket(std::string const& bind_addr, std::uint16_t port, bool ipv6_only) {
+    const bool is_ipv6 = ipv6_only || (bind_addr.find(':') != std::string::npos);
+    const int family = is_ipv6 ? AF_INET6 : AF_INET;
+
+    const int raw_fd = ::socket(family, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    if (raw_fd < 0) {
+        throw std::runtime_error(std::string("open_tcp_server_socket socket(): ") + std::strerror(errno));
+    }
+    // Own the fd immediately so any throw below auto-closes it.
+    event::unique_fd fd(raw_fd);
+
+    const int opt = 1;
+    if (::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) != 0) {
+        throw std::runtime_error(std::string("open_tcp_server_socket setsockopt(SO_REUSEADDR): ") +
+                                 std::strerror(errno));
+    }
+    if (::setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &opt, sizeof(opt)) != 0) {
+        throw std::runtime_error(std::string("open_tcp_server_socket setsockopt(SO_REUSEPORT): ") +
+                                 std::strerror(errno));
+    }
+
+    if (is_ipv6) {
+        const int v6only = ipv6_only ? 1 : 0;
+        if (::setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) != 0) {
+            throw std::runtime_error(std::string("open_tcp_server_socket setsockopt(IPV6_V6ONLY): ") +
+                                     std::strerror(errno));
+        }
+    }
+
+    sockaddr_storage sa{};
+    socklen_t sa_len = 0;
+    if (is_ipv6) {
+        auto* sa6 = reinterpret_cast<sockaddr_in6*>(&sa);
+        sa6->sin6_family = AF_INET6;
+        sa6->sin6_port = htons(port);
+        if (::inet_pton(AF_INET6, bind_addr.c_str(), &sa6->sin6_addr) != 1) {
+            throw std::runtime_error(std::string("open_tcp_server_socket inet_pton IPv6: ") + bind_addr);
+        }
+        sa_len = sizeof(sockaddr_in6);
+    } else {
+        auto* sa4 = reinterpret_cast<sockaddr_in*>(&sa);
+        sa4->sin_family = AF_INET;
+        sa4->sin_port = htons(port);
+        if (::inet_pton(AF_INET, bind_addr.c_str(), &sa4->sin_addr) != 1) {
+            throw std::runtime_error(std::string("open_tcp_server_socket inet_pton IPv4: ") + bind_addr);
+        }
+        sa_len = sizeof(sockaddr_in);
+    }
+
+    if (::bind(fd, reinterpret_cast<sockaddr*>(&sa), sa_len) != 0) {
+        throw std::runtime_error(std::string("open_tcp_server_socket bind(): ") + std::strerror(errno));
+    }
+
+    if (::listen(fd, SOMAXCONN) != 0) {
+        throw std::runtime_error(std::string("open_tcp_server_socket listen(): ") + std::strerror(errno));
+    }
+
+    return fd;
+}
+
 #ifndef EVEREST_NO_PACKET_IGNORE_OUTGOING
 event::unique_fd open_raw_promiscuous_socket(std::string const& if_name) {
     auto const socket_fd = ::socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
@@ -525,6 +589,19 @@ int get_pending_error(int fd) {
         return errno;
     }
     return error;
+}
+
+int consume_poll_error(int fd, event::poll_events kind, int fallback) {
+    int so_error = 0;
+    socklen_t len = sizeof(so_error);
+    // Consumes the pending socket error. Non sockets fail here and fall through.
+    if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &so_error, &len) == 0 and so_error != 0) {
+        return so_error;
+    }
+    if (fallback != 0) {
+        return fallback;
+    }
+    return kind == event::poll_events::hungup ? ENOTCONN : EIO;
 }
 
 bool is_tcp_socket_alive(int sock_fd) {

--- a/lib/everest/io/src/tcp/tcp_socket.cpp
+++ b/lib/everest/io/src/tcp/tcp_socket.cpp
@@ -132,6 +132,10 @@ void tcp_socket::close() {
     discard();
 }
 
+int tcp_socket::release() {
+    return m_fd.release();
+}
+
 bool tcp_socket::set_keep_alive(uint32_t count, uint32_t idle_s, uint32_t intval_s) {
     if (not is_open()) {
         return false;

--- a/lib/everest/io/src/tls/tls_client_socket.cpp
+++ b/lib/everest/io/src/tls/tls_client_socket.cpp
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/tls/detail/tls_result_from_libtls.hpp>
+#include <everest/io/tls/tls_client_config.hpp>
+
+#include <cerrno>
+#include <string>
+#include <utility>
+
+namespace everest::lib::io::tls {
+
+namespace {
+
+bool init_client(std::unique_ptr<::tls::Client>& client, ::tls::Client::config_t const& tls_cfg) {
+    client = std::make_unique<::tls::Client>();
+    if (!client->init(tls_cfg)) {
+        client.reset();
+        return false;
+    }
+    return true;
+}
+
+// Reason text for a rejected TLS configuration. tls::Client::init drains the per-thread OpenSSL
+// error queue through openssl::log, so nothing is left to read back, and it never names the input
+// it rejected, which may not be a file at all. So repeat the configuration without a culprit.
+// An unset field prints <unset> and an empty one '': for cipher_list and ciphersuites libtls reads
+// nullptr as "use the default".
+std::string init_failure_text(::tls::Client::config_t const& cfg) {
+    auto field = [](char const* name, char const* value) {
+        return value != nullptr ? std::string{name} + "='" + value + "'" : std::string{name} + "=<unset>";
+    };
+    auto flag = [](char const* name, bool value) { return std::string{name} + (value ? "=true" : "=false"); };
+    return "tls::Client::init rejected this configuration and does not report which part of it: " +
+           field("certificate_chain_file", cfg.certificate_chain_file) + ", " +
+           field("private_key_file", cfg.private_key_file) + ", " +
+           field("verify_locations_file", cfg.verify_locations_file) + ", " +
+           field("verify_locations_path", cfg.verify_locations_path) + ", " + flag("verify_server", cfg.verify_server) +
+           ", " + flag("verify_subject_name", cfg.verify_subject_name) +
+           ", min_proto_version=" + std::to_string(cfg.min_proto_version);
+}
+
+// Pointers reference the owned Config fields and stay valid for the duration of the
+// tls::Client::init call, which copies everything it needs (OpenSSL copies the cipher strings and
+// loads the files inside SSL_CTX_*, trusted_ca_keys_data is copied into the client).
+::tls::Client::config_t materialize(tls_client_socket::Config::tls_config const& cfg) {
+    ::tls::Client::config_t out{};
+    out.cipher_list = cfg.cipher_list;
+    out.ciphersuites = cfg.ciphersuites;
+    out.certificate_chain_file = cfg.certificate_chain_file;
+    out.private_key_file = cfg.private_key_file;
+    out.private_key_password = cfg.private_key_password;
+    out.verify_locations_file = cfg.verify_locations_file;
+    out.verify_locations_path = cfg.verify_locations_path;
+    out.trusted_ca_keys_data = cfg.trusted_ca_keys_data;
+    out.io_timeout_ms = cfg.io_timeout_ms;
+    out.min_proto_version = cfg.min_proto_version;
+    out.verify_server = cfg.verify_server;
+    out.verify_subject_name = cfg.verify_subject_name;
+    out.status_request = cfg.status_request;
+    out.status_request_v2 = cfg.status_request_v2;
+    out.trusted_ca_keys = cfg.trusted_ca_keys;
+    return out;
+}
+
+} // namespace
+
+bool tls_client_socket::setup(Config cfg, std::string const& remote_host, std::uint16_t remote_port, int timeout_ms) {
+    m_host_for_sni = std::move(cfg.host_for_sni);
+    auto const tls_cfg = materialize(cfg.tls);
+    if (!init_client(m_client, tls_cfg)) {
+        // No descriptor exists yet, so an error left at 0 sends get_error() to the TCP socket,
+        // which answers EBADF: that names the probe, not the bad configuration.
+        m_last_error = EINVAL;
+        m_last_error_text = init_failure_text(tls_cfg);
+        return false;
+    }
+    return m_tcp.setup(remote_host, remote_port, timeout_ms);
+}
+
+void tls_client_socket::connect(std::function<void(bool, int)> const& cb) {
+    m_tcp.connect([this, cb](bool ok, int fd) {
+        if (!ok) {
+            cb(false, -1);
+            return;
+        }
+        // No handshake here: the event loop drives it via step_handshake() once the fd is monitored.
+        m_conn = m_client->wrap_connecting_fd(fd, m_host_for_sni.c_str());
+        if (!m_conn) {
+            // Same reason the setup() path records one: a code with no text leaves the consumer
+            // nothing to act on. The factory reports no reason either, so name what it rules out.
+            m_last_error = EPROTO;
+            m_last_error_text = "tls::Client::wrap_connecting_fd returned no connection: the SSL context is "
+                                "uninitialised or SSL/BIO allocation failed";
+            cb(false, -1);
+            return;
+        }
+        // The connection's BIO (BIO_CLOSE) now owns the fd, so m_tcp surrenders its claim.
+        m_tcp.release();
+        cb(true, m_conn->socket());
+    });
+}
+
+::tls::Connection* tls_client_socket::connection() const {
+    return m_conn.get();
+}
+
+io_result tls_client_socket::step_handshake() {
+    return detail::to_io_result(m_conn->connect(0));
+}
+
+void tls_client_socket::reset_connection() {
+    m_conn.reset();
+}
+
+int tls_client_socket::get_fd() const {
+    if (m_conn) {
+        return m_conn->socket();
+    }
+    return m_tcp.get_fd();
+}
+
+int tls_client_socket::get_error() const {
+    if (m_last_error != 0) {
+        return m_last_error;
+    }
+    if (!m_conn) {
+        return m_tcp.get_error();
+    }
+    return 0;
+}
+
+void tls_client_socket::close() {
+    tls_socket_base::close();
+    m_tcp.close();
+}
+
+tls_client_socket::~tls_client_socket() {
+    close();
+}
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/src/tls/tls_endpoint_base.cpp
+++ b/lib/everest/io/src/tls/tls_endpoint_base.cpp
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/tls/tls_endpoint_base_impl.hpp>
+
+#include <everest/io/tls/tls_server_socket.hpp>
+
+namespace everest::lib::io::tls {
+
+template class tls_endpoint_base<tls_server_socket>;
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/src/tls/tls_listener.cpp
+++ b/lib/everest/io/src/tls/tls_listener.cpp
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/socket/socket.hpp>
+#include <everest/io/tls/tls_listener_config.hpp>
+
+#include <arpa/inet.h>
+#include <cerrno>
+#include <cstdint>
+#include <fcntl.h>
+#include <memory>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <stdexcept>
+#include <string>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace everest::lib::io::tls {
+
+namespace {
+
+// A descriptor worth nothing in itself, kept only to be released when accept runs out.
+event::unique_fd open_reserve_fd() {
+    return event::unique_fd(::open("/dev/null", O_RDONLY | O_CLOEXEC));
+}
+
+std::uint16_t port_from_storage(const sockaddr_storage& ss) {
+    if (ss.ss_family == AF_INET6) {
+        return ntohs(reinterpret_cast<const sockaddr_in6*>(&ss)->sin6_port);
+    }
+    if (ss.ss_family == AF_INET) {
+        return ntohs(reinterpret_cast<const sockaddr_in*>(&ss)->sin_port);
+    }
+    return 0;
+}
+
+} // namespace
+
+tls_listener::tls_listener(Config cfg) : m_server(std::make_unique<::tls::Server>()) {
+    m_listen_fd = socket::open_tcp_server_socket(cfg.bind_addr, cfg.bind_port, cfg.ipv6_only);
+    const int fd = static_cast<int>(m_listen_fd);
+
+    sockaddr_storage bound{};
+    socklen_t bound_len = sizeof(bound);
+    if (::getsockname(fd, reinterpret_cast<sockaddr*>(&bound), &bound_len) == 0) {
+        m_listen_port = port_from_storage(bound);
+    }
+
+    // The libtls Server borrows the fd number only, so wrap_accepted_fd works without its own
+    // bind/listen. Only its blocking serve loop, never run here, would close it, so m_listen_fd
+    // stays the sole owner and there is no double-close on teardown.
+    cfg.tls.socket = fd;
+    const auto state = m_server->init(cfg.tls, nullptr);
+    if (state == ::tls::Server::state_t::init_needed) {
+        throw std::runtime_error("tls_listener: tls::Server::init failed");
+    }
+
+    // Claimed while descriptors are still available, because the point of it is to be spendable
+    // once they are not. A failure here is not fatal: the listener works, it just cannot shed.
+    m_reserve_fd = open_reserve_fd();
+}
+
+tls_listener::~tls_listener() = default;
+
+void tls_listener::report_error(int code, std::string const& what) {
+    if (m_error and code != 0) {
+        m_error(code, what);
+    }
+}
+
+void tls_listener::shed_queued_connection(int accept_errno) {
+    if (not m_reserve_fd.is_fd()) {
+        // Nothing left to spend. The connection stays queued and the loop keeps waking on it, so
+        // say so rather than spinning silently.
+        report_error(accept_errno, "out of descriptors, cannot accept or shed the queued connection");
+        return;
+    }
+    m_reserve_fd.close();
+    const int shed = ::accept4(static_cast<int>(m_listen_fd), nullptr, nullptr, SOCK_CLOEXEC | SOCK_NONBLOCK);
+    if (shed >= 0) {
+        ::close(shed);
+    }
+    m_reserve_fd = open_reserve_fd();
+    report_error(accept_errno, "out of descriptors, dropped the queued connection to keep the loop live");
+}
+
+event::sync_status tls_listener::sync() {
+    sockaddr_storage peer{};
+    socklen_t peer_len = sizeof(peer);
+
+    // SOCK_NONBLOCK is essential: a blocking socket would stall SSL_accept, and with it the
+    // whole loop, until the peer sends data.
+    const int accepted = ::accept4(static_cast<int>(m_listen_fd), reinterpret_cast<sockaddr*>(&peer), &peer_len,
+                                   SOCK_CLOEXEC | SOCK_NONBLOCK);
+
+    if (accepted < 0) {
+        const int err = errno;
+        if (err == EAGAIN || err == EWOULDBLOCK || err == EINTR) {
+            return event::sync_status::ok;
+        }
+        // These leave the connection queued, so the listen fd stays readable and the loop would
+        // wake on it again immediately. Every other errno consumes it.
+        if (err == EMFILE || err == ENFILE || err == ENOBUFS || err == ENOMEM) {
+            shed_queued_connection(err);
+        } else {
+            report_error(err, "accept failed");
+        }
+        return event::sync_status::error;
+    }
+
+    char ip_buf[NI_MAXHOST] = {};
+    if (::getnameinfo(reinterpret_cast<sockaddr*>(&peer), peer_len, ip_buf, sizeof(ip_buf), nullptr, 0,
+                      NI_NUMERICHOST) != 0) {
+        // Peer IP is informational only, never read by wrap_accepted_fd.
+        ip_buf[0] = '\0';
+    }
+
+    const std::uint16_t peer_port = port_from_storage(peer);
+
+    const std::string svc = std::to_string(peer_port);
+    auto raw_conn = m_server->wrap_accepted_fd(accepted, ip_buf, svc.c_str());
+    if (!raw_conn) {
+        // No BIO took the fd on failure, so this side still owns it.
+        ::close(accepted);
+        report_error(EPROTO, "could not wrap the accepted connection");
+        return event::sync_status::error;
+    }
+
+    if (m_cb) {
+        auto srv = std::make_unique<tls_server>(std::move(raw_conn));
+        m_cb(std::move(srv), std::string(ip_buf), peer_port);
+    }
+
+    return event::sync_status::ok;
+}
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/src/tls/tls_public_header_guard.cpp
+++ b/lib/everest/io/src/tls/tls_public_header_guard.cpp
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+// Compiled without libtls on the include path, so re-adding an everest/tls/tls.hpp include to any
+// header below fails here. The impl and config headers need ::tls complete, so they are not listed.
+
+#include <everest/io/tls/tls_client.hpp>
+#include <everest/io/tls/tls_client_socket.hpp>
+#include <everest/io/tls/tls_endpoint_base.hpp>
+#include <everest/io/tls/tls_listener.hpp>
+#include <everest/io/tls/tls_result.hpp>
+#include <everest/io/tls/tls_server.hpp>
+#include <everest/io/tls/tls_server_socket.hpp>
+#include <everest/io/tls/tls_socket_base.hpp>
+
+// A header may reach OpenSSL without naming libtls, which the include path alone would not catch.
+#if defined(OPENSSL_VERSION_NUMBER) || defined(HEADER_SSL_H)
+#error "a public everest_io tls header pulled in OpenSSL"
+#endif

--- a/lib/everest/io/src/tls/tls_server.cpp
+++ b/lib/everest/io/src/tls/tls_server.cpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/tls/tls_server.hpp>
+#include <everest/tls/tls.hpp>
+
+#include <utility>
+
+namespace everest::lib::io::tls {
+
+tls_server::tls_server(std::unique_ptr<::tls::ServerConnection> conn) {
+    m_socket.open(std::move(conn));
+}
+
+bool tls_server::start(event::fd_event_handler& handler) {
+    // The incoming ClientHello kicks the handshake, so read is the only event to monitor.
+    return register_connection_fd(handler, m_socket.get_fd(), event::poll_events::read);
+}
+
+void tls_server::stop() {
+    m_socket.close();
+}
+
+tls_server::~tls_server() {
+    // Backstop for a drop while still registered: remove the fds synchronously so no
+    // this-capturing lambda is left in the handler.
+    if (m_handler != nullptr) {
+        m_handler->unregister_event_handler(this);
+    }
+}
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/src/tls/tls_server_socket.cpp
+++ b/lib/everest/io/src/tls/tls_server_socket.cpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/tls/detail/tls_result_from_libtls.hpp>
+#include <everest/io/tls/tls_server_socket.hpp>
+
+#include <utility>
+
+namespace everest::lib::io::tls {
+
+tls_server_socket::tls_server_socket(tls_server_socket&&) noexcept = default;
+tls_server_socket& tls_server_socket::operator=(tls_server_socket&&) noexcept = default;
+tls_server_socket::~tls_server_socket() = default;
+
+bool tls_server_socket::open(std::unique_ptr<::tls::ServerConnection> conn) {
+    m_conn = std::move(conn);
+    m_handshake_done = false;
+    m_desired = event::poll_events::read;
+    reset_error_state();
+    return static_cast<bool>(m_conn);
+}
+
+::tls::Connection* tls_server_socket::connection() const {
+    return m_conn.get();
+}
+
+io_result tls_server_socket::step_handshake() {
+    return detail::to_io_result(m_conn->accept(0));
+}
+
+void tls_server_socket::reset_connection() {
+    m_conn.reset();
+}
+
+std::function<void()> tls_server_socket::release_closer() {
+    // The BIO owns the fd, so deferring the release keeps the fd open until the closer runs.
+    // shared_ptr, not the move-only unique_ptr, to stay copy-constructible for std::function.
+    return [conn = std::shared_ptr<::tls::ServerConnection>(std::move(m_conn))]() mutable { conn.reset(); };
+}
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/src/tls/tls_socket_base.cpp
+++ b/lib/everest/io/src/tls/tls_socket_base.cpp
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/tls/tls_socket_base_impl.hpp>
+
+#include <everest/io/tls/tls_client_socket.hpp>
+#include <everest/io/tls/tls_server_socket.hpp>
+
+namespace everest::lib::io::tls {
+
+template class tls_socket_base<tls_client_socket>;
+template class tls_socket_base<tls_server_socket>;
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/src/utilities/generic_error_state.cpp
+++ b/lib/everest/io/src/utilities/generic_error_state.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 #include <everest/io/utilities/generic_error_state.hpp>
+
+#include <cerrno>
 #include <string.h>
 
 namespace everest::lib::io::utilities {
@@ -36,9 +38,12 @@ int generic_error_state::current_error() const {
     return m_current_error;
 }
 
-void generic_error_state::call_error_handler(cb_error& handler) const {
+void generic_error_state::call_error_handler(cb_error& handler, std::string const& msg) const {
     if (handler) {
-        handler(m_current_error, strerror(m_current_error));
+        // The callback must never see 0: consumers branch on 'code != 0', so a 0 report would be
+        // dropped while the state stays failed. Unreachable today, kept as a backstop.
+        auto error = m_current_error != 0 ? m_current_error : ECONNRESET;
+        handler(error, msg.empty() ? std::string{strerror(error)} : msg);
     }
 }
 

--- a/lib/everest/io/test/CMakeLists.txt
+++ b/lib/everest/io/test/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_executable(everest_io_tests
   endpoint_test.cpp
   mdns_test.cpp
+  fd_event_client_alias_test.cpp
+  socket_test.cpp
   udp_client_v6_test.cpp
   udp_unconnected_socket_test.cpp
   udp_dualstack_server_socket_test.cpp
@@ -17,3 +19,53 @@ target_link_libraries(everest_io_tests
 
 include(GoogleTest)
 gtest_discover_tests(everest_io_tests TEST_PREFIX "io.")
+
+if(NOT EVEREST_IO_ENABLE_TLS)
+    return()
+endif()
+
+find_package(OpenSSL 3 REQUIRED)
+
+# The alias regression test asserts the tls_client alias too; that header pulls
+# in OpenSSL transitively. Make everest_io_tests aware of TLS and able to find
+# the OpenSSL headers so the guarded static_assert compiles when TLS is on.
+target_compile_definitions(everest_io_tests PRIVATE EVEREST_IO_ENABLE_TLS)
+target_link_libraries(everest_io_tests
+    PRIVATE
+        OpenSSL::SSL
+        OpenSSL::Crypto
+)
+
+add_executable(everest_io_tls_test
+    tls_test_main.cpp
+    tls_server_socket_test.cpp
+    tls_listener_test.cpp
+    tls_client_socket_test.cpp
+    tls_e2e_test.cpp
+)
+
+target_link_libraries(everest_io_tls_test
+    PRIVATE
+        GTest::gtest
+        everest::io
+        OpenSSL::SSL
+        OpenSSL::Crypto
+)
+
+# Reuse existing libtls test fixtures (server_chain.pem etc) by adding the
+# libtls test dir to the test binary's working data path. Existing libtls
+# pki cookbook lives at lib/everest/tls/tests/pki/. The custom main in
+# tls_test_main.cpp invokes ./pki.sh at startup so this binary does not
+# depend on libtls's tls_test having run first under ctest.
+add_dependencies(everest_io_tls_test tls_test_files_target)
+
+add_test(
+    NAME everest_io_tls_test
+    COMMAND everest_io_tls_test
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/lib/everest/tls/tests
+)
+
+# Both this binary and libtls's tls_test regenerate the PKI fixture via
+# ./pki.sh in the same working directory; serialize them under ctest so one
+# does not regenerate certs mid-handshake of the other.
+set_tests_properties(everest_io_tls_test PROPERTIES RESOURCE_LOCK tls_pki)

--- a/lib/everest/io/test/fd_event_client_alias_test.cpp
+++ b/lib/everest/io/test/fd_event_client_alias_test.cpp
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+//
+// Regression gate: every client alias must still resolve, instantiate, and stay on the side of
+// event_client_async_policy_v it was written for. That trait decides whether tx() buffers until the
+// connection resolves or rejects while the client is down, so a policy silently changing sides
+// changes the contract of its alias.
+
+#include <everest/io/can/socket_can.hpp>
+#include <everest/io/event/fd_event_client.hpp>
+#include <everest/io/mdns/mdns_client.hpp>
+#include <everest/io/raw/raw_client.hpp>
+#include <everest/io/serial/event_pty.hpp>
+#include <everest/io/tcp/tcp_client.hpp>
+#include <everest/io/tcp/tcp_socket.hpp>
+#include <everest/io/tun_tap/tap_client.hpp>
+#include <everest/io/udp/udp_client.hpp>
+#include <everest/io/udp/udp_dualstack_server.hpp>
+#include <everest/io/udp/udp_server.hpp>
+#include <everest/io/udp/udp_unconnected_client.hpp>
+#include <everest/io/utilities/event_client_async_policy.hpp>
+
+#ifdef EVEREST_IO_ENABLE_TLS
+#include <everest/io/tls/tls_client.hpp>
+#endif
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <type_traits>
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+// Every alias is pinned three ways: it resolves, it instantiates and its policy keeps its connect
+// behavior. is_class_v accepts an incomplete type, so sizeof is what forces the client template to
+// instantiate on the policy and run the client's own internal assertions.
+
+static_assert(std::is_class_v<everest::lib::io::can::socket_can>, "socket_can alias must resolve");
+static_assert(sizeof(everest::lib::io::can::socket_can) > 0, "fd_event_client must instantiate on socket_can_handler");
+static_assert(not everest::lib::io::utilities::event_client_async_policy_v<everest::lib::io::can::socket_can_handler>,
+              "socket_can_handler must stay a synchronous policy");
+
+static_assert(std::is_class_v<everest::lib::io::mdns::mdns_client>, "mdns_client alias must resolve");
+static_assert(sizeof(everest::lib::io::mdns::mdns_client) > 0, "fd_event_client must instantiate on mdns_socket");
+static_assert(not everest::lib::io::utilities::event_client_async_policy_v<everest::lib::io::mdns::mdns_socket>,
+              "mdns_socket must stay a synchronous policy");
+
+static_assert(std::is_class_v<everest::lib::io::raw::raw_client>, "raw_client alias must resolve");
+static_assert(sizeof(everest::lib::io::raw::raw_client) > 0, "fd_event_client must instantiate on raw_socket");
+static_assert(not everest::lib::io::utilities::event_client_async_policy_v<everest::lib::io::raw::raw_socket>,
+              "raw_socket must stay a synchronous policy");
+
+// The only alias consumed through a derived class rather than directly.
+static_assert(std::is_class_v<everest::lib::io::serial::event_pty_base>, "event_pty_base alias must resolve");
+static_assert(sizeof(everest::lib::io::serial::event_pty_base) > 0, "fd_event_client must instantiate on pty_handler");
+static_assert(not everest::lib::io::utilities::event_client_async_policy_v<everest::lib::io::serial::pty_handler>,
+              "pty_handler must stay a synchronous policy");
+static_assert(std::is_base_of_v<everest::lib::io::serial::event_pty_base, everest::lib::io::serial::event_pty>,
+              "event_pty must keep deriving from the alias");
+
+static_assert(std::is_class_v<everest::lib::io::tcp::tcp_client>, "tcp_client alias must resolve");
+static_assert(sizeof(everest::lib::io::tcp::tcp_client) > 0, "fd_event_client must instantiate on tcp_socket");
+static_assert(everest::lib::io::utilities::event_client_async_policy_v<everest::lib::io::tcp::tcp_socket>,
+              "tcp_socket must stay an async policy");
+
+static_assert(std::is_class_v<everest::lib::io::tun_tap::tap_client>, "tap_client alias must resolve");
+static_assert(sizeof(everest::lib::io::tun_tap::tap_client) > 0, "fd_event_client must instantiate on tap_handler");
+static_assert(not everest::lib::io::utilities::event_client_async_policy_v<everest::lib::io::tun_tap::tap_handler>,
+              "tap_handler must stay a synchronous policy");
+
+// udp_server.hpp redeclares udp_client identically to udp_client.hpp. Both headers are
+// included here, so the redundant typedef stays proven benign.
+static_assert(std::is_class_v<everest::lib::io::udp::udp_client>, "udp_client alias must resolve");
+static_assert(sizeof(everest::lib::io::udp::udp_client) > 0, "fd_event_client must instantiate on udp_client_socket");
+static_assert(everest::lib::io::utilities::event_client_async_policy_v<everest::lib::io::udp::udp_client_socket>,
+              "udp_client_socket must stay an async policy");
+
+// The two server aliases answer the source of the last rx(), so their policies reject tx()
+// until a datagram arrived. Only the wrapper level is pinned for them.
+static_assert(std::is_class_v<everest::lib::io::udp::udp_server>, "udp_server alias must resolve");
+static_assert(sizeof(everest::lib::io::udp::udp_server) > 0, "fd_event_client must instantiate on udp_server_socket");
+static_assert(not everest::lib::io::utilities::event_client_async_policy_v<everest::lib::io::udp::udp_server_socket>,
+              "udp_server_socket must stay a synchronous policy");
+
+static_assert(std::is_class_v<everest::lib::io::udp::udp_dualstack_server>, "udp_dualstack_server alias must resolve");
+static_assert(sizeof(everest::lib::io::udp::udp_dualstack_server) > 0,
+              "fd_event_client must instantiate on udp_dualstack_server_socket");
+static_assert(
+    not everest::lib::io::utilities::event_client_async_policy_v<everest::lib::io::udp::udp_dualstack_server_socket>,
+    "udp_dualstack_server_socket must stay a synchronous policy");
+
+static_assert(std::is_class_v<everest::lib::io::udp::udp_unconnected_client>,
+              "udp_unconnected_client alias must resolve");
+static_assert(sizeof(everest::lib::io::udp::udp_unconnected_client) > 0,
+              "fd_event_client must instantiate on udp_unconnected_socket");
+static_assert(
+    not everest::lib::io::utilities::event_client_async_policy_v<everest::lib::io::udp::udp_unconnected_socket>,
+    "udp_unconnected_socket must stay a synchronous policy");
+
+// Teeth for the handshake-policy assertions below: the trait must discriminate. tcp_socket is
+// hookless, so it must not match, while still satisfying the async setup()/connect() policy.
+static_assert(not everest::lib::io::utilities::event_client_handshake_policy_v<everest::lib::io::tcp::tcp_socket>,
+              "the handshake policy trait must not match a hookless policy");
+
+#ifdef EVEREST_IO_ENABLE_TLS
+static_assert(std::is_class_v<everest::lib::io::tls::tls_client>, "tls_client alias must resolve");
+static_assert(std::is_abstract_v<everest::lib::io::tls::tls_client_interface>,
+              "tls_client_interface alias must resolve to the abstract client interface");
+static_assert(sizeof(everest::lib::io::tls::tls_client) > 0, "fd_event_client must instantiate on tls_client_socket");
+// tls_client_socket must satisfy both policies the generic event client detects, the async
+// setup()/connect() legs and the optional handshake phase. The handshake trait is all-or-nothing,
+// so a partial surface here is a hard compile error in the client.
+static_assert(everest::lib::io::utilities::event_client_async_policy_v<everest::lib::io::tls::tls_client_socket>,
+              "tls_client_socket must stay an async policy");
+static_assert(everest::lib::io::utilities::event_client_handshake_policy_v<everest::lib::io::tls::tls_client_socket>,
+              "tls_client_socket must satisfy the handshake client policy");
+static_assert(everest::lib::io::utilities::has_member_get_error_string_v<everest::lib::io::tls::tls_client_socket>,
+              "tls_client_socket must expose get_error_string()");
+#endif
+
+TEST(fd_event_client_alias, tcp_client_constructs_hookless_path_unchanged) {
+    // A loopback listener gives tcp_socket's async setup()/connect() a real peer.
+    int srv = ::socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(srv, 0);
+    sockaddr_in sa{};
+    sa.sin_family = AF_INET;
+    sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    sa.sin_port = 0;
+    ASSERT_EQ(::bind(srv, reinterpret_cast<sockaddr*>(&sa), sizeof(sa)), 0);
+    ASSERT_EQ(::listen(srv, 1), 0);
+    socklen_t len = sizeof(sa);
+    ASSERT_EQ(::getsockname(srv, reinterpret_cast<sockaddr*>(&sa), &len), 0);
+    const std::uint16_t port = ntohs(sa.sin_port);
+
+    std::atomic<bool> accepted{false};
+    std::thread accept_thread([&]() {
+        int c = ::accept(srv, nullptr, nullptr);
+        if (c >= 0) {
+            accepted = true;
+            std::this_thread::sleep_for(200ms);
+            ::close(c);
+        }
+    });
+
+    everest::lib::io::tcp::tcp_client client("127.0.0.1", port, 1000);
+
+    // The ready action fires via the synchronous open() path with no deferral.
+    std::atomic<bool> ready{false};
+    client.set_on_ready_action([&]() { ready = true; });
+
+    EXPECT_GE(client.get_poll_fd(), 0);
+
+    auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (std::chrono::steady_clock::now() < deadline && not ready.load()) {
+        client.sync(100ms);
+    }
+
+    EXPECT_TRUE(ready.load()) << "hookless tcp_client never reached ready";
+    auto const& raw = client.get_raw_handler();
+    ASSERT_NE(raw, nullptr);
+    EXPECT_GE(raw->get_fd(), 0);
+
+    if (accept_thread.joinable()) {
+        accept_thread.join();
+    }
+    ::close(srv);
+}

--- a/lib/everest/io/test/fd_event_client_async_test.cpp
+++ b/lib/everest/io/test/fd_event_client_async_test.cpp
@@ -3,12 +3,14 @@
 
 #include <everest/io/event/event_fd.hpp>
 #include <everest/io/event/fd_event_client.hpp>
+#include <everest/io/event/fd_event_handler.hpp>
 #include <everest/io/tcp/tcp_client.hpp>
 #include <everest/io/udp/udp_client.hpp>
 #include <everest/io/utilities/event_client_async_policy.hpp>
 #include <everest/io/utilities/generic_error_state.hpp>
 
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <netinet/in.h>
 #include <poll.h>
 #include <sys/socket.h>
@@ -21,10 +23,12 @@
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <functional>
 #include <limits>
 #include <memory>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -37,8 +41,12 @@ using namespace everest::lib::io;
 
 using everest::lib::io::event::event_fd;
 using everest::lib::io::event::fd_event_client;
+using everest::lib::io::event::poll_events;
 using everest::lib::io::event::semaphore_fd;
 using everest::lib::io::utilities::event_client_async_policy_v;
+using everest::lib::io::utilities::event_client_handshake_policy_v;
+using everest::lib::io::utilities::has_member_get_error_string_v;
+using everest::lib::io::utilities::has_member_handshake_timeout_v;
 
 namespace {
 
@@ -595,12 +603,383 @@ char const* state_name(utilities::connection_state state) {
     return "unknown";
 }
 
+static_assert(not event_client_handshake_policy_v<deterministic_async_policy>);
+static_assert(not has_member_get_error_string_v<deterministic_async_policy>);
+
+enum class handshake_step_result {
+    want_read,
+    want_write,
+    want_invalid,
+    complete,
+    fail
+};
+
+class handshake_script {
+public:
+    explicit handshake_script(std::vector<handshake_step_result> steps, int fail_error_code = 0,
+                              std::chrono::milliseconds handshake_timeout = 5s) :
+        m_steps{std::move(steps)}, m_fail_error_code{fail_error_code}, m_handshake_timeout{handshake_timeout} {
+        int fds[2]{-1, -1};
+        if (::socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, fds) == 0) {
+            m_local_fd = fds[0];
+            m_peer_fd = fds[1];
+        }
+    }
+
+    handshake_script(handshake_script const&) = delete;
+    handshake_script& operator=(handshake_script const&) = delete;
+    handshake_script(handshake_script&&) = delete;
+    handshake_script& operator=(handshake_script&&) = delete;
+
+    ~handshake_script() {
+        if (m_local_fd >= 0) {
+            ::close(m_local_fd);
+        }
+        if (m_peer_fd >= 0) {
+            ::close(m_peer_fd);
+        }
+    }
+
+    int local_fd() const {
+        return m_local_fd;
+    }
+
+    int fail_error_code() const {
+        return m_fail_error_code;
+    }
+
+    std::chrono::milliseconds handshake_timeout() const {
+        return m_handshake_timeout;
+    }
+
+    void deliver_peer_record() const {
+        deliver_byte(1);
+    }
+
+    void deliver_byte(char value) const {
+        (void)::send(m_peer_fd, &value, 1, MSG_DONTWAIT);
+    }
+
+    void close_peer() {
+        if (m_peer_fd >= 0) {
+            ::close(m_peer_fd);
+            m_peer_fd = -1;
+        }
+    }
+
+    // Without this a want_read state keeps refiring on the record the step already reacted to.
+    void consume_pending_record() const {
+        char byte{0};
+        (void)::recv(m_local_fd, &byte, 1, MSG_DONTWAIT);
+    }
+
+    handshake_step_result advance() {
+        ++m_step_count;
+        auto const result = m_steps[m_cursor];
+        if (m_cursor + 1 < m_steps.size()) {
+            ++m_cursor;
+        }
+        return result;
+    }
+
+    std::size_t step_count() const {
+        return m_step_count;
+    }
+
+    void register_connect() {
+        ++m_connect_count;
+    }
+
+    std::size_t connect_count() const {
+        return m_connect_count.load();
+    }
+
+    void record_tx(int payload) {
+        m_tx_payloads.push_back(payload);
+    }
+
+    std::vector<int> const& tx_payloads() const {
+        return m_tx_payloads;
+    }
+
+private:
+    std::vector<handshake_step_result> m_steps;
+    int m_fail_error_code{0};
+    std::chrono::milliseconds m_handshake_timeout{5s};
+    std::size_t m_cursor{0};
+    std::size_t m_step_count{0};
+    std::atomic<std::size_t> m_connect_count{0};
+    std::vector<int> m_tx_payloads;
+    int m_local_fd{-1};
+    int m_peer_fd{-1};
+};
+
+class scripted_handshake_policy {
+public:
+    using PayloadT = int;
+
+    scripted_handshake_policy() = default;
+
+    bool setup(std::shared_ptr<handshake_script> script) {
+        m_script = std::move(script);
+        return static_cast<bool>(m_script) and m_script->local_fd() >= 0;
+    }
+
+    void connect(std::function<void(bool, int)> const& cb) {
+        if (not m_script) {
+            cb(false, -1);
+            return;
+        }
+        m_script->register_connect();
+        cb(true, m_script->local_fd());
+    }
+
+    bool handshake_complete() const {
+        return m_complete;
+    }
+
+    bool handshake_step() {
+        if (not m_script) {
+            return false;
+        }
+        m_script->consume_pending_record();
+        switch (m_script->advance()) {
+        case handshake_step_result::want_read:
+            m_desired = poll_events::read;
+            return true;
+        case handshake_step_result::want_write:
+            m_desired = poll_events::write;
+            return true;
+        case handshake_step_result::want_invalid:
+            m_desired = poll_events::priority;
+            return true;
+        case handshake_step_result::complete:
+            m_complete = true;
+            // Poisoned: a completed handshake is monitored for reading, never from this request.
+            m_desired = poll_events::write;
+            return true;
+        case handshake_step_result::fail:
+        default:
+            m_error = m_script->fail_error_code();
+            m_error_string = "scripted handshake failure";
+            return false;
+        }
+    }
+
+    poll_events desired_events() const {
+        return m_desired;
+    }
+
+    std::chrono::milliseconds handshake_timeout() const {
+        return m_script ? m_script->handshake_timeout() : std::chrono::milliseconds{5s};
+    }
+
+    bool tx(PayloadT const& payload) {
+        if (not m_script) {
+            return false;
+        }
+        m_script->record_tx(payload);
+        return true;
+    }
+
+    bool rx(PayloadT& data) {
+        if (not m_script) {
+            return false;
+        }
+        char byte{0};
+        if (::recv(m_script->local_fd(), &byte, 1, MSG_DONTWAIT) != 1) {
+            return false;
+        }
+        data = static_cast<int>(byte);
+        return true;
+    }
+
+    int get_fd() const {
+        return m_script ? m_script->local_fd() : -1;
+    }
+
+    int get_error() const {
+        return m_error;
+    }
+
+    std::string const& get_error_string() const {
+        return m_error_string;
+    }
+
+private:
+    std::shared_ptr<handshake_script> m_script;
+    poll_events m_desired{poll_events::read};
+    bool m_complete{false};
+    int m_error{0};
+    std::string m_error_string;
+};
+
+static_assert(event_client_async_policy_v<scripted_handshake_policy>);
+static_assert(event_client_handshake_policy_v<scripted_handshake_policy>);
+static_assert(has_member_get_error_string_v<scripted_handshake_policy>);
+// The true side of the trait the handshake_timeout() static_assert keys on. Its false side is
+// what that assert lets through, which no compiling translation unit can pin.
+static_assert(has_member_handshake_timeout_v<scripted_handshake_policy>);
+
+class poll_error_script {
+public:
+    explicit poll_error_script(int fd) : m_fd{fd} {
+    }
+
+    poll_error_script(poll_error_script const&) = delete;
+    poll_error_script& operator=(poll_error_script const&) = delete;
+
+    ~poll_error_script() {
+        if (m_fd >= 0) {
+            ::close(m_fd);
+        }
+    }
+
+    int fd() const {
+        return m_fd;
+    }
+
+    void set_policy_error(int code) {
+        m_policy_error.store(code);
+    }
+
+    int policy_error() const {
+        return m_policy_error.load();
+    }
+
+private:
+    int m_fd{-1};
+    std::atomic<int> m_policy_error{0};
+};
+
+class poll_error_policy {
+public:
+    using PayloadT = int;
+
+    poll_error_policy() = default;
+
+    bool setup(std::shared_ptr<poll_error_script> script) {
+        m_script = std::move(script);
+        return static_cast<bool>(m_script) and m_script->fd() >= 0;
+    }
+
+    void connect(std::function<void(bool, int)> const& cb) {
+        if (not m_script) {
+            cb(false, -1);
+            return;
+        }
+        cb(true, m_script->fd());
+    }
+
+    bool tx(PayloadT const&) {
+        return false;
+    }
+
+    bool rx(PayloadT&) {
+        return false;
+    }
+
+    int get_fd() const {
+        return m_script ? m_script->fd() : -1;
+    }
+
+    int get_error() const {
+        return m_script ? m_script->policy_error() : 0;
+    }
+
+private:
+    std::shared_ptr<poll_error_script> m_script;
+};
+
+static_assert(event_client_async_policy_v<poll_error_policy>);
+static_assert(not event_client_handshake_policy_v<poll_error_policy>);
+
+// The port is bound and released so nothing listens on it. poll() does not consume SO_ERROR, so
+// ECONNREFUSED is left unread for the client to resolve.
+int make_refused_tcp_fd() {
+    int probe = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (probe < 0) {
+        return -1;
+    }
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    addr.sin_port = 0;
+    socklen_t addr_len = sizeof(addr);
+    if (::bind(probe, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0 or
+        ::getsockname(probe, reinterpret_cast<sockaddr*>(&addr), &addr_len) != 0) {
+        ::close(probe);
+        return -1;
+    }
+    ::close(probe);
+
+    int fd = ::socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0) {
+        // Something claimed the released port in the meantime.
+        ::close(fd);
+        return -1;
+    }
+    pollfd pfd{fd, POLLOUT, 0};
+    if (::poll(&pfd, 1, 2000) != 1 or (pfd.revents & POLLERR) == 0) {
+        ::close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+int make_hungup_pipe_read_fd() {
+    int fds[2]{-1, -1};
+    if (::pipe2(fds, O_NONBLOCK) != 0) {
+        return -1;
+    }
+    ::close(fds[1]);
+    return fds[0];
+}
+
+int make_errored_pipe_write_fd() {
+    int fds[2]{-1, -1};
+    if (::pipe2(fds, O_NONBLOCK) != 0) {
+        return -1;
+    }
+    ::close(fds[0]);
+    return fds[1];
+}
+
 } // namespace
 
 using deterministic_async_client = fd_event_client<deterministic_async_policy>::type;
 using deterministic_sync_client = fd_event_client<deterministic_sync_policy>::type;
 using rx_capable_sync_client = fd_event_client<rx_capable_sync_policy>::type;
 using faulting_rx_sync_client = fd_event_client<faulting_rx_sync_policy>::type;
+using scripted_handshake_client = fd_event_client<scripted_handshake_policy>::type;
+using poll_error_client = fd_event_client<poll_error_policy>::type;
+
+namespace {
+
+std::string describe_codes(std::vector<int> const& codes) {
+    std::string result;
+    for (auto code : codes) {
+        if (not result.empty()) {
+            result += ", ";
+        }
+        result += std::to_string(code) + " (" + std::strerror(code) + ")";
+    }
+    return result.empty() ? std::string{"none"} : result;
+}
+
+// The handler runs on the loop thread, which is the thread pumping in the tests below.
+template <class Client> void collect_error_codes(Client& client, std::vector<int>& codes) {
+    client.set_error_handler([&codes](int code, std::string const&) {
+        if (code != 0) {
+            codes.push_back(code);
+        }
+    });
+}
+
+} // namespace
 
 // Verify reset and sync do not block when an async connect callback is still
 // pending, protecting against deadlocks in the connect/reset path.
@@ -1476,4 +1855,560 @@ TEST(fd_event_client_error_signal_test, a_failed_read_reports_the_socket_error) 
         << "a read that failed on an established connection reported nothing";
     EXPECT_EQ(codes, (std::vector<int>{0, ECONNRESET})) << "the failed read did not report the socket error";
     EXPECT_TRUE(client.on_error()) << "the client still reports itself up after a failed read";
+}
+
+// Without a handshake phase the client is ready the moment the transport connects, so a
+// registration landing in the publish window and the connected handler would each release.
+TEST(fd_event_client_async_test, ready_action_registered_in_publish_window_fires_once) {
+    auto control = std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{true, 0}});
+    deterministic_async_client client(control);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    control->release(0);
+    ASSERT_TRUE(control->wait_for_attempt_completed(0, 500ms));
+    // Settle without pumping, so the published result is queued but not yet observed.
+    std::this_thread::sleep_for(50ms);
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+
+    pump_for(client, 200ms);
+    EXPECT_EQ(ready_calls.load(), 1) << "on_ready was delivered more than once for one connection";
+}
+
+TEST(fd_event_client_async_test, ready_action_registered_after_ready_fires_immediately) {
+    auto control = std::make_shared<async_connect_control>(std::vector<connect_attempt_plan>{{true, 0}});
+    deterministic_async_client client(control);
+
+    std::atomic<int> first_calls{0};
+    client.set_on_ready_action([&] { ++first_calls; });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return control->attempt_count() >= 1; }));
+    control->release(0);
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return first_calls.load() >= 1; }));
+
+    std::atomic<int> second_calls{0};
+    client.set_on_ready_action([&] { ++second_calls; });
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return second_calls.load() >= 1; }))
+        << "the late registration was dropped on an already ready connection";
+    pump_for(client, 30ms);
+    EXPECT_EQ(second_calls.load(), 1);
+}
+
+TEST(fd_event_client_handshake_test, first_handshake_step_runs_without_fd_readiness) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read, handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+    pump_for(client, 30ms);
+    EXPECT_EQ(script->step_count(), 1u) << "handshake must not advance without a peer record";
+    EXPECT_EQ(ready_calls.load(), 0);
+
+    script->deliver_peer_record();
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() == 1; }));
+    EXPECT_EQ(script->step_count(), 2u);
+    EXPECT_FALSE(client.on_error());
+}
+
+TEST(fd_event_client_handshake_test, handshake_completing_on_first_step_fires_ready) {
+    auto script =
+        std::make_shared<handshake_script>(std::vector<handshake_step_result>{handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() == 1; }));
+    EXPECT_EQ(script->step_count(), 1u);
+    EXPECT_EQ(script->connect_count(), 1u);
+}
+
+TEST(fd_event_client_handshake_test, on_ready_action_waits_for_handshake_completion) {
+    auto script = std::make_shared<handshake_script>(std::vector<handshake_step_result>{
+        handshake_step_result::want_read, handshake_step_result::want_read, handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+    EXPECT_EQ(ready_calls.load(), 0);
+
+    script->deliver_peer_record();
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 2; }));
+    pump_for(client, 30ms);
+    EXPECT_EQ(ready_calls.load(), 0) << "on_ready fired before the handshake completed";
+
+    script->deliver_peer_record();
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() == 1; }));
+    EXPECT_EQ(script->step_count(), 3u) << "the handshake was stepped for an event it did not ask for";
+}
+
+TEST(fd_event_client_handshake_test, payloads_queued_during_handshake_flush_in_order) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read, handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+    ASSERT_EQ(ready_calls.load(), 0);
+
+    EXPECT_TRUE(client.tx(1));
+    EXPECT_TRUE(client.tx(2));
+    EXPECT_TRUE(client.tx(3));
+    pump_for(client, 30ms);
+    EXPECT_TRUE(script->tx_payloads().empty()) << "payloads must not be written during the handshake";
+    EXPECT_EQ(script->step_count(), 1u) << "a queued payload must not drive a handshake step";
+
+    script->deliver_peer_record();
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return script->tx_payloads().size() == 3; }));
+    EXPECT_EQ(script->tx_payloads(), std::vector<int>({1, 2, 3}));
+    EXPECT_EQ(ready_calls.load(), 1);
+}
+
+TEST(fd_event_client_handshake_test, the_tx_buffer_is_bounded_during_the_handshake) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read, handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+
+    constexpr auto cap = scripted_handshake_client::max_buffered_tx_payloads;
+    std::size_t accepted{0};
+    for (std::size_t i = 0; i < cap + 100; ++i) {
+        if (not client.tx(static_cast<int>(i))) {
+            break;
+        }
+        ++accepted;
+    }
+
+    EXPECT_EQ(accepted, cap) << "the handshake buffered " << accepted << " payloads against a cap of " << cap;
+    EXPECT_FALSE(client.tx(0)) << "the buffer accepted a payload past its cap";
+
+    // tx only notifies: without a loop pass the pending handshake is never asked to hold back.
+    pump_for(client, 100ms);
+    EXPECT_EQ(script->step_count(), 1u) << "a buffered payload stepped the handshake";
+    EXPECT_TRUE(script->tx_payloads().empty()) << "payloads must not be written during the handshake";
+}
+
+// The policy reports errno 0 here (a protocol level failure), so the client has to substitute a
+// code that consumers filtering on 'code != 0' actually see. The cleared-error callback is
+// recorded too: 'error cleared' after a fatal failure passes a dead connection off as healthy.
+TEST(fd_event_client_handshake_test, handshake_failure_reports_one_nonzero_error) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read, handshake_step_result::fail}, 0);
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    std::vector<std::pair<int, std::string>> error_reports;
+    client.set_on_ready_action([&] { ++ready_calls; });
+    client.set_error_handler([&](int code, std::string const& msg) { error_reports.emplace_back(code, msg); });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+
+    // The failing step consumes one, so the fd stays readable and would step a dead handshake.
+    script->deliver_peer_record();
+    script->deliver_peer_record();
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return error_reports.size() >= 2; }));
+    pump_for(client, 50ms);
+
+    ASSERT_EQ(error_reports.size(), 2u);
+    EXPECT_EQ(error_reports[0].first, 0);
+    EXPECT_EQ(error_reports[1].first, ECONNRESET);
+    EXPECT_EQ(error_reports[1].second, "scripted handshake failure");
+    EXPECT_EQ(ready_calls.load(), 0);
+    EXPECT_TRUE(client.on_error());
+}
+
+// A socketpair is always writable, so a want_write state advances with no peer record and a
+// want_read state must not. That only holds if monitoring one event removes the other.
+TEST(fd_event_client_handshake_test, handshake_monitors_write_and_read_exclusively) {
+    auto script = std::make_shared<handshake_script>(std::vector<handshake_step_result>{
+        handshake_step_result::want_write, handshake_step_result::want_read, handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 2; }));
+
+    pump_for(client, 30ms);
+    EXPECT_EQ(script->step_count(), 2u) << "writing is still monitored while the handshake waits for reading";
+    EXPECT_EQ(ready_calls.load(), 0);
+
+    script->deliver_peer_record();
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() == 1; }));
+    EXPECT_EQ(script->step_count(), 3u);
+}
+
+TEST(fd_event_client_handshake_test, ready_action_registered_mid_handshake_waits_for_completion) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read, handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+
+    pump_for(client, 30ms);
+    EXPECT_EQ(ready_calls.load(), 0) << "on_ready fired on a connection whose handshake is still pending";
+
+    script->deliver_peer_record();
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() >= 1; }));
+    pump_for(client, 30ms);
+    EXPECT_EQ(ready_calls.load(), 1) << "on_ready was delivered more than once for one connection";
+}
+
+TEST(fd_event_client_handshake_test, completed_handshake_delivers_application_payloads) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_write, handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    std::atomic<int> rx_calls{0};
+    std::atomic<int> last_payload{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+    client.set_rx_handler([&](int const& payload, auto&) {
+        ++rx_calls;
+        last_payload = payload;
+    });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() == 1; }));
+    ASSERT_EQ(script->step_count(), 2u);
+    ASSERT_EQ(rx_calls.load(), 0);
+
+    script->deliver_byte(7);
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return rx_calls.load() >= 1; }))
+        << "the completed handshake left the connection unmonitored for reading";
+    EXPECT_EQ(last_payload.load(), 7);
+}
+
+TEST(fd_event_client_handshake_test, ready_action_fires_again_after_reset) {
+    auto script =
+        std::make_shared<handshake_script>(std::vector<handshake_step_result>{handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() == 1; }));
+
+    ASSERT_TRUE(client.reset());
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() >= 2; }))
+        << "the ready action stayed set from the previous connection";
+    pump_for(client, 30ms);
+    EXPECT_EQ(ready_calls.load(), 2);
+    EXPECT_GE(script->connect_count(), 2u);
+}
+
+TEST(fd_event_client_handshake_test, unsupported_desired_event_fails_the_handshake) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_invalid}, ECONNREFUSED);
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    std::atomic<int> error_calls{0};
+    int last_code{0};
+    std::string last_message;
+    client.set_on_ready_action([&] { ++ready_calls; });
+    client.set_error_handler([&](int code, std::string const& msg) {
+        if (code != 0) {
+            ++error_calls;
+            last_code = code;
+            last_message = msg;
+        }
+    });
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return error_calls.load() >= 1; }));
+    pump_for(client, 30ms);
+    EXPECT_EQ(error_calls.load(), 1);
+    EXPECT_EQ(last_code, EPROTO) << "a local policy error was reported as " << std::strerror(last_code);
+    EXPECT_EQ(last_message, "handshake policy requested an event that is neither read nor write");
+    EXPECT_EQ(ready_calls.load(), 0);
+    EXPECT_TRUE(client.on_error());
+}
+
+TEST(fd_event_client_handshake_test, handshake_failure_keeps_the_policy_error_code) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read, handshake_step_result::fail},
+        ECONNREFUSED);
+    scripted_handshake_client client(script);
+
+    std::atomic<int> error_calls{0};
+    std::atomic<int> last_code{0};
+    std::string last_message;
+    client.set_error_handler([&](int code, std::string const& msg) {
+        if (code != 0) {
+            ++error_calls;
+            last_code = code;
+            last_message = msg;
+        }
+    });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+    script->deliver_peer_record();
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return error_calls.load() >= 1; }));
+
+    EXPECT_EQ(last_code.load(), ECONNREFUSED);
+    EXPECT_EQ(last_message, "scripted handshake failure");
+}
+
+TEST(fd_event_client_handshake_test, reset_after_handshake_failure_steps_again) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read, handshake_step_result::fail},
+        ECONNREFUSED);
+    scripted_handshake_client client(script);
+
+    std::atomic<int> error_calls{0};
+    client.set_error_handler([&](int code, std::string const&) {
+        if (code != 0) {
+            ++error_calls;
+        }
+    });
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+    script->deliver_peer_record();
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return error_calls.load() >= 1; }));
+    auto const steps_before_reset = script->step_count();
+
+    ASSERT_TRUE(client.reset());
+    EXPECT_TRUE(pump_until(client, 500ms,
+                           [&] { return script->connect_count() >= 2 and script->step_count() > steps_before_reset; }));
+    EXPECT_GE(script->connect_count(), 2u);
+    EXPECT_GT(script->step_count(), steps_before_reset) << "the handshake stayed dead across reset";
+}
+
+TEST(fd_event_client_handshake_test, ready_action_registered_after_ready_fires_immediately) {
+    auto script =
+        std::make_shared<handshake_script>(std::vector<handshake_step_result>{handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> first_calls{0};
+    client.set_on_ready_action([&] { ++first_calls; });
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return first_calls.load() == 1; }));
+
+    std::atomic<int> second_calls{0};
+    client.set_on_ready_action([&] { ++second_calls; });
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return second_calls.load() >= 1; }))
+        << "the late registration was dropped on an already ready connection";
+    pump_for(client, 30ms);
+    EXPECT_EQ(second_calls.load(), 1);
+    EXPECT_EQ(first_calls.load(), 1);
+}
+
+// The connected status of a failed connection survives until the queued teardown runs.
+TEST(fd_event_client_handshake_test, ready_action_registered_after_failure_stays_silent) {
+    auto script =
+        std::make_shared<handshake_script>(std::vector<handshake_step_result>{handshake_step_result::complete});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    client.set_on_ready_action([&] { ++ready_calls; });
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() == 1; }));
+
+    // Recorded by the fd handler, which runs before the registration queued below.
+    script->close_peer();
+    std::atomic<int> late_calls{0};
+    client.set_on_ready_action([&] { ++late_calls; });
+
+    pump_for(client, 100ms);
+    EXPECT_EQ(late_calls.load(), 0) << "a failed connection released the ready action";
+    EXPECT_TRUE(client.on_error());
+}
+
+// A peer that connects and then goes silent produces no notification of any kind, so only a
+// deadline turns that into something the consumer can act on.
+TEST(fd_event_client_handshake_test, a_stalled_handshake_fails_on_its_deadline) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read}, 0, 60ms);
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    std::vector<int> codes;
+    client.set_on_ready_action([&] { ++ready_calls; });
+    collect_error_codes(client, codes);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return not codes.empty(); }))
+        << "the stalled handshake was never reported";
+    pump_for(client, 50ms);
+
+    ASSERT_EQ(codes.size(), 1u) << "reported: " << describe_codes(codes);
+    EXPECT_EQ(codes[0], ETIMEDOUT) << "the stalled handshake was reported as " << std::strerror(codes[0]);
+    EXPECT_EQ(ready_calls.load(), 0) << "a client that never negotiated anything was published as ready";
+    EXPECT_EQ(script->step_count(), 1u) << "the handshake was stepped past its deadline";
+    EXPECT_TRUE(client.on_error());
+
+    // A client bounding only its first handshake leaves every reconnect unbounded.
+    ASSERT_TRUE(client.reset());
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return codes.size() >= 2; }))
+        << "the handshake after reset was never bounded, reported: " << describe_codes(codes);
+
+    ASSERT_EQ(codes.size(), 2u) << "reported: " << describe_codes(codes);
+    EXPECT_EQ(codes[1], ETIMEDOUT) << "the stalled handshake after reset was reported as " << std::strerror(codes[1]);
+    EXPECT_EQ(ready_calls.load(), 0) << "a client that never negotiated anything was published as ready";
+}
+
+TEST(fd_event_client_handshake_test, a_dribbling_handshake_fails_on_its_first_deadline) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::want_read, handshake_step_result::want_read,
+                                           handshake_step_result::want_read},
+        0, 200ms);
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    std::vector<int> codes;
+    client.set_on_ready_action([&] { ++ready_calls; });
+    collect_error_codes(client, codes);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+
+    // Stepping every 40ms inside a 200ms bound, for longer than that bound: a deadline restarted
+    // per step would never expire while this runs.
+    auto const stop = std::chrono::steady_clock::now() + 700ms;
+    while (std::chrono::steady_clock::now() < stop and codes.empty()) {
+        script->deliver_peer_record();
+        pump_for(client, 40ms);
+    }
+
+    ASSERT_FALSE(codes.empty()) << "a handshake still stepping was never bounded, after " << script->step_count()
+                                << " steps";
+    ASSERT_EQ(codes.size(), 1u) << "reported: " << describe_codes(codes);
+    EXPECT_EQ(codes[0], ETIMEDOUT) << "the unfinished handshake was reported as " << std::strerror(codes[0]);
+    EXPECT_GT(script->step_count(), 1u) << "the handshake never took a second step, so nothing bounded it";
+    EXPECT_EQ(ready_calls.load(), 0) << "a client that never negotiated anything was published as ready";
+    EXPECT_TRUE(client.on_error());
+}
+
+// The terminal notification arrives on the same descriptor the pending handshake waits on.
+// Handling the handshake first steps a dead connection over and over and reports nothing.
+TEST(fd_event_client_handshake_test, a_peer_drop_during_the_handshake_is_reported_once) {
+    auto script =
+        std::make_shared<handshake_script>(std::vector<handshake_step_result>{handshake_step_result::want_read});
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    std::vector<int> codes;
+    client.set_on_ready_action([&] { ++ready_calls; });
+    collect_error_codes(client, codes);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return script->step_count() >= 1; }));
+    auto const steps_before_drop = script->step_count();
+
+    script->close_peer();
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return not codes.empty(); }))
+        << "the peer drop was never reported, the handshake was stepped " << script->step_count() << " times";
+    pump_for(client, 50ms);
+
+    ASSERT_EQ(codes.size(), 1u) << "reported: " << describe_codes(codes);
+    EXPECT_EQ(codes[0], ENOTCONN) << "the dropped peer was reported as " << std::strerror(codes[0]);
+    EXPECT_EQ(script->step_count(), steps_before_drop) << "the handshake was stepped after the peer was gone";
+    EXPECT_EQ(ready_calls.load(), 0) << "a client whose peer dropped mid handshake was published as ready";
+    EXPECT_TRUE(client.on_error());
+}
+
+TEST(fd_event_client_handshake_test, a_completed_handshake_outlives_its_deadline) {
+    auto script = std::make_shared<handshake_script>(
+        std::vector<handshake_step_result>{handshake_step_result::complete}, 0, 60ms);
+    scripted_handshake_client client(script);
+
+    std::atomic<int> ready_calls{0};
+    std::vector<int> codes;
+    client.set_on_ready_action([&] { ++ready_calls; });
+    collect_error_codes(client, codes);
+
+    ASSERT_TRUE(pump_until(client, 500ms, [&] { return ready_calls.load() == 1; }));
+    pump_for(client, 250ms);
+
+    EXPECT_TRUE(codes.empty()) << "the deadline of the finished handshake failed the connection: "
+                               << describe_codes(codes);
+    EXPECT_FALSE(client.on_error());
+    EXPECT_EQ(ready_calls.load(), 1);
+}
+
+// A terminal notification is level triggered: the descriptor keeps notifying until the queued
+// teardown removes it. Resolving the code reads SO_ERROR, which consumes it, so a re-dispatch
+// would replace the real reason with the fallback.
+TEST(fd_event_client_poll_error_test, socket_error_is_reported_once_and_not_overwritten) {
+    const int fd = make_refused_tcp_fd();
+    ASSERT_GE(fd, 0) << "could not produce a refused loopback connect";
+    auto script = std::make_shared<poll_error_script>(fd);
+    poll_error_client client(script);
+
+    std::vector<int> codes;
+    collect_error_codes(client, codes);
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return not codes.empty(); }));
+    pump_for(client, 50ms);
+
+    ASSERT_FALSE(codes.empty()) << "the terminal notification was never reported";
+    EXPECT_EQ(codes[0], ECONNREFUSED) << "the socket error was consumed and then reported as "
+                                      << std::strerror(codes[0]);
+    EXPECT_EQ(codes.size(), 1u) << "the terminal notification was reported more than once: " << describe_codes(codes);
+    EXPECT_TRUE(client.on_error());
+}
+
+// Injected from the ready action, which runs after the descriptor is monitored and before the
+// loop can dispatch it, so the connect path itself stays clean.
+TEST(fd_event_client_poll_error_test, policy_error_wins_over_the_socket_error) {
+    const int fd = make_refused_tcp_fd();
+    ASSERT_GE(fd, 0) << "could not produce a refused loopback connect";
+    auto script = std::make_shared<poll_error_script>(fd);
+    poll_error_client client(script);
+
+    std::vector<int> codes;
+    collect_error_codes(client, codes);
+    client.set_on_ready_action([&script] { script->set_policy_error(ETIMEDOUT); });
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return not codes.empty(); }));
+    pump_for(client, 50ms);
+
+    ASSERT_FALSE(codes.empty()) << "the terminal notification was never reported";
+    EXPECT_EQ(codes[0], ETIMEDOUT) << "the policy error was discarded in favor of " << std::strerror(codes[0]);
+    EXPECT_EQ(codes.size(), 1u) << "the terminal notification was reported more than once: " << describe_codes(codes);
+}
+
+// A hangup on something that is not a socket has no code to read back: getsockopt fails on a
+// pipe, a serial line and a tun/tap device alike.
+TEST(fd_event_client_poll_error_test, hangup_without_a_code_reports_not_connected) {
+    const int fd = make_hungup_pipe_read_fd();
+    ASSERT_GE(fd, 0) << "could not produce a hung up pipe";
+    auto script = std::make_shared<poll_error_script>(fd);
+    poll_error_client client(script);
+
+    std::vector<int> codes;
+    collect_error_codes(client, codes);
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return not codes.empty(); }));
+    pump_for(client, 50ms);
+
+    ASSERT_FALSE(codes.empty()) << "the terminal notification was never reported";
+    EXPECT_EQ(codes[0], ENOTCONN) << "a bare hangup was reported as " << std::strerror(codes[0]);
+    EXPECT_EQ(codes.size(), 1u) << "the terminal notification was reported more than once: " << describe_codes(codes);
+}
+
+TEST(fd_event_client_poll_error_test, error_without_a_code_reports_io_failure) {
+    const int fd = make_errored_pipe_write_fd();
+    ASSERT_GE(fd, 0) << "could not produce an errored pipe";
+    auto script = std::make_shared<poll_error_script>(fd);
+    poll_error_client client(script);
+
+    std::vector<int> codes;
+    collect_error_codes(client, codes);
+
+    EXPECT_TRUE(pump_until(client, 500ms, [&] { return not codes.empty(); }));
+    pump_for(client, 50ms);
+
+    ASSERT_FALSE(codes.empty()) << "the terminal notification was never reported";
+    EXPECT_EQ(codes[0], EIO) << "a bare error notification was reported as " << std::strerror(codes[0]);
+    EXPECT_EQ(codes.size(), 1u) << "the terminal notification was reported more than once: " << describe_codes(codes);
 }

--- a/lib/everest/io/test/fd_event_handler_test.cpp
+++ b/lib/everest/io/test/fd_event_handler_test.cpp
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <memory>
+#include <thread>
 #include <type_traits>
 
 #include <unistd.h>
@@ -485,4 +486,72 @@ TEST(fd_event_handler_test, unregistering_a_timer_from_another_handler_reports_f
 
     EXPECT_TRUE(owner.unregister_event_handler(&timer));
     EXPECT_FALSE(owner.is_registered(raw));
+}
+
+TEST(fd_event_handler_test, registered_single_shot_timer_fires_once_with_no_mutation) {
+    fd_event_handler handler;
+    timer_fd timer;
+
+    int timer_fired = 0;
+    ASSERT_TRUE(handler.register_event_handler(&timer, [&]() { ++timer_fired; }));
+
+    timer.set_single_shot(true);
+    ASSERT_TRUE(timer.set_timeout(5ms));
+
+    std::this_thread::sleep_for(20ms);
+    EXPECT_TRUE(handler.poll(0ms));
+
+    EXPECT_EQ(timer_fired, 1);
+}
+
+// One epoll_wait harvests a whole batch before dispatching any of it, so a handler early in the
+// batch can retire a timer whose expiry is already in that same batch. disarm() calls
+// timerfd_settime, which clears the expiration counter, so the dispatch wrapper's read finds
+// nothing and recognizes the harvested expiry as stale.
+// Linux appends to the epoll ready list in the order descriptors become ready. Do not reorder the
+// notify/sleep/poll sequence below: it is what makes the race deterministic instead of racy.
+TEST(fd_event_handler_test, disarming_a_timer_from_another_handler_in_the_same_batch_suppresses_its_dispatch) {
+    fd_event_handler handler;
+    event_fd trigger;
+    timer_fd timer;
+
+    int timer_fired = 0;
+    ASSERT_TRUE(handler.register_event_handler(&trigger, [&]() { timer.disarm(); }));
+    ASSERT_TRUE(handler.register_event_handler(&timer, [&]() { ++timer_fired; }));
+
+    timer.set_single_shot(true);
+    ASSERT_TRUE(timer.set_timeout(5ms));
+
+    // Ready first, so epoll places it ahead of the timer in the batch.
+    trigger.notify();
+    // Ready second: sleep past the timeout.
+    std::this_thread::sleep_for(20ms);
+
+    handler.poll(0ms);
+
+    EXPECT_EQ(timer_fired, 0);
+}
+
+// Same defect via a rearm instead of a disarm: a handler pushes a timer's deadline out from under
+// an expiry that already occurred. set_timeout resets the expiration counter just like disarm().
+TEST(fd_event_handler_test, rearming_a_timer_from_another_handler_in_the_same_batch_suppresses_its_dispatch) {
+    fd_event_handler handler;
+    event_fd trigger;
+    timer_fd timer;
+
+    int timer_fired = 0;
+    ASSERT_TRUE(handler.register_event_handler(&trigger, [&]() { timer.set_timeout(10s); }));
+    ASSERT_TRUE(handler.register_event_handler(&timer, [&]() { ++timer_fired; }));
+
+    timer.set_single_shot(true);
+    ASSERT_TRUE(timer.set_timeout(5ms));
+
+    // Ready first, so epoll places it ahead of the timer in the batch.
+    trigger.notify();
+    // Ready second: sleep past the timeout.
+    std::this_thread::sleep_for(20ms);
+
+    handler.poll(0ms);
+
+    EXPECT_EQ(timer_fired, 0);
 }

--- a/lib/everest/io/test/socket_test.cpp
+++ b/lib/everest/io/test/socket_test.cpp
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/socket/socket.hpp>
+
+#include <cerrno>
+#include <cstdint>
+#include <string>
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+using everest::lib::io::event::poll_events;
+using everest::lib::io::socket::consume_poll_error;
+using everest::lib::io::socket::open_tcp_server_socket;
+
+namespace {
+
+std::uint16_t bound_port(int fd) {
+    sockaddr_storage ss{};
+    socklen_t len = sizeof(ss);
+    EXPECT_EQ(::getsockname(fd, reinterpret_cast<sockaddr*>(&ss), &len), 0);
+    return ntohs(ss.ss_family == AF_INET6 ? reinterpret_cast<sockaddr_in6*>(&ss)->sin6_port
+                                          : reinterpret_cast<sockaddr_in*>(&ss)->sin_port);
+}
+
+// A socket whose connect was refused, so SO_ERROR holds ECONNREFUSED until the first read of it.
+// poll() does not consume SO_ERROR, so waiting for the failure here leaves the code to be resolved.
+int make_refused_tcp_fd() {
+    int probe = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (probe < 0) {
+        return -1;
+    }
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    addr.sin_port = 0;
+    socklen_t addr_len = sizeof(addr);
+    if (::bind(probe, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0 or
+        ::getsockname(probe, reinterpret_cast<sockaddr*>(&addr), &addr_len) != 0) {
+        ::close(probe);
+        return -1;
+    }
+    ::close(probe);
+
+    int fd = ::socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0) {
+        // Something claimed the released port in the meantime.
+        ::close(fd);
+        return -1;
+    }
+    pollfd pfd{fd, POLLOUT, 0};
+    if (::poll(&pfd, 1, 2000) != 1 or (pfd.revents & POLLERR) == 0) {
+        ::close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+// Not a socket, so getsockopt fails on it just as it does on a pty or a tun/tap device.
+int make_hungup_pipe_read_fd() {
+    int fds[2]{-1, -1};
+    if (::pipe2(fds, O_NONBLOCK) != 0) {
+        return -1;
+    }
+    ::close(fds[1]);
+    return fds[0];
+}
+
+} // namespace
+
+TEST(open_tcp_server_socket_test, OpenTcpServerSocketV4) {
+    auto fd = open_tcp_server_socket("127.0.0.1", 0, false);
+    ASSERT_GE(static_cast<int>(fd), 0);
+    EXPECT_NE(bound_port(fd), 0);
+}
+
+TEST(open_tcp_server_socket_test, OpenTcpServerSocketV6) {
+    auto fd = open_tcp_server_socket("::1", 0, true);
+    ASSERT_GE(static_cast<int>(fd), 0);
+    EXPECT_NE(bound_port(fd), 0);
+}
+
+TEST(open_tcp_server_socket_test, OpenTcpServerSocketBadAddress) {
+    EXPECT_THROW(open_tcp_server_socket("not.an.ip", 0, false), std::runtime_error);
+}
+
+TEST(consume_poll_error_test, the_pending_socket_error_outranks_the_fallback) {
+    const int fd = make_refused_tcp_fd();
+    ASSERT_GE(fd, 0) << "could not produce a refused loopback connect";
+
+    EXPECT_EQ(consume_poll_error(fd, poll_events::error, ECONNRESET), ECONNREFUSED);
+
+    ::close(fd);
+}
+
+// Reading SO_ERROR clears it, so only the first call can answer with the real code.
+TEST(consume_poll_error_test, the_socket_error_is_consumed_by_the_first_call) {
+    const int fd = make_refused_tcp_fd();
+    ASSERT_GE(fd, 0) << "could not produce a refused loopback connect";
+    ASSERT_EQ(consume_poll_error(fd, poll_events::error, ECONNRESET), ECONNREFUSED);
+
+    EXPECT_EQ(consume_poll_error(fd, poll_events::error, ECONNRESET), ECONNRESET);
+
+    ::close(fd);
+}
+
+// getsockopt fails outright on anything that is not a socket, leaving only the caller's fallback.
+TEST(consume_poll_error_test, a_descriptor_without_a_code_reports_the_fallback) {
+    const int fd = make_hungup_pipe_read_fd();
+    ASSERT_GE(fd, 0) << "could not produce a hung up pipe";
+
+    EXPECT_EQ(consume_poll_error(fd, poll_events::hungup, ECONNRESET), ECONNRESET);
+
+    ::close(fd);
+}
+
+// 0 reads as success on a descriptor that just died, so it is never returned.
+TEST(consume_poll_error_test, a_zero_fallback_resolves_from_the_notification) {
+    const int fd = make_hungup_pipe_read_fd();
+    ASSERT_GE(fd, 0) << "could not produce a hung up pipe";
+
+    EXPECT_EQ(consume_poll_error(fd, poll_events::hungup, 0), ENOTCONN);
+    EXPECT_EQ(consume_poll_error(fd, poll_events::error, 0), EIO);
+
+    ::close(fd);
+}

--- a/lib/everest/io/test/tls_client_socket_test.cpp
+++ b/lib/everest/io/test/tls_client_socket_test.cpp
@@ -1,0 +1,535 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include "tls_test_common.hpp"
+
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tls/tls_client.hpp>
+#include <everest/io/tls/tls_client_config.hpp>
+#include <everest/io/tls/tls_client_socket.hpp>
+#include <everest/tls/tls.hpp>
+
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+namespace test = everest::lib::io::test;
+
+/// Exceeds the 4096-byte rx() chunk buffer, so rx() must drain the remainder via has_pending().
+constexpr std::size_t kLargePayload = 10000;
+
+int make_listen_socket(uint16_t& bound_port) {
+    int listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (listen_fd < 0) {
+        return -1;
+    }
+    int opt = 1;
+    ::setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    addr.sin_port = 0;
+    if (::bind(listen_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0 || ::listen(listen_fd, 1) != 0) {
+        ::close(listen_fd);
+        return -1;
+    }
+
+    sockaddr_in bound{};
+    socklen_t bound_len = sizeof(bound);
+    if (::getsockname(listen_fd, reinterpret_cast<sockaddr*>(&bound), &bound_len) != 0) {
+        ::close(listen_fd);
+        return -1;
+    }
+    bound_port = ntohs(bound.sin_port);
+    return listen_fd;
+}
+
+tls::Server::config_t make_server_config(int listen_fd, std::string const& port_str) {
+    auto scfg = test::server_test_config();
+    scfg.host = "127.0.0.1";
+    scfg.service = port_str.c_str();
+    scfg.ipv6_only = false;
+    scfg.socket = listen_fd; // bypass init_socket()
+    return scfg;
+}
+
+everest::lib::io::tls::tls_client_socket::Config make_client_config() {
+    return test::client_test_config(1000, "localhost");
+}
+
+/// Returns the fd with the connect completed or still in flight, or -1 on a hard failure.
+int start_nonblocking_connect(uint16_t port) {
+    int fd = ::socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    addr.sin_port = htons(port);
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0 && errno != EINPROGRESS) {
+        ::close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+/// True on POLLOUT without POLLERR/POLLHUP; a connect the kernel never completes reports nothing.
+bool connect_completed(int fd, int wait_ms) {
+    pollfd pfd{fd, POLLOUT, 0};
+    return ::poll(&pfd, 1, wait_ms) == 1 && (pfd.revents & POLLOUT) != 0 && (pfd.revents & (POLLERR | POLLHUP)) == 0;
+}
+
+/// A 127.0.0.1 listen socket whose accept queue is deliberately saturated: listen(fd, 1), never
+/// accept, and raw pre-connects until one no longer completes. The kernel then stops completing
+/// handshakes, so a later connect to port() stays pending until the caller's timeout, a
+/// deterministic loopback stand-in for an unreachable host.
+class saturated_loopback_port {
+public:
+    saturated_loopback_port() {
+        m_listen_fd = make_listen_socket(m_port);
+        if (m_listen_fd < 0) {
+            return;
+        }
+        for (int i = 0; i < max_pre_connects; ++i) {
+            const int fd = start_nonblocking_connect(m_port);
+            if (fd < 0) {
+                return;
+            }
+            m_fds.push_back(fd);
+            if (!connect_completed(fd, 200)) {
+                m_saturated = true;
+                return;
+            }
+        }
+    }
+
+    saturated_loopback_port(saturated_loopback_port const&) = delete;
+    saturated_loopback_port& operator=(saturated_loopback_port const&) = delete;
+
+    ~saturated_loopback_port() {
+        for (int fd : m_fds) {
+            ::close(fd);
+        }
+        if (m_listen_fd >= 0) {
+            ::close(m_listen_fd);
+        }
+    }
+
+    bool saturated() const {
+        return m_saturated;
+    }
+    uint16_t port() const {
+        return m_port;
+    }
+
+private:
+    // ~3 connects saturate in practice on Linux; 8 is headroom, not a tuned value.
+    static constexpr int max_pre_connects = 8;
+    int m_listen_fd{-1};
+    uint16_t m_port{0};
+    std::vector<int> m_fds;
+    bool m_saturated{false};
+};
+
+} // namespace
+
+namespace everest::lib::io::tls {
+// Test seam without friendship: re-expose the otherwise-internal tcp_socket.
+struct testable_client_socket : tls_client_socket {
+    using tls_client_socket::m_tcp;
+};
+} // namespace everest::lib::io::tls
+
+namespace {
+/// get_raw_handler() is the only public window on the policy; the client does not expose the fd.
+int connection_fd(everest::lib::io::tls::tls_client& client) {
+    auto const& handle = client.get_raw_handler();
+    return handle ? handle->get_fd() : -1;
+}
+} // namespace
+
+// The connection's BIO becomes the fd's sole owner, so m_tcp must have surrendered it or teardown
+// double-closes.
+TEST(tls_client_socket, fd_ownership_released_after_async_wrap) {
+    uint16_t bound_port = 0;
+    int listen_fd = make_listen_socket(bound_port);
+    ASSERT_GE(listen_fd, 0);
+
+    everest::lib::io::tls::testable_client_socket sock;
+    auto cfg = make_client_config();
+    ASSERT_TRUE(sock.setup(std::move(cfg), "127.0.0.1", bound_port, 2000));
+
+    // connect() only wraps the TCP fd, so the server thread just accepts and exits.
+    std::thread server_thread([&]() {
+        sockaddr peer{};
+        socklen_t peer_len = sizeof(peer);
+        int accepted_fd = ::accept(listen_fd, &peer, &peer_len);
+        if (accepted_fd >= 0) {
+            ::close(accepted_fd);
+        }
+    });
+
+    bool ok = false;
+    sock.connect([&](bool o, int /*fd*/) { ok = o; }); // synchronous
+    const int tcp_fd_after = sock.m_tcp.get_fd();
+
+    // Join before asserting: a fatal ASSERT returning with the thread joinable is std::terminate.
+    sock.close();
+    server_thread.join();
+    ::close(listen_fd);
+
+    ASSERT_TRUE(ok) << "TCP connect / fd wrap failed";
+    EXPECT_EQ(tcp_fd_after, everest::lib::io::event::unique_fd::NO_DESCRIPTOR_SENTINEL)
+        << "m_tcp still owns the fd after async wrap -> double-close on teardown";
+}
+
+TEST(TlsClient, HandshakeAndExchange) {
+    uint16_t bound_port = 0;
+    int listen_fd = make_listen_socket(bound_port);
+    ASSERT_GE(listen_fd, 0);
+    const std::string port_str = std::to_string(bound_port);
+
+    tls::Server server;
+    const auto state = server.init(make_server_config(listen_fd, port_str), nullptr);
+    ASSERT_NE(state, tls::Server::state_t::init_needed)
+        << "tls::Server::init failed: check that server_chain.pem etc. exist "
+           "in the working directory (lib/everest/tls/tests in the build tree).";
+
+    std::atomic<bool> server_ok{false};
+    std::string server_error;
+    std::thread server_thread([&]() {
+        sockaddr peer{};
+        socklen_t peer_len = sizeof(peer);
+        int accepted_fd = ::accept(listen_fd, &peer, &peer_len);
+        if (accepted_fd < 0) {
+            server_error = "accept failed";
+            return;
+        }
+
+        char ip_buf[NI_MAXHOST] = "127.0.0.1";
+        char svc_buf[NI_MAXSERV] = "0";
+        ::getnameinfo(&peer, peer_len, ip_buf, sizeof ip_buf, svc_buf, sizeof svc_buf, NI_NUMERICHOST | NI_NUMERICSERV);
+
+        auto conn = server.wrap_accepted_fd(accepted_fd, ip_buf, svc_buf);
+        if (!conn) {
+            server_error = "wrap_accepted_fd returned nullptr";
+            return;
+        }
+        if (conn->accept(2000) != tls::Connection::result_t::success) {
+            server_error = "server TLS handshake failed";
+            return;
+        }
+
+        std::byte buf[64]{};
+        std::size_t nread = 0;
+        if (conn->read(buf, sizeof buf, nread, 2000) != tls::Connection::result_t::success) {
+            server_error = "server read failed";
+            return;
+        }
+
+        std::vector<uint8_t> reply(kLargePayload);
+        for (std::size_t i = 0; i < reply.size(); ++i) {
+            reply[i] = static_cast<uint8_t>(i & 0xFF);
+        }
+        std::size_t written = 0;
+        if (conn->write(reinterpret_cast<const std::byte*>(reply.data()), reply.size(), written, 2000) !=
+                tls::Connection::result_t::success ||
+            written != reply.size()) {
+            server_error = "server write failed";
+            return;
+        }
+
+        conn->shutdown(0);
+        server_ok = true;
+    });
+
+    // The handler must outlive the client, whose destructor drops its registration.
+    everest::lib::io::event::fd_event_handler ev;
+    everest::lib::io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), bound_port, 2000);
+
+    std::atomic<bool> running{true};
+    std::atomic<bool> ready_fired{false};
+    std::vector<std::uint8_t> rx_buf;
+
+    client.set_on_ready_action([&client, &ready_fired]() {
+        ready_fired = true;
+        everest::lib::io::tls::tls_client_socket::PayloadT msg = {'h', 'i'};
+        client.tx(msg);
+    });
+    client.set_rx_handler(
+        [&rx_buf, &running](everest::lib::io::tls::tls_client_socket::PayloadT const& payload, auto&) {
+            rx_buf.insert(rx_buf.end(), payload.begin(), payload.end());
+            if (rx_buf.size() >= kLargePayload) {
+                running = false;
+            }
+        });
+    ASSERT_TRUE(ev.register_event_handler(&client));
+
+    test::pump_until(
+        ev, [&] { return !running; }, 5s);
+
+    server_thread.join();
+    ::close(listen_fd);
+
+    EXPECT_TRUE(ready_fired) << "on-ready action did not fire after handshake";
+    ASSERT_EQ(rx_buf.size(), kLargePayload) << "rx() did not drain all buffered TLS records in one call";
+    for (std::size_t i = 0; i < rx_buf.size(); ++i) {
+        ASSERT_EQ(rx_buf[i], static_cast<uint8_t>(i & 0xFF)) << "payload corruption at index " << i;
+    }
+    EXPECT_TRUE(server_ok) << "Server error: " << server_error;
+}
+
+// Teardown neither joins nor waits for the connect thread. Destruction clears the shared connect
+// state's active flag, so the thread returns without publishing its result and destroys the policy
+// it moved in on its own stack. It never captures the client.
+TEST(TlsClient, teardown_during_pending_connect_is_clean) {
+    saturated_loopback_port blocked;
+    ASSERT_TRUE(blocked.saturated()) << "could not saturate the loopback accept queue";
+
+    everest::lib::io::event::fd_event_handler ev;
+    // Long enough that a teardown waiting for the connect could not meet the bound below.
+    constexpr int connect_timeout_ms = 400;
+    std::atomic<bool> ready_fired{false};
+    std::atomic<int> error_calls{0};
+    int poll_fd = -1;
+    std::chrono::steady_clock::time_point teardown_start;
+    {
+        everest::lib::io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), blocked.port(),
+                                                 connect_timeout_ms);
+        client.set_on_ready_action([&ready_fired]() { ready_fired = true; });
+        client.set_error_handler([&error_calls](int err, std::string const&) {
+            if (err != 0) {
+                ++error_calls;
+            }
+        });
+        ASSERT_TRUE(ev.register_event_handler(&client));
+        // Drain the deferred handler registrations and leave the connect thread mid-flight.
+        for (int i = 0; i < 3; ++i) {
+            ev.poll(50ms);
+            ev.run_actions();
+        }
+        ASSERT_EQ(connection_fd(client), -1) << "the connect completed, so the backlog saturation did not hold";
+        poll_fd = client.get_poll_fd();
+        ASSERT_GE(poll_fd, 0);
+
+        teardown_start = std::chrono::steady_clock::now();
+        ev.unregister_event_handler(&client);
+        // client destroyed at the closing brace below, connect still pending.
+    }
+    const auto teardown_elapsed = std::chrono::steady_clock::now() - teardown_start;
+
+    EXPECT_LT(teardown_elapsed, 200ms) << "teardown waited for the pending connect instead of abandoning it";
+
+    // A wall-clock window, not a completion signal: under heavy load it can close before the thread
+    // finishes, which makes the checks below vacuous rather than flaky.
+    const auto drain_deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(connect_timeout_ms) + 500ms;
+    while (std::chrono::steady_clock::now() < drain_deadline) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+
+    EXPECT_FALSE(ready_fired) << "the ready action was released for a client that never connected";
+    EXPECT_EQ(error_calls.load(), 0) << "no error was reported while the connect was still pending";
+    EXPECT_FALSE(ev.is_registered(poll_fd))
+        << "the client's nested poll fd is still in the handler map after unregister";
+}
+
+// A peer RST leaves the socket with m_last_error 0, and every shipped consumer ignores the callback
+// via `if (err != 0)`, so an unresolved 0 strands the client.
+TEST(TlsClient, poll_error_delivers_nonzero_code) {
+    uint16_t bound_port = 0;
+    int listen_fd = make_listen_socket(bound_port);
+    ASSERT_GE(listen_fd, 0);
+    const std::string port_str = std::to_string(bound_port);
+
+    tls::Server server;
+    const auto state = server.init(make_server_config(listen_fd, port_str), nullptr);
+    ASSERT_NE(state, tls::Server::state_t::init_needed);
+
+    // Reads the ping first, so the client is handshaked and monitored for read before the RST.
+    std::thread server_thread([&]() {
+        sockaddr peer{};
+        socklen_t peer_len = sizeof(peer);
+        int accepted_fd = ::accept(listen_fd, &peer, &peer_len);
+        if (accepted_fd < 0) {
+            return;
+        }
+        char ip_buf[NI_MAXHOST] = "127.0.0.1";
+        char svc_buf[NI_MAXSERV] = "0";
+        ::getnameinfo(&peer, peer_len, ip_buf, sizeof ip_buf, svc_buf, sizeof svc_buf, NI_NUMERICHOST | NI_NUMERICSERV);
+        auto conn = server.wrap_accepted_fd(accepted_fd, ip_buf, svc_buf);
+        if (!conn) {
+            ::close(accepted_fd);
+            return;
+        }
+        if (conn->accept(2000) != tls::Connection::result_t::success) {
+            return;
+        }
+        std::byte buf[64]{};
+        std::size_t nread = 0;
+        (void)conn->read(buf, sizeof buf, nread, 2000);
+        // Zero linger emits an RST instead of a graceful close_notify, so the client sees
+        // EPOLLERR/EPOLLHUP with no readable TLS record. The BIO closes accepted_fd on reset.
+        struct linger lo {
+            1, 0
+        };
+        ::setsockopt(accepted_fd, SOL_SOCKET, SO_LINGER, &lo, sizeof(lo));
+        conn.reset();
+    });
+
+    // Declared before the client, whose dtor unregisters from it.
+    everest::lib::io::event::fd_event_handler ev;
+    everest::lib::io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), bound_port, 2000);
+
+    std::atomic<bool> got_error{false};
+    std::atomic<bool> ready_fired{false};
+    std::atomic<int> err_code{0};
+    client.set_on_ready_action([&client, &ready_fired]() {
+        ready_fired = true;
+        everest::lib::io::tls::tls_client_socket::PayloadT msg = {'p', 'i', 'n', 'g'};
+        client.tx(msg);
+    });
+    // A cleared error also arrives as code 0 once the connection comes up. Reporting on 0 would stop
+    // the loop before the handshake and hang the server thread on its blocking accept().
+    client.set_error_handler([&](int err, std::string const&) {
+        if (err != 0) {
+            err_code = err;
+            got_error = true;
+        }
+    });
+    ASSERT_TRUE(ev.register_event_handler(&client));
+
+    test::pump_until(
+        ev, [&] { return got_error.load(); }, 5s);
+
+    server_thread.join();
+    ::close(listen_fd);
+
+    ASSERT_TRUE(ready_fired) << "the handshake never completed, so this is not the live-connection path";
+    ASSERT_TRUE(got_error) << "error handler never fired after a peer RST";
+    EXPECT_NE(err_code.load(), 0) << "error handler received code 0 on the poll-error (RST) path";
+}
+
+// setup() returns false before any descriptor exists, so a get_error() left at 0 falls through to
+// the tcp socket and answers EBADF, naming the probe and not the configuration. The trigger is an
+// unreadable client certificate; an unreadable trust anchor is not one, libtls logs and carries on.
+TEST(tls_client_socket, setup_failure_records_error) {
+    everest::lib::io::tls::tls_client_socket sock;
+    auto cfg = make_client_config();
+    cfg.tls.certificate_chain_file = "no_such_cert.pem";
+
+    EXPECT_FALSE(sock.setup(std::move(cfg), "127.0.0.1", 4711, 100));
+    EXPECT_NE(sock.get_error(), 0) << "setup() failed without recording an error";
+    EXPECT_NE(sock.get_error(), EBADF) << "get_error() probed a descriptor that was never assigned";
+    EXPECT_FALSE(sock.get_error_string().empty()) << "setup() failure reported no reason";
+    EXPECT_NE(sock.get_error_string().find("no_such_cert.pem"), std::string::npos)
+        << "setup() failure did not name the offending file: " << sock.get_error_string();
+}
+
+// tls::Client::init also rejects inputs that are not files, so the reason text must not read as if a
+// path were at fault. An unset path must render as visibly unset, not as an empty one, which libtls
+// treats as a different configuration.
+TEST(tls_client_socket, setup_failure_text_describes_the_configuration) {
+    everest::lib::io::tls::tls_client_socket sock;
+    everest::lib::io::tls::tls_client_socket::Config cfg{};
+    cfg.tls.verify_server = false;
+    cfg.tls.verify_subject_name = true;
+
+    EXPECT_FALSE(sock.setup(std::move(cfg), "127.0.0.1", 4711, 100));
+    EXPECT_EQ(sock.get_error(), EINVAL) << "a rejected configuration is an invalid argument, not a socket error";
+    auto const text = sock.get_error_string();
+    EXPECT_NE(text.find("certificate_chain_file=<unset>"), std::string::npos)
+        << "an unset path did not render as unset: " << text;
+    EXPECT_NE(text.find("verify_server=false"), std::string::npos)
+        << "the reason text omits the non-path input that was rejected: " << text;
+    EXPECT_NE(text.find("verify_subject_name=true"), std::string::npos)
+        << "the reason text omits the non-path input that was rejected: " << text;
+}
+
+// Both registrations resolve to the same nested poll fd, so fd_event_handler's exists() guard is
+// what makes the second call a clean false rather than a duplicate entry.
+TEST(TlsClient, double_register_is_rejected_not_fatal) {
+    saturated_loopback_port blocked;
+    ASSERT_TRUE(blocked.saturated()) << "could not saturate the loopback accept queue";
+
+    everest::lib::io::event::fd_event_handler ev;
+    everest::lib::io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), blocked.port(), 300);
+
+    ASSERT_TRUE(ev.register_event_handler(&client)) << "first register should succeed";
+    EXPECT_FALSE(ev.register_event_handler(&client)) << "double register must be rejected, not re-start the endpoint";
+
+    ev.unregister_event_handler(&client);
+    for (int i = 0; i < 3; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+    SUCCEED();
+}
+
+namespace {
+
+// The Config must own every string it carries: the generic client copies it at construction and
+// replays setup() on the first poll and on every reconnect, long after the caller's buffers died.
+everest::lib::io::tls::tls_client_socket::Config config_from_dying_locals() {
+    // All locals, all destroyed when this function returns.
+    std::string cipher_list{"ECDHE-ECDSA-AES128-SHA256"};
+    std::string ciphersuites{}; // set-but-empty disables TLS 1.3, matching the test server
+    std::string trust_anchor{"server_root_cert.pem"};
+    std::string sni{"localhost"};
+
+    everest::lib::io::tls::tls_client_socket::Config cfg{};
+    cfg.tls.cipher_list = cipher_list;
+    cfg.tls.ciphersuites = ciphersuites;
+    cfg.tls.verify_locations_file = trust_anchor;
+    cfg.tls.io_timeout_ms = 2000;
+    cfg.tls.verify_server = true;
+    cfg.host_for_sni = sni;
+    return cfg;
+}
+
+} // namespace
+
+TEST(TlsClient, config_built_from_dead_locals_still_handshakes) {
+    everest::lib::io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    ASSERT_TRUE(rig.registered);
+    ASSERT_GT(rig.port(), 0u);
+
+    everest::lib::io::tls::tls_client client(config_from_dying_locals(), std::string("127.0.0.1"), rig.port(), 2000);
+
+    std::atomic<bool> done{false};
+    client.set_on_ready_action([&client]() {
+        everest::lib::io::tls::tls_client_socket::PayloadT msg = {'h', 'i'};
+        client.tx(msg);
+    });
+    client.set_rx_handler([&done](everest::lib::io::tls::tls_client_socket::PayloadT const& payload, auto&) {
+        if (!payload.empty()) {
+            done = true;
+        }
+    });
+    ASSERT_TRUE(ev.register_event_handler(&client));
+
+    EXPECT_TRUE(test::pump_until(
+        ev, [&] { return done.load(); }, 5s))
+        << "handshake/echo did not complete from a Config built entirely from destroyed locals";
+}

--- a/lib/everest/io/test/tls_e2e_test.cpp
+++ b/lib/everest/io/test/tls_e2e_test.cpp
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+//
+// End-to-end: a tls_listener and a tls_client on one fd_event_handler, on one thread. Only the
+// client's TCP connect runs off-loop, on a detached worker; the listen backlog buffers the SYN so
+// the loop accepts it once polling starts. Both TLS handshakes then run on that one loop.
+
+#include "tls_test_common.hpp"
+
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tls/tls_client.hpp>
+#include <everest/io/tls/tls_listener.hpp>
+#include <everest/io/tls/tls_server.hpp>
+#include <everest/io/tls/tls_server_socket.hpp>
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+namespace io = everest::lib::io;
+namespace test = everest::lib::io::test;
+
+using tls_payload = io::tls::tls_client_socket::PayloadT;
+
+/// Exceeds the 4096-byte rx() chunk buffer, so rx() must drain the remainder via has_pending().
+constexpr std::size_t kLargePayload = 10000;
+
+std::vector<std::uint8_t> make_large_payload() {
+    std::vector<std::uint8_t> payload(kLargePayload);
+    for (std::size_t i = 0; i < payload.size(); ++i) {
+        payload[i] = static_cast<std::uint8_t>((i * 31 + 7) & 0xFF);
+    }
+    return payload;
+}
+
+} // namespace
+
+TEST(TlsE2E, RoundTripLargePayloadSingleLoop) {
+    io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    const auto port = rig.port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+    ASSERT_TRUE(rig.registered);
+
+    const auto expected = make_large_payload();
+
+    io::tls::tls_client client(test::client_test_config(), std::string("127.0.0.1"), port, 2000);
+
+    std::atomic<bool> running{true};
+    std::vector<std::uint8_t> echo;
+    echo.reserve(kLargePayload);
+
+    client.set_on_ready_action([&client, &expected]() {
+        tls_payload msg(expected.begin(), expected.end());
+        client.tx(msg);
+    });
+    client.set_rx_handler([&echo, &running](tls_payload const& payload, io::tls::tls_client_interface&) {
+        echo.insert(echo.end(), payload.begin(), payload.end());
+        if (echo.size() >= kLargePayload) {
+            running = false;
+        }
+    });
+    ev.register_event_handler(&client);
+
+    test::pump_until(
+        ev, [&] { return !running; }, 5s);
+
+    ASSERT_EQ(echo.size(), kLargePayload) << "round-trip did not complete within 5 seconds (drain or echo failed)";
+    EXPECT_EQ(echo, expected) << "echoed payload differs from sent payload";
+}
+
+// The server leaf cert carries a DNS:localhost SAN, so RFC-6125 verification passes even though the
+// TCP connect target is the 127.0.0.1 literal: SNI is the matched name, not the connect target.
+TEST(TlsE2E, HostnameVerificationSucceeds) {
+    io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    const auto port = rig.port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+    ASSERT_TRUE(rig.registered);
+
+    auto cfg = test::client_test_config(2000, "localhost");
+    cfg.tls.verify_subject_name = true;
+
+    io::tls::tls_client client(cfg, std::string("127.0.0.1"), port, 2000);
+
+    std::atomic<bool> running{true};
+    std::atomic<bool> got_echo{false};
+    const std::vector<std::uint8_t> ping = {'p', 'i', 'n', 'g'};
+    std::vector<std::uint8_t> echo;
+
+    client.set_on_ready_action([&client, &ping]() {
+        tls_payload msg(ping.begin(), ping.end());
+        client.tx(msg);
+    });
+    client.set_rx_handler(
+        [&echo, &ping, &got_echo, &running](tls_payload const& payload, io::tls::tls_client_interface&) {
+            echo.insert(echo.end(), payload.begin(), payload.end());
+            if (echo.size() >= ping.size()) {
+                got_echo = true;
+                running = false;
+            }
+        });
+    ev.register_event_handler(&client);
+
+    test::pump_until(
+        ev, [&] { return !running; }, 5s);
+
+    EXPECT_TRUE(got_echo) << "round-trip did not complete with verify_subject_name + correct SNI within 5 seconds";
+    EXPECT_EQ(echo, ping) << "echoed payload differs from sent payload";
+}
+
+// host_for_sni matches no SAN on the server leaf cert, so verification must fail and report.
+TEST(TlsE2E, WrongHostnameVerificationFails) {
+    io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    const auto port = rig.port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+    ASSERT_TRUE(rig.registered);
+
+    auto cfg = test::client_test_config(2000, "wrong.example");
+    cfg.tls.verify_subject_name = true;
+
+    io::tls::tls_client client(cfg, std::string("127.0.0.1"), port, 2000);
+
+    std::atomic<bool> running{true};
+    std::atomic<bool> got_error{false};
+    std::atomic<bool> got_echo{false};
+    const std::vector<std::uint8_t> ping = {'p', 'i', 'n', 'g'};
+    // Written on the loop thread, read on the same thread below, so no atomic is needed.
+    std::string error_text;
+
+    client.set_error_handler([&got_error, &running, &error_text](int err, std::string const& msg) {
+        if (err != 0) {
+            got_error = true;
+            error_text = msg;
+            running = false;
+        }
+    });
+    client.set_on_ready_action([&client, &ping]() {
+        // Should never fire: the handshake fails verification before ready.
+        tls_payload msg(ping.begin(), ping.end());
+        client.tx(msg);
+    });
+    client.set_rx_handler([&got_echo, &running](tls_payload const& /*payload*/, io::tls::tls_client_interface&) {
+        got_echo = true;
+        running = false;
+    });
+    ev.register_event_handler(&client);
+
+    // Short deadline: a mismatch must surface promptly rather than hang.
+    test::pump_until(
+        ev, [&] { return !running; }, 3s);
+
+    EXPECT_FALSE(got_echo) << "round-trip completed despite a hostname mismatch";
+    EXPECT_TRUE(got_error) << "client error handler did not fire on a hostname mismatch within 3 seconds";
+    EXPECT_FALSE(error_text.empty()) << "error handler received an empty string instead of the OpenSSL error text";
+}
+
+// The client's rx fails inside the connection-fd dispatch lambda, which must NOT remove its own fd
+// synchronously from that pass: it would erase the executing std::function and resize the pollfds
+// mid-iteration. The teardown is deferred to a queued action.
+TEST(TlsE2E, ServerCloseTearsDownClientWithoutCrash) {
+    io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    const auto port = rig.port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+    ASSERT_TRUE(rig.registered);
+
+    io::tls::tls_client client(test::client_test_config(), std::string("127.0.0.1"), port, 2000);
+
+    std::atomic<bool> got_error{false};
+    std::atomic<bool> got_echo{false};
+    const std::vector<std::uint8_t> ping = {'p', 'i', 'n', 'g'};
+
+    client.set_on_ready_action([&client, &ping]() {
+        tls_payload msg(ping.begin(), ping.end());
+        client.tx(msg);
+    });
+    client.set_rx_handler(
+        [&got_echo](tls_payload const& /*payload*/, io::tls::tls_client_interface&) { got_echo = true; });
+    client.set_error_handler([&got_error](int err, std::string const& /*msg*/) {
+        if (err != 0) {
+            got_error = true;
+        }
+    });
+    ev.register_event_handler(&client);
+
+    bool dropped = false;
+    test::pump_until(
+        ev,
+        [&] {
+            if (got_echo && not dropped) {
+                // Closes the peer fd, so the client rx fails and routes through fail().
+                ev.unregister_event_handler(rig.server_conn.get());
+                rig.server_conn.reset();
+                dropped = true;
+            }
+            return got_error.load();
+        },
+        5s);
+
+    EXPECT_TRUE(got_echo) << "round-trip did not complete before the server was dropped";
+    EXPECT_TRUE(got_error) << "client error handler did not fire after the server closed within 5 seconds";
+
+    // No crash here is the assertion.
+    for (int i = 0; i < 5; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+}
+
+// The accept callback runs before the accepted connection's handshake, so a payload queued there
+// consumes its one-shot tx-notify while the fd is monitored for the handshake alone. Without a
+// re-notify on handshake completion the payload never leaves the queue.
+TEST(TlsE2E, server_tx_queued_before_accept_handshake_is_flushed) {
+    // Declared first so it outlives every endpoint, whose destructor unregisters from it.
+    io::event::fd_event_handler ev;
+
+    io::tls::tls_listener listener(test::listener_test_config());
+    const auto port = listener.listen_port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+
+    const std::vector<std::uint8_t> greeting = {'h', 'e', 'l', 'l', 'o'};
+
+    std::unique_ptr<io::tls::tls_server> server_conn;
+    listener.set_accept_callback(
+        [&](std::unique_ptr<io::tls::tls_server> srv, std::string /*ip*/, std::uint16_t /*peer_port*/) {
+            // Queued before the accept handshake has even started.
+            EXPECT_TRUE(srv->tx(greeting));
+            ev.register_event_handler(srv.get());
+            server_conn = std::move(srv);
+        });
+    ASSERT_TRUE(ev.register_event_handler(&listener));
+
+    io::tls::tls_client client(test::client_test_config(), std::string("127.0.0.1"), port, 2000);
+
+    std::vector<std::uint8_t> received;
+    client.set_rx_handler([&received](tls_payload const& payload, io::tls::tls_client_interface&) {
+        received.insert(received.end(), payload.begin(), payload.end());
+    });
+    ASSERT_TRUE(ev.register_event_handler(&client));
+
+    test::pump_until(
+        ev, [&] { return received.size() >= greeting.size(); }, 5s);
+
+    ASSERT_EQ(received.size(), greeting.size())
+        << "payload queued before the accept handshake was never flushed within 5 seconds";
+    EXPECT_EQ(received, greeting) << "delivered payload differs from the queued one";
+}
+
+// Two distinct buffering windows. Before the transport is connected, the generic client accepts for
+// an async connect policy until an attempt has actually failed. Once connected, the tx-notify fires
+// while the fd is monitored for the handshake alone, so the completion path must re-arm write.
+TEST(TlsE2E, tx_queued_before_handshake_is_flushed_after_ready) {
+    io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    const auto port = rig.port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+    ASSERT_TRUE(rig.registered);
+
+    io::tls::tls_client client(test::client_test_config(), std::string("127.0.0.1"), port, 2000);
+
+    std::atomic<bool> running{true};
+    const std::vector<std::uint8_t> ping = {'p', 'i', 'n', 'g'};
+    const std::vector<std::uint8_t> pong = {'p', 'o', 'n', 'g'};
+    std::vector<std::uint8_t> echo;
+
+    client.set_rx_handler([&echo, &ping, &pong, &running](tls_payload const& payload, io::tls::tls_client_interface&) {
+        echo.insert(echo.end(), payload.begin(), payload.end());
+        if (echo.size() >= ping.size() + pong.size()) {
+            running = false;
+        }
+    });
+    ASSERT_TRUE(ev.register_event_handler(&client));
+
+    // Before the connect: no connection fd exists yet, so this can only be buffered.
+    tls_payload first(ping.begin(), ping.end());
+    ASSERT_TRUE(client.tx(first)) << "tx() rejected a payload queued before the connect completed";
+
+    // A cleared error state means the connect result was processed. The handshake cannot be done
+    // yet: its first step only sends the ClientHello, and the server shares this loop.
+    ASSERT_TRUE(test::pump_until(
+        ev, [&] { return client.get_raw_handler() != nullptr && !client.on_error(); }, 5s))
+        << "the TCP connect never completed";
+    ASSERT_NE(client.get_raw_handler(), nullptr);
+    ASSERT_FALSE(client.get_raw_handler()->handshake_complete())
+        << "the handshake already completed, so this is no longer the queue-across-the-handshake window";
+
+    // During the handshake: a second window, distinct from the one above.
+    tls_payload second(pong.begin(), pong.end());
+    ASSERT_TRUE(client.tx(second)) << "tx() rejected a payload queued during the handshake";
+
+    test::pump_until(
+        ev, [&] { return !running; }, 5s);
+
+    std::vector<std::uint8_t> expected = ping;
+    expected.insert(expected.end(), pong.begin(), pong.end());
+    ASSERT_EQ(echo.size(), expected.size()) << "payloads queued across the handshake were not both flushed";
+    EXPECT_EQ(echo, expected) << "echoed payloads differ from the sent ones, or arrived out of order";
+}
+
+// Observed through is_registered(), because unregister_event_handler() returns true either way.
+// The destructor drops the registration too, so this is the explicit path, not the only one.
+TEST(TlsE2E, UnregisterClientRemovesPollFd) {
+    io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    const auto port = rig.port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+    ASSERT_TRUE(rig.registered);
+
+    int poll_fd = -1;
+    {
+        io::tls::tls_client client(test::client_test_config(), std::string("127.0.0.1"), port, 2000);
+
+        std::atomic<bool> ready{false};
+        client.set_on_ready_action([&ready]() { ready = true; });
+        ASSERT_TRUE(ev.register_event_handler(&client));
+
+        test::pump_until(
+            ev, [&] { return ready.load(); }, 5s);
+        ASSERT_TRUE(ready) << "client handshake did not complete within 5 seconds";
+
+        poll_fd = client.get_poll_fd();
+        ASSERT_GE(poll_fd, 0);
+        EXPECT_TRUE(ev.unregister_event_handler(&client));
+    } // client destroyed here, while ev outlives it.
+
+    for (int i = 0; i < 5; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+
+    EXPECT_FALSE(ev.is_registered(poll_fd))
+        << "the client's nested poll fd is still in the handler map after unregister";
+}
+
+// libtls reports a peer close as result_t::closed whether or not the session was shut down, so the
+// discriminator is last_error(), empty only on a graceful close and surfaced as the error text.
+TEST(TlsE2E, client_teardown_closes_the_tls_session) {
+    io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    const auto port = rig.port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+    ASSERT_TRUE(rig.registered);
+
+    std::atomic<bool> server_closed{false};
+    std::string server_error_text{"unset"};
+
+    const std::vector<std::uint8_t> ping = {'p', 'i', 'n', 'g'};
+    {
+        io::tls::tls_client client(test::client_test_config(), std::string("127.0.0.1"), port, 2000);
+
+        std::atomic<bool> echoed{false};
+        client.set_rx_handler([&echoed](tls_payload const&, io::tls::tls_client_interface&) { echoed = true; });
+        ASSERT_TRUE(ev.register_event_handler(&client));
+
+        // The accepted endpoint only exists once the listener has run its accept callback.
+        ASSERT_TRUE(test::pump_until(
+            ev, [&] { return rig.server_conn != nullptr; }, 5s))
+            << "the listener never accepted a connection";
+        rig.server_conn->set_error_handler([&](int, std::string const& text) {
+            server_error_text = text;
+            server_closed = true;
+        });
+
+        // Proves both sides finished the handshake, so the close below is not an aborted negotiation.
+        tls_payload payload(ping.begin(), ping.end());
+        ASSERT_TRUE(client.tx(payload));
+        ASSERT_TRUE(test::pump_until(
+            ev, [&] { return echoed.load(); }, 5s))
+            << "the round trip never completed";
+    } // client destroyed here, while ev and the listener outlive it.
+
+    ASSERT_TRUE(test::pump_until(
+        ev, [&] { return server_closed.load(); }, 5s))
+        << "the server never observed the client going away";
+    EXPECT_EQ(server_error_text, std::string{})
+        << "the client dropped the socket without closing the TLS session, so the peer cannot tell "
+           "this from a truncated stream: "
+        << server_error_text;
+}

--- a/lib/everest/io/test/tls_listener_test.cpp
+++ b/lib/everest/io/test/tls_listener_test.cpp
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include "tls_test_common.hpp"
+
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tls/tls_listener.hpp>
+#include <everest/io/tls/tls_server.hpp>
+#include <everest/io/tls/tls_server_socket.hpp>
+
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <cerrno>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+namespace io = everest::lib::io;
+namespace test = everest::lib::io::test;
+
+const std::vector<std::uint8_t> kPayload = {'p', 'i', 'n', 'g'};
+
+/// A blocking TLS client on a worker thread while the main thread pumps the listener's loop.
+void run_round_trip(std::string const& bind_addr, bool ipv6_only) {
+    // Declared first so it outlives every endpoint, whose destructor unregisters from it.
+    io::event::fd_event_handler handler;
+
+    io::tls::tls_listener listener(test::listener_test_config(bind_addr, ipv6_only));
+
+    const auto port = listener.listen_port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+
+    std::atomic<bool> server_rx_fired{false};
+    std::atomic<std::uint16_t> captured_peer_port{0};
+    // Must outlive the accept callback: the loop drives its handshake/rx/tx after registration.
+    std::unique_ptr<io::tls::tls_server> server_conn;
+
+    listener.set_accept_callback(
+        [&](std::unique_ptr<io::tls::tls_server> srv, std::string /*ip*/, std::uint16_t peer_port) {
+            captured_peer_port = peer_port;
+            srv->set_rx_handler([&server_rx_fired](io::tls::tls_server_socket::PayloadT const& payload, auto& self) {
+                server_rx_fired = true;
+                self.tx(payload);
+            });
+            handler.register_event_handler(srv.get());
+            server_conn = std::move(srv);
+        });
+
+    ASSERT_TRUE(handler.register_event_handler(&listener));
+
+    std::atomic<bool> client_ok{false};
+    std::string client_error;
+    std::thread client_thread(
+        [&]() { test::run_blocking_echo_client(bind_addr, port, kPayload, client_ok, client_error); });
+
+    test::pump_until(
+        handler, [&] { return server_rx_fired && client_ok; }, 5s);
+
+    client_thread.join();
+
+    EXPECT_TRUE(server_rx_fired) << "server-side rx handler did not fire within 5 seconds";
+    EXPECT_TRUE(client_ok) << "client round-trip did not complete: " << client_error;
+    EXPECT_GT(captured_peer_port.load(), 0u) << "peer_port not extracted from sockaddr_storage";
+}
+
+} // namespace
+
+TEST(TlsListener, AcceptCallbackFires) {
+    run_round_trip("127.0.0.1", false);
+}
+
+TEST(TlsListener, AcceptCallbackFiresIPv6) {
+    run_round_trip("::1", true);
+}
+
+namespace {
+
+// Makes the listener's accept4 fail the way it would under real load.
+struct fd_exhauster {
+    ~fd_exhauster() {
+        release();
+    }
+    bool exhaust() {
+        for (;;) {
+            const int fd = ::open("/dev/null", O_RDONLY | O_CLOEXEC);
+            if (fd < 0) {
+                return errno == EMFILE || errno == ENFILE;
+            }
+            held.push_back(fd);
+        }
+    }
+    void release() {
+        for (const int fd : held) {
+            ::close(fd);
+        }
+        held.clear();
+    }
+    std::vector<int> held;
+};
+
+// An ASSERT returning early must not leak a descriptor: this binary exhausts the table below.
+struct scoped_fd {
+    explicit scoped_fd(int fd_in) : fd{fd_in} {
+    }
+    scoped_fd(scoped_fd const&) = delete;
+    scoped_fd& operator=(scoped_fd const&) = delete;
+    ~scoped_fd() {
+        reset();
+    }
+    void reset() {
+        if (fd >= 0) {
+            ::close(fd);
+            fd = -1;
+        }
+    }
+    int fd;
+};
+
+// Queue a TCP connection on the listener without accepting it.
+int connect_raw(std::uint16_t port) {
+    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    addr.sin_port = htons(port);
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        ::close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+} // namespace
+
+// Plain HTTP into the TLS port fails the accept handshake. Two properties: the endpoint reports a
+// reason text rather than dying silently, and the failure is contained to that connection.
+//
+// Not covered: fd recycling after the deferred close. One connection is in flight at a time, so the
+// deferred remove always drains before the next accept.
+TEST(TlsListener, handshake_failure_reports_and_loop_stays_healthy) {
+    io::event::fd_event_handler ev;
+    io::tls::tls_listener listener(test::listener_test_config());
+    const auto port = listener.listen_port();
+    ASSERT_GT(port, 0u);
+
+    std::atomic<int> err_code{0};
+    std::atomic<bool> got_error{false};
+    std::string err_text;
+    std::atomic<bool> second_rx_fired{false};
+    // Dropped together at the end: the failed endpoint must not be destroyed while the loop is
+    // still tearing its fd down.
+    std::vector<std::unique_ptr<io::tls::tls_server>> conns;
+
+    listener.set_accept_callback([&](std::unique_ptr<io::tls::tls_server> srv, std::string, std::uint16_t) {
+        srv->set_error_handler([&](int code, std::string const& text) {
+            if (code != 0) {
+                err_code = code;
+                err_text = text;
+                got_error = true;
+            }
+        });
+        srv->set_rx_handler([&second_rx_fired](io::tls::tls_server_socket::PayloadT const& payload, auto& self) {
+            second_rx_fired = true;
+            self.tx(payload);
+        });
+        ev.register_event_handler(srv.get());
+        conns.push_back(std::move(srv));
+    });
+    ASSERT_TRUE(ev.register_event_handler(&listener));
+
+    scoped_fd raw{connect_raw(port)};
+    ASSERT_GE(raw.fd, 0) << "could not connect to the listener";
+    const std::string junk = "GET / HTTP/1.1\r\n\r\n";
+    ASSERT_EQ(::write(raw.fd, junk.data(), junk.size()), static_cast<ssize_t>(junk.size()));
+
+    EXPECT_TRUE(test::pump_until(
+        ev, [&] { return got_error.load(); }, 5s))
+        << "the failed handshake was never reported";
+    raw.reset();
+
+    // libtls collapses every handshake error into result_t::closed, so a terminal accept surfaces as
+    // ECONNRESET, not EPROTO. fail() substitutes the same ECONNRESET for a code of 0, so only the
+    // reason text below proves the socket recorded the failure at all.
+    EXPECT_EQ(err_code.load(), ECONNRESET) << "unexpected errno for a terminal accept handshake";
+    EXPECT_FALSE(err_text.empty()) << "handshake failure reported no reason";
+
+    std::atomic<bool> client_ok{false};
+    std::string client_error;
+    std::thread client_thread(
+        [&]() { test::run_blocking_echo_client("127.0.0.1", port, kPayload, client_ok, client_error); });
+
+    const bool served = test::pump_until(
+        ev, [&] { return second_rx_fired && client_ok; }, 5s);
+    client_thread.join();
+
+    EXPECT_TRUE(served) << "the loop did not serve a good client after the failed handshake: " << client_error;
+    EXPECT_TRUE(client_ok) << "client round-trip did not complete: " << client_error;
+    // The echo alone does not say the listener accepted again: pin the second accept directly.
+    EXPECT_EQ(conns.size(), 2u) << "the listener did not accept a second connection";
+
+    ev.unregister_event_handler(&listener);
+    conns.clear();
+}
+
+// Descriptor exhaustion leaves the connection queued, so the listen fd stays readable and the loop
+// wakes on it every poll. The listener has to drain that connection to stay live.
+TEST(TlsListener, descriptor_exhaustion_does_not_spin_the_loop) {
+    io::event::fd_event_handler ev;
+    io::tls::tls_listener listener(test::listener_test_config());
+    const auto port = listener.listen_port();
+    ASSERT_GT(port, 0u);
+
+    std::atomic<int> error_calls{0};
+    std::atomic<int> last_code{0};
+    std::atomic<int> accepted{0};
+    listener.set_error_handler([&](int code, std::string const&) {
+        last_code = code;
+        ++error_calls;
+    });
+    listener.set_accept_callback([&](std::unique_ptr<io::tls::tls_server>, std::string, std::uint16_t) { ++accepted; });
+    ASSERT_TRUE(ev.register_event_handler(&listener));
+
+    scoped_fd queued{connect_raw(port)};
+    ASSERT_GE(queued.fd, 0) << "could not queue a connection on the listener";
+
+    fd_exhauster hogs;
+    ASSERT_TRUE(hogs.exhaust()) << "could not exhaust the descriptor table";
+
+    constexpr int polls = 10;
+    for (int i = 0; i < polls; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+
+    hogs.release();
+
+    EXPECT_GE(error_calls.load(), 1) << "descriptor exhaustion was never reported";
+    EXPECT_LT(error_calls.load(), polls) << "the listener reported once per poll, so the queued "
+                                            "connection was never drained and the loop is spinning";
+    EXPECT_TRUE(last_code.load() == EMFILE || last_code.load() == ENFILE)
+        << "unexpected errno reported: " << last_code.load();
+
+    queued.reset();
+
+    scoped_fd second{connect_raw(port)};
+    ASSERT_GE(second.fd, 0);
+    EXPECT_TRUE(test::pump_until(
+        ev, [&] { return accepted.load() > 0; }, 5s))
+        << "the listener never accepted again after recovering from exhaustion";
+    second.reset();
+
+    ev.unregister_event_handler(&listener);
+}

--- a/lib/everest/io/test/tls_server_socket_test.cpp
+++ b/lib/everest/io/test/tls_server_socket_test.cpp
@@ -1,0 +1,1401 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include "tls_test_common.hpp"
+
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tls/tls_client.hpp>
+// Impl header: these tests instantiate the base with stub sockets of their own.
+#include <everest/io/tls/tls_endpoint_base_impl.hpp>
+#include <everest/io/tls/tls_server.hpp>
+#include <everest/io/tls/tls_server_socket.hpp>
+#include <everest/tls/tls.hpp>
+
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+namespace test = everest::lib::io::test;
+
+/// Exceeds the 4096-byte rx() chunk buffer, so rx() must drain the remainder via has_pending().
+constexpr std::size_t kLargePayload = 10000;
+
+} // namespace
+
+TEST(TlsServer, HandshakeAndExchange) {
+    int listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(listen_fd, 0);
+
+    int opt = 1;
+    ::setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    addr.sin_port = 0;
+    ASSERT_EQ(::bind(listen_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)), 0);
+    ASSERT_EQ(::listen(listen_fd, 1), 0);
+
+    sockaddr_in bound{};
+    socklen_t bound_len = sizeof(bound);
+    ASSERT_EQ(::getsockname(listen_fd, reinterpret_cast<sockaddr*>(&bound), &bound_len), 0);
+    const uint16_t port = ntohs(bound.sin_port);
+    const std::string port_str = std::to_string(port);
+
+    auto cfg = test::server_test_config();
+    cfg.host = "127.0.0.1";
+    cfg.service = port_str.c_str();
+    cfg.ipv6_only = false;
+    cfg.socket = listen_fd; // bypass init_socket()
+
+    tls::Server server;
+    const auto state = server.init(cfg, nullptr);
+    ASSERT_NE(state, tls::Server::state_t::init_needed)
+        << "tls::Server::init failed: check that server_chain.pem etc. exist "
+           "in the working directory (lib/everest/tls/tests in the build tree).";
+
+    std::vector<uint8_t> msg(kLargePayload);
+    for (std::size_t i = 0; i < msg.size(); ++i) {
+        msg[i] = static_cast<uint8_t>(i & 0xFF);
+    }
+    std::atomic<bool> client_ok{false};
+    std::string client_error;
+    std::thread client_thread(
+        [&]() { test::run_blocking_echo_client("127.0.0.1", port, msg, client_ok, client_error); });
+
+    sockaddr peer{};
+    socklen_t peer_len = sizeof(peer);
+    int accepted_fd = ::accept(listen_fd, &peer, &peer_len);
+    ASSERT_GE(accepted_fd, 0);
+
+    char ip_buf[NI_MAXHOST] = "127.0.0.1";
+    char svc_buf[NI_MAXSERV] = "0";
+    ::getnameinfo(&peer, peer_len, ip_buf, sizeof ip_buf, svc_buf, sizeof svc_buf, NI_NUMERICHOST | NI_NUMERICSERV);
+
+    auto conn = server.wrap_accepted_fd(accepted_fd, ip_buf, svc_buf);
+    ASSERT_TRUE(conn) << "wrap_accepted_fd returned nullptr";
+
+    // The handler must outlive the endpoint, whose dtor unregisters from it, so declare it first.
+    everest::lib::io::event::fd_event_handler ev;
+    everest::lib::io::tls::tls_server srv(std::move(conn));
+
+    std::atomic<bool> rx_fired{false};
+    std::vector<std::uint8_t> in_buf;
+
+    srv.set_rx_handler(
+        [&in_buf, &rx_fired](everest::lib::io::tls::tls_server_socket::PayloadT const& payload, auto& self) {
+            rx_fired = true;
+            in_buf.insert(in_buf.end(), payload.begin(), payload.end());
+            self.tx(payload);
+        });
+    ASSERT_TRUE(ev.register_event_handler(&srv));
+
+    // Stopping when the server merely RECEIVES would race the not-yet-drained echo write.
+    test::pump_until(
+        ev, [&] { return client_ok.load(); }, 5s);
+
+    client_thread.join();
+    ::close(listen_fd);
+
+    EXPECT_TRUE(rx_fired) << "server-side rx handler did not fire";
+    ASSERT_EQ(in_buf.size(), kLargePayload) << "rx() did not drain all buffered TLS records in one call";
+    for (std::size_t i = 0; i < in_buf.size(); ++i) {
+        ASSERT_EQ(in_buf[i], static_cast<uint8_t>(i & 0xFF)) << "payload corruption at index " << i;
+    }
+    EXPECT_TRUE(client_ok) << "Client error: " << client_error;
+}
+
+namespace {
+
+/// Returns the client's connection fd, or -1 when the round trip did not complete.
+int reset_peer_after_round_trip(everest::lib::io::event::fd_event_handler& ev, test::echo_listener& rig) {
+    everest::lib::io::tls::tls_client client(test::client_test_config(), std::string("127.0.0.1"), rig.port(), 2000);
+    std::atomic<bool> got_echo{false};
+    const everest::lib::io::tls::tls_client_socket::PayloadT ping = {'p', 'i', 'n', 'g'};
+    client.set_on_ready_action([&client, &ping]() { client.tx(ping); });
+    client.set_rx_handler([&got_echo](everest::lib::io::tls::tls_client_socket::PayloadT const&,
+                                      everest::lib::io::tls::tls_client_interface&) { got_echo = true; });
+    if (not ev.register_event_handler(&client)) {
+        return -1;
+    }
+    if (not test::pump_until(
+            ev, [&] { return got_echo.load(); }, 5s)) {
+        ev.unregister_event_handler(&client);
+        return -1;
+    }
+    auto const& handle = client.get_raw_handler();
+    const int client_fd = handle ? handle->get_fd() : -1;
+    if (client_fd >= 0) {
+        // Zero linger emits an RST instead of a graceful close_notify.
+        struct linger lo {
+            1, 0
+        };
+        ::setsockopt(client_fd, SOL_SOCKET, SO_LINGER, &lo, sizeof(lo));
+    }
+    ev.unregister_event_handler(&client);
+    return client_fd;
+}
+
+} // namespace
+
+// A peer RST leaves the socket with m_last_error 0, and every shipped consumer ignores the callback
+// via `if (err != 0)`, so an unresolved 0 strands the endpoint dead but silent.
+TEST(TlsServer, poll_error_delivers_nonzero_code) {
+    everest::lib::io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    ASSERT_TRUE(rig.registered);
+    ASSERT_GT(rig.port(), 0u) << "listener bound to port 0 unexpectedly";
+
+    std::atomic<bool> got_error{false};
+    std::atomic<int> err_code{-1};
+    ASSERT_GE(reset_peer_after_round_trip(ev, rig), 0) << "the round trip did not complete within 5 seconds";
+    ASSERT_NE(rig.server_conn, nullptr) << "the listener never accepted a connection";
+    rig.server_conn->set_error_handler([&](int err, std::string const&) {
+        err_code = err;
+        got_error = true;
+    });
+
+    ASSERT_TRUE(test::pump_until(
+        ev, [&] { return got_error.load(); }, 5s))
+        << "the server endpoint never reported the peer reset";
+    EXPECT_NE(err_code.load(), 0) << "the endpoint error callback received code 0 on the poll-error path";
+}
+
+namespace {
+
+struct stub_socket {
+    int get_error() const {
+        return error;
+    }
+    std::string const& get_error_string() const {
+        return text;
+    }
+    std::function<void()> release_closer() {
+        return []() {};
+    }
+    void close() {
+    }
+    int error{0};
+    std::string text;
+};
+
+struct poll_error_probe : everest::lib::io::tls::tls_endpoint_base<stub_socket> {
+    bool start(everest::lib::io::event::fd_event_handler&) override {
+        return true;
+    }
+    void stop() override {
+    }
+    int probe(int fd) {
+        return consume_poll_error(fd);
+    }
+    void set_socket_error(int error) {
+        m_socket.error = error;
+    }
+};
+
+// The connection-fd dispatch lambda names all of these, so they must exist even for a probe that
+// never dispatches.
+struct monitor_stub_socket {
+    int get_error() const {
+        return 0;
+    }
+    std::string const& get_error_string() const {
+        return text;
+    }
+    bool handshake_complete() const {
+        return true;
+    }
+    bool is_open() const {
+        return true;
+    }
+    bool handshake_step() {
+        return true;
+    }
+    bool rx(std::vector<std::uint8_t>&) {
+        return false;
+    }
+    bool tx(std::vector<std::uint8_t>&) {
+        return true;
+    }
+    everest::lib::io::event::poll_events desired_events() const {
+        return everest::lib::io::event::poll_events::read;
+    }
+    void close() {
+    }
+    std::function<void()> release_closer() {
+        return []() {};
+    }
+    std::string text;
+};
+
+struct monitor_probe : everest::lib::io::tls::tls_endpoint_base<monitor_stub_socket> {
+    explicit monitor_probe(int fd) : m_start_fd(fd) {
+    }
+    bool start(everest::lib::io::event::fd_event_handler& handler) override {
+        return register_connection_fd(handler, m_start_fd, everest::lib::io::event::poll_events::read);
+    }
+    void stop() override {
+    }
+    bool monitor(int fd) {
+        return monitor_for(fd, everest::lib::io::event::poll_events::read);
+    }
+    int m_start_fd;
+};
+
+// Both success paths reset m_desired to read, mirroring tls_socket_base, so the stub cannot produce
+// a completed operation that still wants the descriptor writable. That is why no loop-driven test
+// reaches the routing table's `none` rows paired with a write want; the table walk sets m_desired
+// directly instead. Should production stop resetting there, this stub has to follow.
+struct steady_state_stub_socket {
+    using poll_events = everest::lib::io::event::poll_events;
+
+    int get_error() const {
+        return 0;
+    }
+    std::string const& get_error_string() const {
+        return text;
+    }
+    // Counted here because an rx/tx counter cannot see a loop spinning on an empty queue plus a
+    // monitored write, which calls neither.
+    bool handshake_complete() const {
+        ++dispatches;
+        return true;
+    }
+    bool is_open() const {
+        return true;
+    }
+    bool handshake_step() {
+        return true;
+    }
+    bool rx(std::vector<std::uint8_t>& buffer) {
+        ++rx_calls;
+        if (rx_succeeds) {
+            buffer.assign({'r'});
+            m_desired = poll_events::read;
+            return true;
+        }
+        m_desired = rx_wants;
+        return false;
+    }
+    bool tx(std::vector<std::uint8_t>& payload) {
+        ++tx_calls;
+        if (tx_succeeds) {
+            payload.clear();
+            m_desired = poll_events::read;
+            return true;
+        }
+        m_desired = tx_wants;
+        return false;
+    }
+    poll_events desired_events() const {
+        return m_desired;
+    }
+    void close() {
+    }
+    std::function<void()> release_closer() {
+        return []() {};
+    }
+
+    poll_events rx_wants{poll_events::write};
+    poll_events tx_wants{poll_events::read};
+    bool tx_succeeds{false};
+    bool rx_succeeds{false};
+    poll_events m_desired{poll_events::read};
+    int rx_calls{0};
+    int tx_calls{0};
+    mutable int dispatches{0};
+    std::string text;
+};
+
+struct steady_state_probe : everest::lib::io::tls::tls_endpoint_base<steady_state_stub_socket> {
+    explicit steady_state_probe(int fd) : m_start_fd(fd) {
+    }
+    bool start(everest::lib::io::event::fd_event_handler& handler) override {
+        return register_connection_fd(handler, m_start_fd, everest::lib::io::event::poll_events::read);
+    }
+    void stop() override {
+    }
+    steady_state_stub_socket& socket() {
+        return m_socket;
+    }
+    std::size_t queue_depth() const {
+        return m_tx_buffer.size();
+    }
+    bool request_the_mask_already_held() {
+        return monitor_for(m_start_fd, everest::lib::io::event::poll_events::read);
+    }
+    using everest::lib::io::tls::tls_endpoint_base<steady_state_stub_socket>::direction;
+    bool route(direction blocked) {
+        return route_desired_events(m_start_fd, blocked);
+    }
+    bool monitors_read() const {
+        return m_monitored_read;
+    }
+    bool monitors_write() const {
+        return m_monitored_write;
+    }
+    void set_queue_depth(std::size_t depth) {
+        while (m_tx_buffer.size() > depth) {
+            m_tx_buffer.pop();
+        }
+        while (m_tx_buffer.size() < depth) {
+            m_tx_buffer.push({'a'});
+        }
+    }
+    int m_start_fd;
+};
+
+} // namespace
+
+TEST(TlsEndpointBase, poll_error_prefers_the_socket_error) {
+    int fds[2]{-1, -1};
+    ASSERT_EQ(::pipe(fds), 0);
+    poll_error_probe probe;
+    probe.set_socket_error(EPIPE);
+
+    EXPECT_EQ(probe.probe(fds[0]), EPIPE);
+
+    ::close(fds[0]);
+    ::close(fds[1]);
+}
+
+// The endpoint always sits on a real socket, so the last rung names a network errno rather than
+// deriving one from the notification kind.
+TEST(TlsEndpointBase, poll_error_without_a_code_reports_connection_reset) {
+    // Not a socket, so getsockopt fails and the ladder falls through to its last rung.
+    int fds[2]{-1, -1};
+    ASSERT_EQ(::pipe(fds), 0);
+    poll_error_probe probe;
+
+    const int code = probe.probe(fds[0]);
+    EXPECT_EQ(code, ECONNRESET) << "the fallback resolved to " << std::strerror(code);
+
+    ::close(fds[0]);
+    ::close(fds[1]);
+}
+
+namespace everest::lib::io::tls {
+// Test seam without friendship: a derived class may name a protected member of its base, and the
+// resulting pointer to member applies to any tls_server. Never instantiated.
+struct endpoint_peek : tls_server {
+    static int connection_fd(tls_server& endpoint) {
+        return endpoint.*(&endpoint_peek::m_fd);
+    }
+    static int tx_notify_fd(tls_server& endpoint) {
+        return (endpoint.*(&endpoint_peek::m_tx_notify)).get_raw_fd();
+    }
+    static std::size_t tx_queue_depth(tls_server& endpoint) {
+        return (endpoint.*(&endpoint_peek::m_tx_buffer)).size();
+    }
+    static everest::lib::io::event::poll_events desired_events(tls_server& endpoint) {
+        return (endpoint.*(&endpoint_peek::m_socket)).desired_events();
+    }
+    // The error report is deferred, so the callback cannot mark the moment fail() ran.
+    static bool errored(tls_server& endpoint) {
+        return endpoint.*(&endpoint_peek::m_errored);
+    }
+};
+} // namespace everest::lib::io::tls
+
+// ~tls_server() is the only backstop: fd_event_register_interface records nothing and defaults its
+// destructor, so any further endpoint derived from it needs its own.
+TEST(TlsServer, drop_registered_server_unregisters_fds) {
+    everest::lib::io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    ASSERT_TRUE(rig.registered);
+    ASSERT_GT(rig.port(), 0u) << "listener bound to port 0 unexpectedly";
+
+    int conn_fd = -1;
+    int notify_fd = -1;
+    {
+        everest::lib::io::tls::tls_client client(test::client_test_config(), std::string("127.0.0.1"), rig.port(),
+                                                 2000);
+        std::atomic<bool> ready{false};
+        client.set_on_ready_action([&ready]() { ready = true; });
+        ASSERT_TRUE(ev.register_event_handler(&client));
+        ASSERT_TRUE(test::pump_until(
+            ev, [&] { return ready.load(); }, 5s))
+            << "the handshake did not complete within 5 seconds";
+        ASSERT_NE(rig.server_conn, nullptr) << "the listener never accepted a connection";
+
+        conn_fd = everest::lib::io::tls::endpoint_peek::connection_fd(*rig.server_conn);
+        notify_fd = everest::lib::io::tls::endpoint_peek::tx_notify_fd(*rig.server_conn);
+        ASSERT_GE(conn_fd, 0);
+        ASSERT_GE(notify_fd, 0);
+
+        EXPECT_FALSE(ev.register_event_handler(rig.server_conn.get()))
+            << "a second register on a live endpoint must be rejected, not restart it";
+
+        // Drop WITHOUT unregister: the destructor has to clean up after itself.
+        rig.server_conn.reset();
+        ev.unregister_event_handler(&client);
+    }
+
+    // Nothing below opens new fds, so both numbers stay closed but unclaimed.
+    for (int i = 0; i < 5; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+
+    EXPECT_FALSE(ev.is_registered(conn_fd)) << "connection fd still registered after dropping the endpoint";
+    EXPECT_FALSE(ev.is_registered(notify_fd)) << "tx-notify eventfd still registered after dropping the endpoint";
+}
+
+// A synchronous close would let an accept in the same poll batch recycle the fd number, and the
+// queued remove-by-number would then strand the new connection.
+TEST(TlsServer, endpoint_failure_defers_fd_close_until_after_unregister) {
+    everest::lib::io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    ASSERT_TRUE(rig.registered);
+    ASSERT_GT(rig.port(), 0u) << "listener bound to port 0 unexpectedly";
+
+    std::atomic<bool> server_error{false};
+    ASSERT_GE(reset_peer_after_round_trip(ev, rig), 0) << "the round trip did not complete within 5 seconds";
+    ASSERT_NE(rig.server_conn, nullptr) << "the listener never accepted a connection";
+    const int conn_fd = everest::lib::io::tls::endpoint_peek::connection_fd(*rig.server_conn);
+    ASSERT_GE(conn_fd, 0);
+    rig.server_conn->set_error_handler([&server_error](int err, std::string const&) {
+        if (err != 0) {
+            server_error = true;
+        }
+    });
+
+    bool checked_open = false;
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (std::chrono::steady_clock::now() < deadline && !checked_open) {
+        ev.poll(50ms);
+        // Probe the state, not the callback: the report is deferred and fires too late for this.
+        if (everest::lib::io::tls::endpoint_peek::errored(*rig.server_conn)) {
+            // fail() ran in this pass, before run_actions() drains the queued remove.
+            EXPECT_NE(::fcntl(conn_fd, F_GETFD), -1)
+                << "connection fd was closed synchronously in fail() (recycle race window)";
+            EXPECT_FALSE(server_error.load())
+                << "the error report reached the handler inside fail(), so a consumer that drops the "
+                   "endpoint there resumes on freed memory";
+            checked_open = true;
+        }
+        ev.run_actions();
+    }
+    ASSERT_TRUE(checked_open) << "the server endpoint never failed";
+
+    EXPECT_EQ(::fcntl(conn_fd, F_GETFD), -1) << "connection fd still open after run_actions()";
+    EXPECT_FALSE(ev.is_registered(conn_fd)) << "connection fd still registered after the deferred teardown";
+    EXPECT_TRUE(server_error.load()) << "the deferred error report never reached the handler";
+}
+
+TEST(TlsEndpointBase, monitoring_an_unregistered_fd_reports_failure) {
+    int fds[2]{-1, -1};
+    ASSERT_EQ(::pipe(fds), 0);
+    everest::lib::io::event::fd_event_handler ev;
+    monitor_probe probe(fds[0]);
+    ASSERT_TRUE(ev.register_event_handler(&probe)) << "the probe's own connection fd was rejected";
+
+    EXPECT_FALSE(probe.monitor(fds[1])) << "monitoring a descriptor outside the handler reported success";
+
+    ev.unregister_event_handler(&probe);
+    ::close(fds[0]);
+    ::close(fds[1]);
+}
+
+// epoll rejects a regular file with EPERM, so the connection fd never reaches the handler and
+// registration must say so rather than report the unrelated success of its tx-notify fd.
+TEST(TlsEndpointBase, register_reports_failure_when_the_connection_fd_is_rejected) {
+    char path[] = "/tmp/everest_io_tls_endpoint_XXXXXX";
+    const int file_fd = ::mkstemp(path);
+    ASSERT_GE(file_fd, 0);
+    ::unlink(path);
+
+    everest::lib::io::event::fd_event_handler ev;
+    monitor_probe probe(file_fd);
+
+    EXPECT_FALSE(ev.register_event_handler(&probe))
+        << "registration reported success though the connection fd was rejected";
+
+    ev.unregister_event_handler(&probe);
+    ::close(file_fd);
+}
+
+// A post-handshake SSL_read may want the descriptor writable (a rekey has a record to flush). The
+// descriptor is held unwritable for the whole window on purpose, which pins the routing decision
+// rather than what happens after it.
+TEST(TlsEndpointBase, rx_wanting_write_routes_the_monitored_event) {
+    int fds[2]{-1, -1};
+    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    ASSERT_NE(::fcntl(fds[0], F_SETFL, O_NONBLOCK), -1);
+    ASSERT_NE(::fcntl(fds[1], F_SETFL, O_NONBLOCK), -1);
+
+    const std::vector<char> filler(4096, 'f');
+    std::size_t filled = 0;
+    while (::write(fds[0], filler.data(), filler.size()) > 0) {
+        filled += filler.size();
+    }
+    ASSERT_EQ(errno, EAGAIN);
+    ASSERT_GT(filled, 0u) << "the socketpair accepted nothing, so it was never writable";
+
+    everest::lib::io::event::fd_event_handler ev;
+    steady_state_probe probe(fds[0]);
+    ASSERT_TRUE(ev.register_event_handler(&probe));
+
+    // The stub never consumes it, so the descriptor stays readable while read is monitored.
+    const char byte = 'x';
+    ASSERT_EQ(::write(fds[1], &byte, 1), 1);
+
+    for (int i = 0; i < 10; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+
+    EXPECT_EQ(probe.socket().rx_calls, 1)
+        << "rx() answered want_write but read stayed monitored, so the loop re-drove it " << probe.socket().rx_calls
+        << " times";
+
+    // A tx() must not re-arm read behind the routing decision that just dropped it: rx() still
+    // answers want_write, so read back on is the same re-drive.
+    ASSERT_TRUE(probe.tx({'a'}));
+    for (int i = 0; i < 10; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+    EXPECT_EQ(probe.socket().rx_calls, 1) << "tx() re-armed read on a descriptor whose rx() answers want_write, so "
+                                             "the loop re-drove the receive "
+                                          << probe.socket().rx_calls << " times";
+
+    ev.unregister_event_handler(&probe);
+    ::close(fds[0]);
+    ::close(fds[1]);
+}
+
+// A TLS record split across TCP segments makes SSL_read answer want_read on a descriptor that did
+// report readable. This is the common case, so dropping POLLOUT here strands queues routinely.
+TEST(TlsEndpointBase, a_receive_would_block_keeps_a_queued_payload_monitored) {
+    int fds[2]{-1, -1};
+    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    ASSERT_NE(::fcntl(fds[0], F_SETFL, O_NONBLOCK), -1);
+    ASSERT_NE(::fcntl(fds[1], F_SETFL, O_NONBLOCK), -1);
+
+    // Fill the endpoint's send buffer so its descriptor is readable but not writable, which keeps
+    // the read and the write dispatch in separate poll passes.
+    const std::vector<char> filler(4096, 'f');
+    std::size_t filled = 0;
+    while (::write(fds[0], filler.data(), filler.size()) > 0) {
+        filled += filler.size();
+    }
+    ASSERT_EQ(errno, EAGAIN);
+    ASSERT_GT(filled, 0u) << "the socketpair accepted nothing, so it was never writable";
+
+    everest::lib::io::event::fd_event_handler ev;
+    steady_state_probe probe(fds[0]);
+    probe.socket().rx_wants = everest::lib::io::event::poll_events::read;
+    probe.socket().tx_succeeds = true;
+    ASSERT_TRUE(ev.register_event_handler(&probe));
+    ASSERT_TRUE(probe.tx({'a'}));
+
+    const char byte = 'x';
+    ASSERT_EQ(::write(fds[1], &byte, 1), 1);
+    for (int i = 0; i < 10; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+    ASSERT_GT(probe.socket().rx_calls, 0) << "the receive never ran";
+    ASSERT_EQ(probe.socket().tx_calls, 0) << "the descriptor became writable too early to prove anything";
+
+    std::vector<char> sink(filler.size());
+    while (::read(fds[1], sink.data(), sink.size()) > 0) {
+    }
+    ASSERT_EQ(errno, EAGAIN);
+    for (int i = 0; i < 10; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+
+    EXPECT_EQ(probe.socket().tx_calls, 1) << "the queued payload was stranded: a receive would-block "
+                                             "dropped POLLOUT even though the tx buffer was not empty";
+
+    ev.unregister_event_handler(&probe);
+    ::close(fds[0]);
+    ::close(fds[1]);
+}
+
+// The mirror case: a post-handshake SSL_write may want the descriptor readable.
+TEST(TlsEndpointBase, tx_wanting_read_routes_the_monitored_event) {
+    int fds[2]{-1, -1};
+    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    everest::lib::io::event::fd_event_handler ev;
+    steady_state_probe probe(fds[0]);
+    ASSERT_TRUE(ev.register_event_handler(&probe));
+    // Nothing is written to fds[1], so read never fires and only the tx path runs.
+    ASSERT_TRUE(probe.tx({'a'}));
+
+    for (int i = 0; i < 10; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+
+    EXPECT_EQ(probe.socket().tx_calls, 1)
+        << "tx() answered want_read but write stayed monitored, so the loop re-drove it " << probe.socket().tx_calls
+        << " times";
+
+    ev.unregister_event_handler(&probe);
+    ::close(fds[0]);
+    ::close(fds[1]);
+}
+
+// An SSL_write answering want_write means only a full kernel send buffer and says nothing about the
+// receive side. Dropping POLLIN there deadlocks against a peer that writes before it reads.
+TEST(TlsEndpointBase, a_send_would_block_keeps_read_monitored) {
+    int fds[2]{-1, -1};
+    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    everest::lib::io::event::fd_event_handler ev;
+    steady_state_probe probe(fds[0]);
+    probe.socket().rx_wants = everest::lib::io::event::poll_events::read;
+    probe.socket().tx_wants = everest::lib::io::event::poll_events::write;
+    ASSERT_TRUE(ev.register_event_handler(&probe));
+    ASSERT_TRUE(probe.tx({'a'}));
+
+    for (int i = 0; i < 10; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+    ASSERT_GT(probe.socket().tx_calls, 0) << "the send never ran, so nothing blocked on writability";
+    ASSERT_EQ(probe.socket().m_desired, everest::lib::io::event::poll_events::write)
+        << "the send did not leave the socket wanting the descriptor writable";
+    ASSERT_EQ(probe.socket().rx_calls, 0) << "the receive ran before the peer sent anything";
+
+    const char byte = 'x';
+    ASSERT_EQ(::write(fds[1], &byte, 1), 1);
+    for (int i = 0; i < 10; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+
+    EXPECT_GT(probe.socket().rx_calls, 0)
+        << "a send blocked on writability dropped POLLIN, so the peer's payload was never received";
+
+    ev.unregister_event_handler(&probe);
+    ::close(fds[0]);
+    ::close(fds[1]);
+}
+
+// A completed send leaves the socket's need at read, the same value a send parked on readability
+// reports. Reading the completed one as parked drops POLLOUT, and only tx() re-arms it.
+TEST(TlsEndpointBase, a_completed_send_keeps_the_rest_of_the_queue_monitored) {
+    int fds[2]{-1, -1};
+    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    everest::lib::io::event::fd_event_handler ev;
+    steady_state_probe probe(fds[0]);
+    probe.socket().tx_succeeds = true;
+    ASSERT_TRUE(ev.register_event_handler(&probe));
+    ASSERT_TRUE(probe.tx({'a'}));
+    ASSERT_TRUE(probe.tx({'b'}));
+
+    for (int i = 0; i < 10; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+
+    EXPECT_EQ(probe.queue_depth(), 0u) << "the drain stopped after the first payload: a completed send dropped "
+                                          "POLLOUT while the queue still held "
+                                       << probe.queue_depth();
+    EXPECT_EQ(probe.socket().tx_calls, 2);
+
+    ev.unregister_event_handler(&probe);
+    ::close(fds[0]);
+    ::close(fds[1]);
+}
+
+// The write dispatch calls no socket operation on an empty queue, so nothing can move the desired
+// event off write.
+TEST(TlsEndpointBase, an_unsatisfiable_write_want_does_not_spin_the_loop) {
+    int fds[2]{-1, -1};
+    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    ASSERT_NE(::fcntl(fds[0], F_SETFL, O_NONBLOCK), -1);
+    everest::lib::io::event::fd_event_handler ev;
+    steady_state_probe probe(fds[0]);
+    probe.socket().rx_wants = everest::lib::io::event::poll_events::write;
+    ASSERT_TRUE(ev.register_event_handler(&probe));
+
+    const char byte = 'x';
+    ASSERT_EQ(::write(fds[1], &byte, 1), 1);
+    for (int i = 0; i < 10 && probe.socket().rx_calls == 0; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+    ASSERT_GT(probe.socket().rx_calls, 0) << "the receive never ran";
+    ASSERT_EQ(probe.socket().m_desired, everest::lib::io::event::poll_events::write);
+    ASSERT_EQ(probe.queue_depth(), 0u);
+
+    // Consume the byte the stub never read, so read alone would leave the loop idle in epoll_wait.
+    char sink = 0;
+    ASSERT_EQ(::read(fds[0], &sink, 1), 1);
+
+    // One write dispatch is due: the receive's want_write put POLLOUT on, and the empty-queue write
+    // dispatch is what takes it back off.
+    ASSERT_TRUE(ev.poll(200ms)) << "the POLLOUT the receive asked for never fired";
+    ev.run_actions();
+
+    // Asserted on the loop, not a socket-call count, which caching the handshake state would zero.
+    // poll() reports false only when it sat in epoll_wait for the whole timeout.
+    probe.socket().dispatches = 0;
+    EXPECT_FALSE(ev.poll(200ms)) << "the loop returned from epoll_wait with nothing to do ("
+                                 << probe.socket().dispatches
+                                 << " connection-fd dispatches): POLLOUT stayed monitored on an always-writable "
+                                    "descriptor with an empty tx buffer";
+
+    ev.unregister_event_handler(&probe);
+    ::close(fds[0]);
+    ::close(fds[1]);
+}
+
+// A send that answered want_read parks the queue behind readability and drops POLLOUT. Only routing
+// puts it back, since the tx-notify fires from tx() alone.
+TEST(TlsEndpointBase, a_receive_success_restores_a_queued_payload) {
+    int fds[2]{-1, -1};
+    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    everest::lib::io::event::fd_event_handler ev;
+    steady_state_probe probe(fds[0]);
+    probe.socket().tx_wants = everest::lib::io::event::poll_events::read;
+    ASSERT_TRUE(ev.register_event_handler(&probe));
+    ASSERT_TRUE(probe.tx({'a'}));
+
+    for (int i = 0; i < 10; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+    ASSERT_EQ(probe.socket().tx_calls, 1) << "the send did not park on readability";
+    ASSERT_EQ(probe.queue_depth(), 1u);
+
+    // The rx handler is unset, so nothing replies and routing is the only thing that can recover.
+    probe.socket().rx_succeeds = true;
+    probe.socket().tx_succeeds = true;
+    const char byte = 'x';
+    ASSERT_EQ(::write(fds[1], &byte, 1), 1);
+    for (int i = 0; i < 10; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+
+    ASSERT_GT(probe.socket().rx_calls, 0) << "the receive never ran";
+    EXPECT_EQ(probe.queue_depth(), 0u) << "a successful receive left the queued payload stranded: POLLOUT was "
+                                          "dropped by the send would-block and never restored";
+
+    ev.unregister_event_handler(&probe);
+    ::close(fds[0]);
+    ::close(fds[1]);
+}
+
+// A descriptor monitored for nothing never dispatches again, reports no error and hits no timeout.
+// No row reaching the loop would notice an edit breaking that, so the table is walked directly.
+TEST(TlsEndpointBase, no_routing_decision_leaves_the_descriptor_unmonitored) {
+    using poll_events = everest::lib::io::event::poll_events;
+    using dir = steady_state_probe::direction;
+
+    int fds[2]{-1, -1};
+    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    everest::lib::io::event::fd_event_handler ev;
+    steady_state_probe probe(fds[0]);
+    ASSERT_TRUE(ev.register_event_handler(&probe));
+
+    for (auto queued : {std::size_t{0}, std::size_t{1}}) {
+        for (auto wants : {poll_events::read, poll_events::write}) {
+            for (auto who : {dir::receive, dir::send, dir::none}) {
+                probe.set_queue_depth(queued);
+                probe.socket().m_desired = wants;
+                const std::string row = "queued=" + std::to_string(queued) +
+                                        " wants_write=" + std::to_string(wants == poll_events::write) +
+                                        " blocked=" + std::to_string(static_cast<int>(who));
+                EXPECT_TRUE(probe.route(who)) << "the routing decision was rejected: " << row;
+                EXPECT_TRUE(probe.monitors_read() or probe.monitors_write())
+                    << "the descriptor was left monitored for nothing, so nothing will ever dispatch it "
+                       "again: "
+                    << row;
+            }
+        }
+    }
+
+    probe.set_queue_depth(0);
+    ev.unregister_event_handler(&probe);
+    ::close(fds[0]);
+    ::close(fds[1]);
+}
+
+// The mask cache answers an unchanged request without reaching the handler, but only while the
+// registration it describes exists. Otherwise a future caller ends up with a descriptor monitored
+// for nothing while the endpoint reports healthy.
+TEST(TlsEndpointBase, a_mask_unchanged_request_fails_once_the_fd_is_gone) {
+    int fds[2]{-1, -1};
+    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    everest::lib::io::event::fd_event_handler ev;
+    steady_state_probe probe(fds[0]);
+    ASSERT_TRUE(ev.register_event_handler(&probe));
+
+    ASSERT_TRUE(probe.request_the_mask_already_held()) << "the cache rejected the mask the handler holds";
+
+    // Behind the endpoint's back, so the cache describes a descriptor the handler no longer knows.
+    ASSERT_TRUE(ev.remove_event_handler(fds[0]));
+
+    EXPECT_FALSE(probe.request_the_mask_already_held())
+        << "the mask cache reported success for a descriptor the handler no longer holds";
+
+    ev.unregister_event_handler(&probe);
+    ::close(fds[0]);
+    ::close(fds[1]);
+}
+
+// The tx-notify eventfd is one-shot, drained by the wrapper before the callback runs, so a monitor
+// request that fails there is never retried.
+TEST(TlsEndpointBase, a_failed_tx_notify_monitor_fails_the_endpoint) {
+    int fds[2]{-1, -1};
+    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    everest::lib::io::event::fd_event_handler ev;
+    steady_state_probe probe(fds[0]);
+    ASSERT_TRUE(ev.register_event_handler(&probe));
+
+    std::atomic<int> err_code{0};
+    probe.set_error_handler([&err_code](int err, std::string const&) { err_code = err; });
+    // Behind the endpoint's back, so the notify callback's modify request finds no entry.
+    ASSERT_TRUE(ev.remove_event_handler(fds[0]));
+    ASSERT_TRUE(probe.tx({'a'}));
+
+    for (int i = 0; i < 10 && err_code.load() == 0; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+
+    EXPECT_EQ(err_code.load(), EPROTO) << "a failed tx-notify monitor request left the endpoint reporting healthy "
+                                          "with a queue nothing will drain";
+
+    ev.unregister_event_handler(&probe);
+    ::close(fds[0]);
+    ::close(fds[1]);
+}
+
+namespace {
+
+/// Blocking libtls peer that handshakes and then stops reading, so the server's send buffer backs up
+/// and SSL_write starts answering want_write. Reads only once `drain` is set. Its trailer, sent once
+/// it has everything, proves the endpoint is still monitored for read after the queue drained.
+struct stalled_peer {
+    std::atomic<bool> handshaked{false};
+    std::atomic<bool> probe{false};
+    std::atomic<bool> probe_sent{false};
+    std::atomic<bool> drain{false};
+    std::atomic<bool> failed{false};
+    std::atomic<bool> finished{false};
+    std::atomic<bool> close_now{false};
+    std::size_t expected{0};
+    std::string error;
+    std::vector<std::uint8_t> received;
+};
+
+const std::vector<std::uint8_t> peer_trailer = {'p', 'o', 'n', 'g'};
+
+const std::vector<std::uint8_t> peer_probe = {'p', 'r', 'o', 'b', 'e'};
+
+void run_stalled_peer(std::uint16_t port, stalled_peer& peer) {
+    struct done_guard {
+        stalled_peer& p;
+        ~done_guard() {
+            p.finished = true;
+        }
+    } guard{peer};
+
+    ::tls::Client client;
+    ::tls::Client::config_t ccfg;
+    ccfg.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    ccfg.verify_locations_file = "server_root_cert.pem";
+    ccfg.io_timeout_ms = 5000;
+    ccfg.verify_server = true;
+    if (!client.init(ccfg)) {
+        peer.error = "client.init failed";
+        peer.failed = true;
+        return;
+    }
+
+    const std::string port_str = std::to_string(port);
+    auto conn = client.connect("127.0.0.1", port_str.c_str(), false, 5000);
+    if (!conn || conn->connect() != ::tls::Connection::result_t::success) {
+        peer.error = "TLS handshake failed on peer side";
+        peer.failed = true;
+        return;
+    }
+
+    // Do not shrink the receive buffer to back the endpoint up sooner: that throttles the drain to a
+    // few KiB per poll and the test stops being about the endpoint. Not reading is enough.
+    peer.handshaked = true;
+
+    // Sending while still not reading is the shape that deadlocks an endpoint which drops POLLIN
+    // whenever its own send wants the descriptor writable.
+    while (!peer.probe.load() && !peer.drain.load()) {
+        std::this_thread::sleep_for(2ms);
+    }
+    if (peer.probe.load()) {
+        std::size_t sent = 0;
+        if (conn->write(reinterpret_cast<const std::byte*>(peer_probe.data()), peer_probe.size(), sent, 5000) !=
+            ::tls::Connection::result_t::success) {
+            peer.error = "peer probe write failed";
+            peer.failed = true;
+            return;
+        }
+        peer.probe_sent = true;
+    }
+
+    while (!peer.drain.load()) {
+        std::this_thread::sleep_for(2ms);
+    }
+
+    while (peer.received.size() < peer.expected) {
+        std::byte buf[8192]{};
+        std::size_t nread = 0;
+        if (conn->read(buf, sizeof buf, nread, 5000) != ::tls::Connection::result_t::success) {
+            peer.error = "peer read failed after " + std::to_string(peer.received.size()) + " bytes";
+            peer.failed = true;
+            return;
+        }
+        peer.received.insert(peer.received.end(), reinterpret_cast<std::uint8_t*>(buf),
+                             reinterpret_cast<std::uint8_t*>(buf) + nread);
+    }
+
+    std::size_t written = 0;
+    if (conn->write(reinterpret_cast<const std::byte*>(peer_trailer.data()), peer_trailer.size(), written, 5000) !=
+        ::tls::Connection::result_t::success) {
+        peer.error = "peer trailer write failed";
+        peer.failed = true;
+        return;
+    }
+
+    // A close_notify here would fail the endpoint before the test can tell a stranded read apart
+    // from a peer that simply hung up.
+    while (!peer.close_now.load()) {
+        std::this_thread::sleep_for(2ms);
+    }
+    conn->shutdown();
+}
+
+/// Keyed on its index, so a reordered delivery is visible in the byte stream, not just the length.
+std::vector<std::uint8_t> indexed_payload(std::size_t index, std::size_t size) {
+    std::vector<std::uint8_t> payload(size);
+    for (std::size_t i = 0; i < size; ++i) {
+        payload[i] = static_cast<std::uint8_t>((index * 31 + i) & 0xFF);
+    }
+    return payload;
+}
+
+/// Returns the accepted endpoint's connection fd, or -1 without a completed handshake on both sides.
+int connect_stalled_peer(everest::lib::io::event::fd_event_handler& ev, test::echo_listener& rig, stalled_peer& peer) {
+    if (not test::pump_until(
+            ev, [&] { return peer.handshaked.load() || peer.failed.load(); }, 5s)) {
+        return -1;
+    }
+    if (peer.failed.load()) {
+        return -1;
+    }
+    // The handshake completed with the peer's connect(), but the endpoint still needs a loop tick.
+    if (not test::pump_until(
+            ev, [&] { return rig.server_conn != nullptr; }, 5s)) {
+        return -1;
+    }
+    return everest::lib::io::tls::endpoint_peek::connection_fd(*rig.server_conn);
+}
+
+} // namespace
+
+// libtls never enables SSL_MODE_ENABLE_PARTIAL_WRITE, so a want_write mid-payload means the front
+// payload must be retried byte for byte, and POLLOUT must stay monitored while it is.
+TEST(TlsServer, backpressure_preserves_payload_order) {
+    everest::lib::io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    ASSERT_TRUE(rig.registered);
+    ASSERT_GT(rig.port(), 0u) << "listener bound to port 0 unexpectedly";
+
+    stalled_peer peer;
+    std::thread worker([&]() { run_stalled_peer(rig.port(), peer); });
+    struct joiner {
+        stalled_peer& p;
+        std::thread& t;
+        ~joiner() {
+            p.drain = true;
+            p.close_now = true;
+            if (t.joinable()) {
+                t.join();
+            }
+        }
+    } join_worker{peer, worker};
+
+    const int conn_fd = connect_stalled_peer(ev, rig, peer);
+    ASSERT_GE(conn_fd, 0) << "the stalled peer never reached a live connection: " << peer.error;
+
+    // The kernel floors this well above the requested value; it only has to be small enough that one
+    // payload cannot be absorbed in a single write.
+    int sndbuf = 2048;
+    ASSERT_EQ(::setsockopt(conn_fd, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf)), 0);
+
+    std::atomic<bool> errored{false};
+    rig.server_conn->set_error_handler([&errored](int, std::string const&) { errored = true; });
+    std::vector<std::uint8_t> trailer;
+    rig.server_conn->set_rx_handler(
+        [&trailer](everest::lib::io::tls::tls_server_socket::PayloadT const& payload, auto&) {
+            trailer.insert(trailer.end(), payload.begin(), payload.end());
+        });
+
+    // Too large for the shrunken send buffer, so SSL_write answers want_write mid-payload rather
+    // than the descriptor simply never becoming writable.
+    constexpr std::size_t payload_size = 64 * 1024;
+    constexpr std::size_t min_queued = 3;
+    constexpr std::size_t max_payloads = 64;
+    std::vector<std::uint8_t> expected;
+    std::size_t queued = 0;
+    while (everest::lib::io::tls::endpoint_peek::tx_queue_depth(*rig.server_conn) < min_queued &&
+           queued < max_payloads) {
+        auto payload = indexed_payload(queued, payload_size);
+        ASSERT_TRUE(rig.server_conn->tx(payload)) << "tx() rejected payload " << queued;
+        expected.insert(expected.end(), payload.begin(), payload.end());
+        ++queued;
+        ev.poll(1ms);
+        ev.run_actions();
+    }
+    ASSERT_GE(everest::lib::io::tls::endpoint_peek::tx_queue_depth(*rig.server_conn), min_queued)
+        << "the send path never backed up after " << queued << " payloads of " << payload_size << " bytes";
+    ASSERT_FALSE(errored.load()) << "a backed-up send buffer failed the endpoint instead of queueing";
+    // Without this the test also passes on a peer that merely stopped being writable, which never
+    // reaches SSL_write and pins neither the retry nor the re-arm.
+    ASSERT_EQ(everest::lib::io::tls::endpoint_peek::desired_events(*rig.server_conn),
+              everest::lib::io::event::poll_events::write)
+        << "SSL_write never answered want_write, so the payload was never retried mid-write";
+
+    // The trailer arrives only after the peer read everything, so it proves both that the queue
+    // drained and that the endpoint went back to monitoring read.
+    peer.expected = expected.size();
+    peer.drain = true;
+    ASSERT_TRUE(test::pump_until(
+        ev, [&] { return trailer.size() >= peer_trailer.size() || peer.failed.load(); }, 30s))
+        << "the peer's trailer never arrived, so the endpoint stopped monitoring read once the "
+        << "backed-up tx queue drained"
+        << " [queued=" << queued << " expected=" << expected.size()
+        << " depth=" << everest::lib::io::tls::endpoint_peek::tx_queue_depth(*rig.server_conn)
+        << " desired=" << static_cast<int>(everest::lib::io::tls::endpoint_peek::desired_events(*rig.server_conn))
+        << "]";
+    ASSERT_FALSE(peer.failed.load()) << peer.error;
+    EXPECT_EQ(trailer, peer_trailer);
+    EXPECT_FALSE(errored.load()) << "the endpoint failed while draining a backed-up queue";
+
+    peer.close_now = true;
+    ASSERT_TRUE(test::pump_until(
+        ev, [&] { return peer.finished.load(); }, 10s));
+    worker.join();
+
+    ASSERT_FALSE(peer.failed.load()) << peer.error;
+    ASSERT_EQ(peer.received.size(), expected.size()) << "the drained byte count does not match what was accepted";
+    EXPECT_EQ(peer.received, expected) << "the drained bytes are not the accepted payloads in order";
+}
+
+// The full-duplex shape every request/response client has: write, then read. An endpoint that stops
+// monitoring read while its own send is backed up goes deaf, and against a peer itself blocked
+// writing the queue never drains: no error fires and the connection is frozen for good.
+TEST(TlsServer, a_backed_up_send_still_receives) {
+    everest::lib::io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    ASSERT_TRUE(rig.registered);
+    ASSERT_GT(rig.port(), 0u) << "listener bound to port 0 unexpectedly";
+
+    stalled_peer peer;
+    std::thread worker([&]() { run_stalled_peer(rig.port(), peer); });
+    struct joiner {
+        stalled_peer& p;
+        std::thread& t;
+        ~joiner() {
+            p.probe = true;
+            p.drain = true;
+            p.close_now = true;
+            if (t.joinable()) {
+                t.join();
+            }
+        }
+    } join_worker{peer, worker};
+
+    const int conn_fd = connect_stalled_peer(ev, rig, peer);
+    ASSERT_GE(conn_fd, 0) << "the stalled peer never reached a live connection: " << peer.error;
+
+    int sndbuf = 2048;
+    ASSERT_EQ(::setsockopt(conn_fd, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf)), 0);
+
+    std::atomic<bool> errored{false};
+    rig.server_conn->set_error_handler([&errored](int, std::string const&) { errored = true; });
+    std::vector<std::uint8_t> received;
+    rig.server_conn->set_rx_handler(
+        [&received](everest::lib::io::tls::tls_server_socket::PayloadT const& payload, auto&) {
+            received.insert(received.end(), payload.begin(), payload.end());
+        });
+
+    constexpr std::size_t payload_size = 64 * 1024;
+    constexpr std::size_t min_queued = 3;
+    constexpr std::size_t max_payloads = 64;
+    std::vector<std::uint8_t> expected;
+    std::size_t queued = 0;
+    while (everest::lib::io::tls::endpoint_peek::tx_queue_depth(*rig.server_conn) < min_queued &&
+           queued < max_payloads) {
+        auto payload = indexed_payload(queued, payload_size);
+        ASSERT_TRUE(rig.server_conn->tx(payload)) << "tx() rejected payload " << queued;
+        expected.insert(expected.end(), payload.begin(), payload.end());
+        ++queued;
+        ev.poll(1ms);
+        ev.run_actions();
+    }
+    ASSERT_GE(everest::lib::io::tls::endpoint_peek::tx_queue_depth(*rig.server_conn), min_queued)
+        << "the send path never backed up after " << queued << " payloads of " << payload_size << " bytes";
+    ASSERT_EQ(everest::lib::io::tls::endpoint_peek::desired_events(*rig.server_conn),
+              everest::lib::io::event::poll_events::write)
+        << "SSL_write never answered want_write, so the receive side was never at risk";
+    ASSERT_FALSE(errored.load()) << "a backed-up send buffer failed the endpoint instead of queueing";
+
+    // Without draining anything, so the endpoint's send buffer stays full for the whole window.
+    peer.probe = true;
+    ASSERT_TRUE(test::pump_until(
+        ev, [&] { return peer.probe_sent.load() || peer.failed.load(); }, 5s))
+        << "the peer never managed to send while stalled: " << peer.error;
+    ASSERT_FALSE(peer.failed.load()) << peer.error;
+
+    ASSERT_TRUE(test::pump_until(
+        ev, [&] { return received.size() >= peer_probe.size(); }, 5s))
+        << "the endpoint never received the peer's payload while its own send was backed up "
+        << "[depth=" << everest::lib::io::tls::endpoint_peek::tx_queue_depth(*rig.server_conn)
+        << " desired=" << static_cast<int>(everest::lib::io::tls::endpoint_peek::desired_events(*rig.server_conn))
+        << "]";
+    EXPECT_EQ(received, peer_probe);
+    EXPECT_FALSE(errored.load()) << "the endpoint failed instead of receiving while backed up";
+
+    peer.expected = expected.size();
+    peer.drain = true;
+    peer.close_now = true;
+    ASSERT_TRUE(test::pump_until(
+        ev, [&] { return peer.finished.load(); }, 30s))
+        << "the backed-up queue never drained";
+    worker.join();
+    ASSERT_FALSE(peer.failed.load()) << peer.error;
+    EXPECT_EQ(peer.received, expected) << "the drained bytes are not the accepted payloads in order";
+}
+
+// Unbounded, a producer that never checks the return value grows the queue until the process dies.
+// Rejecting is not a failure: the connection stays live and everything accepted still arrives.
+TEST(TlsServer, tx_rejects_past_the_buffer_cap) {
+    everest::lib::io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    ASSERT_TRUE(rig.registered);
+    ASSERT_GT(rig.port(), 0u) << "listener bound to port 0 unexpectedly";
+
+    stalled_peer peer;
+    std::thread worker([&]() { run_stalled_peer(rig.port(), peer); });
+    struct joiner {
+        stalled_peer& p;
+        std::thread& t;
+        ~joiner() {
+            p.drain = true;
+            p.close_now = true;
+            if (t.joinable()) {
+                t.join();
+            }
+        }
+    } join_worker{peer, worker};
+
+    ASSERT_GE(connect_stalled_peer(ev, rig, peer), 0)
+        << "the stalled peer never reached a live connection: " << peer.error;
+
+    std::atomic<bool> errored{false};
+    rig.server_conn->set_error_handler([&errored](int, std::string const&) { errored = true; });
+    std::vector<std::uint8_t> trailer;
+    rig.server_conn->set_rx_handler(
+        [&trailer](everest::lib::io::tls::tls_server_socket::PayloadT const& payload, auto&) {
+            trailer.insert(trailer.end(), payload.begin(), payload.end());
+        });
+
+    // The loop is not driven while pushing, so nothing drains and every accepted payload stays
+    // queued.
+    constexpr std::size_t payload_size = 8;
+    const std::size_t cap = everest::lib::io::tls::tls_server::max_buffered_tx_payloads;
+    const std::size_t attempts = cap + 16;
+    std::vector<std::uint8_t> expected;
+    std::size_t accepted = 0;
+    for (std::size_t i = 0; i < attempts; ++i) {
+        auto payload = indexed_payload(i, payload_size);
+        if (not rig.server_conn->tx(payload)) {
+            break;
+        }
+        expected.insert(expected.end(), payload.begin(), payload.end());
+        ++accepted;
+    }
+
+    EXPECT_EQ(accepted, cap) << "tx() accepted " << accepted << " payloads against a cap of " << cap;
+    EXPECT_EQ(everest::lib::io::tls::endpoint_peek::tx_queue_depth(*rig.server_conn), accepted);
+    ASSERT_FALSE(errored.load()) << "hitting the cap tore the connection down instead of rejecting";
+
+    peer.expected = expected.size();
+    peer.drain = true;
+    ASSERT_TRUE(test::pump_until(
+        ev, [&] { return trailer.size() >= peer_trailer.size() || peer.failed.load(); }, 30s))
+        << "the accepted payloads were not delivered and acknowledged within 30 seconds";
+    ASSERT_FALSE(peer.failed.load()) << peer.error;
+    EXPECT_EQ(trailer, peer_trailer);
+    EXPECT_FALSE(errored.load()) << "the endpoint failed while draining after a rejected tx()";
+
+    peer.close_now = true;
+    ASSERT_TRUE(test::pump_until(
+        ev, [&] { return peer.finished.load(); }, 10s));
+    worker.join();
+
+    ASSERT_FALSE(peer.failed.load()) << peer.error;
+    EXPECT_EQ(peer.received, expected) << "a payload accepted before the cap was not delivered";
+}
+
+// A peer that TCP-connects and never sends a ClientHello would otherwise pin the accepted
+// endpoint, its fd, and its tx queue forever: the accept handshake is kicked by the incoming
+// data, so a silent peer generates no event at all.
+TEST(TlsServer, handshake_deadline_fails_a_silent_peer_with_etimedout) {
+    int listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(listen_fd, 0);
+    int opt = 1;
+    ::setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    addr.sin_port = 0;
+    ASSERT_EQ(::bind(listen_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)), 0);
+    ASSERT_EQ(::listen(listen_fd, 1), 0);
+    sockaddr_in bound{};
+    socklen_t bound_len = sizeof(bound);
+    ASSERT_EQ(::getsockname(listen_fd, reinterpret_cast<sockaddr*>(&bound), &bound_len), 0);
+
+    auto cfg = test::server_test_config();
+    cfg.host = "127.0.0.1";
+    const std::string port_str = std::to_string(ntohs(bound.sin_port));
+    cfg.service = port_str.c_str();
+    cfg.ipv6_only = false;
+    cfg.socket = listen_fd; // bypass init_socket()
+    tls::Server server;
+    ASSERT_NE(server.init(cfg, nullptr), tls::Server::state_t::init_needed);
+
+    // Plain TCP peer that never speaks: loopback connect completes without any handshake bytes.
+    int silent_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(silent_fd, 0);
+    ASSERT_EQ(::connect(silent_fd, reinterpret_cast<sockaddr*>(&bound), sizeof(bound)), 0);
+
+    sockaddr peer{};
+    socklen_t peer_len = sizeof(peer);
+    int accepted_fd = ::accept(listen_fd, &peer, &peer_len);
+    ASSERT_GE(accepted_fd, 0);
+    auto conn = server.wrap_accepted_fd(accepted_fd, "127.0.0.1", "0");
+    ASSERT_TRUE(conn);
+
+    everest::lib::io::event::fd_event_handler ev;
+    everest::lib::io::tls::tls_server srv(std::move(conn));
+    srv.set_handshake_timeout(200ms);
+
+    std::atomic<bool> got_error{false};
+    std::atomic<int> err_code{0};
+    std::string err_text;
+    srv.set_error_handler([&](int err, std::string const& text) {
+        err_code = err;
+        err_text = text;
+        got_error = true;
+    });
+    ASSERT_TRUE(ev.register_event_handler(&srv));
+
+    const auto armed = std::chrono::steady_clock::now();
+    ASSERT_TRUE(test::pump_until(
+        ev, [&] { return got_error.load(); }, 5s))
+        << "the silent peer never expired the accept handshake";
+    EXPECT_LT(std::chrono::steady_clock::now() - armed, 2s) << "the deadline fired far past its 200ms bound";
+    EXPECT_EQ(err_code.load(), ETIMEDOUT);
+    EXPECT_EQ(err_text, "handshake deadline expired");
+
+    ::close(silent_fd);
+    ::close(listen_fd);
+}
+
+// tls_server tells its owner to drop the unique_ptr on error, and the error callback is the only
+// notification of one. Reporting from inside fail() made following that instruction a
+// heap-use-after-free: fail() reads m_fd, m_handler and m_socket after the callback returns, and the
+// connection dispatch reads m_errored after flush_rx. Only a sanitizer sees it.
+TEST(TlsServer, dropping_the_server_inside_its_error_handler_is_safe) {
+    everest::lib::io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    ASSERT_TRUE(rig.registered);
+    ASSERT_GT(rig.port(), 0u) << "listener bound to port 0 unexpectedly";
+
+    ASSERT_GE(reset_peer_after_round_trip(ev, rig), 0) << "the round trip did not complete within 5 seconds";
+    ASSERT_NE(rig.server_conn, nullptr) << "the listener never accepted a connection";
+
+    std::atomic<int> reported_code{0};
+    rig.server_conn->set_error_handler([&rig, &reported_code](int code, std::string const&) {
+        reported_code = code;
+        rig.server_conn.reset();
+    });
+
+    ASSERT_TRUE(test::pump_until(
+        ev, [&] { return reported_code.load() != 0; }, 5s))
+        << "the server endpoint never reported the peer reset";
+    EXPECT_EQ(rig.server_conn, nullptr) << "the error handler ran but the drop did not";
+
+    // The queued teardown runs before the report, so nothing here may touch the freed endpoint.
+    for (int i = 0; i < 5; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+}
+
+// Same guarantee for the other deferred callback: on-ready also runs from run_actions() with no
+// `this` alive across it, so it carries the same permission. The rx handler does not, since it is
+// handed *this and the dispatch keeps reading members after it returns.
+TEST(TlsServer, dropping_the_server_inside_its_on_ready_action_is_safe) {
+    // Declared before the listener and the connection, both of which unregister from it on the way out.
+    everest::lib::io::event::fd_event_handler ev;
+    std::unique_ptr<everest::lib::io::tls::tls_server> server_conn;
+    std::atomic<bool> dropped{false};
+
+    everest::lib::io::tls::tls_listener listener(test::listener_test_config());
+    listener.set_accept_callback(
+        [&](std::unique_ptr<everest::lib::io::tls::tls_server> srv, std::string, std::uint16_t) {
+            // maybe_fire_ready() consults m_on_ready once, at handshake completion, so an action
+            // installed after the accept callback returns could miss its only chance to run.
+            srv->set_on_ready_action([&server_conn, &dropped]() {
+                server_conn.reset();
+                dropped = true;
+            });
+            ev.register_event_handler(srv.get());
+            server_conn = std::move(srv);
+        });
+    ASSERT_TRUE(ev.register_event_handler(&listener));
+    ASSERT_GT(listener.listen_port(), 0u) << "listener bound to port 0 unexpectedly";
+
+    everest::lib::io::tls::tls_client client(test::client_test_config(), std::string("127.0.0.1"),
+                                             listener.listen_port(), 2000);
+    ASSERT_TRUE(ev.register_event_handler(&client));
+
+    ASSERT_TRUE(test::pump_until(
+        ev, [&] { return dropped.load(); }, 5s))
+        << "the accept handshake never completed";
+    EXPECT_EQ(server_conn, nullptr) << "the on-ready action ran but the drop did not";
+
+    for (int i = 0; i < 5; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+    ev.unregister_event_handler(&client);
+    ev.unregister_event_handler(&listener);
+}

--- a/lib/everest/io/test/tls_test_common.hpp
+++ b/lib/everest/io/test/tls_test_common.hpp
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+//
+// Shared helpers for the everest_io_tls_test binary. All four TLS test TUs compile into one
+// executable, so everything here is inline.
+//
+// The PKI fixture files are resolved relative to the working directory, which ctest pins to
+// build/lib/everest/tls/tests, so always run this binary via ctest.
+//
+// Naming: inside everest::lib::io::test an unqualified `tls::` finds the sibling
+// everest::lib::io::tls namespace; the libtls types need the fully qualified `::tls::`.
+
+#pragma once
+
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tls/tls_client_config.hpp>
+#include <everest/io/tls/tls_client_socket.hpp>
+#include <everest/io/tls/tls_listener.hpp>
+#include <everest/io/tls/tls_listener_config.hpp>
+#include <everest/io/tls/tls_server.hpp>
+#include <everest/io/tls/tls_server_socket.hpp>
+#include <everest/tls/tls.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace everest::lib::io::test {
+
+/// Server-side chain/cipher core matching the test PKI, with TLS 1.3 disabled. Callers add the
+/// transport specifics (host/service/socket for a raw ::tls::Server, or listener_test_config()).
+inline ::tls::Server::config_t server_test_config() {
+    ::tls::Server::config_t scfg;
+    scfg.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    scfg.ciphersuites = "";
+    auto& chain = scfg.chains.emplace_back();
+    chain.certificate_chain_file = "server_chain.pem";
+    chain.private_key_file = "server_priv.pem";
+    chain.trust_anchor_file = "server_root_cert.pem";
+    chain.ocsp_response_files = {"ocsp_response.der", "ocsp_response.der"};
+    scfg.verify_client = false;
+    scfg.io_timeout_ms = 1000;
+    return scfg;
+}
+
+inline tls::tls_listener::Config listener_test_config(std::string bind_addr = "127.0.0.1", bool ipv6_only = false) {
+    tls::tls_listener::Config lcfg;
+    lcfg.tls = server_test_config();
+    lcfg.bind_addr = std::move(bind_addr);
+    lcfg.bind_port = 0;
+    lcfg.ipv6_only = ipv6_only;
+    return lcfg;
+}
+
+/// TLS 1.3 disabled to match server_test_config(). Hostname verification is left off; tests opt in
+/// via verify_subject_name.
+inline tls::tls_client_socket::Config client_test_config(std::int32_t io_timeout_ms = 2000,
+                                                         std::string host_for_sni = {}) {
+    tls::tls_client_socket::Config cfg;
+    cfg.tls.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    cfg.tls.ciphersuites = "";
+    cfg.tls.verify_locations_file = "server_root_cert.pem";
+    cfg.tls.io_timeout_ms = io_timeout_ms;
+    cfg.tls.verify_server = true;
+    cfg.host_for_sni = std::move(host_for_sni);
+    return cfg;
+}
+
+/// Returns whether done() was satisfied. The timed poll re-checks the deadline every tick even with
+/// no events, so a stall fails the test deterministically instead of hanging.
+template <class Predicate>
+inline bool pump_until(event::fd_event_handler& ev, Predicate&& done, std::chrono::milliseconds budget) {
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    bool satisfied = done();
+    while (!satisfied && std::chrono::steady_clock::now() < deadline) {
+        ev.poll(std::chrono::milliseconds(50));
+        ev.run_actions();
+        satisfied = done();
+    }
+    return satisfied;
+}
+
+/// The accepted tls_server is registered on the given handler and owned by server_conn, which must
+/// outlive the accept callback; tests drop it to simulate a server-side close. Only one connection
+/// is kept. Non-movable (the accept callback captures `this`), so construct via make_echo_listener().
+struct echo_listener {
+    explicit echo_listener(event::fd_event_handler& ev, tls::tls_listener::Config cfg = listener_test_config()) :
+        listener(std::move(cfg)) {
+        listener.set_accept_callback([this, &ev](std::unique_ptr<tls::tls_server> srv, std::string /*ip*/,
+                                                 std::uint16_t /*peer_port*/) {
+            srv->set_rx_handler([](tls::tls_server_socket::PayloadT const& payload, auto& self) { self.tx(payload); });
+            ev.register_event_handler(srv.get());
+            server_conn = std::move(srv);
+        });
+        registered = ev.register_event_handler(&listener);
+    }
+
+    std::uint16_t port() const {
+        return listener.listen_port();
+    }
+
+    tls::tls_listener listener;
+    std::unique_ptr<tls::tls_server> server_conn;
+    bool registered{false};
+};
+
+inline echo_listener make_echo_listener(event::fd_event_handler& ev,
+                                        tls::tls_listener::Config cfg = listener_test_config()) {
+    return echo_listener(ev, std::move(cfg));
+}
+
+/// Blocking peer for a worker thread while the main thread drives the event loop. ciphersuites stays
+/// at the library default: the test servers disable TLS 1.3, so TLS 1.2 is negotiated either way.
+inline void run_blocking_echo_client(std::string const& host, std::uint16_t port,
+                                     std::vector<std::uint8_t> const& payload, std::atomic<bool>& client_ok,
+                                     std::string& client_error) {
+    ::tls::Client client;
+    ::tls::Client::config_t ccfg;
+    ccfg.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    ccfg.verify_locations_file = "server_root_cert.pem";
+    ccfg.io_timeout_ms = 2000;
+    ccfg.verify_server = true;
+    if (!client.init(ccfg)) {
+        client_error = "client.init failed";
+        return;
+    }
+
+    const std::string port_str = std::to_string(port);
+    auto conn = client.connect(host.c_str(), port_str.c_str(), false, 2000);
+    if (!conn) {
+        client_error = "client.connect returned nullptr";
+        return;
+    }
+    if (conn->connect() != ::tls::Connection::result_t::success) {
+        client_error = "TLS handshake failed on client side";
+        return;
+    }
+
+    std::size_t written = 0;
+    if (conn->write(reinterpret_cast<const std::byte*>(payload.data()), payload.size(), written, 2000) !=
+            ::tls::Connection::result_t::success ||
+        written != payload.size()) {
+        client_error = "client write failed";
+        return;
+    }
+
+    std::vector<std::uint8_t> echo;
+    echo.reserve(payload.size());
+    while (echo.size() < payload.size()) {
+        std::byte buf[8192]{};
+        std::size_t nread = 0;
+        if (conn->read(buf, sizeof buf, nread, 2000) != ::tls::Connection::result_t::success) {
+            client_error = "client read failed";
+            return;
+        }
+        echo.insert(echo.end(), reinterpret_cast<std::uint8_t*>(buf), reinterpret_cast<std::uint8_t*>(buf) + nread);
+    }
+
+    if (echo != payload) {
+        client_error = "client echo mismatch";
+        return;
+    }
+
+    conn->shutdown();
+    client_ok = true;
+}
+
+} // namespace everest::lib::io::test

--- a/lib/everest/io/test/tls_test_main.cpp
+++ b/lib/everest/io/test/tls_test_main.cpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+//
+// Custom GoogleTest main for everest_io_tls_test.
+//
+// The TLS tests reuse the libtls test PKI fixtures, produced by ./pki.sh in the libtls test build
+// directory. libtls's own tls_test runs ./pki.sh from its main(); this binary must not rely on that
+// having happened first under ctest, so it regenerates the fixtures itself.
+
+#include <csignal>
+#include <cstdlib>
+#include <iostream>
+#include <linux/limits.h>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+    // OpenSSL drives its socket BIO through write() without MSG_NOSIGNAL, so a write to a
+    // peer-reset connection raises SIGPIPE and kills the process. Without this the RST-teardown
+    // tests would abort.
+    std::signal(SIGPIPE, SIG_IGN);
+    if (std::system("./pki.sh") != 0) {
+        std::cerr << "Problem creating test certificates and keys" << std::endl;
+        char buf[PATH_MAX];
+        if (::getcwd(&buf[0], sizeof(buf)) != nullptr) {
+            std::cerr << "./pki.sh not found in " << buf << std::endl;
+        }
+        return 1;
+    }
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Describe your changes

A TLS layer for `lib/everest/io` driven entirely from an existing `fd_event_handler`, so a TLS
connection is polled alongside everything else instead of owning a thread.

- **Client.** `tls_client` is a one-line alias for
  `event::fd_event_client<tls_client_socket>::type`. All behavior comes from `tls_client_socket`, a
  policy satisfying both the async-connect traits and the handshake traits the generic client already
  detects, so user code wires no handshake hooks. The blocking TCP connect reuses the generic
  client's existing short-lived thread; this layer starts none of its own.
- **Server.** `tls_listener` owns the listen socket and an embedded `tls::Server`, yielding a
  `std::unique_ptr<tls_server>` per accepted connection. `tls_server` derives from
  `tls_endpoint_base`, which wires one connection flat onto the handler and drives the accept
  handshake inside its own dispatch callback. The client deliberately does not use
  `tls_endpoint_base`: it nests its own handler and needs a connect, the server is handed a connected
  descriptor.

Points worth a reviewer's attention:

- **Teardown from inside a dispatch callback.** `fail()` cannot remove its own descriptor
  synchronously, since that destroys the `std::function` currently executing. Removal and close are
  deferred together, ordered remove then close so the number stays reserved until it is out of the
  handler; a synchronous close would let an accept in the same batch recycle it and the stale remove
  strand it. The deferred action captures the descriptor and a moved closer, never `this`.
- **Steady-state events are routed by direction.** The post-handshake dispatch ignored
  `desired_events()`, so `SSL_write` returning `WANT_READ` busy-spun POLLOUT and `SSL_read` returning
  `WANT_WRITE` stalled. Routing is now per direction rather than through the exclusive `monitor_for`,
  which would have removed POLLOUT on an ordinary read would-block and stranded the queue. POLLIN
  stays monitored while a send drains: dropping it there went deaf for the whole drain and deadlocked
  a peer that writes before it reads, with no error to notice it by.
- **The server tx queue is bounded** at `max_buffered_tx_payloads`, matching the client's name and
  value. Rejection is backpressure, not failure: the connection stays live and everything already
  accepted is still delivered.
- **`tls::Client::init` failures are recorded.** `setup()` returned false leaving the error at 0, so
  `get_error()` probed an unassigned descriptor and answered `EBADF` with no text. It now reports
  `EINVAL` and names the rejected configuration, since `init` does not say which input it refused.

Known limitation, filed rather than hidden: `tls_socket_base` has a single desired-event slot shared
by both directions, so it cannot express "rx wants write while tx wants read". A would-block is
routed correctly but the blocked operation is not re-driven, which needs per-direction state and a
dispatch that drives it. Reaching that state requires a TLS 1.3 KeyUpdate or a TLS 1.2 renegotiation.

Separately, `tls::Client::init` tolerates an unreadable `verify_locations_file`: it logs and continues
without failing, so a typo'd trust anchor yields a client with an empty trust store whose later
handshakes fail for a reason pointing nowhere near the typo. That is in `lib/everest/tls`, outside
this PR.

### Decoupling the public headers from libtls

Based on a patch from Jan Christoph Hoppe. The layer named `::tls::Connection::result_t` in its own
API; that type is nested, so it cannot be forward declared, and naming it chained libtls and the
OpenSSL headers into anything including these headers.

- `io_result` replaces it, translated in one function. `to_io_result` lists every libtls enumerator
  with no `default:`, so `-Wswitch` breaks the build if libtls adds one.
- The two class templates keep their contract in the public header and their member definitions in
  `*_impl.hpp`, with the library's policies instantiated once each in a `.cpp`. A consumer adding a
  policy of its own includes the impl header instead.
- `tls_client_socket` and `tls_listener` each held a libtls type by value, which is what blocked a
  forward declaration. `Config` is now an incomplete nested type defined in a sibling config header,
  `tls_listener` holds its `Server` by pointer, and the client keeps only the SNI host it reads
  after `setup()`.
- A guard translation unit compiles all eight public headers with libtls off the include path, so
  re-adding an include fails the build and names the header. Verified by injecting one.

The win is in-tree layering and compile time, not installability: a consumer still needs a config
header to construct a client or listener, and those include libtls, so `PATTERN "tls" EXCLUDE`
stays. Making these installable needs libtls exported, which is out of scope here.

Separately, `tls_client_socket` now declares `buffer_tx_before_connect`. #2562 made pre-connect tx
buffering opt in and off by default; a TLS session carries a stream rather than setpoints, and
`tls_endpoint_base` buffered that window before the client moved onto `fd_event_client`. Without the
opt in, `TlsE2E.tx_queued_before_handshake_is_flushed_after_ready` and
`TlsE2E.client_teardown_closes_the_tls_session` fail.

## Issue ticket number and link

N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

---

### Stack

Six PR series, two rooted on `main`. (#2558 and #2559 have merged.)

This PR is 4 above `main`, so 3 PRs (#2561, #2562, #2563) must merge before it.

- `main`
  - #2560 `fix/io-connect-errno-and-backoff`
  - #2561 `fix/io-event-handler-truthfulness`
    - #2562 `feat/io-client-tx-tristate`
      - #2563 `feat/io-fd-event-client-handshake-phase`
        - **#2564 `feat/io-tls-policies-rebuilt` (this PR)**
      - #2565 `refactor/chargebridge-drop-hand-rolled-tx-gates`

