### PR TITLE
fix(EvseV2G): log responses with their own length in the V2G message log

### DIFF
--- a/modules/EVSE/EvseV2G/v2g_server.cpp
+++ b/modules/EVSE/EvseV2G/v2g_server.cpp
@@ -271,9 +271,14 @@ static types::iso15118::V2gMessageId get_v2g_message_id(enum V2gMsgTypeId v2g_ms
 static void publish_var_V2G_Message(v2g_connection* conn, bool is_req) {
     types::iso15118::V2gMessages v2g_message;
 
+    /* conn->payload_len only holds the length of the received request; responses are
+     * encoded into the same buffer and their length lives in the EXI stream position */
+    const size_t msg_len =
+        is_req ? static_cast<size_t>(conn->payload_len) + V2GTP_HEADER_LENGTH : exi_bitstream_get_length(&conn->stream);
+
     u_int8_t* tempbuff = conn->buffer;
     std::string msg_as_hex_string;
-    for (int i = 0; ((tempbuff != NULL) && (i < conn->payload_len + V2GTP_HEADER_LENGTH)); i++) {
+    for (size_t i = 0; ((tempbuff != NULL) && (i < msg_len)); i++) {
         char hex[4];
         snprintf(hex, 4, "%x", *tempbuff); // to hex
         if (std::string(hex).size() == 1)
@@ -284,7 +289,7 @@ static void publish_var_V2G_Message(v2g_connection* conn, bool is_req) {
 
     std::string EXI_Base64;
 
-    EXI_Base64 = openssl::base64_encode(conn->buffer, conn->payload_len + V2GTP_HEADER_LENGTH);
+    EXI_Base64 = openssl::base64_encode(conn->buffer, msg_len);
     if (EXI_Base64.size() == 0) {
         dlog(DLOG_LEVEL_WARNING, "Unable to base64 encode EXI buffer");
     }
@@ -583,16 +588,17 @@ int v2g_handle_connection(struct v2g_connection* conn) {
     /* stream setup for sending is done within v2g_handle_apphandshake */
     /* send supportedAppRes message */
     if ((rvAppHandshake == V2G_EVENT_SEND_AND_TERMINATE) || (rvAppHandshake == V2G_EVENT_NO_EVENT)) {
-        /* form the content of V2G_Message type and publish the response for debugging*/
-        if (conn->ctx->debugMode == true) {
-            publish_var_V2G_Message(conn, false);
-        }
-
         rv = v2g_outgoing_v2gtp(conn);
 
         if (rv == -1) {
             dlog(DLOG_LEVEL_ERROR, "v2g_outgoing_v2gtp() failed");
             goto error_out;
+        }
+
+        /* form the content of V2G_Message type and publish the response for debugging;
+         * after v2g_outgoing_v2gtp() so the V2GTP header of the response is written */
+        if (conn->ctx->debugMode == true) {
+            publish_var_V2G_Message(conn, false);
         }
     }
 
@@ -754,16 +760,17 @@ int v2g_handle_connection(struct v2g_connection* conn) {
             }
         }
         case V2G_EVENT_SEND_RECV_EXI_MSG: { // fall-through intended
-            /* form the content of V2G_Message type and publish the response for debugging*/
-            if (conn->ctx->debugMode == true) {
-                publish_var_V2G_Message(conn, false);
-            }
-
             /* Write header and send next res-msg */
             if ((rv != 0) || ((rv = v2g_outgoing_v2gtp(conn)) == -1)) {
                 dlog(DLOG_LEVEL_ERROR, "v2g_outgoing_v2gtp() \"%s\" failed: %d",
                      v2g_msg_type[conn->ctx->current_v2g_msg], rv);
                 break;
+            }
+
+            /* form the content of V2G_Message type and publish the response for debugging;
+             * after v2g_outgoing_v2gtp() so the V2GTP header of the response is written */
+            if (conn->ctx->debugMode == true) {
+                publish_var_V2G_Message(conn, false);
             }
             break;
         }


### PR DESCRIPTION
## Describe your changes

With `debug_mode` enabled, `publish_var_V2G_Message()` sizes the hex/base64 dump of every logged frame with `conn->payload_len + V2GTP_HEADER_LENGTH` — for requests *and* responses. `conn->payload_len` is only written by `V2GTP_ReadHeader()` when a request arrives; the response is encoded into the same buffer and its length lives in the EXI stream position, which only `v2g_outgoing_v2gtp()` reads. The response was also published *before* `v2g_outgoing_v2gtp()` writes the V2GTP header, so the logged frame still carried the request's stale header bytes.

Every logged response is therefore truncated (or padded) to its **request's** length:

| message | req on wire | res on wire | res as logged |
|---|---|---|---|
| ServiceDiscovery | 13 B | 19 B | 13 B — undecodable, `FreeService` flag cut off |
| PaymentServiceSelection | 16 B | 16 B | 16 B — decodes by coincidence |
| Authorization | 13 B | 13 B | 13 B — decodes by coincidence |

Found while verifying #2527 on hardware: the session log's `ServiceDiscoveryRes` hex could not be EXI-decoded, while tcpdump on the same session showed a well-formed 19-byte frame. Wire traffic is unaffected — `v2g_outgoing_v2gtp()` computes its own length — only the published `V2gMessages` debug var is wrong.

### Fix

- `publish_var_V2G_Message()` sizes responses from `exi_bitstream_get_length(&conn->stream)`; requests keep using `payload_len`.
- The two response call sites publish after `v2g_outgoing_v2gtp()` succeeds, so the log contains exactly the frame that was sent (header included). Responses that fail to send are no longer logged as if they had been.

## Issue ticket number and link

None — found during review/verification of #2527. Can open one if preferred.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (none needed — debug logging only)
- [x] I read the contribution documentation and made sure that my changes meet its requirements

### Verification

Reproduced and verified on a DC charger (AM62x) running SIL sessions against PyEvJosev over ISO 15118-2: before the fix, logged `ServiceDiscoveryRes` was 13 bytes with a stale header (undecodable); after the fix the logged frame matches the pcap byte-for-byte and decodes with libcbv2g.
