### PR TITLE
refactor(chargebridge): log rejected serial tx

### DIFF
--- a/applications/pionix_chargebridge/include/charge_bridge/serial_bridge.hpp
+++ b/applications/pionix_chargebridge/include/charge_bridge/serial_bridge.hpp
@@ -41,6 +41,7 @@ private:
     utilities::symlink m_symlink;
     std::string m_identifier;
     int m_tcp_last_error_id = -1;
+    bool m_tcp_tx_rejected{false};
     std::uint16_t m_tcp_port{0};
     std::string m_tcp_remote;
     bool m_tcp_ready{false};

--- a/applications/pionix_chargebridge/src/serial_bridge.cpp
+++ b/applications/pionix_chargebridge/src/serial_bridge.cpp
@@ -39,6 +39,8 @@ serial_bridge::serial_bridge(serial_bridge_config const& config, everest::lib::i
 }
 
 void serial_bridge::create_tcp_client(std::string const& remote, uint16_t remote_port) {
+    // Dedup latch is per client instance.
+    m_tcp_tx_rejected = false;
     m_tcp = std::make_unique<everest::lib::io::tcp::tcp_client>(remote, remote_port, default_udp_timeout_ms);
     m_tcp->set_on_ready_action([this]() {
         m_tcp->get_raw_handler()->set_keep_alive(3, 1, 1);
@@ -46,9 +48,14 @@ void serial_bridge::create_tcp_client(std::string const& remote, uint16_t remote
     });
 
     m_pty.set_data_handler([this](auto const& data, auto&) {
-        if (m_tcp) {
-            m_tcp->tx(data);
+        if (not m_tcp) {
+            return;
         }
+        auto accepted = m_tcp->tx(data);
+        if (not accepted and not m_tcp_tx_rejected) {
+            utilities::print_error(m_identifier, "SERIAL/TCP", -1) << "Dropped serial data, tx rejected" << std::endl;
+        }
+        m_tcp_tx_rejected = not accepted;
     });
     m_tcp->set_rx_handler([this](auto const& data, auto&) { m_pty.tx(data); });
     m_tcp->set_error_handler([this](auto id, auto const& msg) {


### PR DESCRIPTION
## Describe your changes

`serial_bridge`'s pty data handler discarded what `tx()` returned, so serial data was dropped with
nothing in the log. It now checks the return and logs on the transition into the rejected state, so a
streak of drops reports once rather than per payload.

The window this covers widened with #2562: pre-connect tx buffering is opt in there and off by
default, and `serial_bridge` does not opt in, so `tx()` rejects for the whole connect window rather
than only once a buffer fills. The latch is indifferent to why a payload was rejected, so it reports
that window the same way, once per streak.

The rejected-state latch is also cleared when the tcp client is recreated, so a streak recorded
against a destroyed client cannot suppress the first rejection log of its replacement. The reset sits
in `create_tcp_client()`, the sole construction site, rather than beside the sibling
`m_tcp_last_error_id` reset in the teardown path, so it does not depend on teardown always being
paired with a recreate.

### Scope reduced on rebase

This PR previously also removed the `m_udp_on_error` tx gates from `gpio_bridge` and
`heartbeat_service` and drove their client reset from the heartbeat tick, on the grounds that their
`handle_error_timer` was never registered with an event handler. That premise no longer holds on
current `main`: #2421 registers `m_error_timer` and resets the client from it, and `m_udp_on_error`
now also feeds the readiness signal and the endpoint reconnect path, so removing it would break live
behavior. `gpio_bridge` no longer exists. Both halves were dropped rather than reapplied.

## Issue ticket number and link

N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

---

### Stack

Six PR series, two rooted on `main`. (#2558 and #2559 have merged.)

This PR is 3 above `main`, so 2 PRs (#2561, #2562) must merge before it.

- `main`
  - #2560 `fix/io-connect-errno-and-backoff`
  - #2561 `fix/io-event-handler-truthfulness`
    - #2562 `feat/io-client-tx-tristate`
      - #2563 `feat/io-fd-event-client-handshake-phase`
        - #2564 `feat/io-tls-policies-rebuilt`
      - **#2565 `refactor/chargebridge-drop-hand-rolled-tx-gates` (this PR)**

