### PR TITLE
feat(ocpp): report SuspendedEVSE reason changes over OCPP 1.6

### DIFF
--- a/lib/everest/ocpp/config/common/component_config/standardized/InternalCtrlr.json
+++ b/lib/everest/ocpp/config/common/component_config/standardized/InternalCtrlr.json
@@ -457,6 +457,22 @@
         "default": false,
         "type": "boolean"
       },
+      "ReportSuspendedEVSEReasonChange": {
+        "variable_name": "ReportSuspendedEVSEReasonChange",
+        "characteristics": {
+            "supportsMonitoring": false,
+            "dataType": "boolean"
+        },
+        "attributes": [
+            {
+                "type": "Actual",
+                "mutability": "ReadWrite"
+            }
+        ],
+        "description": "Resend StatusNotification when the SuspendedEVSE reason changes while the status stays SuspendedEVSE. OCPP 1.6 only.",
+        "default": false,
+        "type": "boolean"
+      },
       "IFace": {
         "variable_name": "IFace",
         "characteristics": {

--- a/lib/everest/ocpp/config/v16/profile_schemas/Internal.json
+++ b/lib/everest/ocpp/config/v16/profile_schemas/Internal.json
@@ -353,6 +353,12 @@
             "type": "boolean",
             "readOnly": true
         },
+        "ReportSuspendedEVSEReasonChange": {
+            "$comment": "Resend StatusNotification when the SuspendedEVSE reason changes while the status stays SuspendedEVSE",
+            "type": "boolean",
+            "readOnly": false,
+            "default": false
+        },
         "MessageTypesDiscardForQueueing": {
             "$comment": "Comma seperated list of message types that shall not be queued (when offline) even in case QueueAllMessages is true. If QueueAllMessages is false, the configuration of this paramater has no effect.",
             "type": "string",

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point.hpp
@@ -338,8 +338,10 @@ public:
     void on_suspend_charging_ev(std::int32_t connector, const std::optional<CiString<50>> info = std::nullopt);
 
     /// \brief This function should be called when EVSE indicates that it suspends charging on the given \p connector
+    /// . The \p info is always forwarded verbatim, but unless ReportSuspendedEVSEReasonChange is set a suspend on an
+    /// already suspended connector is discarded.
     /// \param connector
-    /// \param reason
+    /// \param info
     void on_suspend_charging_evse(std::int32_t connector, const std::optional<CiString<50>> info = std::nullopt);
 
     /// \brief This function should be called when charging resumes on the given \p connector

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration.hpp
@@ -129,6 +129,9 @@ public:
     bool getVerifyCsmsAllowWildcards() override;
     void setVerifyCsmsAllowWildcards(bool verify_csms_allow_wildcards) override;
     KeyValue getVerifyCsmsAllowWildcardsKeyValue() override;
+    bool getReportSuspendedEVSEReasonChange() override;
+    void setReportSuspendedEVSEReasonChange(bool report_suspended_evse_reason_change) override;
+    KeyValue getReportSuspendedEVSEReasonChangeKeyValue() override;
     bool getUseTPM() override;
     KeyValue getUseTPMKeyValue() override;
     bool getUseTPMSeccLeafCertificate() override;

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
@@ -42,6 +42,7 @@ protected:
     SetResult setInternalOcspRequestInterval(const std::string& value);
     SetResult setInternalRejectRemoteStartTransactionWithoutConnectorId(const std::string& value);
     SetResult setInternalRemoteStartTransactionWithoutConnectorIdFindFirst(const std::string& value);
+    SetResult setInternalReportSuspendedEVSEReasonChange(const std::string& value);
     SetResult setInternalRetryBackoffRandomRange(const std::string& value);
     SetResult setInternalRetryBackoffRepeatTimes(const std::string& value);
     SetResult setInternalRetryBackoffWaitMinimum(const std::string& value);
@@ -162,6 +163,7 @@ public:
     bool getLogMessagesRaw() override;
     bool getLogRotation() override;
     bool getLogRotationDateSuffix() override;
+    bool getReportSuspendedEVSEReasonChange() override;
     bool getStopTransactionIfUnlockNotSupported() override;
     bool getUseSslDefaultVerifyPaths() override;
     bool getUseTPM() override;
@@ -224,6 +226,7 @@ public:
     KeyValue getMaxCompositeScheduleDurationKeyValue() override;
     KeyValue getMaxMessageSizeKeyValue() override;
     KeyValue getOcspRequestIntervalKeyValue() override;
+    KeyValue getReportSuspendedEVSEReasonChangeKeyValue() override;
     KeyValue getRetryBackoffRandomRangeKeyValue() override;
     KeyValue getRetryBackoffRepeatTimesKeyValue() override;
     KeyValue getRetryBackoffWaitMinimumKeyValue() override;
@@ -275,6 +278,7 @@ public:
     void setOcspRequestInterval(std::int32_t ocsp_request_interval) override;
     void setRejectRemoteStartTransactionWithoutConnectorId(bool reject) override;
     void setRemoteStartTransactionWithoutConnectorIdFindFirst(bool find_first) override;
+    void setReportSuspendedEVSEReasonChange(bool report_suspended_evse_reason_change) override;
     void setRetryBackoffRandomRange(std::int32_t retry_backoff_random_range) override;
     void setRetryBackoffRepeatTimes(std::int32_t retry_backoff_repeat_times) override;
     void setRetryBackoffWaitMinimum(std::int32_t retry_backoff_wait_minimum) override;

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_interface.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_interface.hpp
@@ -67,6 +67,7 @@ public:
     virtual bool getLogMessagesRaw() = 0;
     virtual bool getLogRotation() = 0;
     virtual bool getLogRotationDateSuffix() = 0;
+    virtual bool getReportSuspendedEVSEReasonChange() = 0;
     virtual bool getStopTransactionIfUnlockNotSupported() = 0;
     virtual bool getUseSslDefaultVerifyPaths() = 0;
     virtual bool getUseTPM() = 0;
@@ -129,6 +130,7 @@ public:
     virtual KeyValue getMaxCompositeScheduleDurationKeyValue() = 0;
     virtual KeyValue getMaxMessageSizeKeyValue() = 0;
     virtual KeyValue getOcspRequestIntervalKeyValue() = 0;
+    virtual KeyValue getReportSuspendedEVSEReasonChangeKeyValue() = 0;
     virtual KeyValue getRetryBackoffRandomRangeKeyValue() = 0;
     virtual KeyValue getRetryBackoffRepeatTimesKeyValue() = 0;
     virtual KeyValue getRetryBackoffWaitMinimumKeyValue() = 0;
@@ -180,6 +182,7 @@ public:
     virtual void setOcspRequestInterval(std::int32_t ocsp_request_interval) = 0;
     virtual void setRejectRemoteStartTransactionWithoutConnectorId(bool reject) = 0;
     virtual void setRemoteStartTransactionWithoutConnectorIdFindFirst(bool find_first) = 0;
+    virtual void setReportSuspendedEVSEReasonChange(bool report_suspended_evse_reason_change) = 0;
     virtual void setRetryBackoffRandomRange(std::int32_t retry_backoff_random_range) = 0;
     virtual void setRetryBackoffRepeatTimes(std::int32_t retry_backoff_repeat_times) = 0;
     virtual void setRetryBackoffWaitMinimum(std::int32_t retry_backoff_wait_minimum) = 0;

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
@@ -251,6 +251,9 @@ private:
                              const std::optional<CiString<255>>& vendor_id = std::nullopt,
                              const std::optional<CiString<50>>& vendor_error_code = std::nullopt,
                              bool initiated_by_trigger_message = false);
+    /// \brief Answers a TriggerMessage(StatusNotification) for \p connector . An active error owns the info field; in
+    /// its absence a suspended connector reports its suspend reason if ReportSuspendedEVSEReasonChange is set.
+    void triggered_status_notification(const std::int32_t connector);
     void diagnostic_status_notification(DiagnosticsStatus status, bool initiated_by_trigger_message = false);
     void firmware_status_notification(FirmwareStatus status, bool initiated_by_trigger_message = false,
                                       bool disable_connectors_during_install = true);
@@ -668,6 +671,8 @@ public:
     void on_suspend_charging_ev(std::int32_t connector, const std::optional<CiString<50>> info = std::nullopt);
 
     /// \brief This function should be called when EVSE indicates that it suspends charging on the given \p connector
+    /// . The \p info is always forwarded verbatim, but unless ReportSuspendedEVSEReasonChange is set a suspend on an
+    /// already suspended connector is discarded.
     /// \param connector
     /// \param info
     void on_suspend_charging_evse(std::int32_t connector, const std::optional<CiString<50>> info = std::nullopt);

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_state_machine.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_state_machine.hpp
@@ -82,6 +82,9 @@ public:
     FSMState get_state();
     std::optional<ErrorInfo> get_latest_error();
 
+    /// \brief The info of the transition that put the connector into SuspendedEVSE, empty in any other state
+    std::optional<CiString<50>> get_suspend_reason() const;
+
 private:
     StatusNotificationCallback status_notification_callback;
     // track current state
@@ -89,8 +92,14 @@ private:
     FSMState state;
     std::unordered_map<std::string, ErrorInfo> active_errors;
     const bool report_cleared_errors;
+    std::optional<CiString<50>> last_emitted_info;
+    std::optional<CiString<50>> suspend_reason;
 
     bool is_faulted();
+    void emit_status_notification(FSMState reported_state, ChargePointErrorCode error_code,
+                                  const ocpp::DateTime& timestamp, const std::optional<CiString<50>>& info,
+                                  const std::optional<CiString<255>>& vendor_id,
+                                  const std::optional<CiString<50>>& vendor_error_code);
 };
 
 class ChargePointStates {
@@ -112,6 +121,9 @@ public:
 
     ChargePointStatus get_state(int connector_id);
     std::optional<ErrorInfo> get_latest_error(int connector_id);
+
+    /// \brief The info of the transition that put \p connector_id into SuspendedEVSE, empty in any other state
+    std::optional<CiString<50>> get_suspend_reason(int connector_id);
 
 private:
     ConnectorStatusCallback connector_status_callback;

--- a/lib/everest/ocpp/include/ocpp/v16/known_keys.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/known_keys.hpp
@@ -97,6 +97,7 @@ namespace ocpp::v16::keys {
     mapping(UseSslDefaultVerifyPaths, UseSslDefaultVerifyPaths) \
     mapping(VerifyCsmsCommonName, VerifyCsmsCommonName) \
     mapping(VerifyCsmsAllowWildcards, VerifyCsmsAllowWildcards) \
+    mapping(ReportSuspendedEVSEReasonChange, ReportSuspendedEVSEReasonChange) \
     mapping(OcspRequestInterval, OcspRequestInterval) \
     mapping(SeccLeafSubjectCommonName, ISO15118CtrlrSeccId) \
     mapping(SeccLeafSubjectCountry, ISO15118CtrlrCountryName) \
@@ -284,6 +285,7 @@ namespace ocpp::v16::keys {
     key(Internal, RejectRemoteStartTransactionWithoutConnectorId) \
     key(Internal, RemoteStartTransactionWithoutConnectorIdFindFirst) \
     key(Internal, ReportClearedErrors) \
+    key(Internal, ReportSuspendedEVSEReasonChange) \
     key(Internal, RetryBackoffRandomRange) \
     key(Internal, RetryBackoffRepeatTimes) \
     key(Internal, RetryBackoffWaitMinimum) \

--- a/lib/everest/ocpp/include/ocpp/v2/ctrlr_component_variables.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/ctrlr_component_variables.hpp
@@ -140,6 +140,7 @@ extern const ComponentVariable VerifyCsmsCommonName;
 extern const ComponentVariable UseTPM;
 extern const ComponentVariable UseTPMSeccLeafCertificate;
 extern const ComponentVariable VerifyCsmsAllowWildcards;
+extern const ComponentVariable ReportSuspendedEVSEReasonChange;
 extern const ComponentVariable IFace;
 extern const ComponentVariable EnableTLSKeylog;
 extern const ComponentVariable TLSKeylogFile;

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
@@ -536,6 +536,15 @@ void ChargePointConfiguration::setVerifyCsmsAllowWildcards(bool verify_csms_allo
     this->setInUserConfig("Internal", "VerifyCsmsAllowWildcards", verify_csms_allow_wildcards);
 }
 
+bool ChargePointConfiguration::getReportSuspendedEVSEReasonChange() {
+    return this->config["Internal"]["ReportSuspendedEVSEReasonChange"];
+}
+
+void ChargePointConfiguration::setReportSuspendedEVSEReasonChange(bool report_suspended_evse_reason_change) {
+    this->config["Internal"]["ReportSuspendedEVSEReasonChange"] = report_suspended_evse_reason_change;
+    this->setInUserConfig("Internal", "ReportSuspendedEVSEReasonChange", report_suspended_evse_reason_change);
+}
+
 std::string ChargePointConfiguration::getSupportedMeasurands() {
     return this->config["Internal"]["SupportedMeasurands"];
 }
@@ -798,6 +807,14 @@ KeyValue ChargePointConfiguration::getVerifyCsmsAllowWildcardsKeyValue() {
     kv.key = "VerifyCsmsAllowWildcards";
     kv.readonly = true;
     kv.value.emplace(ocpp::conversions::bool_to_string(this->getVerifyCsmsAllowWildcards()));
+    return kv;
+}
+
+KeyValue ChargePointConfiguration::getReportSuspendedEVSEReasonChangeKeyValue() {
+    KeyValue kv;
+    kv.key = "ReportSuspendedEVSEReasonChange";
+    kv.readonly = false;
+    kv.value.emplace(ocpp::conversions::bool_to_string(this->getReportSuspendedEVSEReasonChange()));
     return kv;
 }
 
@@ -3337,6 +3354,9 @@ std::optional<KeyValue> ChargePointConfiguration::get(const CiString<50>& key) {
     if (key == "VerifyCsmsAllowWildcards") {
         return this->getVerifyCsmsAllowWildcardsKeyValue();
     }
+    if (key == "ReportSuspendedEVSEReasonChange") {
+        return this->getReportSuspendedEVSEReasonChangeKeyValue();
+    }
     if (key == "OcspRequestInterval") {
         return this->getOcspRequestIntervalKeyValue();
     }
@@ -4143,6 +4163,12 @@ std::optional<ConfigurationStatus> ChargePointConfiguration::set(const CiString<
     } else if (key == "VerifyCsmsAllowWildcards") {
         if (isBool(value.get())) {
             this->setVerifyCsmsAllowWildcards(ocpp::conversions::string_to_bool(value.get()));
+        } else {
+            return ConfigurationStatus::Rejected;
+        }
+    } else if (key == "ReportSuspendedEVSEReasonChange") {
+        if (isBool(value.get())) {
+            this->setReportSuspendedEVSEReasonChange(ocpp::conversions::string_to_bool(value.get()));
         } else {
             return ConfigurationStatus::Rejected;
         }

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
@@ -561,6 +561,11 @@ ChargePointConfigurationDeviceModel::setInternalRemoteStartTransactionWithoutCon
 }
 
 ChargePointConfigurationDeviceModel::SetResult
+ChargePointConfigurationDeviceModel::setInternalReportSuspendedEVSEReasonChange(const std::string& value) {
+    return set_value(isBool, *storage, keys::valid_keys::ReportSuspendedEVSEReasonChange, value);
+}
+
+ChargePointConfigurationDeviceModel::SetResult
 ChargePointConfigurationDeviceModel::setInternalCentralSystemURI(const std::string& value) {
     namespace NC = ocpp::v2::NetworkConfigurationComponentVariables;
     const auto cv = NC::get_component_variable(get_active_network_slot(*storage), NC::OcppCsmsUrl);
@@ -1862,6 +1867,10 @@ bool ChargePointConfigurationDeviceModel::getLogRotationDateSuffix() {
     return get_value<bool>(*storage, keys::valid_keys::LogRotationDateSuffix);
 }
 
+bool ChargePointConfigurationDeviceModel::getReportSuspendedEVSEReasonChange() {
+    return get_value<bool>(*storage, keys::valid_keys::ReportSuspendedEVSEReasonChange);
+}
+
 bool ChargePointConfigurationDeviceModel::getStopTransactionIfUnlockNotSupported() {
     return get_value<bool>(*storage, keys::valid_keys::StopTransactionIfUnlockNotSupported);
 }
@@ -2204,6 +2213,10 @@ KeyValue ChargePointConfigurationDeviceModel::getVerifyCsmsAllowWildcardsKeyValu
     return get_key_value(*storage, keys::valid_keys::VerifyCsmsAllowWildcards);
 }
 
+KeyValue ChargePointConfigurationDeviceModel::getReportSuspendedEVSEReasonChangeKeyValue() {
+    return get_key_value(*storage, keys::valid_keys::ReportSuspendedEVSEReasonChange);
+}
+
 KeyValue ChargePointConfigurationDeviceModel::getWaitForStopTransactionsOnResetTimeoutKeyValue() {
     return get_key_value(*storage, keys::valid_keys::WaitForStopTransactionsOnResetTimeout);
 }
@@ -2450,6 +2463,10 @@ void ChargePointConfigurationDeviceModel::setSwitchSecurityProfileConnectionTime
 
 void ChargePointConfigurationDeviceModel::setVerifyCsmsAllowWildcards(bool verify_csms_allow_wildcards) {
     setInternalVerifyCsmsAllowWildcards(to_string(verify_csms_allow_wildcards));
+}
+
+void ChargePointConfigurationDeviceModel::setReportSuspendedEVSEReasonChange(bool report_suspended_evse_reason_change) {
+    setInternalReportSuspendedEVSEReasonChange(to_string(report_suspended_evse_reason_change));
 }
 
 void ChargePointConfigurationDeviceModel::setWaitForStopTransactionsOnResetTimeout(
@@ -3576,6 +3593,9 @@ std::optional<ConfigurationStatus> ChargePointConfigurationDeviceModel::set(cons
             break;
         case keys::valid_keys::RemoteStartTransactionWithoutConnectorIdFindFirst:
             result = convert(setInternalRemoteStartTransactionWithoutConnectorIdFindFirst(value_str));
+            break;
+        case keys::valid_keys::ReportSuspendedEVSEReasonChange:
+            result = convert(setInternalReportSuspendedEVSEReasonChange(value_str));
             break;
         case keys::valid_keys::RetryBackoffRandomRange:
             result = convert(setInternalRetryBackoffRandomRange(value_str));

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -2706,20 +2706,29 @@ void ChargePointImpl::handleTriggerMessageRequest(ocpp::Call<TriggerMessageReque
         if (!call.msg.connectorId.has_value()) {
             // send a status notification for every connector
             for (std::int32_t c = 0; c <= this->configuration.getNumberOfConnectors(); c++) {
-                const ErrorInfo error_info =
-                    this->status->get_latest_error(c).value_or(ErrorInfo("", ChargePointErrorCode::NoError, false));
-                this->status_notification(c, error_info.error_code, this->status->get_state(c), ocpp::DateTime(),
-                                          error_info.info, error_info.vendor_id, error_info.vendor_error_code, true);
+                this->triggered_status_notification(c);
             }
         } else {
-            const ErrorInfo error_info =
-                this->status->get_latest_error(connector).value_or(ErrorInfo("", ChargePointErrorCode::NoError, false));
-            this->status_notification(connector, error_info.error_code, this->status->get_state(connector),
-                                      ocpp::DateTime(), error_info.info, error_info.vendor_id,
-                                      error_info.vendor_error_code, true);
+            this->triggered_status_notification(connector);
         }
         break;
     }
+}
+
+void ChargePointImpl::triggered_status_notification(const std::int32_t connector) {
+    const auto latest_error = this->status->get_latest_error(connector);
+    const ErrorInfo error_info = latest_error.value_or(ErrorInfo("", ChargePointErrorCode::NoError, false));
+    const auto status = this->status->get_state(connector);
+
+    auto info = error_info.info;
+    if (not latest_error.has_value() and status == ChargePointStatus::SuspendedEVSE and
+        this->configuration.getReportSuspendedEVSEReasonChange()) {
+        // no error owns the info field, so report why the connector is suspended
+        info = this->status->get_suspend_reason(connector);
+    }
+
+    this->status_notification(connector, error_info.error_code, status, ocpp::DateTime(), info, error_info.vendor_id,
+                              error_info.vendor_error_code, true);
 }
 
 void ChargePointImpl::handleGetDiagnosticsRequest(ocpp::Call<GetDiagnosticsRequest> call) {
@@ -4657,6 +4666,11 @@ void ChargePointImpl::on_suspend_charging_ev(std::int32_t connector, const std::
 }
 
 void ChargePointImpl::on_suspend_charging_evse(std::int32_t connector, const std::optional<CiString<50>> info) {
+    if (not this->configuration.getReportSuspendedEVSEReasonChange() and
+        this->status->get_state(connector) == ChargePointStatus::SuspendedEVSE) {
+        // the SuspendedEVSE self transition is not offered to the state machine at all
+        return;
+    }
     this->status->submit_event(connector, FSMEvent::PauseChargingEVSE, ocpp::DateTime(), info);
 }
 

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_state_machine.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_state_machine.cpp
@@ -50,6 +50,7 @@ static const FSMDefinition FSM_DEF = {
          {FSMEvent::BecomeAvailable, FSMState::Available},
          {FSMEvent::StartCharging, FSMState::Charging},
          {FSMEvent::PauseChargingEV, FSMState::SuspendedEV},
+         {FSMEvent::PauseChargingEVSE, FSMState::SuspendedEVSE},
          {FSMEvent::TransactionStoppedAndUserActionRequired, FSMState::Finishing},
          {FSMEvent::ChangeAvailabilityToUnavailable, FSMState::Unavailable},
      }},
@@ -158,6 +159,10 @@ bool ChargePointFSM::is_faulted() {
            this->active_errors.end();
 }
 
+std::optional<CiString<50>> ChargePointFSM::get_suspend_reason() const {
+    return this->suspend_reason;
+}
+
 std::optional<ErrorInfo> ChargePointFSM::get_latest_error() {
     if (this->active_errors.empty()) {
         return std::nullopt;
@@ -172,6 +177,14 @@ std::optional<ErrorInfo> ChargePointFSM::get_latest_error() {
     return latest_error;
 }
 
+void ChargePointFSM::emit_status_notification(FSMState reported_state, ChargePointErrorCode error_code,
+                                              const ocpp::DateTime& timestamp, const std::optional<CiString<50>>& info,
+                                              const std::optional<CiString<255>>& vendor_id,
+                                              const std::optional<CiString<50>>& vendor_error_code) {
+    this->last_emitted_info = info;
+    this->status_notification_callback(reported_state, error_code, timestamp, info, vendor_id, vendor_error_code);
+}
+
 bool ChargePointFSM::handle_event(FSMEvent event, const ocpp::DateTime timestamp,
                                   const std::optional<CiString<50>>& info) {
     const auto& transitions = FSM_DEF.at(state);
@@ -182,15 +195,22 @@ bool ChargePointFSM::handle_event(FSMEvent event, const ocpp::DateTime timestamp
         return false;
     }
 
+    // a self transition only carries new information if the reported info changed
+    if (dest_state_it->second == this->state and info == this->last_emitted_info) {
+        return false;
+    }
+
     // fall through: transition found
     state = dest_state_it->second;
 
     const auto error_info = this->get_latest_error().value_or(ErrorInfo("", ChargePointErrorCode::NoError, false));
 
+    this->suspend_reason = (state == FSMState::SuspendedEVSE) ? info : std::nullopt;
+
     // only send a StatusNotification.req with the updated state if not in faulted
     if (!this->is_faulted()) {
-        status_notification_callback(state, error_info.error_code, timestamp, info, error_info.vendor_id,
-                                     error_info.vendor_error_code);
+        this->emit_status_notification(state, error_info.error_code, timestamp, info, error_info.vendor_id,
+                                       error_info.vendor_error_code);
     }
 
     return true;
@@ -205,11 +225,11 @@ bool ChargePointFSM::handle_error(const ErrorInfo& error_info) {
     this->active_errors.insert({error_info.uuid, error_info});
 
     if (!this->is_faulted()) {
-        status_notification_callback(this->state, error_info.error_code, error_info.timestamp, error_info.info,
-                                     error_info.vendor_id, error_info.vendor_error_code);
+        this->emit_status_notification(this->state, error_info.error_code, error_info.timestamp, error_info.info,
+                                       error_info.vendor_id, error_info.vendor_error_code);
     } else {
-        status_notification_callback(FSMState::Faulted, error_info.error_code, error_info.timestamp, error_info.info,
-                                     error_info.vendor_id, error_info.vendor_error_code);
+        this->emit_status_notification(FSMState::Faulted, error_info.error_code, error_info.timestamp, error_info.info,
+                                       error_info.vendor_id, error_info.vendor_error_code);
     }
     return true;
 }
@@ -263,15 +283,15 @@ bool ChargePointFSM::handle_error_cleared(const std::string uuid) {
     }
 
     // Send a StatusNotification.req
-    status_notification_callback(state, error_code, DateTime(), info, vendor_id, vendor_error_code);
+    this->emit_status_notification(state, error_code, DateTime(), info, vendor_id, vendor_error_code);
 
     return true;
 }
 
 bool ChargePointFSM::handle_all_errors_cleared() {
     this->active_errors.clear();
-    status_notification_callback(this->state, ChargePointErrorCode::NoError, DateTime(), std::nullopt, std::nullopt,
-                                 std::nullopt);
+    this->emit_status_notification(this->state, ChargePointErrorCode::NoError, DateTime(), std::nullopt, std::nullopt,
+                                   std::nullopt);
     return true;
 }
 
@@ -279,11 +299,11 @@ void ChargePointFSM::trigger_status_notification() {
     // get latest error or report NoError
     const auto error_info = this->get_latest_error().value_or(ErrorInfo("", ChargePointErrorCode::NoError, false));
     if (!this->is_faulted()) {
-        status_notification_callback(this->state, error_info.error_code, error_info.timestamp, error_info.info,
-                                     error_info.vendor_id, error_info.vendor_error_code);
+        this->emit_status_notification(this->state, error_info.error_code, error_info.timestamp, error_info.info,
+                                       error_info.vendor_id, error_info.vendor_error_code);
     } else {
-        status_notification_callback(FSMState::Faulted, error_info.error_code, error_info.timestamp, error_info.info,
-                                     error_info.vendor_id, error_info.vendor_error_code);
+        this->emit_status_notification(FSMState::Faulted, error_info.error_code, error_info.timestamp, error_info.info,
+                                       error_info.vendor_id, error_info.vendor_error_code);
     }
 }
 
@@ -400,6 +420,14 @@ std::optional<ErrorInfo> ChargePointStates::get_latest_error(int connector_id) {
         return state_machines.at(connector_id - 1).get_latest_error();
     }
     return state_machine_connector_zero->get_latest_error();
+}
+
+std::optional<CiString<50>> ChargePointStates::get_suspend_reason(int connector_id) {
+    const std::lock_guard<std::mutex> lck(state_machines_mutex);
+    if (connector_id > 0 && static_cast<size_t>(connector_id) <= this->state_machines.size()) {
+        return state_machines.at(connector_id - 1).get_suspend_reason();
+    }
+    return state_machine_connector_zero->get_suspend_reason();
 }
 
 } // namespace v16

--- a/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
@@ -245,6 +245,12 @@ const ComponentVariable VerifyCsmsAllowWildcards = {
         "VerifyCsmsAllowWildcards",
     }),
 };
+const ComponentVariable ReportSuspendedEVSEReasonChange = {
+    ControllerComponents::InternalCtrlr,
+    std::optional<Variable>({
+        "ReportSuspendedEVSEReasonChange",
+    }),
+};
 const ComponentVariable IFace = {
     ControllerComponents::InternalCtrlr,
     std::optional<Variable>({

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(libocpp_unit_tests PRIVATE
         test_composite_schedule.cpp
         test_charge_point_connectivity.cpp
         test_devicemodel_connectivity.cpp
+        test_charge_point_suspend_reason.cpp
         test_config_validation.cpp
         utils_tests.cpp
         test_configuration.cpp

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/test_charge_point_state_machine.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/test_charge_point_state_machine.cpp
@@ -243,6 +243,163 @@ TEST_F(ChargePointStateMachineTest, HandleErrorCleared__ResolvedErrorInfoTruncat
     state_machine->handle_error_cleared(error_info.uuid);
 }
 
+TEST_F(ChargePointStateMachineTest, SuspendedEVSE__ReasonChangeEmits) {
+    create_state_machine(false);
+    const std::optional<ocpp::CiString<50>> first_reason("NoEnergy");
+    const std::optional<ocpp::CiString<50>> second_reason("Error,NoEnergy");
+
+    EXPECT_CALL(mock_callback, Call(_, _, _, _, _, _)).Times(0);
+    {
+        InSequence seq;
+        EXPECT_CALL(mock_callback, Call(FSMState::SuspendedEVSE, ChargePointErrorCode::NoError, _, first_reason, _, _));
+        EXPECT_CALL(mock_callback,
+                    Call(FSMState::SuspendedEVSE, ChargePointErrorCode::NoError, _, second_reason, _, _));
+    }
+
+    EXPECT_TRUE(state_machine->handle_event(FSMEvent::PauseChargingEVSE, ocpp::DateTime(), first_reason));
+    EXPECT_TRUE(state_machine->handle_event(FSMEvent::PauseChargingEVSE, ocpp::DateTime(), second_reason));
+    EXPECT_EQ(state_machine->get_state(), FSMState::SuspendedEVSE);
+}
+
+TEST_F(ChargePointStateMachineTest, SuspendedEVSE__IdenticalReasonSuppressed) {
+    create_state_machine(false);
+    const std::optional<ocpp::CiString<50>> reason("NoEnergy");
+
+    EXPECT_CALL(mock_callback, Call(_, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(mock_callback, Call(FSMState::SuspendedEVSE, ChargePointErrorCode::NoError, _, reason, _, _)).Times(1);
+
+    EXPECT_TRUE(state_machine->handle_event(FSMEvent::PauseChargingEVSE, ocpp::DateTime(), reason));
+    EXPECT_FALSE(state_machine->handle_event(FSMEvent::PauseChargingEVSE, ocpp::DateTime(), reason));
+}
+
+TEST_F(ChargePointStateMachineTest, SuspendedEVSE__NulloptRepeatSuppressed) {
+    create_state_machine(false);
+
+    EXPECT_CALL(mock_callback, Call(_, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(mock_callback, Call(FSMState::SuspendedEVSE, ChargePointErrorCode::NoError, _,
+                                    std::optional<ocpp::CiString<50>>(), _, _))
+        .Times(1);
+
+    EXPECT_TRUE(state_machine->handle_event(FSMEvent::PauseChargingEVSE, ocpp::DateTime(), std::nullopt));
+    EXPECT_FALSE(state_machine->handle_event(FSMEvent::PauseChargingEVSE, ocpp::DateTime(), std::nullopt));
+}
+
+TEST_F(ChargePointStateMachineTest, SuspendedEVSE__InterleavedErrorThenIdenticalReasonEmits) {
+    create_state_machine(false);
+    const std::optional<ocpp::CiString<50>> reason("NoEnergy");
+    const ErrorInfo error_info("uuid1", ChargePointErrorCode::OtherError, false, "SomeError");
+
+    EXPECT_CALL(mock_callback, Call(_, _, _, _, _, _)).Times(0);
+    {
+        InSequence seq;
+        EXPECT_CALL(mock_callback, Call(FSMState::SuspendedEVSE, ChargePointErrorCode::NoError, _, reason, _, _));
+        EXPECT_CALL(mock_callback, Call(FSMState::SuspendedEVSE, ChargePointErrorCode::OtherError, _,
+                                        std::optional<ocpp::CiString<50>>("SomeError"), _, _));
+        EXPECT_CALL(mock_callback, Call(FSMState::SuspendedEVSE, ChargePointErrorCode::OtherError, _, reason, _, _));
+    }
+
+    EXPECT_TRUE(state_machine->handle_event(FSMEvent::PauseChargingEVSE, ocpp::DateTime(), reason));
+    EXPECT_TRUE(state_machine->handle_error(error_info));
+    EXPECT_TRUE(state_machine->handle_event(FSMEvent::PauseChargingEVSE, ocpp::DateTime(), reason));
+}
+
+// A connector that leaves SuspendedEVSE and is suspended again for the same reason must report the re-entry. The
+// self-transition guard must stay narrow enough to let this through.
+TEST_F(ChargePointStateMachineTest, SuspendedEVSE__SameReasonAfterChargingEmits) {
+    create_state_machine(false);
+    const std::optional<ocpp::CiString<50>> reason("NoEnergy");
+
+    EXPECT_CALL(mock_callback, Call(_, _, _, _, _, _)).Times(0);
+    {
+        InSequence seq;
+        EXPECT_CALL(mock_callback, Call(FSMState::SuspendedEVSE, ChargePointErrorCode::NoError, _, reason, _, _));
+        EXPECT_CALL(mock_callback, Call(FSMState::Charging, ChargePointErrorCode::NoError, _,
+                                        std::optional<ocpp::CiString<50>>(), _, _));
+        EXPECT_CALL(mock_callback, Call(FSMState::SuspendedEVSE, ChargePointErrorCode::NoError, _, reason, _, _));
+    }
+
+    EXPECT_TRUE(state_machine->handle_event(FSMEvent::PauseChargingEVSE, ocpp::DateTime(), reason));
+    EXPECT_TRUE(state_machine->handle_event(FSMEvent::StartCharging, ocpp::DateTime(), std::nullopt));
+    EXPECT_TRUE(state_machine->handle_event(FSMEvent::PauseChargingEVSE, ocpp::DateTime(), reason));
+    EXPECT_EQ(state_machine->get_state(), FSMState::SuspendedEVSE);
+    EXPECT_EQ(state_machine->get_suspend_reason(), reason);
+}
+
+TEST_F(ChargePointStateMachineTest, Finishing__PauseChargingEVSERejected) {
+    create_state_machine(false);
+    const std::optional<ocpp::CiString<50>> reason("NoEnergy");
+
+    EXPECT_CALL(mock_callback, Call(_, _, _, _, _, _)).Times(0);
+    {
+        InSequence seq;
+        EXPECT_CALL(mock_callback, Call(FSMState::SuspendedEVSE, ChargePointErrorCode::NoError, _, reason, _, _));
+        EXPECT_CALL(mock_callback, Call(FSMState::Finishing, ChargePointErrorCode::NoError, _, _, _, _));
+    }
+
+    EXPECT_TRUE(state_machine->handle_event(FSMEvent::PauseChargingEVSE, ocpp::DateTime(), reason));
+    EXPECT_TRUE(
+        state_machine->handle_event(FSMEvent::TransactionStoppedAndUserActionRequired, ocpp::DateTime(), std::nullopt));
+    EXPECT_FALSE(state_machine->handle_event(FSMEvent::PauseChargingEVSE, ocpp::DateTime(), reason));
+    EXPECT_EQ(state_machine->get_state(), FSMState::Finishing);
+}
+
+TEST_F(ChargePointStateMachineTest, SuspendedEVSE__NoEmitWhileFaulted) {
+    create_state_machine(false);
+    const std::optional<ocpp::CiString<50>> reason("NoEnergy");
+    const std::optional<ocpp::CiString<50>> changed_reason("Error,NoEnergy");
+    const ErrorInfo fault("uuid1", ChargePointErrorCode::GroundFailure, true);
+
+    EXPECT_CALL(mock_callback, Call(_, _, _, _, _, _)).Times(0);
+    {
+        InSequence seq;
+        EXPECT_CALL(mock_callback, Call(FSMState::SuspendedEVSE, ChargePointErrorCode::NoError, _, reason, _, _));
+        EXPECT_CALL(mock_callback, Call(FSMState::Faulted, ChargePointErrorCode::GroundFailure, _, _, _, _));
+    }
+
+    EXPECT_TRUE(state_machine->handle_event(FSMEvent::PauseChargingEVSE, ocpp::DateTime(), reason));
+    EXPECT_TRUE(state_machine->handle_error(fault));
+    EXPECT_TRUE(state_machine->handle_event(FSMEvent::PauseChargingEVSE, ocpp::DateTime(), changed_reason));
+    EXPECT_EQ(state_machine->get_state(), FSMState::Faulted);
+}
+
+// ChargePointFSM::trigger_status_notification drives the per-connector StatusNotification.req burst that follows an
+// accepted BootNotification and a reconnect. It reports error state only: without an active error the burst carries no
+// info, whatever info the last transition happened to carry.
+TEST_F(ChargePointStateMachineTest, StatusNotificationBurst__NoInfoWithoutActiveError) {
+    create_state_machine(false);
+    const std::optional<ocpp::CiString<50>> reason("NoEnergy");
+
+    EXPECT_CALL(mock_callback, Call(_, _, _, _, _, _)).Times(0);
+    {
+        InSequence seq;
+        EXPECT_CALL(mock_callback, Call(FSMState::SuspendedEVSE, ChargePointErrorCode::NoError, _, reason, _, _));
+        EXPECT_CALL(mock_callback, Call(FSMState::SuspendedEVSE, ChargePointErrorCode::NoError, _,
+                                        std::optional<ocpp::CiString<50>>(), _, _));
+    }
+
+    EXPECT_TRUE(state_machine->handle_event(FSMEvent::PauseChargingEVSE, ocpp::DateTime(), reason));
+    state_machine->trigger_status_notification();
+}
+
+TEST_F(ChargePointStateMachineTest, StatusNotificationBurst__ReportsActiveErrorInfo) {
+    create_state_machine(false);
+    const std::optional<ocpp::CiString<50>> reason("NoEnergy");
+    const ErrorInfo error_info("uuid1", ChargePointErrorCode::OtherError, false, "SomeError");
+
+    EXPECT_CALL(mock_callback, Call(_, _, _, _, _, _)).Times(0);
+    {
+        InSequence seq;
+        EXPECT_CALL(mock_callback, Call(FSMState::SuspendedEVSE, ChargePointErrorCode::NoError, _, reason, _, _));
+        EXPECT_CALL(mock_callback, Call(FSMState::SuspendedEVSE, ChargePointErrorCode::OtherError, _,
+                                        std::optional<ocpp::CiString<50>>("SomeError"), _, _))
+            .Times(2);
+    }
+
+    EXPECT_TRUE(state_machine->handle_event(FSMEvent::PauseChargingEVSE, ocpp::DateTime(), reason));
+    EXPECT_TRUE(state_machine->handle_error(error_info));
+    state_machine->trigger_status_notification();
+}
+
 TEST_F(ChargePointStateMachineTest, HandleErrorCleared__NonFault__StillActive__Disabled__ReportsLatestRemainingInfo) {
     create_state_machine(false);
     ErrorInfo error_info_1("uuid1", ChargePointErrorCode::ConnectorLockFailure, false, "Info1", "VendorA", "VE1");

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/test_charge_point_suspend_reason.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/test_charge_point_suspend_reason.cpp
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+/// \file test_charge_point_suspend_reason.cpp
+/// \brief Wire-level tests for the v16 suspend entry points of ChargePointImpl.
+///
+/// A ChargePointImpl is driven through a mocked ConnectivityManager. Outgoing calls are captured and answered by a
+/// responder thread so the message queue keeps flowing, which makes the emitted StatusNotification.req sequence
+/// observable.
+
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include <ocpp/common/connectivity_manager.hpp>
+#include <ocpp/v16/charge_point_configuration.hpp>
+#include <ocpp/v16/charge_point_impl.hpp>
+
+#include "connectivity_manager_mock.hpp"
+#include "evse_security_mock.hpp"
+
+namespace fs = std::filesystem;
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+namespace ocpp {
+namespace v16 {
+
+namespace {
+constexpr auto WAIT_TIMEOUT = std::chrono::seconds(10);
+constexpr auto SETTLE_TIMEOUT = std::chrono::milliseconds(500);
+constexpr std::int32_t CONNECTOR = 1;
+} // namespace
+
+class ChargePointSuspendReasonTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        this->evse_security = std::make_shared<NiceMock<EvseSecurityMock>>();
+        this->connectivity_manager = std::make_shared<NiceMock<ConnectivityManagerMock>>();
+
+        this->tmp_dir = fs::temp_directory_path() /
+                        ("ocpp_v16_suspend_reason_test_" + std::to_string(reinterpret_cast<std::uintptr_t>(this)));
+        fs::create_directories(this->tmp_dir);
+
+        // A per-test user config keeps configuration writes out of the shared test resources.
+        const auto user_config = this->tmp_dir / "user_config.json";
+        std::ofstream(user_config) << "{}";
+
+        std::ifstream ifs(CONFIG_FILE_LOCATION_V16);
+        const std::string config_file((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
+        this->configuration = std::make_unique<ChargePointConfiguration>(config_file, CONFIG_DIR_V16, user_config);
+
+        ON_CALL(*this->connectivity_manager, is_websocket_connected()).WillByDefault(Return(true));
+        ON_CALL(*this->connectivity_manager, set_message_callback(_))
+            .WillByDefault(Invoke(
+                [this](const std::function<void(const std::string&)>& callback) { this->to_charge_point = callback; }));
+        ON_CALL(*this->connectivity_manager, send_to_websocket(_))
+            .WillByDefault(Invoke([this](const std::string& message) { return this->record_and_answer(message); }));
+
+        this->responder = std::thread([this]() { this->run_responder(); });
+    }
+
+    void TearDown() override {
+        {
+            const std::lock_guard<std::mutex> lock(this->mtx);
+            this->stop_responder = true;
+        }
+        this->cv.notify_all();
+        if (this->responder.joinable()) {
+            this->responder.join();
+        }
+        std::error_code ec;
+        fs::remove_all(this->tmp_dir, ec);
+    }
+
+    std::unique_ptr<ChargePointImpl> make_charge_point() {
+        return std::make_unique<ChargePointImpl>(
+            *this->configuration, /*share_path=*/fs::path(CONFIG_DIR_V16), /*database_path=*/this->tmp_dir,
+            /*sql_init_path=*/fs::path(MIGRATION_FILES_LOCATION_V16), /*message_log_path=*/this->tmp_dir,
+            this->evse_security, this->connectivity_manager, /*security_configuration=*/std::nullopt,
+            /*message_callback=*/nullptr);
+    }
+
+    /// \brief Capture an outgoing call and queue a CallResult for the responder thread.
+    bool record_and_answer(const std::string& message) {
+        const auto call = nlohmann::json::parse(message, nullptr, false);
+        if (call.is_discarded() or not call.is_array() or call.size() < 4 or call.at(0) != 2) {
+            return true;
+        }
+
+        const std::string unique_id = call.at(1);
+        const std::string action = call.at(2);
+
+        {
+            const std::lock_guard<std::mutex> lock(this->mtx);
+            this->sent.push_back(call);
+            this->pending_responses.push_back(
+                nlohmann::json::array({3, unique_id, this->response_payload_for(action)}));
+        }
+        this->cv.notify_all();
+        return true;
+    }
+
+    nlohmann::json response_payload_for(const std::string& action) const {
+        if (action == "BootNotification") {
+            return nlohmann::json{
+                {"currentTime", ocpp::DateTime().to_rfc3339()}, {"interval", 86400}, {"status", "Accepted"}};
+        }
+        return nlohmann::json::object();
+    }
+
+    /// \brief Deliver queued CallResults off the message-queue worker thread to avoid re-entering it.
+    void run_responder() {
+        while (true) {
+            nlohmann::json response;
+            {
+                std::unique_lock<std::mutex> lock(this->mtx);
+                this->cv.wait(lock, [this]() { return this->stop_responder or not this->pending_responses.empty(); });
+                if (this->stop_responder) {
+                    return;
+                }
+                response = this->pending_responses.front();
+                this->pending_responses.pop_front();
+            }
+            if (this->to_charge_point) {
+                this->to_charge_point(response.dump());
+            }
+        }
+    }
+
+    /// \brief Wait until a StatusNotification.req reporting \p status for \p CONNECTOR has been sent.
+    bool wait_for_status(const std::string& status) {
+        std::unique_lock<std::mutex> lock(this->mtx);
+        return this->cv.wait_for(lock, WAIT_TIMEOUT,
+                                 [this, &status]() { return this->count_status_locked(status) != 0; });
+    }
+
+    /// \brief Wait for a StatusNotification.req carrying \p info . Used with a short \p timeout to assert absence.
+    bool wait_for_info(const std::string& info, std::chrono::milliseconds timeout) {
+        std::unique_lock<std::mutex> lock(this->mtx);
+        return this->cv.wait_for(lock, timeout, [this, &info]() {
+            for (const auto& call : this->sent) {
+                if (call.at(2) == "StatusNotification" and call.at(3).value("info", std::string{}) == info) {
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    std::size_t count_status(const std::string& status) {
+        const std::lock_guard<std::mutex> lock(this->mtx);
+        return this->count_status_locked(status);
+    }
+
+    std::size_t sent_count() {
+        const std::lock_guard<std::mutex> lock(this->mtx);
+        return this->sent.size();
+    }
+
+    /// \brief Feed a CSMS TriggerMessage(StatusNotification) into the charge point.
+    void trigger_status_notification(const std::optional<std::int32_t> connector_id) {
+        nlohmann::json payload{{"requestedMessage", "StatusNotification"}};
+        if (connector_id.has_value()) {
+            payload["connectorId"] = connector_id.value();
+        }
+        const auto unique_id = "trigger-" + std::to_string(++this->trigger_counter);
+        this->to_charge_point(nlohmann::json::array({2, unique_id, "TriggerMessage", payload}).dump());
+    }
+
+    /// \brief Wait for the first StatusNotification.req for \p CONNECTOR recorded at or after index \p from .
+    std::optional<nlohmann::json> wait_for_status_notification_after(std::size_t from) {
+        std::unique_lock<std::mutex> lock(this->mtx);
+        const auto found = this->cv.wait_for(lock, WAIT_TIMEOUT, [this, from]() {
+            for (std::size_t i = from; i < this->sent.size(); ++i) {
+                if (this->sent.at(i).at(2) == "StatusNotification" and
+                    this->sent.at(i).at(3).at("connectorId") == CONNECTOR) {
+                    return true;
+                }
+            }
+            return false;
+        });
+        if (not found) {
+            return std::nullopt;
+        }
+        for (std::size_t i = from; i < this->sent.size(); ++i) {
+            if (this->sent.at(i).at(2) == "StatusNotification" and
+                this->sent.at(i).at(3).at("connectorId") == CONNECTOR) {
+                return this->sent.at(i).at(3);
+            }
+        }
+        return std::nullopt;
+    }
+
+    /// \brief Bring a charge point up to an accepted BootNotification with \p CONNECTOR available.
+    std::unique_ptr<ChargePointImpl> make_booted_charge_point() {
+        auto charge_point = make_charge_point();
+        charge_point->start({{0, ChargePointStatus::Available}, {CONNECTOR, ChargePointStatus::Available}},
+                            BootReasonEnum::PowerUp, {});
+        charge_point->on_websocket_connected(0, ocpp::v2::NetworkConnectionProfile{}, ocpp::OcppProtocolVersion::v16);
+        return charge_point;
+    }
+
+    std::size_t count_status_locked(const std::string& status) const {
+        std::size_t count = 0;
+        for (const auto& call : this->sent) {
+            if (call.at(2) == "StatusNotification" and call.at(3).at("connectorId") == CONNECTOR and
+                call.at(3).at("status") == status) {
+                ++count;
+            }
+        }
+        return count;
+    }
+
+    std::shared_ptr<NiceMock<EvseSecurityMock>> evse_security;
+    std::shared_ptr<NiceMock<ConnectivityManagerMock>> connectivity_manager;
+    std::unique_ptr<ChargePointConfiguration> configuration;
+    fs::path tmp_dir;
+
+    std::mutex mtx;
+    std::condition_variable cv;
+    std::vector<nlohmann::json> sent;
+    std::deque<nlohmann::json> pending_responses;
+    std::function<void(const std::string&)> to_charge_point;
+    std::thread responder;
+    bool stop_responder{false};
+    std::int32_t trigger_counter{0};
+};
+
+// ChargePointV16 decides whether to encode a pause reason by reading the variable back over GetConfiguration, so the
+// key has to be dispatched by name. An unknownKey here would leave the feature permanently off.
+TEST_F(ChargePointSuspendReasonTest, ConfigurationKeyIsReadableByName) {
+    auto charge_point = make_charge_point();
+
+    GetConfigurationRequest request;
+    request.key = {CiString<50>("ReportSuspendedEVSEReasonChange")};
+
+    auto response = charge_point->get_configuration_key(request);
+    EXPECT_FALSE(response.unknownKey.has_value());
+    ASSERT_TRUE(response.configurationKey.has_value());
+    ASSERT_EQ(response.configurationKey->size(), 1u);
+    ASSERT_TRUE(response.configurationKey->at(0).value.has_value());
+    EXPECT_EQ(static_cast<std::string>(response.configurationKey->at(0).value.value()), "false");
+
+    this->configuration->setReportSuspendedEVSEReasonChange(true);
+
+    response = charge_point->get_configuration_key(request);
+    ASSERT_TRUE(response.configurationKey.has_value());
+    ASSERT_EQ(response.configurationKey->size(), 1u);
+    ASSERT_TRUE(response.configurationKey->at(0).value.has_value());
+    EXPECT_EQ(static_cast<std::string>(response.configurationKey->at(0).value.value()), "true");
+}
+
+// With ReportSuspendedEVSEReasonChange at its default false, a phase switch reported while the connector already sits
+// in SuspendedEVSE must not reach the wire. Releases before the SuspendedEVSE self-transition existed dropped it in
+// the state machine; the ungated entry point has to drop it now.
+TEST_F(ChargePointSuspendReasonTest, PhaseSwitchWhileSuspendedIsNotReported) {
+    ASSERT_FALSE(this->configuration->getReportSuspendedEVSEReasonChange());
+
+    auto charge_point = make_charge_point();
+    charge_point->start({{0, ChargePointStatus::Available}, {CONNECTOR, ChargePointStatus::Available}},
+                        BootReasonEnum::PowerUp, {});
+    charge_point->on_websocket_connected(0, ocpp::v2::NetworkConnectionProfile{}, ocpp::OcppProtocolVersion::v16);
+
+    ASSERT_TRUE(wait_for_status("Available")) << "boot handshake did not produce the initial StatusNotification.req";
+
+    charge_point->on_suspend_charging_evse(CONNECTOR);
+    ASSERT_TRUE(wait_for_status("SuspendedEVSE")) << "the entry transition was not reported";
+
+    charge_point->on_suspend_charging_evse(CONNECTOR, CiString<50>("SwitchingPhases"));
+
+    // The notification timer runs at zero seconds, so an emitted message shows up well inside this window.
+    EXPECT_FALSE(wait_for_info("SwitchingPhases", SETTLE_TIMEOUT))
+        << "a phase switch on an already suspended connector reached the wire";
+    EXPECT_EQ(count_status("SuspendedEVSE"), 1u);
+
+    // The pipeline is still live: the next genuine transition is reported.
+    charge_point->on_resume_charging(CONNECTOR);
+    EXPECT_TRUE(wait_for_status("Charging")) << "the resume transition was not reported";
+
+    charge_point->stop();
+}
+
+// A phase switch that genuinely enters SuspendedEVSE still carries its info verbatim.
+TEST_F(ChargePointSuspendReasonTest, PhaseSwitchEnteringSuspendedIsReported) {
+    auto charge_point = make_charge_point();
+    charge_point->start({{0, ChargePointStatus::Available}, {CONNECTOR, ChargePointStatus::Available}},
+                        BootReasonEnum::PowerUp, {});
+    charge_point->on_websocket_connected(0, ocpp::v2::NetworkConnectionProfile{}, ocpp::OcppProtocolVersion::v16);
+
+    ASSERT_TRUE(wait_for_status("Available")) << "boot handshake did not produce the initial StatusNotification.req";
+
+    charge_point->on_suspend_charging_evse(CONNECTOR, CiString<50>("SwitchingPhases"));
+    ASSERT_TRUE(wait_for_status("SuspendedEVSE")) << "the entry transition was not reported";
+
+    EXPECT_TRUE(wait_for_info("SwitchingPhases", SETTLE_TIMEOUT)) << "the entry transition dropped its info";
+
+    charge_point->stop();
+}
+
+// With ReportSuspendedEVSEReasonChange set, the guard on the ungated entry point must not fire, so a phase switch on
+// an already suspended connector reaches the wire.
+TEST_F(ChargePointSuspendReasonTest, PhaseSwitchWhileSuspendedIsReportedWhenEnabled) {
+    this->configuration->setReportSuspendedEVSEReasonChange(true);
+
+    auto charge_point = make_charge_point();
+    charge_point->start({{0, ChargePointStatus::Available}, {CONNECTOR, ChargePointStatus::Available}},
+                        BootReasonEnum::PowerUp, {});
+    charge_point->on_websocket_connected(0, ocpp::v2::NetworkConnectionProfile{}, ocpp::OcppProtocolVersion::v16);
+
+    ASSERT_TRUE(wait_for_status("Available")) << "boot handshake did not produce the initial StatusNotification.req";
+
+    charge_point->on_suspend_charging_evse(CONNECTOR);
+    ASSERT_TRUE(wait_for_status("SuspendedEVSE")) << "the entry transition was not reported";
+
+    charge_point->on_suspend_charging_evse(CONNECTOR, CiString<50>("SwitchingPhases"));
+    EXPECT_TRUE(wait_for_info("SwitchingPhases", WAIT_TIMEOUT)) << "the phase switch was suppressed";
+
+    charge_point->stop();
+}
+
+// With the variable at its default false, a triggered StatusNotification reports error state only, even for a
+// connector that entered SuspendedEVSE carrying an info.
+TEST_F(ChargePointSuspendReasonTest, TriggeredStatusNotificationOmitsInfoWhenDisabled) {
+    ASSERT_FALSE(this->configuration->getReportSuspendedEVSEReasonChange());
+
+    auto charge_point = make_booted_charge_point();
+    ASSERT_TRUE(wait_for_status("Available")) << "boot handshake did not produce the initial StatusNotification.req";
+
+    charge_point->on_suspend_charging_evse(CONNECTOR, CiString<50>("SwitchingPhases"));
+    ASSERT_TRUE(wait_for_status("SuspendedEVSE")) << "the entry transition was not reported";
+
+    const auto from = sent_count();
+    trigger_status_notification(CONNECTOR);
+
+    const auto triggered = wait_for_status_notification_after(from);
+    ASSERT_TRUE(triggered.has_value()) << "the TriggerMessage produced no StatusNotification.req";
+    EXPECT_EQ(triggered->at("status"), "SuspendedEVSE");
+    EXPECT_FALSE(triggered->contains("info")) << "a triggered message reported info with the variable off";
+
+    charge_point->stop();
+}
+
+// With the variable set, a triggered StatusNotification falls back to the current suspend reason when the connector
+// is suspended and carries no active error.
+TEST_F(ChargePointSuspendReasonTest, TriggeredStatusNotificationReportsSuspendReasonWhenEnabled) {
+    this->configuration->setReportSuspendedEVSEReasonChange(true);
+
+    auto charge_point = make_booted_charge_point();
+    ASSERT_TRUE(wait_for_status("Available")) << "boot handshake did not produce the initial StatusNotification.req";
+
+    charge_point->on_suspend_charging_evse(CONNECTOR, CiString<50>("NoEnergy"));
+    ASSERT_TRUE(wait_for_status("SuspendedEVSE")) << "the entry transition was not reported";
+
+    const auto from = sent_count();
+    trigger_status_notification(CONNECTOR);
+
+    const auto triggered = wait_for_status_notification_after(from);
+    ASSERT_TRUE(triggered.has_value()) << "the TriggerMessage produced no StatusNotification.req";
+    EXPECT_EQ(triggered->at("status"), "SuspendedEVSE");
+    EXPECT_EQ(triggered->value("info", std::string{}), "NoEnergy");
+
+    charge_point->stop();
+}
+
+// The all-connectors form of the TriggerMessage reports the suspend reason too.
+TEST_F(ChargePointSuspendReasonTest, TriggeredStatusNotificationForAllConnectorsReportsSuspendReason) {
+    this->configuration->setReportSuspendedEVSEReasonChange(true);
+
+    auto charge_point = make_booted_charge_point();
+    ASSERT_TRUE(wait_for_status("Available")) << "boot handshake did not produce the initial StatusNotification.req";
+
+    charge_point->on_suspend_charging_evse(CONNECTOR, CiString<50>("NoEnergy"));
+    ASSERT_TRUE(wait_for_status("SuspendedEVSE")) << "the entry transition was not reported";
+
+    const auto from = sent_count();
+    trigger_status_notification(std::nullopt);
+
+    const auto triggered = wait_for_status_notification_after(from);
+    ASSERT_TRUE(triggered.has_value()) << "the TriggerMessage produced no StatusNotification.req";
+    EXPECT_EQ(triggered->at("status"), "SuspendedEVSE");
+    EXPECT_EQ(triggered->value("info", std::string{}), "NoEnergy");
+
+    charge_point->stop();
+}
+
+// An active error still owns the info field: the suspend reason is a fallback, not an override.
+TEST_F(ChargePointSuspendReasonTest, TriggeredStatusNotificationKeepsActiveErrorInfo) {
+    this->configuration->setReportSuspendedEVSEReasonChange(true);
+
+    auto charge_point = make_booted_charge_point();
+    ASSERT_TRUE(wait_for_status("Available")) << "boot handshake did not produce the initial StatusNotification.req";
+
+    charge_point->on_suspend_charging_evse(CONNECTOR, CiString<50>("NoEnergy"));
+    ASSERT_TRUE(wait_for_status("SuspendedEVSE")) << "the entry transition was not reported";
+
+    charge_point->on_error(CONNECTOR, ErrorInfo("uuid1", ChargePointErrorCode::OtherError, false, "SomeError"));
+    ASSERT_TRUE(wait_for_info("SomeError", WAIT_TIMEOUT)) << "the error was not reported";
+
+    const auto from = sent_count();
+    trigger_status_notification(CONNECTOR);
+
+    const auto triggered = wait_for_status_notification_after(from);
+    ASSERT_TRUE(triggered.has_value()) << "the TriggerMessage produced no StatusNotification.req";
+    EXPECT_EQ(triggered->at("status"), "SuspendedEVSE");
+    EXPECT_EQ(triggered->at("errorCode"), "OtherError");
+    EXPECT_EQ(triggered->value("info", std::string{}), "SomeError");
+
+    charge_point->stop();
+}
+
+} // namespace v16
+} // namespace ocpp

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/memory_storage.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/memory_storage.cpp
@@ -44,6 +44,7 @@ const std::map<std::string, std::string> required_vars_internal = {
     {"UseTPM", "false"},
     {"UseTPMSeccLeafCertificate", "false"},
     {"VerifyCsmsAllowWildcards", "false"},
+    {"ReportSuspendedEVSEReasonChange", "false"},
     {"MaxMessageSize", "65000"},
     {"MaxCompositeScheduleDuration", "31536000"},
     {"OcspRequestInterval", "604800"},

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_custom.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_custom.cpp
@@ -38,6 +38,7 @@ const std::map<std::string, std::string> expected_key_value = {
     {"MaxCompositeScheduleDuration", "31536000"},
     {"MaxMessageSize", "65000"},
     {"OcspRequestInterval", "604800"},
+    {"ReportSuspendedEVSEReasonChange", "false"},
     {"RetryBackoffRandomRange", "10"},
     {"RetryBackoffRepeatTimes", "3"},
     {"RetryBackoffWaitMinimum", "3"},
@@ -205,6 +206,35 @@ TEST_P(Configuration, Set) {
     EXPECT_EQ(get()->getTLSKeylogFile(), "/tmp/ocpp_tls_keylog.txt");
 
     // custom key (none defined)
+}
+
+TEST_P(Configuration, SetGetReportSuspendedEVSEReasonChange) {
+    using ConfigurationStatus = ocpp::v16::ConfigurationStatus;
+    ASSERT_NE(get(), nullptr);
+
+    auto kv = get()->get("ReportSuspendedEVSEReasonChange");
+    ASSERT_TRUE(kv);
+    EXPECT_EQ(kv.value().key, "ReportSuspendedEVSEReasonChange");
+    EXPECT_EQ(kv.value().value, "false");
+    EXPECT_FALSE(kv.value().readonly);
+
+    EXPECT_EQ(get()->set("ReportSuspendedEVSEReasonChange", "true"), ConfigurationStatus::Accepted);
+    kv = get()->get("ReportSuspendedEVSEReasonChange");
+    ASSERT_TRUE(kv);
+    EXPECT_EQ(kv.value().key, "ReportSuspendedEVSEReasonChange");
+    EXPECT_EQ(kv.value().value, "true");
+    EXPECT_FALSE(kv.value().readonly);
+
+    EXPECT_EQ(get()->set("ReportSuspendedEVSEReasonChange", "NotABool"), ConfigurationStatus::Rejected);
+    kv = get()->get("ReportSuspendedEVSEReasonChange");
+    ASSERT_TRUE(kv);
+    EXPECT_EQ(kv.value().value, "true");
+
+    // restore the default, the JSON backend persists to the user config
+    EXPECT_EQ(get()->set("ReportSuspendedEVSEReasonChange", "false"), ConfigurationStatus::Accepted);
+    kv = get()->get("ReportSuspendedEVSEReasonChange");
+    ASSERT_TRUE(kv);
+    EXPECT_EQ(kv.value().value, "false");
 }
 
 TEST_P(Configuration, GetAllKeyValue) {

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_internal.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_internal.cpp
@@ -548,6 +548,24 @@ TEST_P(ConfigurationFull, RemoteStartTransactionWithoutConnectorIdFindFirst) {
     EXPECT_EQ(get()->getRemoteStartTransactionWithoutConnectorIdFindFirst().value(), true);
 }
 
+TEST_P(Configuration, ReportSuspendedEVSEReasonChange) {
+    ASSERT_NE(get(), nullptr);
+
+    get()->setReportSuspendedEVSEReasonChange(true);
+    EXPECT_TRUE(get()->getReportSuspendedEVSEReasonChange());
+    auto kv = get()->getReportSuspendedEVSEReasonChangeKeyValue();
+    EXPECT_EQ(kv.key, "ReportSuspendedEVSEReasonChange");
+    EXPECT_EQ(kv.value, "true");
+    EXPECT_FALSE(kv.readonly);
+
+    get()->setReportSuspendedEVSEReasonChange(false);
+    EXPECT_FALSE(get()->getReportSuspendedEVSEReasonChange());
+    kv = get()->getReportSuspendedEVSEReasonChangeKeyValue();
+    EXPECT_EQ(kv.key, "ReportSuspendedEVSEReasonChange");
+    EXPECT_EQ(kv.value, "false");
+    EXPECT_FALSE(kv.readonly);
+}
+
 TEST_P(Configuration, UseSslDefaultVerifyPaths) {
     ASSERT_NE(get(), nullptr);
     // initial values are from the JSON unit test config files

--- a/modules/EVSE/OCPPmulti/docs/index.rst
+++ b/modules/EVSE/OCPPmulti/docs/index.rst
@@ -520,6 +520,9 @@ OCPP 1.6 limitations: individual errors cannot be cleared selectively via **Stat
 from MREC, simultaneous errors are reported in one message per error instead of a single semicolon-separated
 message, because of the field length limits.
 
+The ``info`` field has a second, unrelated use: reporting why a connector is suspended. See
+:ref:`suspend reason reporting <handwritten_ocppmulti_suspend-reason-reporting>` below.
+
 OCPP 2.x
 ^^^^^^^^
 
@@ -533,6 +536,37 @@ status **Faulted** for the Inoperative case above). All other errors are reporte
 
 The variable is constantly set to **Problem** for now; a more fine-grained mapping of errors to component-variable
 combinations may be added in the future.
+
+.. _handwritten_ocppmulti_suspend-reason-reporting:
+
+Suspend reason reporting in OCPP 1.6
+====================================
+
+While a connector sits in **SuspendedEVSE**, the reason can change without the status changing: a user pause during an
+energy shortage, or a fault raised on an already suspended connector. OCPP 1.6 has no field for that, so the reason set
+is reported in the free-text ``info`` field of a further **StatusNotification.req**, reusing the field the error path
+above writes.
+
+The feature is off by default. Set the ``InternalCtrlr`` variable ``ReportSuspendedEVSEReasonChange`` (boolean,
+ReadWrite, default ``false``) to enable it. It doubles as an OCPP 1.6 configuration key of the same name and is read on
+every suspend event, so **ChangeConfiguration** takes effect without a restart.
+
+With it enabled, a reason change on an already suspended connector emits one **StatusNotification.req** with ``status``
+unchanged at **SuspendedEVSE**, ``errorCode`` **NoError** (or the most recent active error's code), and the reasons in
+``info``: ``UserPause``, ``Error`` and/or ``NoEnergy``, comma joined. Repeats are suppressed, and an empty set omits
+``info`` rather than sending an empty string. **TriggerMessage(StatusNotification)** reports the current reason when
+no error is active.
+
+Limitations:
+
+* All energy-related causes collapse into the single ``NoEnergy`` value. A schedule limit, load balancing and a
+  missing PV surplus are not distinguishable at the CSMS.
+* ``SwitchingPhases`` shares the ``info`` field with the pause reasons, so a phase switch followed by a pause
+  alternates between the two, one message per cycle.
+* When a fault clears while the connector is paused, the notification carries the cleared error's ``info`` rather than
+  the live pause reason; a **TriggerMessage(StatusNotification)** recovers it.
+* Turning the variable off at runtime does not clear a reason already reported; the CSMS holds it until the connector
+  leaves **SuspendedEVSE**.
 
 Energy management and smart charging
 ====================================

--- a/modules/EVSE/OCPPmulti/tests/v16_chargepoint_tests.cpp
+++ b/modules/EVSE/OCPPmulti/tests/v16_chargepoint_tests.cpp
@@ -78,4 +78,70 @@ TEST(ChargePointV16, defaultVendorErrorCodeOriginal) {
     EXPECT_EQ(ChargePointV16::default_vendor_error_code(error), "def/ghi/apples");
 }
 
+TEST(ChargePointV16, encodePauseReasonsEmpty) {
+    EXPECT_EQ(ChargePointV16::encode_pause_reasons(std::nullopt), std::nullopt);
+
+    types::evse_manager::ChargingPausedEVSEReasons reasons;
+    EXPECT_TRUE(reasons.reasons.empty());
+    EXPECT_EQ(ChargePointV16::encode_pause_reasons(reasons), std::nullopt);
+}
+
+TEST(ChargePointV16, encodePauseReasonsSingle) {
+    types::evse_manager::ChargingPausedEVSEReasons reasons;
+
+    reasons.reasons = {types::evse_manager::PauseChargingEVSEReasonEnum::NoEnergy};
+    auto encoded = ChargePointV16::encode_pause_reasons(reasons);
+    ASSERT_TRUE(encoded.has_value());
+    EXPECT_EQ(static_cast<std::string>(encoded.value()), "NoEnergy");
+
+    reasons.reasons = {types::evse_manager::PauseChargingEVSEReasonEnum::Error};
+    encoded = ChargePointV16::encode_pause_reasons(reasons);
+    ASSERT_TRUE(encoded.has_value());
+    EXPECT_EQ(static_cast<std::string>(encoded.value()), "Error");
+
+    reasons.reasons = {types::evse_manager::PauseChargingEVSEReasonEnum::UserPause};
+    encoded = ChargePointV16::encode_pause_reasons(reasons);
+    ASSERT_TRUE(encoded.has_value());
+    EXPECT_EQ(static_cast<std::string>(encoded.value()), "UserPause");
+}
+
+TEST(ChargePointV16, encodePauseReasonsDeduplicates) {
+    types::evse_manager::ChargingPausedEVSEReasons reasons;
+    reasons.reasons = {types::evse_manager::PauseChargingEVSEReasonEnum::UserPause,
+                       types::evse_manager::PauseChargingEVSEReasonEnum::UserPause,
+                       types::evse_manager::PauseChargingEVSEReasonEnum::Error};
+    const auto encoded = ChargePointV16::encode_pause_reasons(reasons);
+    ASSERT_TRUE(encoded.has_value());
+    EXPECT_EQ(static_cast<std::string>(encoded.value()), "Error,UserPause");
+}
+
+TEST(ChargePointV16, encodePauseReasonsSortedAlphabetically) {
+    types::evse_manager::ChargingPausedEVSEReasons reasons;
+
+    reasons.reasons = {types::evse_manager::PauseChargingEVSEReasonEnum::Error,
+                       types::evse_manager::PauseChargingEVSEReasonEnum::NoEnergy,
+                       types::evse_manager::PauseChargingEVSEReasonEnum::UserPause};
+    const auto encoded = ChargePointV16::encode_pause_reasons(reasons);
+    ASSERT_TRUE(encoded.has_value());
+    EXPECT_EQ(static_cast<std::string>(encoded.value()), "Error,NoEnergy,UserPause");
+
+    reasons.reasons = {types::evse_manager::PauseChargingEVSEReasonEnum::UserPause,
+                       types::evse_manager::PauseChargingEVSEReasonEnum::NoEnergy,
+                       types::evse_manager::PauseChargingEVSEReasonEnum::Error};
+    const auto reversed = ChargePointV16::encode_pause_reasons(reasons);
+    ASSERT_TRUE(reversed.has_value());
+    EXPECT_EQ(static_cast<std::string>(reversed.value()), "Error,NoEnergy,UserPause");
+}
+
+TEST(ChargePointV16, encodePauseReasonsFitsCiString) {
+    types::evse_manager::ChargingPausedEVSEReasons reasons;
+    reasons.reasons = {types::evse_manager::PauseChargingEVSEReasonEnum::UserPause,
+                       types::evse_manager::PauseChargingEVSEReasonEnum::Error,
+                       types::evse_manager::PauseChargingEVSEReasonEnum::NoEnergy};
+    const auto encoded = ChargePointV16::encode_pause_reasons(reasons);
+    ASSERT_TRUE(encoded.has_value());
+    EXPECT_EQ(static_cast<std::string>(encoded.value()).size(), 24u);
+    EXPECT_EQ(static_cast<std::string>(encoded.value()), "Error,NoEnergy,UserPause");
+}
+
 } // namespace

--- a/modules/EVSE/OCPPmulti/v16_chargepoint.cpp
+++ b/modules/EVSE/OCPPmulti/v16_chargepoint.cpp
@@ -11,7 +11,12 @@
 #include <everest/ocpp_module_common/v16/conversions.hpp>
 #include <everest/ocpp_module_common/v16/error_mapping.hpp>
 
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+#include <string_view>
 #include <utility>
+#include <vector>
 
 namespace conversions_v16 = ocpp_module_common::v16::conversions;
 
@@ -30,6 +35,7 @@ constexpr const auto ISO15118_PNC_ENABLED_VARIABLE = "PnCEnabled";
 
 constexpr const auto INOPERATIVE_ERROR_TYPE = "evse_manager/Inoperative";
 constexpr const auto SWITCHING_PHASES_REASON = "SwitchingPhases";
+constexpr const auto REPORT_SUSPENDED_EVSE_REASON_CHANGE_CONFIG_KEY = "ReportSuspendedEVSEReasonChange";
 
 template <typename T> std::optional<T> get(ocpp::v16::ChargePoint& charge_point, const std::string_view& variable) {
     std::optional<T> result;
@@ -40,7 +46,12 @@ template <typename T> std::optional<T> get(ocpp::v16::ChargePoint& charge_point,
         for (const auto& key_value : response.configurationKey.value()) {
             if (static_cast<std::string>(key_value.key) == variable) {
                 if (key_value.value) {
-                    result = ocpp::v2::to_specific_type<T>(key_value.value.value());
+                    try {
+                        result = ocpp::v2::to_specific_type<T>(key_value.value.value());
+                    } catch (const std::exception& e) {
+                        EVLOG_warning << "Configuration key " << variable << " holds an unusable value '"
+                                      << key_value.value.value() << "': " << e.what();
+                    }
                 }
             }
         }
@@ -76,6 +87,14 @@ inline std::int32_t ocpp_connector_id(const ocpp_multi::GenericChargePointInterf
                                       std::int32_t evse_id, std::optional<int32_t> connector_id) {
     const auto everest_connector_id = connector_id.value_or(1);
     return mapping.at(evse_id).at(everest_connector_id);
+}
+
+std::optional<std::string_view> to_pause_reason_string(types::evse_manager::PauseChargingEVSEReasonEnum reason) {
+    try {
+        return types::evse_manager::pause_charging_evsereason_enum_to_string_view(reason);
+    } catch (const std::out_of_range&) {
+        return std::nullopt;
+    }
 }
 
 } // namespace
@@ -819,7 +838,10 @@ void ChargePointV16::on_event_charging_paused_evse(std::int32_t evse_id, std::in
                                                    const types::evse_manager::SessionEvent& session_event) {
     check_configured("on_event_charging_paused_evse");
     const auto cid = ocpp_connector_id(m_connector_mapping, evse_id, session_event.connector_id);
-    m_charge_point->on_suspend_charging_evse(cid);
+    const auto report_reason =
+        get<bool>(*m_charge_point, REPORT_SUSPENDED_EVSE_REASON_CHANGE_CONFIG_KEY).value_or(false);
+    m_charge_point->on_suspend_charging_evse(
+        cid, report_reason ? encode_pause_reasons(session_event.charging_paused_evse) : std::nullopt);
 }
 void ChargePointV16::on_event_charging_started(std::int32_t evse_id, std::int32_t connector_id,
                                                const types::evse_manager::SessionEvent& session_event) {
@@ -1079,6 +1101,46 @@ ChargePointV16::validate_token(const types::authorization::ProvidedIdToken& prov
 
 bool ChargePointV16::default_is_fault(const Everest::error::Error& error) {
     return false;
+}
+
+std::optional<ocpp::CiString<50>>
+ChargePointV16::encode_pause_reasons(const std::optional<types::evse_manager::ChargingPausedEVSEReasons>& reasons) {
+    if (!reasons.has_value()) {
+        return std::nullopt;
+    }
+    if (reasons->reasons.empty()) {
+        EVLOG_warning << "ChargingPausedEVSEReasons published with an empty reason list, which violates the "
+                         "evse_manager minItems: 1 contract; omitting StatusNotification.info";
+        return std::nullopt;
+    }
+
+    std::vector<std::string_view> encoded;
+    encoded.reserve(reasons->reasons.size());
+    for (const auto& reason : reasons->reasons) {
+        const auto item = to_pause_reason_string(reason);
+        if (!item.has_value()) {
+            EVLOG_error << "OCPP 1.6 StatusNotification.info: no wire encoding for PauseChargingEVSEReasonEnum value "
+                        << static_cast<int>(reason) << ", omitting from pause reason list";
+            continue;
+        }
+        encoded.push_back(item.value());
+    }
+    std::sort(encoded.begin(), encoded.end());
+    encoded.erase(std::unique(encoded.begin(), encoded.end()), encoded.end());
+
+    if (encoded.empty()) {
+        return std::nullopt;
+    }
+
+    std::string result;
+    for (const auto& item : encoded) {
+        if (!result.empty()) {
+            result.push_back(',');
+        }
+        result.append(item);
+    }
+
+    return ocpp::CiString<50>{result, ocpp::StringTooLarge::Truncate};
 }
 
 std::string ChargePointV16::default_vendor_error_code(const Everest::error::Error& error) {

--- a/modules/EVSE/OCPPmulti/v16_chargepoint.hpp
+++ b/modules/EVSE/OCPPmulti/v16_chargepoint.hpp
@@ -205,6 +205,8 @@ public:
     ocpp::v2::AuthorizeResponse validate_token(const types::authorization::ProvidedIdToken& provided_token) override;
 
     static bool default_is_fault(const Everest::error::Error& error);
+    static std::optional<ocpp::CiString<50>>
+    encode_pause_reasons(const std::optional<types::evse_manager::ChargingPausedEVSEReasons>& reasons);
     static std::string default_vendor_error_code(const Everest::error::Error& error);
 };
 


### PR DESCRIPTION
# feat(ocpp): report SuspendedEVSE reason changes over OCPP 1.6

## Problem

While a connector sits in `SuspendedEVSE`, the reason can change without the status
changing: a user pause during an energy shortage, or a fault raised on an already
suspended connector. `EvseManager` republishes the reason set, but the OCPP layer
discarded it, so the CSMS kept showing a stale explanation.

## What changes

The reason set is reported in the free-text `info` field of a further
`StatusNotification.req`, with `status` unchanged at `SuspendedEVSE`. Off by default
behind a new device model variable:

| Component | Variable | Type | Mutability | Default |
|---|---|---|---|---|
| `InternalCtrlr` | `ReportSuspendedEVSEReasonChange` | boolean | ReadWrite | `false` |

It doubles as an OCPP 1.6 configuration key of the same name, served by both v16
backends, and is read per suspend event so `ChangeConfiguration` applies without a
restart.

Reasons come from `PauseChargingEVSEReasonEnum` (`UserPause`, `Error`, `NoEnergy`),
sorted alphabetically, deduplicated and comma joined. Worst case
`Error,NoEnergy,UserPause`, 24 of the 50 characters allowed.
`TriggerMessage(StatusNotification)` reports the current reason when no error owns the
`info` field.

## Default-off behavior is unchanged

The main design constraint. With the variable `false` the wire matches the base commit
on every path: a pause on an already suspended connector is discarded before the state
machine (previously it was submitted and dropped for want of a self-transition); a
genuine transition forwards `info` verbatim, so the pre-existing `SwitchingPhases`
literal still reaches the wire; `TriggerMessage` and the boot/reconnect burst report
error state only. `modules/EVSE/OCPP/` has a zero diff against base.

The gate is split deliberately: `OCPPmulti` decides whether a reason exists, since it
owns the wire format; `ChargePointImpl` decides whether a repeat reaches the state
machine and whether `TriggerMessage` may fall back, since both need state the module
cannot see.

## Testing

`libocpp_unit_tests` 1433 run / 1425 passed / 8 pre-existing skips / 0 failed;
`ctest -R OCPPmulti` 1/1; build clean.

New coverage: state machine transitions (changed reason emits, unchanged suppressed,
re-entry after `Charging` emits, no emit while faulted), wire-level tests over a real
`ChargePointImpl` for both variable states and the `TriggerMessage` fallback, key-name
dispatch on both config backends, and encoder cases for empty, single, sorted,
deduplicated and length-bounded input.

Not covered automatically: enabling the variable at runtime against a live CSMS.

## Known limitations

- All energy-related causes collapse into `NoEnergy`, so schedule limits, load balancing
  and missing PV surplus are indistinguishable.
- `MinimumStatusDuration` replaces rather than queues, so a reason flapping inside that
  window collapses into one duplicate message.
- `SwitchingPhases` shares the `info` channel and alternates with the reason string.
- When a fault clears while paused, the notification carries the cleared error's `info`;
  a `TriggerMessage` recovers the reason.
- Turning the variable off at runtime does not clear a reason already reported.

## Scope

OCPP 1.6 only. No OCPP 2.x code path reads the variable; the only v2 files touched are
`ctrlr_component_variables.{hpp,cpp}` (+7 lines) for the `ComponentVariable` that
`MAPPING_INTERNAL` needs to map the 1.6 key onto the device model. Under OCPP 2.x a
suspend reason belongs in a `NotifyEvent.req` against a dedicated component-variable.
