### PR TITLE
fix(ev-cli): keep array payload in to_json for no-required types

### DIFF
--- a/applications/utils/ev-dev-tools/src/ev_cli/templates/types.hpp.j2
+++ b/applications/utils/ev-dev-tools/src/ev_cli/templates/types.hpp.j2
@@ -147,19 +147,8 @@ struct {{ parsed_type.name }} {
         {% if not property.required %}
         if (k.{{property.name}}) {
                     {% if property.type.startswith('std::vector<') %}
-                    {%- if parsed_type.properties|selectattr('required')|list|length %}
             j.emplace("{{property.name}}", *k.{{property.name}});
-                    {%- else %}
-        {#only optional keys in json#}
-        {#TODO: add key to json when there are no required keys but multiple optional keys#}
-        {# FIXME: this is never generated?#}
-            if (j.size() == 0) {
-                j = json{{'{{"'+property.name+'", json::array()}};'}}
-            } else {
-                j.emplace("{{property.name}}", *k.{{property.name}});
-            }
-        {% endif %}
-        {% else %}
+        {%- else %}
         {%- if property.enum %}
         j.emplace("{{property.name}}", {{ enum_to_string_view(property.type) }}(*k.{{ property.name }}));
             {%- else %}

--- a/lib/everest/everest_api_types/src/everest_api_types/display_message/json_codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/display_message/json_codec.cpp
@@ -314,11 +314,7 @@ void from_json(const json& j, SetDisplayMessageResponse& k) {
 void to_json(json& j, GetDisplayMessageRequest const& k) noexcept {
     j = json({});
     if (k.id) {
-        if (j.size() == 0) {
-            j = json{{"id", json::array()}};
-        } else {
-            j["id"] = json::array();
-        }
+        j["id"] = json::array();
         for (auto val : k.id.value()) {
             j["id"].push_back(val);
         }
@@ -354,11 +350,7 @@ void to_json(json& j, GetDisplayMessageResponse const& k) noexcept {
         j["status_info"] = k.status_info.value();
     }
     if (k.messages) {
-        if (j.size() == 0) {
-            j = json{{"messages", json::array()}};
-        } else {
-            j["messages"] = json::array();
-        }
+        j["messages"] = json::array();
         for (auto val : k.messages.value()) {
             j["messages"].push_back(val);
         }

--- a/lib/everest/everest_api_types/src/everest_api_types/session_cost/json_codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/session_cost/json_codec.cpp
@@ -236,11 +236,7 @@ void to_json(json& j, SessionCost const& k) noexcept {
         j["id_tag"] = k.id_tag.value();
     }
     if (k.cost_chunks) {
-        if (j.size() == 0) {
-            j = json{{"cost_chunks", json::array()}};
-        } else {
-            j["cost_chunks"] = json::array();
-        }
+        j["cost_chunks"] = json::array();
         for (auto val : k.cost_chunks.value()) {
             j["cost_chunks"].push_back(val);
         }
@@ -255,11 +251,7 @@ void to_json(json& j, SessionCost const& k) noexcept {
         j["next_period"] = k.next_period.value();
     }
     if (k.message) {
-        if (j.size() == 0) {
-            j = json{{"message", json::array()}};
-        } else {
-            j["message"] = json::array();
-        }
+        j["message"] = json::array();
         for (auto val : k.message.value()) {
             j["message"].push_back(val);
         }

--- a/modules/EVSE/OCPPmulti/tests/display_messageIntf_tests.cpp
+++ b/modules/EVSE/OCPPmulti/tests/display_messageIntf_tests.cpp
@@ -199,7 +199,7 @@ TEST_F(GenericOcppRequiresTester, callGetDisplayMessages) {
     const auto response = ocpp->cb_get_display_message(request);
 
     ASSERT_EQ(received.size(), 1);
-    EXPECT_EQ(received[0], R"({"request":{"id":[],"priority":"AlwaysFront","state":"Charging"}})"_json);
+    EXPECT_EQ(received[0], R"({"request":{"id":[1,2,3],"priority":"AlwaysFront","state":"Charging"}})"_json);
 
     // response is std::vector<ocpp::DisplayMessage>
     ASSERT_EQ(response.size(), 1);

--- a/types/tests/enum_serialization_test.cpp
+++ b/types/tests/enum_serialization_test.cpp
@@ -4,11 +4,19 @@
 
 #include <nlohmann/json.hpp>
 
+#include <generated/types/display_message.hpp>
 #include <generated/types/evse_manager.hpp>
+#include <generated/types/grid_support.hpp>
+#include <generated/types/iso15118.hpp>
+#include <generated/types/text_message.hpp>
 
 using json = nlohmann::json;
 using namespace types::evse_manager;
 using namespace types::iso15118;
+
+namespace display_message = types::display_message;
+namespace text_message = types::text_message;
+namespace grid_support = types::grid_support;
 
 // Regression test for enum serialization in generated types.
 SCENARIO("Enums nested in a vector serialize as strings", "[codec]") {
@@ -99,6 +107,152 @@ SCENARIO("Scalar enum struct fields serialize as strings", "[codec]") {
 
             THEN("The event is the string variant") {
                 CHECK(j.at("event") == "ChargingPausedEVSE");
+            }
+        }
+    }
+}
+
+// Types without any required property start `to_json` from an empty object. An
+// array-typed optional emitted while `j` is still empty must carry its payload.
+SCENARIO("Array optionals in types without required properties keep their payload", "[codec]") {
+
+    GIVEN("A GetDisplayMessageRequest whose first declared optional is the array") {
+        display_message::GetDisplayMessageRequest request;
+        request.id = std::vector<int32_t>{1, 2, 3};
+
+        WHEN("It is serialized to json") {
+            const json j = request;
+
+            THEN("The array holds the given ids") {
+                REQUIRE(j.at("id").is_array());
+                CHECK(j.at("id") == json::array({1, 2, 3}));
+            }
+        }
+
+        WHEN("It is round-tripped through json") {
+            const auto back = json(request).get<display_message::GetDisplayMessageRequest>();
+
+            THEN("The value is preserved") {
+                CHECK(back == request);
+            }
+        }
+    }
+
+    // `status_info` must stay unset so that `messages` is the first present optional.
+    GIVEN("A GetDisplayMessageResponse with only the later array optional set") {
+        text_message::MessageContent content;
+        content.content = "Charging paused";
+
+        display_message::DisplayMessage message;
+        message.message = content;
+
+        display_message::GetDisplayMessageResponse response;
+        response.messages = std::vector<display_message::DisplayMessage>{message};
+
+        WHEN("It is serialized to json") {
+            const json j = response;
+
+            THEN("The array holds the given message") {
+                REQUIRE(j.at("messages").is_array());
+                REQUIRE(j.at("messages").size() == 1);
+                CHECK(j.at("messages").at(0).at("message").at("content") == "Charging paused");
+            }
+
+            THEN("No key is invented for the unset optional") {
+                CHECK(j.find("status_info") == j.end());
+            }
+        }
+
+        WHEN("It is round-tripped through json") {
+            const auto back = json(response).get<display_message::GetDisplayMessageResponse>();
+
+            THEN("The value is preserved") {
+                CHECK(back == response);
+            }
+        }
+    }
+
+    GIVEN("A GetDisplayMessageRequest with every optional unset") {
+        const display_message::GetDisplayMessageRequest request;
+
+        WHEN("It is serialized to json") {
+            const json j = request;
+
+            THEN("The result is an empty object") {
+                CHECK(j == json::object());
+            }
+        }
+    }
+
+    GIVEN("A GetDisplayMessageResponse with an earlier optional already present") {
+        text_message::MessageContent content;
+        content.content = "Charging paused";
+
+        display_message::DisplayMessage message;
+        message.message = content;
+
+        display_message::GetDisplayMessageResponse response;
+        response.status_info = "Accepted";
+        response.messages = std::vector<display_message::DisplayMessage>{message};
+
+        WHEN("It is serialized to json") {
+            const json j = response;
+
+            THEN("Both the earlier optional and the array survive") {
+                CHECK(j.at("status_info") == "Accepted");
+                REQUIRE(j.at("messages").size() == 1);
+                CHECK(j.at("messages").at(0).at("message").at("content") == "Charging paused");
+            }
+        }
+    }
+
+    GIVEN("A DERChargingParameters with a vector-of-enum as its first optional") {
+        types::iso15118::DERChargingParameters parameters;
+        parameters.ev_supported_dercontrol = std::vector<grid_support::DirectiveType>{
+            grid_support::DirectiveType::VoltVar, grid_support::DirectiveType::FreqWatt};
+
+        WHEN("It is serialized to json") {
+            const json j = parameters;
+
+            THEN("The enum elements are strings, not integers") {
+                REQUIRE(j.at("ev_supported_dercontrol").is_array());
+                REQUIRE(j.at("ev_supported_dercontrol").size() == 2);
+                CHECK(j.at("ev_supported_dercontrol").at(0).is_string());
+                CHECK(j.at("ev_supported_dercontrol") == json::array({"VoltVar", "FreqWatt"}));
+            }
+        }
+
+        WHEN("It is round-tripped through json") {
+            const auto back = json(parameters).get<types::iso15118::DERChargingParameters>();
+
+            THEN("The value is preserved") {
+                CHECK(back == parameters);
+            }
+        }
+    }
+
+    // Declared after 30-odd other optionals, all left unset here so that it is the
+    // one emitted while `j` is still empty.
+    GIVEN("A DERChargingParameters with only a later vector-of-enum set") {
+        types::iso15118::DERChargingParameters parameters;
+        parameters.ev_islanding_detection_method =
+            std::vector<types::iso15118::IslandingDetection>{types::iso15118::IslandingDetection::RoCoF};
+
+        WHEN("It is serialized to json") {
+            const json j = parameters;
+
+            THEN("The enum elements are strings, not integers") {
+                REQUIRE(j.at("ev_islanding_detection_method").is_array());
+                REQUIRE(j.at("ev_islanding_detection_method").size() == 1);
+                CHECK(j.at("ev_islanding_detection_method") == json::array({"RoCoF"}));
+            }
+        }
+
+        WHEN("It is round-tripped through json") {
+            const auto back = json(parameters).get<types::iso15118::DERChargingParameters>();
+
+            THEN("The value is preserved") {
+                CHECK(back == parameters);
             }
         }
     }


### PR DESCRIPTION
## Describe your changes

ev-cli's `to_json` codegen silently discarded the payload of array-typed optionals in types that declare no required properties.

For such a type the generated `to_json` opens with `j = json({})`. The template then branched on `j.size() == 0`, and that branch assigned an empty `json::array()` without ever reading `*k.<property>`:

```cpp
if (k.id) {
    if (j.size() == 0) {
        j = json{{"id", json::array()}};   // payload discarded
    } else {
        j.emplace("id", *k.id);
    }
}
```

Nothing errored downstream, because the key was present and well-formed. The trigger is data-dependent rather than positional: it fires for whichever array optional is serialized first while the object is still empty. `helpers.py:328` sorts properties required-first, so a type with any required property can never reach it, which is why the blast radius is small and why the template's own `FIXME: this is never generated?` looked plausible. It was wrong on both counts: it was generated, at four sites, and when generated it always took the broken arm.

Scanning every `types/*.yaml` and `interfaces/*.yaml` for the trigger (no `required` plus at least one `array` optional) yields exactly three affected types:

| type | array optionals |
|---|---|
| `display_message::GetDisplayMessageRequest` | `id` |
| `display_message::GetDisplayMessageResponse` | `messages` |
| `iso15118::DERChargingParameters` | `ev_supported_dercontrol`, `ev_islanding_detection_method` |

**This broke `GetDisplayMessages` in both directions.** These generated codecs are what crosses MQTT between modules. A provider that left `status_info` unset (for example `modules/Examples/CppExamples/TerminalDisplayMessage/`) sent `{"messages": []}`, so `OCPP201.cpp:817` saw an empty list, answered the CSMS `Unknown`, and never sent `NotifyDisplayMessages`. In the request direction the `id` filter was lost: `request.id.has_value()` was true with an empty vector. The existing integration test at `tests/ocpp_tests/test_sets/ocpp201/display_message.py` is blind to both, because its probe mock ignores the request and returns a fixed list over MQTT as a Python dict.

It also explains `NotifyEVChargingNeeds.derChargingParameters.evSupportedDERControl` arriving at the CSMS as `[]`.

## How it was fixed

`applications/utils/ev-dev-tools/src/ev_cli/templates/types.hpp.j2` now emits the same unconditional `j.emplace(...)` that the has-required path already used. `json({})` constructs an empty **object** (not null), and `emplace` is valid on it, so the special case was never needed. The `startswith('std::vector<')` guard is kept so an array property can never reach the scalar-enum arm.

`modules/EVSE/OCPPmulti/tests/display_messageIntf_tests.cpp:202` asserted the defect as correct: it set `request.id = {1,2,3}` and expected `"id":[]`. Corrected to `"id":[1,2,3]`, so its red-to-green flip is the regression pin at the real MQTT payload boundary.

Separately, four hand-written codecs in `lib/everest/everest_api_types/` carried the same `j.size() == 0` shape. Those were **not** defective (both arms assigned an empty array before a `push_back` fill loop, so the payload survived) but they are the trap that makes the pattern look correct. Removed, with no behavior change and no API version bump.

No source-hash repin was needed: `expected_{types,interfaces}_file_hashes.csv` hash source YAML, and this change touches none.

## Issue ticket number and link

None.

## How to verify it

- [x] `ctest` in the build directory: **538/538 pass**.
- [x] `everest-core_types_tests`: new scenarios cover the first-declared case, a later member with earlier optionals unset, an all-unset guard against over-correction, and both vector-of-enum sites. Verified failing before the fix (6 assertions) and passing after (33).
- [x] `grep -rln 'j.size() == 0' build/generated/` returns nothing after regeneration.
- [x] Regenerated headers diffed against a pre-fix snapshot: exactly 2 files and 4 sites change, byte-identical across the other 30 generated headers.

`Sender.single_frame_goes_through_all_delays` flaked once under build load. It is a pre-existing timing test (wall-clock delays at +-1ms, in the Huawei GOOSE library, with no reference to generated types or nlohmann) and passed 15/15 in isolation plus both surrounding full runs.

## Description for the changelog

Fix ev-cli generating `to_json` that dropped array-valued optionals in types with no required properties, which caused `GetDisplayMessages` to lose its id filter and return no messages.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation — no change needed; the module docs already described the intended behavior, the codegen did not implement it
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
