### PR TITLE
fix(ocpp): queue NotifyEvent until registration is accepted

### DIFF
--- a/lib/everest/ocpp/config/common/component_config/standardized/OCPPCommCtrlr.json
+++ b/lib/everest/ocpp/config/common/component_config/standardized/OCPPCommCtrlr.json
@@ -226,6 +226,22 @@
       "description": "Comma seperated list of message types that shall not be queued (when offline) even in case QueueAllMessages is true. If QueueAllMessages is false, the configuration of this paramater has no effect.",
       "type": "string"
     },
+    "QueueNotifyEventMessages": {
+      "variable_name": "QueueNotifyEventMessages",
+      "characteristics": {
+        "supportsMonitoring": true,
+        "dataType": "boolean"
+      },
+      "attributes": [
+        {
+          "type": "Actual",
+          "mutability": "ReadWrite",
+          "value": false
+        }
+      ],
+      "description": "When this variable is set to true, NotifyEventRequest messages generated before the CSMS accepted the BootNotification are queued and sent once registration is accepted, instead of being discarded.",
+      "type": "boolean"
+    },
     "ResetRetries": {
       "variable_name": "ResetRetries",
       "characteristics": {

--- a/lib/everest/ocpp/include/ocpp/common/message_queue.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/message_queue.hpp
@@ -99,12 +99,13 @@ class MalformedRpcMessage : public std::runtime_error {
 inline MessageTransmissionPriority get_message_transmission_priority(bool is_boot_notification_message, bool triggered,
                                                                      bool registration_already_accepted,
                                                                      bool is_transaction_related,
-                                                                     bool queue_all_message) {
+                                                                     bool queue_all_message,
+                                                                     bool queue_until_accepted = false) {
     if (registration_already_accepted || is_boot_notification_message || triggered) {
         return MessageTransmissionPriority::SendImmediately;
     }
 
-    if (is_transaction_related || queue_all_message) {
+    if (is_transaction_related || queue_all_message || queue_until_accepted) {
         return MessageTransmissionPriority::SendAfterRegistrationStatusAccepted;
     }
 

--- a/lib/everest/ocpp/include/ocpp/v2/ctrlr_component_variables.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/ctrlr_component_variables.hpp
@@ -246,6 +246,7 @@ extern const RequiredComponentVariable NetworkProfileConnectionAttempts;
 extern const RequiredComponentVariable OfflineThreshold;
 extern const ComponentVariable QueueAllMessages;
 extern const ComponentVariable MessageTypesDiscardForQueueing;
+extern const ComponentVariable QueueNotifyEventMessages;
 extern const RequiredComponentVariable ResetRetries;
 extern const RequiredComponentVariable RetryBackOffRandomRange;
 extern const RequiredComponentVariable RetryBackOffRepeatTimes;

--- a/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
@@ -844,6 +844,12 @@ const ComponentVariable MessageTypesDiscardForQueueing = {
         "MessageTypesDiscardForQueueing",
     }),
 };
+const ComponentVariable QueueNotifyEventMessages = {
+    ControllerComponents::OCPPCommCtrlr,
+    std::optional<Variable>({
+        "QueueNotifyEventMessages",
+    }),
+};
 const RequiredComponentVariable ResetRetries = {
     ControllerComponents::OCPPCommCtrlr,
     std::optional<Variable>({

--- a/lib/everest/ocpp/lib/ocpp/v2/message_dispatcher.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/message_dispatcher.cpp
@@ -9,10 +9,17 @@ namespace v2 {
 
 void MessageDispatcher::dispatch_call(const json& call, bool triggered) {
     const auto message_type = conversions::string_to_messagetype(call.at(CALL_ACTION));
+    // NotifyEvent is fire-and-forget, so discarding it before registration is accepted loses the event
+    // (e.g. the cause of a fault already active at boot) permanently
+    const bool queue_until_accepted =
+        message_type == MessageType::NotifyEvent and
+        this->device_model.get_optional_value<bool>(ControllerComponentVariables::QueueNotifyEventMessages)
+            .value_or(false);
     const auto message_transmission_priority = get_message_transmission_priority(
         is_boot_notification_message(message_type), triggered,
         (this->registration_status == RegistrationStatusEnum::Accepted), is_transaction_message(message_type),
-        this->device_model.get_optional_value<bool>(ControllerComponentVariables::QueueAllMessages).value_or(false));
+        this->device_model.get_optional_value<bool>(ControllerComponentVariables::QueueAllMessages).value_or(false),
+        queue_until_accepted);
     switch (message_transmission_priority) {
     case MessageTransmissionPriority::SendImmediately:
         this->message_queue.push_call(call);

--- a/lib/everest/ocpp/tests/lib/ocpp/common/test_message_queue.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/common/test_message_queue.cpp
@@ -249,6 +249,34 @@ protected:
     };
 };
 
+// \brief Test transmission priority decisions before and after registration is accepted
+TEST(MessageTransmissionPriorityTest, test_non_transactional_discarded_before_registration) {
+    EXPECT_EQ(get_message_transmission_priority(false, false, false, false, false),
+              MessageTransmissionPriority::Discard);
+}
+
+TEST(MessageTransmissionPriorityTest, test_sent_immediately_after_registration) {
+    EXPECT_EQ(get_message_transmission_priority(false, false, true, false, false),
+              MessageTransmissionPriority::SendImmediately);
+    EXPECT_EQ(get_message_transmission_priority(false, false, true, false, false, true),
+              MessageTransmissionPriority::SendImmediately);
+}
+
+TEST(MessageTransmissionPriorityTest, test_transactional_queued_before_registration) {
+    EXPECT_EQ(get_message_transmission_priority(false, false, false, true, false),
+              MessageTransmissionPriority::SendAfterRegistrationStatusAccepted);
+}
+
+TEST(MessageTransmissionPriorityTest, test_queue_all_messages_queued_before_registration) {
+    EXPECT_EQ(get_message_transmission_priority(false, false, false, false, true),
+              MessageTransmissionPriority::SendAfterRegistrationStatusAccepted);
+}
+
+TEST(MessageTransmissionPriorityTest, test_queue_until_accepted_queued_before_registration) {
+    EXPECT_EQ(get_message_transmission_priority(false, false, false, false, false, true),
+              MessageTransmissionPriority::SendAfterRegistrationStatusAccepted);
+}
+
 // \brief Test sending a transactional message
 TEST_F(MessageQueueTest, test_transactional_message_is_sent) {
 


### PR DESCRIPTION
## Describe your changes

`NotifyEvent` requests dispatched before the CSMS has accepted the `BootNotification` are currently silently discarded: `get_message_transmission_priority()` returns `Discard` for non-transaction messages pre-registration unless `QueueAllMessages` is set (it is unset by default).

This permanently loses monitoring/fault events that are generated while the station is not yet registered. The most visible case is a hardware fault that is already active at boot: the OCPP201 module queues errors raised before start and drains that queue right after `connect_websocket()` — before `BootNotificationResponse(Accepted)` — so the resulting `NotifyEvent` calls are dropped. The CSMS only ever sees `StatusNotification(Faulted)` with no cause. A charging station that boots faulted never tells the CSMS why.

Bench evidence (AM62x-based DC charger, DC power stage unpowered at boot): `power_supply_DC/CommunicationFault` raised ~11 s before OCPP start; journal shows the queued error event being processed; zero `NotifyEvent` on the wire.

Note that OCPP 1.6 does not suffer the equivalent information loss: the connector state machine keeps the latest error and `handleBootNotificationResponse(Accepted)` re-sends `StatusNotification` including `errorCode`/`vendorErrorCode`. In OCPP 2.x the fault detail travels only in the fire-and-forget `NotifyEvent`, so discarding it loses the information permanently.

Discarding is allowed by the specification, so this is an information-loss / robustness gap rather than a spec violation. The precedent for "this message type must not be discarded before registration" is `SecurityEventNotification` (#633).

### Change

- `get_message_transmission_priority()` gains an optional `queue_until_accepted` flag mapping to `SendAfterRegistrationStatusAccepted`.
- New `OCPPCommCtrlr` variable `QueueNotifyEventMessages` (boolean, `ReadWrite`, default `false`). When enabled, the v2 `MessageDispatcher::dispatch_call()` sets the flag for `MessageType::NotifyEvent`, so pre-registration NotifyEvents are held in the message queue (`push_call(call, true)`) and flushed once registration is accepted, instead of being discarded. Post-registration behaviour is unchanged (`SendImmediately`).
- v1.6 behaviour is unchanged.

`QueueAllMessages` + `MessageTypesDiscardForQueueing` cannot express this: `MessageTypesDiscardForQueueing` is only evaluated in `MessageQueueConfig::check_queue()` (offline queueing and DB persistence), not in `get_message_transmission_priority()`, so it cannot narrow pre-registration queueing down to a single message type.

Related: EVerest/libocpp#758 (FirmwareStatusNotification dropped pre-registration, same mechanism).

## Issue ticket number and link

N/A — found during OCPP 2.0.1 fault-reporting verification on our hardware.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
