### PR TITLE
fix(libiso15118): Fix link error on older clang/gcc version: avoid odr-use of TypeTrait::type with catch2

### DIFF
--- a/lib/everest/iso15118/test/iso15118/session/tbd_controller_start_session.cpp
+++ b/lib/everest/iso15118/test/iso15118/session/tbd_controller_start_session.cpp
@@ -216,7 +216,8 @@ Response require_response(const std::optional<std::vector<uint8_t>>& response,
 
     const iso15118::io::StreamInputView view{payload, payload_len};
     const iso15118::message_20::Variant variant(payload_type, view);
-    REQUIRE(variant.get_type() == iso15118::message_20::TypeTrait<Response>::type);
+    const auto exptected_type = iso15118::message_20::TypeTrait<Response>::type;
+    REQUIRE(variant.get_type() == exptected_type);
 
     return variant.get<Response>();
 }


### PR DESCRIPTION
## Describe your changes
A local copy is enough to fix this issue.

## Issue ticket number and link
Because of #2547: `REQUIRE(variant.get_type() == iso15118::message_20::TypeTrait<Response>::type);` was added to a test.
This line dont link with older clang/gcc versions. With the fix linking is working again.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

