### PR TITLE
docs: add AGENTS.md agent guidelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__/
 *.diff
 *.orig
 *.rej
+CLAUDE.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,14 +121,16 @@ requires in `manifest.yaml`, is wired to other modules by a configuration YAML u
 `config/`, and communicates only over MQTT through `everest-framework`. Contracts are
 the source of truth for wiring: read `interfaces/*.yaml`, `types/*.yaml` and
 `errors/*.yaml` before the C++. Lifecycle is `init()` then `ready()`, implemented per
-provided interface in `*Impl.cpp`: subscribe in `init()`; call commands in `ready()` or
-later. Generated headers land under `build/generated/`.
+provided interface in `*Impl.cpp`: subscribe in `init()`; call commands and publish in
+`ready()` or later. Generated headers land under `build/generated/`.
 
 ```cpp
 // modules/EVSE/EvseManager
-r_bsp->subscribe_event([this](auto ev) { ... });  // subscribe: init()
-p_evse->publish_ready(true);                      // publish on a provided interface
-r_bsp->call_enable(true);                         // commands: ready() or later only
+r_bsp->subscribe_event([this](auto ev) {   // subscribe: init()
+    p_evse->publish_ready(true);           // publishing from the callback: fine
+});
+p_evse->publish_ready(true);               // at init() top level: never
+r_bsp->call_enable(true);                  // commands: ready() or later only
 ```
 
 In a configuration YAML, a `connections` entry maps a requirement ID from the consuming
@@ -211,6 +213,8 @@ Full C++ conventions: `docs/source/how-to-guides/c++-coding-guidelines.rst`.
 - Never use `std::cout` or `fprintf` for logging.
 - Never call `mod->r_*->call_*()` inside `init()`. Command calls belong in `ready()` or
   later.
+- Never `publish_*()` or raise an error inside `init()` either. Neither is retained, so
+  subscribers still in their own `init()` miss it.
 - Never skip formatting before proposing C++ changes. CI fails on it, see Code style.
 
 ## Contributing essentials

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,15 @@ behavior, docs describe intent. Say so when you find the two diverging.
 Docs are rendered at <https://everest.github.io>, starting with the
 [Getting Started Guides](https://everest.github.io/nightly/how-to-guides/getting-started/index.html).
 Sphinx sources are under `docs/source/`: `explanation/` for concepts, `how-to-guides/`
-for recipes. Per-module docs are at `modules/<Category>/<Module>/docs/index.rst`; update
-them when a module's public behavior changes.
+for recipes. Per-module docs are at `modules/<Category>/<Module>/docs/index.rst`.
+
+Docs are updated in the same change as the code they describe. After changing a
+module's public behavior (interface or type YAML, config keys, state machines, error
+semantics), check the module's `docs/index.rst` and any `docs/source/` page describing
+that behavior, and fix what went stale. Libraries document themselves in
+`lib/everest/<lib>/README.md` and their own doc trees (`docs/` usually, `doc/` in
+libocpp); internal library changes count too when they touch documented behavior. A
+change to build, run, test or codegen mechanics means updating this file as well.
 
 ## Build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,9 +83,9 @@ cd build && ctest -R <regex>
 ```
 
 `ctest -R` matches **registered test names, not build targets**, and the two often differ
-in case and spelling. List with `ctest -N` first. Coverage targets exist only under
-`-DEVEREST_ENABLE_COVERAGE=ON`; build `everest-core_create_coverage` and the HTML report
-lands at `build/everest-core_create_coverage/index.html`.
+in case and spelling. List with `ctest -N` first. Coverage needs
+`-DEVEREST_ENABLE_COVERAGE=ON`; the `everest-core_create_coverage` target writes
+`build/everest-core_create_coverage/index.html`.
 
 Integration tests use pytest; the virtualenv is `build/venv`:
 
@@ -155,13 +155,13 @@ Traps:
 - Regeneration is decided by mtime, not content. A target newer than its manifest is
   skipped with `Skipping <name> (up-to-date)`, so a recent edit makes ev-cli silently
   under-generate. Preview with `-d`, force with `-f`, and confirm the change landed.
-- `--disable-clang-format` is in the command above because formatting through ev-cli runs
-  whatever clang-format is on `PATH`, not the version CI uses. Format afterwards, see Code
-  style. `--clang-format-file`, if you do use it, takes a directory, not a file.
-- Editing `types/*.yaml` or `interfaces/*.yaml` fails the ctest
-  `everest-core_API_serialize_tests` until the sha256 pins in
-  `lib/everest/everest_api_types/tests/expected_types_file_hashes.csv` and
-  `expected_interfaces_file_hashes.csv` are updated.
+- `--disable-clang-format` (used above): ev-cli formats with whatever clang-format is on
+  `PATH`, not the version CI uses. Format afterwards (see Code style).
+  `--clang-format-file` takes a directory, not a file.
+- Editing `types/*.yaml` or `interfaces/*.yaml` fails `everest-core_API_serialize_tests`
+  until the sha256 pins in
+  `lib/everest/everest_api_types/tests/expected_{types,interfaces}_file_hashes.csv`
+  are updated.
 
 `ev-cli --help` lists the available actions; `--only which` lists the files an action
 would touch.
@@ -180,9 +180,8 @@ Full C++ conventions: `docs/source/how-to-guides/c++-coding-guidelines.rst`.
       ghcr.io/everest/everest-ci/build-env-base:v1.6.0 xargs clang-format -i
   ```
 
-  The tag tracks `ref_everest_ci` in `.github/workflows/on_pr.yaml`. A locally installed
-  clang-format also works, but different versions produce differing results, so the
-  container is what matches CI exactly.
+  The tag tracks `ref_everest_ci` in `.github/workflows/on_pr.yaml`. A local clang-format
+  also works, but versions differ in output; the container matches CI.
 - PascalCase for classes and structs, `snake_case` for functions and methods,
   `m_`-prefixed `snake_case` for member variables, `snake_case` for library file names.
   No camelCase.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,14 @@
-# EVerest Core: Agent Guidelines
+# EVerest: Agent Guidelines
 
-Guidance for AI coding agents working in `everest-core`: runtime manager, modules,
-shared libraries, interface definitions, test infrastructure. C++ primary, plus Python,
-Rust and JavaScript. CMake with Ninja; CI also builds with Bazel.
+Guidance for AI coding agents working in `EVerest`, the mono-repository formerly named
+`everest-core`: runtime manager, modules, shared libraries, interface definitions, test
+infrastructure. C++ primary, plus Python, Rust and JavaScript. CMake with Ninja; CI also
+builds with Bazel.
+
+Libraries that once lived in separate `lib*` repositories are now in-tree under
+`lib/everest/` and are edited in place; there is no upstream repository to mirror them
+to. A few EVerest components are still external dependencies in `dependencies.yaml`,
+notably the Python Josev stack (`ext-switchev-iso15118`).
 
 Contributor policy (licensing, DCO, review, and the project's position on AI-generated
 contributions) is in `docs/source/project/contributing.rst`. This file covers mechanics
@@ -10,8 +16,11 @@ only: build, run, test, code generation, and invariants.
 
 ## Documentation
 
-Prefer project docs over inference, and cite them. Rendered at
-<https://everest.github.io>, starting with the
+Prefer project docs over your own assumptions, and cite them. When docs and the tree
+disagree, the tree wins: manifests, `interfaces/*.yaml` and code describe current
+behavior, docs describe intent. Say so when you find the two diverging.
+
+Docs are rendered at <https://everest.github.io>, starting with the
 [Getting Started Guides](https://everest.github.io/nightly/how-to-guides/getting-started/index.html).
 Sphinx sources are under `docs/source/`: `explanation/` for concepts, `how-to-guides/`
 for recipes. Per-module docs are at `modules/<Category>/<Module>/docs/index.rst`; update
@@ -138,7 +147,7 @@ ev-cli mod update <Category>/<Name> --work-dir . --build-dir build -f
 cmake -S . -B build     # codegen for build/generated/ runs at configure time
 ```
 
-Three traps:
+Traps:
 
 - The module argument is a path relative to `modules/`, so `EVSE/EvseManager`, not a
   bare `EvseManager`. A bare name fails with `Could not open type definition file`.
@@ -148,9 +157,8 @@ Three traps:
 - `--clang-format-file` takes a directory, not a file, and formatting through ev-cli
   bypasses the version CI uses. Prefer `--disable-clang-format`.
 
-Actions: `mod create|update|generate-loader` (`c|u|gl`), `if generate-headers` and
-`ty generate-headers` (`gh`), `hlp generate-uuids|yaml2json|json2yaml`. `--only which`
-lists the files an action would touch.
+`ev-cli --help` lists the available actions; `--only which` lists the files an action
+would touch.
 
 ## Code style
 
@@ -175,9 +183,6 @@ Full C++ conventions: `docs/source/how-to-guides/c++-coding-guidelines.rst`.
 | API module | `modules/API/API/` | directory name is doubled |
 | libocpp | `lib/everest/ocpp/` | vendored |
 
-Shared libraries under `lib/everest/` are edited in place. There is no separate upstream
-repository to mirror them to.
-
 ## Invariants
 
 - Never remove `// ev@<uuid>:v1` markers from `*Impl.cpp` or `CMakeLists.txt`.
@@ -191,8 +196,8 @@ repository to mirror them to.
 
 ## Contributing essentials
 
-Full policy: `docs/source/project/contributing.rst`. The four items agents get wrong
-most often:
+Full policy: `docs/source/project/contributing.rst`. The items agents get wrong most
+often:
 
 - Sign off every commit (`Signed-off-by`, DCO), enforced by
   `.github/workflows/job_dco-check.yaml`.
@@ -201,5 +206,7 @@ most often:
   was addressed. Squashing to a single commit once approved is how changes land.
 - Every contribution must be reviewed and understood by a human before submission.
 
-Commit subjects follow Conventional Commits and name the affected module, for example
-`fix(EvseManager): handle unplug during timed charging`.
+Commit subjects and pull request titles follow Conventional Commits and name the affected
+module, for example `fix(EvseManager): handle unplug during timed charging`. Changes land
+as GitHub squash merges, so the pull request title becomes the commit subject and the
+description becomes its body.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,27 +87,21 @@ in case and spelling. List with `ctest -N` first. Coverage needs
 `-DEVEREST_ENABLE_COVERAGE=ON`; the `everest-core_create_coverage` target writes
 `build/everest-core_create_coverage/index.html`.
 
-Integration tests use pytest; the virtualenv is `build/venv`:
+Integration tests use pytest through the unified runner `tests/run-tests.sh`, against a
+built and installed prefix. The runner installs the OCPP certificate and component-config
+fixtures itself but not the venv, so activate `build/venv` first:
 
 ```bash
 . build/venv/bin/activate
 cmake --build build --target install_everest_testing
-cd tests && pytest --everest-prefix ../build/dist core_tests/ framework_tests/
+./tests/run-tests.sh core            # suites: all, integration, core, framework,
+                                     # asyncapi, ocpp, ocpp16, ocpp201, ocpp21, eebus
+./tests/run-tests.sh ocpp201 -k authorization   # -k filters; -- passes args to pytest
 ```
 
-OCPP tests also need certificate and per-EVSE component-config fixtures in the prefix.
-`tests/run-tests.sh` handles this; calling pytest directly means re-running the fixture
-scripts after any `ninja install` that touches the prefix. From the repo root:
-
-```bash
-cmake --build build --target everestpy_pip_install_dist
-cmake --build build --target everest-testing_pip_install_dist
-cmake --build build --target iso15118_pip_install_dist
-(cd tests/ocpp_tests/test_sets/everest-aux && \
-  ./install_certs.sh ../../../../build/dist && \
-  ./install_configs.sh ../../../../build/dist)
-cd tests/ocpp_tests && pytest --everest-prefix ../../build/dist test_sets/ocpp201/ -v
-```
+OCPP suites also need the pip packages built into the venv once:
+`everestpy_pip_install_dist`, `everest-testing_pip_install_dist` and
+`iso15118_pip_install_dist` (`cmake --build build --target <name>`).
 
 ISO 15118 has no dedicated suite. It is covered by `tests/core_tests/smoke_tests.py`
 (AC and DC end to end), CSMS-side helpers in
@@ -221,6 +215,8 @@ often:
 - While review is open, do not rebase or force-push, so reviewers can see that feedback
   was addressed. Squashing to a single commit once approved is how changes land.
 - Every contribution must be reviewed and understood by a human before submission.
+- Releases, versioning and what counts as a breaking change:
+  `docs/source/project/releases/releases-and-versioning.rst`.
 
 Commit subjects and pull request titles follow Conventional Commits and name the affected
 module, for example `fix(EvseManager): handle unplug during timed charging`. Changes land

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,8 @@ cd build && ctest -R <regex>
 
 `ctest -R` matches **registered test names, not build targets**, and the two often differ
 in case and spelling. List with `ctest -N` first. Coverage targets exist only under
-`-DEVEREST_ENABLE_COVERAGE=ON`.
+`-DEVEREST_ENABLE_COVERAGE=ON`; build `everest-core_create_coverage` and the HTML report
+lands at `build/everest-core_create_coverage/index.html`.
 
 Integration tests use pytest; the virtualenv is `build/venv`:
 
@@ -96,7 +97,7 @@ cd tests && pytest --everest-prefix ../build/dist core_tests/ framework_tests/
 
 OCPP tests also need certificate and per-EVSE component-config fixtures in the prefix.
 `tests/run-tests.sh` handles this; calling pytest directly means re-running the fixture
-scripts after any `ninja install` that touches the prefix:
+scripts after any `ninja install` that touches the prefix. From the repo root:
 
 ```bash
 cmake --build build --target everestpy_pip_install_dist
@@ -143,7 +144,7 @@ Adding a config key to a manifest means regenerating, not editing the struct.
 
 ```bash
 . build/venv/bin/activate
-ev-cli mod update <Category>/<Name> --work-dir . --build-dir build -f
+ev-cli mod update <Category>/<Name> --work-dir . --build-dir build --disable-clang-format -f
 cmake -S . -B build     # codegen for build/generated/ runs at configure time
 ```
 
@@ -154,8 +155,13 @@ Traps:
 - Regeneration is decided by mtime, not content. A target newer than its manifest is
   skipped with `Skipping <name> (up-to-date)`, so a recent edit makes ev-cli silently
   under-generate. Preview with `-d`, force with `-f`, and confirm the change landed.
-- `--clang-format-file` takes a directory, not a file, and formatting through ev-cli
-  bypasses the version CI uses. Prefer `--disable-clang-format`.
+- `--disable-clang-format` is in the command above because formatting through ev-cli runs
+  whatever clang-format is on `PATH`, not the version CI uses. Format afterwards, see Code
+  style. `--clang-format-file`, if you do use it, takes a directory, not a file.
+- Editing `types/*.yaml` or `interfaces/*.yaml` fails the ctest
+  `everest-core_API_serialize_tests` until the sha256 pins in
+  `lib/everest/everest_api_types/tests/expected_types_file_hashes.csv` and
+  `expected_interfaces_file_hashes.csv` are updated.
 
 `ev-cli --help` lists the available actions; `--only which` lists the files an action
 would touch.
@@ -165,7 +171,18 @@ would touch.
 Full C++ conventions: `docs/source/how-to-guides/c++-coding-guidelines.rst`.
 
 - clang-format, LLVM base, 4-space indent, 120 columns (`.clang-format`). CI enforces it
-  over `.hpp` and `.cpp` via `.github/workflows/job_lint.yml`.
+  over `.hpp` and `.cpp` via `.github/workflows/job_lint.yml`. Format changed files with
+  the version CI uses:
+
+  ```bash
+  git diff --name-only --diff-filter=ACMR origin/main -- '*.cpp' '*.hpp' | \
+    docker run --rm -i -v "$PWD:/source" -w /source \
+      ghcr.io/everest/everest-ci/build-env-base:v1.6.0 xargs clang-format -i
+  ```
+
+  The tag tracks `ref_everest_ci` in `.github/workflows/on_pr.yaml`. A locally installed
+  clang-format also works, but different versions produce differing results, so the
+  container is what matches CI exactly.
 - PascalCase for classes and structs, `snake_case` for functions and methods,
   `m_`-prefixed `snake_case` for member variables, `snake_case` for library file names.
   No camelCase.
@@ -181,7 +198,7 @@ Full C++ conventions: `docs/source/how-to-guides/c++-coding-guidelines.rst`.
 | OCPP 1.6 module | `modules/EVSE/OCPP/` | not `OCPP16/` |
 | OCPP 2.0.1 and 2.1 | `modules/EVSE/OCPP201/` | one module serves both versions |
 | API module | `modules/API/API/` | directory name is doubled |
-| libocpp | `lib/everest/ocpp/` | vendored |
+| libocpp | `lib/everest/ocpp/` | in-tree |
 
 ## Invariants
 
@@ -192,7 +209,7 @@ Full C++ conventions: `docs/source/how-to-guides/c++-coding-guidelines.rst`.
 - Never use `std::cout` or `fprintf` for logging.
 - Never call `mod->r_*->call_*()` inside `init()`. Command calls belong in `ready()` or
   later.
-- Never skip formatting before proposing C++ changes. CI fails on it.
+- Never skip formatting before proposing C++ changes. CI fails on it, see Code style.
 
 ## Contributing essentials
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,9 +70,16 @@ LD_LIBRARY_PATH=<prefix>/<libdir>:$LD_LIBRARY_PATH \
 an extensionless name, looked up in the installed config directory. `--check` validates
 a config and exits 0 on success.
 
-Log verbosity is per module in the deployed
-`build/dist/share/everest/modules/<Module>/logging.ini` (template
-`cmake/assets/logging.ini`). Severities: DEBG, INFO, WARN, ERRO, CRIT.
+Logging is one Boost.Log config for the whole system, not per module: the manager reads
+`<prefix>/etc/everest/default_logging.cfg` (`cmake/assets/logging.ini` renamed at
+install; `--log_config` overrides). Per-module verbosity is a filter in that file:
+
+```ini
+Filter="(%Process% contains OCPP201 and %Severity% >= DEBG) or %Severity% >= INFO"
+```
+
+Without the `or` clause, other modules go silent. Severities: DEBG, INFO, WARN, ERRO,
+CRIT.
 
 ## Testing
 
@@ -114,12 +121,14 @@ requires in `manifest.yaml`, is wired to other modules by a configuration YAML u
 `config/`, and communicates only over MQTT through `everest-framework`. Contracts are
 the source of truth for wiring: read `interfaces/*.yaml`, `types/*.yaml` and
 `errors/*.yaml` before the C++. Lifecycle is `init()` then `ready()`, implemented per
-provided interface in `*Impl.cpp`. Generated headers land under `build/generated/`.
+provided interface in `*Impl.cpp`: subscribe in `init()`; call commands in `ready()` or
+later. Generated headers land under `build/generated/`.
 
 ```cpp
-mod->r_evse_manager->subscribe_session_event(...);   // required interface, init() ok
-mod->p_main->publish_ready(true);                    // provided interface
-auto result = mod->r_auth->call_validate_token(tok); // command: ready() or later only
+// modules/EVSE/EvseManager
+r_bsp->subscribe_event([this](auto ev) { ... });  // subscribe: init()
+p_evse->publish_ready(true);                      // publish on a provided interface
+r_bsp->call_enable(true);                         // commands: ready() or later only
 ```
 
 In a configuration YAML, a `connections` entry maps a requirement ID from the consuming

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,205 @@
+# EVerest Core: Agent Guidelines
+
+Guidance for AI coding agents working in `everest-core`: runtime manager, modules,
+shared libraries, interface definitions, test infrastructure. C++ primary, plus Python,
+Rust and JavaScript. CMake with Ninja; CI also builds with Bazel.
+
+Contributor policy (licensing, DCO, review, and the project's position on AI-generated
+contributions) is in `docs/source/project/contributing.rst`. This file covers mechanics
+only: build, run, test, code generation, and invariants.
+
+## Documentation
+
+Prefer project docs over inference, and cite them. Rendered at
+<https://everest.github.io>, starting with the
+[Getting Started Guides](https://everest.github.io/nightly/how-to-guides/getting-started/index.html).
+Sphinx sources are under `docs/source/`: `explanation/` for concepts, `how-to-guides/`
+for recipes. Per-module docs are at `modules/<Category>/<Module>/docs/index.rst`; update
+them when a module's public behavior changes.
+
+## Build
+
+`make build`, `make test` and `make lint` do not exist here.
+
+```bash
+cmake -S . -B build -GNinja \
+  -DCMAKE_INSTALL_PREFIX=./build/dist \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+  -DBUILD_TESTING=ON \
+  -DEVEREST_ENABLE_COMPILE_WARNINGS=ON
+ninja -C build install -j$(nproc)
+```
+
+Dependencies are pinned in `dependencies.yaml` and fetched by edm at configure time;
+`-DDISABLE_EDM=ON` uses system packages. `ISO15118_2_GENERATE_AND_INSTALL_CERTIFICATES`
+defaults to ON, so development certificates need no extra flag.
+
+To iterate faster, build one module (`ninja -C build OCPP201`) or skip heavy ones with
+`-DEVEREST_EXCLUDE_MODULES="EvseSlac;EvseV2G;IsoMux"`, quoting the list. `cmake -LH build`
+lists all options; the two easiest to miss are `EVEREST_ENABLE_COVERAGE` and
+`CMAKE_RUN_CLANG_TIDY`, both OFF.
+
+## Running
+
+Generated run scripts are the simplest entry point:
+
+```bash
+ls build/run-scripts/                 # every generated configuration
+build/run-scripts/run-sil.sh          # AC software-in-the-loop
+```
+
+Each wraps the manager with the environment it needs (template
+`cmake/assets/run_template.sh.in`). By hand, set the same three things:
+
+```bash
+LD_LIBRARY_PATH=<prefix>/<libdir>:$LD_LIBRARY_PATH \
+  ./build/dist/bin/manager --prefix <prefix> --config <full path to config yaml>
+```
+
+`<libdir>` is `lib` or `lib64`, following `CMAKE_INSTALL_LIBDIR`. `--config` also takes
+an extensionless name, looked up in the installed config directory. `--check` validates
+a config and exits 0 on success.
+
+Log verbosity is per module in the deployed
+`build/dist/share/everest/modules/<Module>/logging.ini` (template
+`cmake/assets/logging.ini`). Severities: DEBG, INFO, WARN, ERRO, CRIT.
+
+## Testing
+
+```bash
+cd build && ctest --output-on-failure
+cd build && ctest -N                  # list registered names before filtering
+cd build && ctest -R <regex>
+```
+
+`ctest -R` matches **registered test names, not build targets**, and the two often differ
+in case and spelling. List with `ctest -N` first. Coverage targets exist only under
+`-DEVEREST_ENABLE_COVERAGE=ON`.
+
+Integration tests use pytest; the virtualenv is `build/venv`:
+
+```bash
+. build/venv/bin/activate
+cmake --build build --target install_everest_testing
+cd tests && pytest --everest-prefix ../build/dist core_tests/ framework_tests/
+```
+
+OCPP tests also need certificate and per-EVSE component-config fixtures in the prefix.
+`tests/run-tests.sh` handles this; calling pytest directly means re-running the fixture
+scripts after any `ninja install` that touches the prefix:
+
+```bash
+cmake --build build --target everestpy_pip_install_dist
+cmake --build build --target everest-testing_pip_install_dist
+cmake --build build --target iso15118_pip_install_dist
+(cd tests/ocpp_tests/test_sets/everest-aux && \
+  ./install_certs.sh ../../../../build/dist && \
+  ./install_configs.sh ../../../../build/dist)
+cd tests/ocpp_tests && pytest --everest-prefix ../../build/dist test_sets/ocpp201/ -v
+```
+
+ISO 15118 has no dedicated suite. It is covered by `tests/core_tests/smoke_tests.py`
+(AC and DC end to end), CSMS-side helpers in
+`tests/ocpp_tests/test_sets/validations.py`, and `modules/EVSE/EvseV2G/tests/`.
+
+## Architecture
+
+Each module is an independent process. It declares the interfaces it provides and
+requires in `manifest.yaml`, is wired to other modules by a configuration YAML under
+`config/`, and communicates only over MQTT through `everest-framework`. Contracts are
+the source of truth for wiring: read `interfaces/*.yaml`, `types/*.yaml` and
+`errors/*.yaml` before the C++. Lifecycle is `init()` then `ready()`, implemented per
+provided interface in `*Impl.cpp`. Generated headers land under `build/generated/`.
+
+```cpp
+mod->r_evse_manager->subscribe_session_event(...);   // required interface, init() ok
+mod->p_main->publish_ready(true);                    // provided interface
+auto result = mod->r_auth->call_validate_token(tok); // command: ready() or later only
+```
+
+In a configuration YAML, a `connections` entry maps a requirement ID from the consuming
+module's manifest to a `module_id` plus that module's `implementation_id`.
+
+## Code generation with ev-cli
+
+`ev-cli` turns `manifest.yaml`, `interfaces/*.yaml` and `types/*.yaml` into C++
+scaffolding. It lives in-tree at `applications/utils/ev-dev-tools/`, installs into the
+build venv, and templates are under `src/ev_cli/templates/`.
+
+A file is ev-cli-managed if it carries `// ev@<uuid>:v1` markers. Content between paired
+markers is yours; everything else is regenerated. This includes files that look
+hand-written, notably `modules/<Category>/<Name>/<Name>.hpp`, which holds `struct Conf`.
+Adding a config key to a manifest means regenerating, not editing the struct.
+
+```bash
+. build/venv/bin/activate
+ev-cli mod update <Category>/<Name> --work-dir . --build-dir build -f
+cmake -S . -B build     # codegen for build/generated/ runs at configure time
+```
+
+Three traps:
+
+- The module argument is a path relative to `modules/`, so `EVSE/EvseManager`, not a
+  bare `EvseManager`. A bare name fails with `Could not open type definition file`.
+- Regeneration is decided by mtime, not content. A target newer than its manifest is
+  skipped with `Skipping <name> (up-to-date)`, so a recent edit makes ev-cli silently
+  under-generate. Preview with `-d`, force with `-f`, and confirm the change landed.
+- `--clang-format-file` takes a directory, not a file, and formatting through ev-cli
+  bypasses the version CI uses. Prefer `--disable-clang-format`.
+
+Actions: `mod create|update|generate-loader` (`c|u|gl`), `if generate-headers` and
+`ty generate-headers` (`gh`), `hlp generate-uuids|yaml2json|json2yaml`. `--only which`
+lists the files an action would touch.
+
+## Code style
+
+Full C++ conventions: `docs/source/how-to-guides/c++-coding-guidelines.rst`.
+
+- clang-format, LLVM base, 4-space indent, 120 columns (`.clang-format`). CI enforces it
+  over `.hpp` and `.cpp` via `.github/workflows/job_lint.yml`.
+- PascalCase for classes and structs, `snake_case` for functions and methods,
+  `m_`-prefixed `snake_case` for member variables, `snake_case` for library file names.
+  No camelCase.
+- `#pragma once` for include guards.
+- `EVLOG_debug`, `EVLOG_info`, `EVLOG_warning`, `EVLOG_error` for logging.
+- Return values and `std::optional` over exceptions for expected conditions.
+- JavaScript and YAML: prettier, 2-space indent, single quotes (`.prettierrc.yaml`).
+
+## Paths that surprise people
+
+| Thing | Path | Note |
+|---|---|---|
+| OCPP 1.6 module | `modules/EVSE/OCPP/` | not `OCPP16/` |
+| OCPP 2.0.1 and 2.1 | `modules/EVSE/OCPP201/` | one module serves both versions |
+| API module | `modules/API/API/` | directory name is doubled |
+| libocpp | `lib/everest/ocpp/` | vendored |
+
+Shared libraries under `lib/everest/` are edited in place. There is no separate upstream
+repository to mirror them to.
+
+## Invariants
+
+- Never remove `// ev@<uuid>:v1` markers from `*Impl.cpp` or `CMakeLists.txt`.
+- Never hand-edit ev-cli-managed content outside your own marker-delimited regions,
+  `struct Conf` included. Regenerate instead.
+- Never edit anything under `build/`, including `build/generated/`. It is overwritten.
+- Never use `std::cout` or `fprintf` for logging.
+- Never call `mod->r_*->call_*()` inside `init()`. Command calls belong in `ready()` or
+  later.
+- Never skip formatting before proposing C++ changes. CI fails on it.
+
+## Contributing essentials
+
+Full policy: `docs/source/project/contributing.rst`. The four items agents get wrong
+most often:
+
+- Sign off every commit (`Signed-off-by`, DCO), enforced by
+  `.github/workflows/job_dco-check.yaml`.
+- New files need copyright and license headers.
+- While review is open, do not rebase or force-push, so reviewers can see that feedback
+  was addressed. Squashing to a single commit once approved is how changes land.
+- Every contribution must be reviewed and understood by a human before submission.
+
+Commit subjects follow Conventional Commits and name the affected module, for example
+`fix(EvseManager): handle unplug during timed charging`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+@AGENTS.md
+
+## Claude Code specifics
+
+Project guidance lives in `AGENTS.md`, imported above, so that every coding agent reads
+the same instructions. Put project-wide changes there rather than here.
+
+Personal, uncommitted instructions belong in `CLAUDE.local.md` at the repository root.
+It is gitignored and loads after this file.
+
+If you work across several git worktrees of this repository, note that a gitignored
+`CLAUDE.local.md` exists only in the worktree where you created it. Keep per-user
+preferences in `~/.claude/rules/` instead, which is not per-checkout.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Project guidance lives in `AGENTS.md`, imported above, so that every coding agent reads
 the same instructions. Put project-wide changes there rather than here.
 
-Personal, uncommitted instructions belong in `CLAUDE.local.md` at the repository root.
-It is gitignored and loads after this file. Being gitignored, it exists only in the
-worktree where you created it, so it does not follow you across several worktrees of
-this repository. The stable place for per-user preferences is your home directory:
-`~/.claude/CLAUDE.md` for general instructions, `~/.claude/rules/` for scoped rule
-files. Neither is per-checkout.
+Personal, uncommitted instructions belong in `CLAUDE.local.md` at the repository root;
+it is gitignored and loads after this file. Gitignored means per-worktree: it does not
+follow you across worktrees. Preferences that should follow you belong in
+`~/.claude/CLAUDE.md` or in scoped rule files under `~/.claude/rules/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,8 @@ Project guidance lives in `AGENTS.md`, imported above, so that every coding agen
 the same instructions. Put project-wide changes there rather than here.
 
 Personal, uncommitted instructions belong in `CLAUDE.local.md` at the repository root.
-It is gitignored and loads after this file.
-
-If you work across several git worktrees of this repository, note that a gitignored
-`CLAUDE.local.md` exists only in the worktree where you created it. Keep per-user
-preferences in `~/.claude/rules/` instead, which is not per-checkout.
+It is gitignored and loads after this file. Being gitignored, it exists only in the
+worktree where you created it, so it does not follow you across several worktrees of
+this repository. The stable place for per-user preferences is your home directory:
+`~/.claude/CLAUDE.md` for general instructions, `~/.claude/rules/` for scoped rule
+files. Neither is per-checkout.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,5 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Project guidance lives in `AGENTS.md`, imported above, so that every coding agent reads
 the same instructions. Put project-wide changes there rather than here.
 
-Personal, uncommitted instructions belong in `CLAUDE.local.md` at the repository root;
-it is gitignored and loads after this file. Gitignored means per-worktree: it does not
-follow you across worktrees. Preferences that should follow you belong in
-`~/.claude/CLAUDE.md` or in scoped rule files under `~/.claude/rules/`.
+Personal, uncommitted instructions belong in `CLAUDE.local.md` at the repository root
+(gitignored).


### PR DESCRIPTION
## Describe your changes

Adds `AGENTS.md` with build, test, code generation and style guidance for AI coding
agents, a 17-line `CLAUDE.md` that imports it, and one `.gitignore` line. Docs only.

Agents reliably get project conventions wrong: `camelCase` where the C++ guidelines
require `snake_case`, hand-edited `struct Conf` instead of `ev-cli` regeneration, command
calls in `init()` rather than `ready()`. All of it is already decided in the tree, none
of it anywhere an agent reads. `contributing.rst` already states a position on
AI-generated contributions; this is its practical companion.

Two files because Claude Code reads `CLAUDE.md`, not `AGENTS.md`. `AGENTS.md` holds the
content and stays vendor-neutral; the adapter just imports it. A symlink also works but
needs Administrator or Developer Mode on Windows. `CLAUDE.local.md` is gitignored so
personal instructions need no committed reference, which is the only `.gitignore` change.

Policy stays in `contributing.rst`; `AGENTS.md` inlines only the four items agents most
often violate and links out for the rest. No `.claude/` directory or editor config is
committed.

Claims were verified against a clean `main` checkout and anything untraceable was dropped
rather than published. That corrected eight errors, including inverted naming
conventions, `ev-cli if update` and `ty update` (the real actions are
`generate-headers`), and a coverage command that needs `-DEVEREST_ENABLE_COVERAGE=ON`.
Verification was static plus cheap commands; the documented cmake, ninja and pytest runs
were not executed end to end.

Follow-up, deliberately not in this PR: large monorepos commonly split agent guidance
into nested `AGENTS.md` files placed next to the code they describe (Grafana and Sentry
both do, for example `tests/AGENTS.md` or `pkg/storage/unified/AGENTS.md`). Agents read
the nearest file in the directory tree, so subsystem detail such as the ev-cli traps or
per-library quirks could later move into `lib/everest/<lib>/` and `tests/` files, keeping
the root file short. This PR starts with a single root file.

Open questions: is `AGENTS.md` the filename you want, should it live at the root or under
`docs/`, and is the mechanics/policy split drawn where you would draw it?

## Issue ticket number and link

None. Documentation-only addition.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

