### PR TITLE
fix(ocpp): accept integral threshold/delta monitor values on integer variables

### DIFF
--- a/lib/everest/ocpp/lib/ocpp/v2/device_model.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/device_model.cpp
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
 
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
 #include <everest/database/exceptions.hpp>
 #include <ocpp/common/constants.hpp>
 #include <ocpp/common/utils.hpp>
@@ -260,6 +264,17 @@ bool validate_value(const VariableCharacteristics& characteristics, const std::s
         }
     }
     return false;
+}
+
+/// \brief Converts a monitor \p value to a string suitable for validate_value() given the variable's \p data_type.
+/// std::to_string(float) always renders six decimals (e.g. "950.000000"), which would fail integer validation even
+/// for integral values, so integral values for integer-typed variables are rendered without decimals.
+std::string monitor_value_to_string(const float value, const DataEnum data_type) {
+    if (data_type == DataEnum::integer and std::rint(value) == value and
+        std::abs(value) < static_cast<float>(std::numeric_limits<std::int32_t>::max())) {
+        return std::to_string(static_cast<std::int32_t>(value));
+    }
+    return std::to_string(value);
 }
 
 bool include_in_summary_inventory(const ComponentVariable& cv, const VariableAttribute& attribute) {
@@ -831,7 +846,8 @@ std::vector<SetMonitoringResult> DeviceModel::set_monitors(const std::vector<Set
                 valid_value = true;
             } else {
                 try {
-                    valid_value = validate_value(characteristics, std::to_string(request.value),
+                    valid_value = validate_value(characteristics,
+                                                 monitor_value_to_string(request.value, characteristics.dataType),
                                                  allow_zero(request.component, request.variable));
                 } catch (const std::exception& e) {
                     EVLOG_warning << "Could not validate monitor value: " << request.value

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_device_model.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_device_model.cpp
@@ -168,6 +168,61 @@ TEST_F(DeviceModelTest, test_set_monitors) {
     ASSERT_EQ(results[1].status, SetMonitoringStatusEnum::Rejected);
 }
 
+TEST_F(DeviceModelTest, test_set_threshold_and_delta_monitors_on_integer_variable) {
+    Component component;
+    component.name = "AlignedDataCtrlr";
+
+    Variable variable;
+    variable.name = "Interval";
+
+    // Clear all existing monitors for a clean test state
+    auto existing_monitors = dm->get_monitors({}, {{component, variable}});
+    for (auto& result : existing_monitors) {
+        std::vector<std::int32_t> ids;
+        for (auto& monitor : result.variableMonitoring) {
+            ids.push_back(monitor.id);
+        }
+        dm->clear_monitors(ids, true);
+    }
+
+    SetMonitoringData upper_threshold;
+    upper_threshold.value = 950.0;
+    upper_threshold.type = MonitorEnum::UpperThreshold;
+    upper_threshold.severity = 3;
+    upper_threshold.component = component;
+    upper_threshold.variable = variable;
+
+    SetMonitoringData lower_threshold;
+    lower_threshold.value = 10.0;
+    lower_threshold.type = MonitorEnum::LowerThreshold;
+    lower_threshold.severity = 3;
+    lower_threshold.component = component;
+    lower_threshold.variable = variable;
+
+    SetMonitoringData delta;
+    delta.value = 30.0;
+    delta.type = MonitorEnum::Delta;
+    delta.severity = 3;
+    delta.component = component;
+    delta.variable = variable;
+
+    // Non-integral values remain invalid for integer-typed variables
+    SetMonitoringData non_integral;
+    non_integral.value = 4.579;
+    non_integral.type = MonitorEnum::UpperThreshold;
+    non_integral.severity = 4;
+    non_integral.component = component;
+    non_integral.variable = variable;
+
+    auto results = dm->set_monitors({upper_threshold, lower_threshold, delta, non_integral});
+    ASSERT_EQ(results.size(), 4);
+
+    EXPECT_EQ(results[0].status, SetMonitoringStatusEnum::Accepted);
+    EXPECT_EQ(results[1].status, SetMonitoringStatusEnum::Accepted);
+    EXPECT_EQ(results[2].status, SetMonitoringStatusEnum::Accepted);
+    EXPECT_EQ(results[3].status, SetMonitoringStatusEnum::Rejected);
+}
+
 TEST_F(DeviceModelTest, test_get_monitors) {
     // Set 'Interval' to not support monitoring.
     VariableCharacteristics c;


### PR DESCRIPTION
# Describe your changes

`DeviceModel::set_monitors()` validates the float `SetMonitoringData.value` by round-tripping it through `std::to_string()`, which always renders six decimals (e.g. `950.0` → `"950.000000"`). For integer-typed variables that string fails `is_integer()` inside `validate_value()`, so **every** `SetVariableMonitoring` request of type `UpperThreshold`, `LowerThreshold` or `Delta` on an integer variable is answered with `Rejected` — regardless of the value sent.

Since most monitorable variables in the standardized component configs are integers, CSMS-defined threshold/delta monitoring is effectively unusable. `Periodic`/`PeriodicClockAligned` monitors are unaffected because they skip value validation.

Reproduced against an unmodified build (OCPP 2.0.1, `AlignedDataCtrlr`/`Interval`: `dataType=integer`, `supportsMonitoring=true`):

```json
[3, "...", {"setMonitoringResult": [{"status": "Rejected", "type": "UpperThreshold", "severity": 3,
  "component": {"name": "AlignedDataCtrlr"}, "variable": {"name": "Interval"}}]}]
```

## Fix

Format the monitor value appropriately for the variable's `dataType` before validation: integral values for integer-typed variables are rendered without decimals (`950.0` → `"950"`). Non-integral values (e.g. `4.579`) on integer variables are still rejected, matching the existing `test_set_monitors` expectation.

The stored monitor value is unaffected — `set_monitoring_data()` continues to receive the raw float.

# Issue ticket number and link

(none — found during downstream OCPP 2.0.1 monitoring verification; related to the monitoring subsystem touched by #2554)

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (n/a — behavior fix)
- [x] I read the contribution documentation and made sure that my changes meet its requirements
