### PR TITLE
feat(libiso15118): EV BPT (AC + DC)

### DIFF
--- a/config/config-sil-ac-bpt-d20-evcpp.yaml
+++ b/config/config-sil-ac-bpt-d20-evcpp.yaml
@@ -1,0 +1,176 @@
+active_modules:
+  iso15118_charger:
+    module: Evse15118D20
+    config_module:
+      device: auto
+    connections:
+      security:
+        - module_id: evse_security
+          implementation_id: main
+  iso15118_car:
+    module: EvIso15118D20
+    config_module:
+      device: auto
+      evcc_id: "AA:BB:CC:DD:EE:01"
+      response_timeout_ms: 8000
+      ac_max_charge_power_w: 11040
+      ac_min_charge_power_w: 1380
+      ac_max_discharge_power_w: 11040
+      ac_min_discharge_power_w: 1380
+  evse_manager:
+    module: EvseManager
+    config_module:
+      ac_enforce_hlc: false
+      ac_hlc_enabled: true
+      ac_hlc_use_5percent: false
+      ac_nominal_voltage: 230
+      supported_iso_ac_bpt: true
+      charge_mode: AC
+      connector_id: 1
+      ev_receipt_required: false
+      evse_id: DE*PNX*E12345*1
+      has_ventilation: true
+      payment_enable_contract: false
+      payment_enable_eim: true
+      session_logging: true
+      session_logging_path: /tmp/everest-logs
+      session_logging_xml: false
+      switch_3ph1ph_delay_s: 5
+      switch_3ph1ph_cp_state: X1
+      bpt_channel: Unified
+      bpt_generator_mode: GridFollowing
+      bpt_grid_code_island_method: Passive
+    connections:
+      bsp:
+        - module_id: connector_1_powerpath
+          implementation_id: board_support
+      hlc:
+        - module_id: iso15118_charger
+          implementation_id: charger
+      powermeter_car_side:
+        - module_id: connector_1_powerpath
+          implementation_id: powermeter
+      slac:
+        - module_id: slac
+          implementation_id: evse
+      ac_rcd:
+        - implementation_id: rcd
+          module_id: connector_1_powerpath
+      connector_lock:
+        - implementation_id: connector_lock
+          module_id: connector_1_powerpath
+  connector_1_powerpath:
+    config_module:
+      connector_id: 1
+    connections: {}
+    module: YetiSimulator
+    telemetry:
+      id: 1
+  slac:
+    module: SlacSimulator
+  ev_manager:
+    module: EvManager
+    config_module:
+      connector_id: 1
+      auto_enable: true
+      auto_exec: false
+      auto_exec_commands: sleep 3;iso_wait_slac_matched;iso_start_v2g_session AC_BPT;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 20;iso_wait_v2g_session_stopped;unplug
+    connections:
+      ev_board_support:
+        - module_id: connector_1_powerpath
+          implementation_id: ev_board_support
+      ev:
+        - module_id: iso15118_car
+          implementation_id: ev
+      slac:
+        - module_id: slac
+          implementation_id: ev
+  auth:
+    module: Auth
+    config_module:
+      connection_timeout: 10
+      selection_algorithm: FindFirst
+    connections:
+      token_provider:
+        - module_id: token_provider
+          implementation_id: main
+      token_validator:
+        - module_id: token_validator
+          implementation_id: main
+      evse_manager:
+        - module_id: evse_manager
+          implementation_id: evse
+  token_provider:
+    module: DummyTokenProvider
+    config_implementation:
+      main:
+        timeout: 10
+        token: DEADBEEF
+    connections:
+      evse:
+        - module_id: evse_manager
+          implementation_id: evse
+  token_validator:
+    module: DummyTokenValidator
+    config_implementation:
+      main:
+        validation_result: Accepted
+        validation_reason: Token seems valid
+        sleep: 0.25
+  evse_security:
+    module: EvseSecurity
+    config_module:
+      private_key_password: "123456"
+  energy_manager:
+    module: EnergyManager
+    config_module:
+      schedule_total_duration: 1
+      schedule_interval_duration: 60
+      debug: false
+    connections:
+      energy_trunk:
+        - module_id: grid_connection_point
+          implementation_id: energy_grid
+  grid_connection_point:
+    module: EnergyNode
+    config_module:
+      fuse_limit_A: 40.0
+      phase_count: 3
+    connections:
+      price_information: []
+      energy_consumer:
+        - module_id: api_sink
+          implementation_id: energy_grid
+      powermeter:
+        - module_id: connector_1_powerpath
+          implementation_id: powermeter
+  api_sink:
+    module: EnergyNode
+    mapping:
+      module:
+        evse: 1
+    config_module:
+      fuse_limit_A: 32.0
+      phase_count: 3
+    connections:
+      energy_consumer:
+        - module_id: evse_manager
+          implementation_id: energy_grid
+  api:
+    module: API
+    connections:
+      evse_manager:
+        - module_id: evse_manager
+          implementation_id: evse
+      error_history:
+        - module_id: error_history
+          implementation_id: error_history
+      evse_energy_sink:
+        - module_id: api_sink
+          implementation_id: external_limits
+  error_history:
+    module: ErrorHistory
+    config_implementation:
+      error_history:
+        database_path: /tmp/error_history.db
+x-module-layout: {}

--- a/config/config-sil-ac-bpt-d20-evcpp.yaml
+++ b/config/config-sil-ac-bpt-d20-evcpp.yaml
@@ -14,9 +14,9 @@ active_modules:
       evcc_id: "AA:BB:CC:DD:EE:01"
       response_timeout_ms: 8000
       ac_max_charge_power_w: 11040
-      ac_min_charge_power_w: 1380
+      ac_min_charge_power_w: 4140
       ac_max_discharge_power_w: 11040
-      ac_min_discharge_power_w: 1380
+      ac_min_discharge_power_w: 4140
   evse_manager:
     module: EvseManager
     config_module:

--- a/config/config-sil-ac-d20-evcpp.yaml
+++ b/config/config-sil-ac-d20-evcpp.yaml
@@ -14,7 +14,7 @@ active_modules:
       evcc_id: "AA:BB:CC:DD:EE:01"
       response_timeout_ms: 8000
       ac_max_charge_power_w: 11040
-      ac_min_charge_power_w: 1380
+      ac_min_charge_power_w: 4140
   evse_manager:
     module: EvseManager
     config_module:

--- a/config/config-sil-dc-bpt-d20-evcpp.yaml
+++ b/config/config-sil-dc-bpt-d20-evcpp.yaml
@@ -1,0 +1,176 @@
+active_modules:
+  iso15118_charger:
+    module: Evse15118D20
+    config_module:
+      device: auto
+    connections:
+      security:
+        - module_id: evse_security
+          implementation_id: main
+  iso15118_car:
+    module: EvIso15118D20
+    config_module:
+      device: auto
+      evcc_id: "AA:BB:CC:DD:EE:01"
+      response_timeout_ms: 8000
+      dc_max_discharge_power_w: 150000
+      dc_min_discharge_power_w: 0
+      dc_max_discharge_current_a: 200
+  evse_manager:
+    module: EvseManager
+    config_module:
+      connector_id: 1
+      evse_id: DE*PNX*E12345*1
+      evse_id_din: 49A80737A45678
+      session_logging: true
+      session_logging_xml: false
+      session_logging_path: /tmp/everest-logs
+      charge_mode: DC
+      payment_enable_contract: false
+      bpt_channel: Unified
+      bpt_generator_mode: GridFollowing
+    connections:
+      bsp:
+        - module_id: yeti_driver
+          implementation_id: board_support
+      powermeter_car_side:
+        - module_id: powersupply_dc
+          implementation_id: powermeter
+      slac:
+        - module_id: slac
+          implementation_id: evse
+      hlc:
+        - module_id: iso15118_charger
+          implementation_id: charger
+      powersupply_DC:
+        - module_id: powersupply_dc
+          implementation_id: main
+      imd:
+        - module_id: imd
+          implementation_id: main
+  powersupply_dc:
+    module: DCSupplySimulator
+  yeti_driver:
+    module: YetiSimulator
+    config_module:
+      connector_id: 1
+  slac:
+    module: SlacSimulator
+  imd:
+    config_implementation:
+      main:
+        selftest_success: true
+    module: IMDSimulator
+  ev_manager:
+    module: EvManager
+    config_module:
+      connector_id: 1
+      auto_enable: true
+      auto_exec: false
+      auto_exec_commands: sleep 3;iso_wait_slac_matched;iso_start_v2g_session DC_BPT;iso_wait_pwr_ready;iso_dc_power_on;iso_wait_for_stop 15;iso_wait_v2g_session_stopped;unplug;
+      dc_target_current: 20
+      dc_target_voltage: 400
+    connections:
+      ev_board_support:
+        - module_id: yeti_driver
+          implementation_id: ev_board_support
+      ev:
+        - module_id: iso15118_car
+          implementation_id: ev
+      slac:
+        - module_id: slac
+          implementation_id: ev
+  auth:
+    module: Auth
+    config_module:
+      connection_timeout: 10
+      selection_algorithm: FindFirst
+    connections:
+      token_provider:
+        - module_id: token_provider
+          implementation_id: main
+      token_validator:
+        - module_id: token_validator
+          implementation_id: main
+      evse_manager:
+        - module_id: evse_manager
+          implementation_id: evse
+  token_provider:
+    module: DummyTokenProvider
+    config_implementation:
+      main:
+        token: TOKEN1
+    connections:
+      evse:
+        - module_id: evse_manager
+          implementation_id: evse
+  token_validator:
+    module: DummyTokenValidator
+    config_implementation:
+      main:
+        validation_result: Accepted
+        validation_reason: Token seems valid
+        sleep: 0.25
+  evse_security:
+    module: EvseSecurity
+    config_module:
+      private_key_password: "123456"
+  energy_manager:
+    module: EnergyManager
+    config_module:
+      schedule_total_duration: 1
+      schedule_interval_duration: 60
+      debug: false
+    connections:
+      energy_trunk:
+        - module_id: grid_connection_point
+          implementation_id: energy_grid
+  grid_connection_point:
+    module: EnergyNode
+    config_module:
+      fuse_limit_A: 40.0
+      phase_count: 3
+    connections:
+      price_information: []
+      energy_consumer:
+        - module_id: api_sink
+          implementation_id: energy_grid
+      powermeter:
+        - module_id: yeti_driver
+          implementation_id: powermeter
+  api_sink:
+    module: EnergyNode
+    mapping:
+      module:
+        evse: 1
+    config_module:
+      fuse_limit_A: 32.0
+      phase_count: 3
+    connections:
+      energy_consumer:
+        - module_id: evse_manager
+          implementation_id: energy_grid
+  api:
+    module: API
+    connections:
+      evse_manager:
+        - module_id: evse_manager
+          implementation_id: evse
+      error_history:
+        - module_id: error_history
+          implementation_id: error_history
+      evse_energy_sink:
+        - module_id: api_sink
+          implementation_id: external_limits
+  ev_api:
+    module: EvAPI
+    connections:
+      ev_manager:
+        - implementation_id: ev_manager
+          module_id: ev_manager
+  error_history:
+    module: ErrorHistory
+    config_implementation:
+      error_history:
+        database_path: /tmp/error_history.db
+x-module-layout: {}

--- a/lib/everest/iso15118/include/iso15118/ev/ac_charge_params.hpp
+++ b/lib/everest/iso15118/include/iso15118/ev/ac_charge_params.hpp
@@ -16,6 +16,8 @@ struct AcChargeParams {
     // Static: advertised limits.
     float max_charge_power{0.0f};
     float min_charge_power{0.0f};
+    float max_discharge_power{0.0f};
+    float min_discharge_power{0.0f};
 
     // Drives whether the optional L2/L3 phase limits are emitted.
     bool three_phase{false};

--- a/lib/everest/iso15118/include/iso15118/ev/ac_charge_params.hpp
+++ b/lib/everest/iso15118/include/iso15118/ev/ac_charge_params.hpp
@@ -13,14 +13,13 @@ namespace iso15118::ev {
  * Context::get_ac_params().
  */
 struct AcChargeParams {
-    // Static: advertised limits.
+    // Static: advertised limits, as three-phase totals. The optional per-phase
+    // L2/L3 fields are never emitted: there is no per-phase measurement to put
+    // in them, and repeating the total on each phase would overstate the limit.
     float max_charge_power{0.0f};
     float min_charge_power{0.0f};
     float max_discharge_power{0.0f};
     float min_discharge_power{0.0f};
-
-    // Drives whether the optional L2/L3 phase limits are emitted.
-    bool three_phase{false};
 
     // Live: refreshed by the module during the session.
     float present_active_power{0.0f};

--- a/lib/everest/iso15118/include/iso15118/ev/d20/context.hpp
+++ b/lib/everest/iso15118/include/iso15118/ev/d20/context.hpp
@@ -177,6 +177,27 @@ public:
         return *h;
     }
 
+    // Last present voltage the SECC reported in a DC charge-loop response. The EV has no
+    // measurement source for its own mandatory present voltage yet, so the charge loop
+    // approximates it from this. Held here so it outlives a single loop iteration.
+    std::optional<float> evse_present_voltage() const {
+        return evse_present_voltage_;
+    }
+
+    void set_evse_present_voltage(float voltage) {
+        evse_present_voltage_ = voltage;
+    }
+
+    // Last active-power target the SECC dictated in an AC charge-loop response. Same
+    // role as evse_present_voltage() for the mandatory AC present active power.
+    std::optional<float> evse_target_active_power() const {
+        return evse_target_active_power_;
+    }
+
+    void set_evse_target_active_power(float power) {
+        evse_target_active_power_ = power;
+    }
+
     // Energy service the EV drives this session. Defaults to the service requested
     // at construction and is refined once ServiceSelection negotiates.
     message_20::datatypes::ServiceCategory selected_service() const {
@@ -236,6 +257,10 @@ private:
 
     // Module -> FSM AC-params channel; same locked-copy-snapshot contract as dc_params.
     everest::lib::util::monitor<AcChargeParams>& ac_params;
+
+    std::optional<float> evse_present_voltage_{};
+
+    std::optional<float> evse_target_active_power_{};
 
     message_20::datatypes::ServiceCategory selected_service_;
 

--- a/lib/everest/iso15118/include/iso15118/ev/d20/context.hpp
+++ b/lib/everest/iso15118/include/iso15118/ev/d20/context.hpp
@@ -107,7 +107,7 @@ public:
     std::unique_ptr<message_20::Variant> pull_response();
     message_20::Type peek_response_type() const;
 
-    template <typename MessageType> void respond(const MessageType& msg) {
+    template <typename MessageType> void send_request(const MessageType& msg) {
         message_exchange.set_request(msg);
     }
 

--- a/lib/everest/iso15118/include/iso15118/ev/dc_charge_params.hpp
+++ b/lib/everest/iso15118/include/iso15118/ev/dc_charge_params.hpp
@@ -16,6 +16,9 @@ struct DcChargeParams {
     // Static: negotiated/advertised limits and targets.
     float max_charge_power{0.0f};
     float max_charge_current{0.0f};
+    float max_discharge_power{0.0f};
+    float min_discharge_power{0.0f};
+    float max_discharge_current{0.0f};
     float max_voltage{0.0f};
     float min_voltage{0.0f};
     float energy_capacity{0.0f};

--- a/lib/everest/iso15118/include/iso15118/ev/session/feedback.hpp
+++ b/lib/everest/iso15118/include/iso15118/ev/session/feedback.hpp
@@ -9,6 +9,7 @@
 #include <iso15118/message/ac_charge_loop.hpp>
 #include <iso15118/message/ac_charge_parameter_discovery.hpp>
 #include <iso15118/message/ac_der_iec_charge_loop.hpp>
+#include <iso15118/message/dc_charge_parameter_discovery.hpp>
 #include <iso15118/message/session_setup.hpp>
 #include <iso15118/message/type.hpp>
 
@@ -26,6 +27,8 @@ struct Callbacks {
     std::function<void()> dc_power_on;
     std::function<void()> stop_from_charger;
     std::function<void(const message_20::datatypes::AC_CPDResEnergyTransferMode&)> ac_limits;
+    std::function<void(const message_20::datatypes::BPT_AC_CPDResEnergyTransferMode&)> ac_bpt_limits;
+    std::function<void(const message_20::datatypes::BPT_DC_CPDResEnergyTransferMode&)> dc_bpt_limits;
     std::function<void(const message_20::datatypes::Dynamic_AC_CLResControlMode&)> ac_target_power;
     std::function<void(const message_20::datatypes::DER_Dynamic_AC_CLResControlMode&)> der_control;
 };
@@ -47,6 +50,8 @@ public:
     void dc_power_on() const;
     void stop_from_charger() const;
     void ac_limits(const message_20::datatypes::AC_CPDResEnergyTransferMode&) const;
+    void ac_bpt_limits(const message_20::datatypes::BPT_AC_CPDResEnergyTransferMode&) const;
+    void dc_bpt_limits(const message_20::datatypes::BPT_DC_CPDResEnergyTransferMode&) const;
     void ac_target_power(const message_20::datatypes::Dynamic_AC_CLResControlMode&) const;
     void der_control(const message_20::datatypes::DER_Dynamic_AC_CLResControlMode&) const;
 

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_charge_loop.cpp
@@ -13,19 +13,31 @@ namespace {
 
 namespace dt = message_20::datatypes;
 
-void fill_dynamic_charge(dt::Dynamic_AC_CLReqControlMode& mode, const AcChargeParams& params) {
+// Approximation, not a measurement: the EV has no power measurement feeding the stack yet
+// and the field is mandatory on the wire, where a zero reads as a measured zero. Prefer a
+// module-fed value, else the target the SECC dictated and the EV is expected to follow.
+float approximate_present_active_power(const AcChargeParams& params, std::optional<float> target_dictated_by_evse) {
+    if (params.present_active_power != 0.0f) {
+        return params.present_active_power;
+    }
+    return target_dictated_by_evse.value_or(0.0f);
+}
+
+void fill_dynamic_charge(dt::Dynamic_AC_CLReqControlMode& mode, const AcChargeParams& params,
+                         std::optional<float> target_dictated_by_evse) {
     mode.departure_time = std::nullopt;
     mode.target_energy_request = {0, 0};
     mode.max_energy_request = {0, 0};
     mode.min_energy_request = {0, 0};
     mode.max_charge_power = dt::from_float(params.max_charge_power);
     mode.min_charge_power = dt::from_float(params.min_charge_power);
-    mode.present_active_power = dt::from_float(params.present_active_power);
+    mode.present_active_power = dt::from_float(approximate_present_active_power(params, target_dictated_by_evse));
     mode.present_reactive_power = {0, 0};
 }
 
 message_20::AC_ChargeLoopRequest make_request(const SessionId& session, const AcChargeParams& params,
-                                              dt::ServiceCategory service) {
+                                              dt::ServiceCategory service,
+                                              std::optional<float> target_dictated_by_evse) {
     message_20::AC_ChargeLoopRequest req;
     setup_header(req.header, session);
     req.meter_info_requested = false;
@@ -33,13 +45,13 @@ message_20::AC_ChargeLoopRequest make_request(const SessionId& session, const Ac
 
     if (service == dt::ServiceCategory::AC_BPT) {
         dt::BPT_Dynamic_AC_CLReqControlMode mode;
-        fill_dynamic_charge(mode, params);
+        fill_dynamic_charge(mode, params, target_dictated_by_evse);
         mode.max_discharge_power = dt::from_float(params.max_discharge_power);
         mode.min_discharge_power = dt::from_float(params.min_discharge_power);
         req.control_mode = mode;
     } else {
         dt::Dynamic_AC_CLReqControlMode mode;
-        fill_dynamic_charge(mode, params);
+        fill_dynamic_charge(mode, params, target_dictated_by_evse);
         req.control_mode = mode;
     }
 
@@ -50,7 +62,8 @@ message_20::AC_ChargeLoopRequest make_request(const SessionId& session, const Ac
 
 void AC_ChargeLoop::enter() {
     logf_debug("Enter state: AC_ChargeLoop");
-    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_ac_params(), m_ctx.selected_service()));
+    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_ac_params(), m_ctx.selected_service(),
+                                    m_ctx.evse_target_active_power()));
 }
 
 Result AC_ChargeLoop::feed(Event ev) {
@@ -86,7 +99,9 @@ Result AC_ChargeLoop::feed(Event ev) {
     }
 
     m_ctx.feedback.ac_target_power(*mode);
-    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_ac_params(), m_ctx.selected_service()));
+    m_ctx.set_evse_target_active_power(dt::from_RationalNumber(mode->target_active_power));
+    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_ac_params(), m_ctx.selected_service(),
+                                    m_ctx.evse_target_active_power()));
     return {};
 }
 

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_charge_loop.cpp
@@ -64,7 +64,7 @@ message_20::AC_ChargeLoopRequest make_request(const SessionId& session, const Ac
 
 void AC_ChargeLoop::enter() {
     logf_debug("Enter state: AC_ChargeLoop");
-    m_ctx.respond(make_request(m_ctx.get_session(), m_ctx.get_ac_params(), m_ctx.selected_service()));
+    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_ac_params(), m_ctx.selected_service()));
 }
 
 Result AC_ChargeLoop::feed(Event ev) {
@@ -100,7 +100,7 @@ Result AC_ChargeLoop::feed(Event ev) {
     }
 
     m_ctx.feedback.ac_target_power(*mode);
-    m_ctx.respond(make_request(m_ctx.get_session(), m_ctx.get_ac_params(), m_ctx.selected_service()));
+    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_ac_params(), m_ctx.selected_service()));
     return {};
 }
 

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_charge_loop.cpp
@@ -22,14 +22,6 @@ void fill_dynamic_charge(dt::Dynamic_AC_CLReqControlMode& mode, const AcChargePa
     mode.min_charge_power = dt::from_float(params.min_charge_power);
     mode.present_active_power = dt::from_float(params.present_active_power);
     mode.present_reactive_power = {0, 0};
-    if (params.three_phase) {
-        mode.max_charge_power_L2 = mode.max_charge_power;
-        mode.max_charge_power_L3 = mode.max_charge_power;
-        mode.min_charge_power_L2 = mode.min_charge_power;
-        mode.min_charge_power_L3 = mode.min_charge_power;
-        mode.present_active_power_L2 = mode.present_active_power;
-        mode.present_active_power_L3 = mode.present_active_power;
-    }
 }
 
 message_20::AC_ChargeLoopRequest make_request(const SessionId& session, const AcChargeParams& params,
@@ -44,12 +36,6 @@ message_20::AC_ChargeLoopRequest make_request(const SessionId& session, const Ac
         fill_dynamic_charge(mode, params);
         mode.max_discharge_power = dt::from_float(params.max_discharge_power);
         mode.min_discharge_power = dt::from_float(params.min_discharge_power);
-        if (params.three_phase) {
-            mode.max_discharge_power_L2 = mode.max_discharge_power;
-            mode.max_discharge_power_L3 = mode.max_discharge_power;
-            mode.min_discharge_power_L2 = mode.min_discharge_power;
-            mode.min_discharge_power_L3 = mode.min_discharge_power;
-        }
         req.control_mode = mode;
     } else {
         dt::Dynamic_AC_CLReqControlMode mode;

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_charge_loop.cpp
@@ -13,13 +13,7 @@ namespace {
 
 namespace dt = message_20::datatypes;
 
-message_20::AC_ChargeLoopRequest make_request(const SessionId& session, const AcChargeParams& params) {
-    message_20::AC_ChargeLoopRequest req;
-    setup_header(req.header, session);
-    req.meter_info_requested = false;
-    req.display_parameters = std::nullopt;
-
-    dt::Dynamic_AC_CLReqControlMode mode;
+void fill_dynamic_charge(dt::Dynamic_AC_CLReqControlMode& mode, const AcChargeParams& params) {
     mode.departure_time = std::nullopt;
     mode.target_energy_request = {0, 0};
     mode.max_energy_request = {0, 0};
@@ -36,7 +30,32 @@ message_20::AC_ChargeLoopRequest make_request(const SessionId& session, const Ac
         mode.present_active_power_L2 = mode.present_active_power;
         mode.present_active_power_L3 = mode.present_active_power;
     }
-    req.control_mode = mode;
+}
+
+message_20::AC_ChargeLoopRequest make_request(const SessionId& session, const AcChargeParams& params,
+                                              dt::ServiceCategory service) {
+    message_20::AC_ChargeLoopRequest req;
+    setup_header(req.header, session);
+    req.meter_info_requested = false;
+    req.display_parameters = std::nullopt;
+
+    if (service == dt::ServiceCategory::AC_BPT) {
+        dt::BPT_Dynamic_AC_CLReqControlMode mode;
+        fill_dynamic_charge(mode, params);
+        mode.max_discharge_power = dt::from_float(params.max_discharge_power);
+        mode.min_discharge_power = dt::from_float(params.min_discharge_power);
+        if (params.three_phase) {
+            mode.max_discharge_power_L2 = mode.max_discharge_power;
+            mode.max_discharge_power_L3 = mode.max_discharge_power;
+            mode.min_discharge_power_L2 = mode.min_discharge_power;
+            mode.min_discharge_power_L3 = mode.min_discharge_power;
+        }
+        req.control_mode = mode;
+    } else {
+        dt::Dynamic_AC_CLReqControlMode mode;
+        fill_dynamic_charge(mode, params);
+        req.control_mode = mode;
+    }
 
     return req;
 }
@@ -45,7 +64,7 @@ message_20::AC_ChargeLoopRequest make_request(const SessionId& session, const Ac
 
 void AC_ChargeLoop::enter() {
     logf_debug("Enter state: AC_ChargeLoop");
-    m_ctx.respond(make_request(m_ctx.get_session(), m_ctx.get_ac_params()));
+    m_ctx.respond(make_request(m_ctx.get_session(), m_ctx.get_ac_params(), m_ctx.selected_service()));
 }
 
 Result AC_ChargeLoop::feed(Event ev) {
@@ -60,7 +79,10 @@ Result AC_ChargeLoop::feed(Event ev) {
         return {};
     }
 
-    const auto* mode = std::get_if<dt::Dynamic_AC_CLResControlMode>(&res->control_mode);
+    const dt::Dynamic_AC_CLResControlMode* mode =
+        (m_ctx.selected_service() == dt::ServiceCategory::AC_BPT)
+            ? std::get_if<dt::BPT_Dynamic_AC_CLResControlMode>(&res->control_mode)
+            : std::get_if<dt::Dynamic_AC_CLResControlMode>(&res->control_mode);
     if (mode == nullptr) {
         logf_error("AC_ChargeLoopResponse offers a control mode the EV did not request");
         m_ctx.stop_session();
@@ -78,7 +100,7 @@ Result AC_ChargeLoop::feed(Event ev) {
     }
 
     m_ctx.feedback.ac_target_power(*mode);
-    m_ctx.respond(make_request(m_ctx.get_session(), m_ctx.get_ac_params()));
+    m_ctx.respond(make_request(m_ctx.get_session(), m_ctx.get_ac_params(), m_ctx.selected_service()));
     return {};
 }
 

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_charge_parameter_discovery.cpp
@@ -51,7 +51,7 @@ void AC_ChargeParameterDiscovery::enter() {
         req.transfer_mode = mode;
     }
 
-    m_ctx.respond(req);
+    m_ctx.send_request(req);
 }
 
 Result AC_ChargeParameterDiscovery::feed(Event ev) {

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_charge_parameter_discovery.cpp
@@ -15,12 +15,6 @@ namespace dt = message_20::datatypes;
 void fill_charge_limits(dt::AC_CPDReqEnergyTransferMode& mode, const AcChargeParams& p) {
     mode.max_charge_power = dt::from_float(p.max_charge_power);
     mode.min_charge_power = dt::from_float(p.min_charge_power);
-    if (p.three_phase) {
-        mode.max_charge_power_L2 = mode.max_charge_power;
-        mode.max_charge_power_L3 = mode.max_charge_power;
-        mode.min_charge_power_L2 = mode.min_charge_power;
-        mode.min_charge_power_L3 = mode.min_charge_power;
-    }
 }
 
 } // namespace
@@ -38,12 +32,6 @@ void AC_ChargeParameterDiscovery::enter() {
         fill_charge_limits(mode, p);
         mode.max_discharge_power = dt::from_float(p.max_discharge_power);
         mode.min_discharge_power = dt::from_float(p.min_discharge_power);
-        if (p.three_phase) {
-            mode.max_discharge_power_L2 = mode.max_discharge_power;
-            mode.max_discharge_power_L3 = mode.max_discharge_power;
-            mode.min_discharge_power_L2 = mode.min_discharge_power;
-            mode.min_discharge_power_L3 = mode.min_discharge_power;
-        }
         req.transfer_mode = mode;
     } else {
         dt::AC_CPDReqEnergyTransferMode mode{};

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_charge_parameter_discovery.cpp
@@ -8,24 +8,49 @@
 
 namespace iso15118::ev::d20::state {
 
-void AC_ChargeParameterDiscovery::enter() {
-    logf_debug("Enter state: AC_ChargeParameterDiscovery");
+namespace {
 
-    const auto p = m_ctx.get_ac_params();
+namespace dt = message_20::datatypes;
 
-    message_20::datatypes::AC_CPDReqEnergyTransferMode mode{};
-    mode.max_charge_power = message_20::datatypes::from_float(p.max_charge_power);
-    mode.min_charge_power = message_20::datatypes::from_float(p.min_charge_power);
+void fill_charge_limits(dt::AC_CPDReqEnergyTransferMode& mode, const AcChargeParams& p) {
+    mode.max_charge_power = dt::from_float(p.max_charge_power);
+    mode.min_charge_power = dt::from_float(p.min_charge_power);
     if (p.three_phase) {
         mode.max_charge_power_L2 = mode.max_charge_power;
         mode.max_charge_power_L3 = mode.max_charge_power;
         mode.min_charge_power_L2 = mode.min_charge_power;
         mode.min_charge_power_L3 = mode.min_charge_power;
     }
+}
+
+} // namespace
+
+void AC_ChargeParameterDiscovery::enter() {
+    logf_debug("Enter state: AC_ChargeParameterDiscovery");
+
+    const auto p = m_ctx.get_ac_params();
 
     message_20::AC_ChargeParameterDiscoveryRequest req;
     setup_header(req.header, m_ctx.get_session());
-    req.transfer_mode = mode;
+
+    if (m_ctx.selected_service() == dt::ServiceCategory::AC_BPT) {
+        dt::BPT_AC_CPDReqEnergyTransferMode mode{};
+        fill_charge_limits(mode, p);
+        mode.max_discharge_power = dt::from_float(p.max_discharge_power);
+        mode.min_discharge_power = dt::from_float(p.min_discharge_power);
+        if (p.three_phase) {
+            mode.max_discharge_power_L2 = mode.max_discharge_power;
+            mode.max_discharge_power_L3 = mode.max_discharge_power;
+            mode.min_discharge_power_L2 = mode.min_discharge_power;
+            mode.min_discharge_power_L3 = mode.min_discharge_power;
+        }
+        req.transfer_mode = mode;
+    } else {
+        dt::AC_CPDReqEnergyTransferMode mode{};
+        fill_charge_limits(mode, p);
+        req.transfer_mode = mode;
+    }
+
     m_ctx.respond(req);
 }
 
@@ -41,7 +66,18 @@ Result AC_ChargeParameterDiscovery::feed(Event ev) {
         return {};
     }
 
-    const auto* mode = std::get_if<message_20::datatypes::AC_CPDResEnergyTransferMode>(&res->transfer_mode);
+    if (m_ctx.selected_service() == dt::ServiceCategory::AC_BPT) {
+        const auto* mode = std::get_if<dt::BPT_AC_CPDResEnergyTransferMode>(&res->transfer_mode);
+        if (mode == nullptr) {
+            logf_error("AC_ChargeParameterDiscoveryResponse offers a non-BPT transfer mode the EV did not request");
+            m_ctx.stop_session();
+            return {};
+        }
+        m_ctx.feedback.ac_bpt_limits(*mode);
+        return m_ctx.create_state<ScheduleExchange>();
+    }
+
+    const auto* mode = std::get_if<dt::AC_CPDResEnergyTransferMode>(&res->transfer_mode);
     if (mode == nullptr) {
         logf_error("AC_ChargeParameterDiscoveryResponse offers a BPT transfer mode the EV did not request");
         m_ctx.stop_session();

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_der_iec_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_der_iec_charge_loop.cpp
@@ -15,7 +15,18 @@ namespace {
 
 namespace dt = message_20::datatypes;
 
-message_20::DER_AC_ChargeLoopRequest make_request(const SessionId& session, const AcChargeParams& params) {
+// Approximation, not a measurement: the EV has no power measurement feeding the stack yet
+// and the field is mandatory on the wire, where a zero reads as a measured zero. Prefer a
+// module-fed value, else the target the SECC dictated and the EV is expected to follow.
+float approximate_present_active_power(const AcChargeParams& params, std::optional<float> target_dictated_by_evse) {
+    if (params.present_active_power != 0.0f) {
+        return params.present_active_power;
+    }
+    return target_dictated_by_evse.value_or(0.0f);
+}
+
+message_20::DER_AC_ChargeLoopRequest make_request(const SessionId& session, const AcChargeParams& params,
+                                                  std::optional<float> target_dictated_by_evse) {
     message_20::DER_AC_ChargeLoopRequest req;
     setup_header(req.header, session);
     req.meter_info_requested = false;
@@ -28,10 +39,10 @@ message_20::DER_AC_ChargeLoopRequest make_request(const SessionId& session, cons
     mode.min_energy_request = {0, 0};
     mode.max_charge_power = dt::from_float(params.max_charge_power);
     mode.min_charge_power = dt::from_float(params.min_charge_power);
-    mode.present_active_power = dt::from_float(params.present_active_power);
+    mode.present_active_power = dt::from_float(approximate_present_active_power(params, target_dictated_by_evse));
     mode.present_reactive_power = {0, 0};
-    mode.max_discharge_power = dt::from_float(params.max_charge_power);
-    mode.min_discharge_power = dt::from_float(params.min_charge_power);
+    mode.max_discharge_power = dt::from_float(params.max_discharge_power);
+    mode.min_discharge_power = dt::from_float(params.min_discharge_power);
     mode.grid_event_condition = 0;
     req.control_mode = mode;
 
@@ -42,7 +53,7 @@ message_20::DER_AC_ChargeLoopRequest make_request(const SessionId& session, cons
 
 void AC_DER_IEC_ChargeLoop::enter() {
     logf_debug("Enter state: AC_DER_IEC_ChargeLoop");
-    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_ac_params()));
+    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_ac_params(), m_ctx.evse_target_active_power()));
 }
 
 Result AC_DER_IEC_ChargeLoop::feed(Event ev) {
@@ -89,7 +100,8 @@ Result AC_DER_IEC_ChargeLoop::feed(Event ev) {
     }
 
     m_ctx.feedback.der_control(directive);
-    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_ac_params()));
+    m_ctx.set_evse_target_active_power(dt::from_RationalNumber(mode->target_active_power));
+    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_ac_params(), m_ctx.evse_target_active_power()));
     return {};
 }
 

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_der_iec_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_der_iec_charge_loop.cpp
@@ -54,7 +54,7 @@ message_20::DER_AC_ChargeLoopRequest make_request(const SessionId& session, cons
 
 void AC_DER_IEC_ChargeLoop::enter() {
     logf_debug("Enter state: AC_DER_IEC_ChargeLoop");
-    m_ctx.respond(make_request(m_ctx.get_session(), m_ctx.get_ac_params()));
+    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_ac_params()));
 }
 
 Result AC_DER_IEC_ChargeLoop::feed(Event ev) {
@@ -101,7 +101,7 @@ Result AC_DER_IEC_ChargeLoop::feed(Event ev) {
     }
 
     m_ctx.feedback.der_control(directive);
-    m_ctx.respond(make_request(m_ctx.get_session(), m_ctx.get_ac_params()));
+    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_ac_params()));
     return {};
 }
 

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_der_iec_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_der_iec_charge_loop.cpp
@@ -33,18 +33,6 @@ message_20::DER_AC_ChargeLoopRequest make_request(const SessionId& session, cons
     mode.max_discharge_power = dt::from_float(params.max_charge_power);
     mode.min_discharge_power = dt::from_float(params.min_charge_power);
     mode.grid_event_condition = 0;
-    if (params.three_phase) {
-        mode.max_charge_power_L2 = mode.max_charge_power;
-        mode.max_charge_power_L3 = mode.max_charge_power;
-        mode.min_charge_power_L2 = mode.min_charge_power;
-        mode.min_charge_power_L3 = mode.min_charge_power;
-        mode.present_active_power_L2 = mode.present_active_power;
-        mode.present_active_power_L3 = mode.present_active_power;
-        mode.max_discharge_power_L2 = mode.max_discharge_power;
-        mode.max_discharge_power_L3 = mode.max_discharge_power;
-        mode.min_discharge_power_L2 = mode.min_discharge_power;
-        mode.min_discharge_power_L3 = mode.min_discharge_power;
-    }
     req.control_mode = mode;
 
     return req;

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_der_iec_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_der_iec_charge_parameter_discovery.cpp
@@ -35,7 +35,7 @@ void AC_DER_IEC_ChargeParameterDiscovery::enter() {
     message_20::DER_AC_ChargeParameterDiscoveryRequest req;
     setup_header(req.header, m_ctx.get_session());
     req.transfer_mode = mode;
-    m_ctx.respond(req);
+    m_ctx.send_request(req);
 }
 
 Result AC_DER_IEC_ChargeParameterDiscovery::feed(Event ev) {

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_der_iec_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/ac_der_iec_charge_parameter_discovery.cpp
@@ -20,16 +20,6 @@ void AC_DER_IEC_ChargeParameterDiscovery::enter() {
     mode.min_charge_power = dt::from_float(p.min_charge_power);
     mode.max_discharge_power = dt::from_float(p.max_charge_power);
     mode.min_discharge_power = dt::from_float(p.min_charge_power);
-    if (p.three_phase) {
-        mode.max_charge_power_L2 = mode.max_charge_power;
-        mode.max_charge_power_L3 = mode.max_charge_power;
-        mode.min_charge_power_L2 = mode.min_charge_power;
-        mode.min_charge_power_L3 = mode.min_charge_power;
-        mode.max_discharge_power_L2 = mode.max_discharge_power;
-        mode.max_discharge_power_L3 = mode.max_discharge_power;
-        mode.min_discharge_power_L2 = mode.min_discharge_power;
-        mode.min_discharge_power_L3 = mode.min_discharge_power;
-    }
     mode.processing = dt::Processing::Finished;
 
     message_20::DER_AC_ChargeParameterDiscoveryRequest req;

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/authorization.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/authorization.cpp
@@ -38,7 +38,7 @@ void Authorization::enter() {
         return;
     }
 
-    m_ctx.respond(make_request(m_ctx));
+    m_ctx.send_request(make_request(m_ctx));
 }
 
 Result Authorization::feed(Event ev) {
@@ -54,7 +54,7 @@ Result Authorization::feed(Event ev) {
     }
 
     if (res->evse_processing == message_20::datatypes::Processing::Ongoing) {
-        m_ctx.respond(make_request(m_ctx));
+        m_ctx.send_request(make_request(m_ctx));
         return {};
     }
 

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/authorization_setup.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/authorization_setup.cpp
@@ -16,7 +16,7 @@ void AuthorizationSetup::enter() {
 
     message_20::AuthorizationSetupRequest req;
     setup_header(req.header, m_ctx.get_session());
-    m_ctx.respond(req);
+    m_ctx.send_request(req);
 }
 
 Result AuthorizationSetup::feed(Event ev) {

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/dc_cable_check.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/dc_cable_check.cpp
@@ -20,7 +20,7 @@ message_20::DC_CableCheckRequest make_request(const SessionId& session) {
 } // namespace
 
 void DC_CableCheck::enter() {
-    m_ctx.respond(make_request(m_ctx.get_session()));
+    m_ctx.send_request(make_request(m_ctx.get_session()));
 }
 
 Result DC_CableCheck::feed(Event ev) {
@@ -40,7 +40,7 @@ Result DC_CableCheck::feed(Event ev) {
     }
 
     // Processing::Ongoing: re-poll
-    m_ctx.respond(make_request(m_ctx.get_session()));
+    m_ctx.send_request(make_request(m_ctx.get_session()));
     return {};
 }
 

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/dc_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/dc_charge_loop.cpp
@@ -13,14 +13,7 @@ namespace {
 
 namespace dt = message_20::datatypes;
 
-message_20::DC_ChargeLoopRequest make_request(const SessionId& session, const DcChargeParams& params) {
-    message_20::DC_ChargeLoopRequest req;
-    setup_header(req.header, session);
-    req.meter_info_requested = false;
-    req.display_parameters = std::nullopt;
-    req.present_voltage = dt::from_float(params.present_voltage);
-
-    dt::Dynamic_DC_CLReqControlMode mode;
+void fill_dynamic_charge(dt::Dynamic_DC_CLReqControlMode& mode, const DcChargeParams& params) {
     mode.departure_time = std::nullopt;
     mode.target_energy_request = dt::from_float(params.energy_capacity);
     mode.max_energy_request = dt::from_float(params.energy_capacity);
@@ -30,7 +23,28 @@ message_20::DC_ChargeLoopRequest make_request(const SessionId& session, const Dc
     mode.max_charge_current = dt::from_float(params.max_charge_current);
     mode.max_voltage = dt::from_float(params.max_voltage);
     mode.min_voltage = dt::from_float(params.min_voltage);
-    req.control_mode = mode;
+}
+
+message_20::DC_ChargeLoopRequest make_request(const SessionId& session, const DcChargeParams& params,
+                                              dt::ServiceCategory service) {
+    message_20::DC_ChargeLoopRequest req;
+    setup_header(req.header, session);
+    req.meter_info_requested = false;
+    req.display_parameters = std::nullopt;
+    req.present_voltage = dt::from_float(params.present_voltage);
+
+    if (service == dt::ServiceCategory::DC_BPT) {
+        dt::BPT_Dynamic_DC_CLReqControlMode mode;
+        fill_dynamic_charge(mode, params);
+        mode.max_discharge_power = dt::from_float(params.max_discharge_power);
+        mode.min_discharge_power = dt::from_float(params.min_discharge_power);
+        mode.max_discharge_current = dt::from_float(params.max_discharge_current);
+        req.control_mode = mode;
+    } else {
+        dt::Dynamic_DC_CLReqControlMode mode;
+        fill_dynamic_charge(mode, params);
+        req.control_mode = mode;
+    }
 
     return req;
 }
@@ -39,7 +53,7 @@ message_20::DC_ChargeLoopRequest make_request(const SessionId& session, const Dc
 
 void DC_ChargeLoop::enter() {
     logf_debug("Enter state: DC_ChargeLoop");
-    m_ctx.respond(make_request(m_ctx.get_session(), m_ctx.get_dc_params()));
+    m_ctx.respond(make_request(m_ctx.get_session(), m_ctx.get_dc_params(), m_ctx.selected_service()));
 }
 
 Result DC_ChargeLoop::feed(Event ev) {
@@ -54,6 +68,17 @@ Result DC_ChargeLoop::feed(Event ev) {
         return {};
     }
 
+    const bool mode_matches_session =
+        (m_ctx.selected_service() == dt::ServiceCategory::DC_BPT)
+            ? std::holds_alternative<dt::BPT_Dynamic_DC_CLResControlMode>(res->control_mode)
+            : std::holds_alternative<dt::Dynamic_DC_CLResControlMode>(res->control_mode);
+    if (not mode_matches_session) {
+        logf_error("DC_ChargeLoopResponse offers a control mode the EV did not request");
+        m_ctx.stop_session();
+        // no transition; the session finishes on the stop flag
+        return {};
+    }
+
     if (res->status.has_value() and res->status->notification == dt::EvseNotification::Terminate) {
         m_ctx.feedback.stop_from_charger();
         return m_ctx.create_state<PowerDelivery>(dt::Progress::Stop);
@@ -63,7 +88,7 @@ Result DC_ChargeLoop::feed(Event ev) {
         return m_ctx.create_state<PowerDelivery>(dt::Progress::Stop);
     }
 
-    m_ctx.respond(make_request(m_ctx.get_session(), m_ctx.get_dc_params()));
+    m_ctx.respond(make_request(m_ctx.get_session(), m_ctx.get_dc_params(), m_ctx.selected_service()));
     return {};
 }
 

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/dc_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/dc_charge_loop.cpp
@@ -53,7 +53,7 @@ message_20::DC_ChargeLoopRequest make_request(const SessionId& session, const Dc
 
 void DC_ChargeLoop::enter() {
     logf_debug("Enter state: DC_ChargeLoop");
-    m_ctx.respond(make_request(m_ctx.get_session(), m_ctx.get_dc_params(), m_ctx.selected_service()));
+    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_dc_params(), m_ctx.selected_service()));
 }
 
 Result DC_ChargeLoop::feed(Event ev) {
@@ -88,7 +88,7 @@ Result DC_ChargeLoop::feed(Event ev) {
         return m_ctx.create_state<PowerDelivery>(dt::Progress::Stop);
     }
 
-    m_ctx.respond(make_request(m_ctx.get_session(), m_ctx.get_dc_params(), m_ctx.selected_service()));
+    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_dc_params(), m_ctx.selected_service()));
     return {};
 }
 

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/dc_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/dc_charge_loop.cpp
@@ -25,13 +25,24 @@ void fill_dynamic_charge(dt::Dynamic_DC_CLReqControlMode& mode, const DcChargePa
     mode.min_voltage = dt::from_float(params.min_voltage);
 }
 
+// Approximation, not a measurement: the EV has no present-voltage source of its own yet
+// and the field is mandatory on the wire, where a zero reads as a measured zero. Prefer a
+// module-fed value, else the voltage the SECC last reported, else the EV's target.
+float approximate_present_voltage(const DcChargeParams& params, std::optional<float> reported_by_evse) {
+    if (params.present_voltage != 0.0f) {
+        return params.present_voltage;
+    }
+    return reported_by_evse.value_or(params.target_voltage);
+}
+
 message_20::DC_ChargeLoopRequest make_request(const SessionId& session, const DcChargeParams& params,
-                                              dt::ServiceCategory service) {
+                                              dt::ServiceCategory service,
+                                              std::optional<float> present_voltage_reported_by_evse) {
     message_20::DC_ChargeLoopRequest req;
     setup_header(req.header, session);
     req.meter_info_requested = false;
     req.display_parameters = std::nullopt;
-    req.present_voltage = dt::from_float(params.present_voltage);
+    req.present_voltage = dt::from_float(approximate_present_voltage(params, present_voltage_reported_by_evse));
 
     if (service == dt::ServiceCategory::DC_BPT) {
         dt::BPT_Dynamic_DC_CLReqControlMode mode;
@@ -53,7 +64,8 @@ message_20::DC_ChargeLoopRequest make_request(const SessionId& session, const Dc
 
 void DC_ChargeLoop::enter() {
     logf_debug("Enter state: DC_ChargeLoop");
-    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_dc_params(), m_ctx.selected_service()));
+    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_dc_params(), m_ctx.selected_service(),
+                                    m_ctx.evse_present_voltage()));
 }
 
 Result DC_ChargeLoop::feed(Event ev) {
@@ -79,6 +91,8 @@ Result DC_ChargeLoop::feed(Event ev) {
         return {};
     }
 
+    m_ctx.set_evse_present_voltage(dt::from_RationalNumber(res->present_voltage));
+
     if (res->status.has_value() and res->status->notification == dt::EvseNotification::Terminate) {
         m_ctx.feedback.stop_from_charger();
         return m_ctx.create_state<PowerDelivery>(dt::Progress::Stop);
@@ -88,7 +102,8 @@ Result DC_ChargeLoop::feed(Event ev) {
         return m_ctx.create_state<PowerDelivery>(dt::Progress::Stop);
     }
 
-    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_dc_params(), m_ctx.selected_service()));
+    m_ctx.send_request(make_request(m_ctx.get_session(), m_ctx.get_dc_params(), m_ctx.selected_service(),
+                                    m_ctx.evse_present_voltage()));
     return {};
 }
 

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/dc_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/dc_charge_parameter_discovery.cpp
@@ -47,7 +47,7 @@ void DC_ChargeParameterDiscovery::enter() {
         req.transfer_mode = mode;
     }
 
-    m_ctx.respond(req);
+    m_ctx.send_request(req);
 }
 
 Result DC_ChargeParameterDiscovery::feed(Event ev) {

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/dc_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/dc_charge_parameter_discovery.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Pionix GmbH and Contributors to EVerest
 #include <iso15118/detail/helper.hpp>
+#include <iso15118/ev/d20/context.hpp>
 #include <iso15118/ev/d20/state/dc_charge_parameter_discovery.hpp>
 #include <iso15118/ev/d20/state/schedule_exchange.hpp>
 #include <iso15118/ev/detail/d20/context_helper.hpp>
@@ -8,23 +9,44 @@
 
 namespace iso15118::ev::d20::state {
 
+namespace {
+
+namespace dt = message_20::datatypes;
+
+void fill_charge_limits(dt::DC_CPDReqEnergyTransferMode& mode, const DcChargeParams& p) {
+    mode.max_charge_power = dt::from_float(p.max_charge_power);
+    mode.min_charge_power = dt::RationalNumber{0, 0};
+    mode.max_charge_current = dt::from_float(p.max_charge_current);
+    mode.min_charge_current = dt::RationalNumber{0, 0};
+    mode.max_voltage = dt::from_float(p.max_voltage);
+    mode.min_voltage = dt::from_float(p.min_voltage);
+    mode.target_soc = std::nullopt;
+}
+
+} // namespace
+
 void DC_ChargeParameterDiscovery::enter() {
     logf_debug("Enter state: DC_ChargeParameterDiscovery");
 
     const auto p = m_ctx.get_dc_params();
 
-    message_20::datatypes::DC_CPDReqEnergyTransferMode mode{};
-    mode.max_charge_power = message_20::datatypes::from_float(p.max_charge_power);
-    mode.min_charge_power = message_20::datatypes::RationalNumber{0, 0};
-    mode.max_charge_current = message_20::datatypes::from_float(p.max_charge_current);
-    mode.min_charge_current = message_20::datatypes::RationalNumber{0, 0};
-    mode.max_voltage = message_20::datatypes::from_float(p.max_voltage);
-    mode.min_voltage = message_20::datatypes::from_float(p.min_voltage);
-    mode.target_soc = std::nullopt;
-
     message_20::DC_ChargeParameterDiscoveryRequest req;
     setup_header(req.header, m_ctx.get_session());
-    req.transfer_mode = mode;
+
+    if (m_ctx.selected_service() == dt::ServiceCategory::DC_BPT) {
+        dt::BPT_DC_CPDReqEnergyTransferMode mode{};
+        fill_charge_limits(mode, p);
+        mode.max_discharge_power = dt::from_float(p.max_discharge_power);
+        mode.min_discharge_power = dt::from_float(p.min_discharge_power);
+        mode.max_discharge_current = dt::from_float(p.max_discharge_current);
+        mode.min_discharge_current = dt::RationalNumber{0, 0};
+        req.transfer_mode = mode;
+    } else {
+        dt::DC_CPDReqEnergyTransferMode mode{};
+        fill_charge_limits(mode, p);
+        req.transfer_mode = mode;
+    }
+
     m_ctx.respond(req);
 }
 
@@ -37,6 +59,24 @@ Result DC_ChargeParameterDiscovery::feed(Event ev) {
 
     const auto* res = expect_response<message_20::DC_ChargeParameterDiscoveryResponse>(m_ctx, *variant);
     if (res == nullptr) {
+        return {};
+    }
+
+    if (m_ctx.selected_service() == dt::ServiceCategory::DC_BPT) {
+        const auto* mode = std::get_if<dt::BPT_DC_CPDResEnergyTransferMode>(&res->transfer_mode);
+        if (mode == nullptr) {
+            logf_error("DC_ChargeParameterDiscoveryResponse offers a non-BPT transfer mode the EV did not request");
+            m_ctx.stop_session();
+            return {};
+        }
+        m_ctx.feedback.dc_bpt_limits(*mode);
+        return m_ctx.create_state<ScheduleExchange>();
+    }
+
+    const auto* mode = std::get_if<dt::DC_CPDResEnergyTransferMode>(&res->transfer_mode);
+    if (mode == nullptr) {
+        logf_error("DC_ChargeParameterDiscoveryResponse offers a BPT transfer mode the EV did not request");
+        m_ctx.stop_session();
         return {};
     }
 

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/dc_pre_charge.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/dc_pre_charge.cpp
@@ -31,7 +31,7 @@ message_20::DC_PreChargeRequest make_request(const SessionId& session, message_2
 
 void DC_PreCharge::enter() {
     const auto params = m_ctx.get_dc_params();
-    m_ctx.respond(make_request(m_ctx.get_session(), message_20::datatypes::Processing::Ongoing, params));
+    m_ctx.send_request(make_request(m_ctx.get_session(), message_20::datatypes::Processing::Ongoing, params));
 }
 
 Result DC_PreCharge::feed(Event ev) {
@@ -58,7 +58,7 @@ Result DC_PreCharge::feed(Event ev) {
     // Not in tolerance: resend one Ongoing request and stay. The SECC keeps answering
     // precharge requests while its converter ramps, so the EV converges here before
     // transitioning; no Finished precharge request is ever emitted.
-    m_ctx.respond(make_request(m_ctx.get_session(), message_20::datatypes::Processing::Ongoing, params));
+    m_ctx.send_request(make_request(m_ctx.get_session(), message_20::datatypes::Processing::Ongoing, params));
     return {};
 }
 

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/dc_welding_detection.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/dc_welding_detection.cpp
@@ -22,7 +22,7 @@ message_20::DC_WeldingDetectionRequest make_request(const SessionId& session,
 } // namespace
 
 void DC_WeldingDetection::enter() {
-    m_ctx.respond(make_request(m_ctx.get_session(), message_20::datatypes::Processing::Ongoing));
+    m_ctx.send_request(make_request(m_ctx.get_session(), message_20::datatypes::Processing::Ongoing));
 }
 
 Result DC_WeldingDetection::feed(Event ev) {

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/power_delivery.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/power_delivery.cpp
@@ -49,7 +49,7 @@ Result PowerDelivery::feed(Event ev) {
     using Progress = message_20::datatypes::Progress;
     using ServiceCategory = message_20::datatypes::ServiceCategory;
     const auto service = m_ctx.selected_service();
-    const bool is_ac = service == ServiceCategory::AC;
+    const bool is_ac = service == ServiceCategory::AC or service == ServiceCategory::AC_BPT;
     const bool is_ac_der_iec = service == ServiceCategory::AC_DER_IEC;
     switch (m_charge_progress) {
     case Progress::Start:

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/power_delivery.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/power_delivery.cpp
@@ -31,7 +31,7 @@ make_request(const SessionId& session, message_20::datatypes::Progress charge_pr
 } // namespace
 
 void PowerDelivery::enter() {
-    m_ctx.respond(make_request(m_ctx.get_session(), m_charge_progress));
+    m_ctx.send_request(make_request(m_ctx.get_session(), m_charge_progress));
 }
 
 Result PowerDelivery::feed(Event ev) {

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/schedule_exchange.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/schedule_exchange.cpp
@@ -51,6 +51,7 @@ Result ScheduleExchange::feed(Event ev) {
         m_ctx.feedback.ev_power_ready();
         const auto service = m_ctx.selected_service();
         if (service == message_20::datatypes::ServiceCategory::AC or
+            service == message_20::datatypes::ServiceCategory::AC_BPT or
             service == message_20::datatypes::ServiceCategory::AC_DER_IEC) {
             return m_ctx.create_state<PowerDelivery>(message_20::datatypes::Progress::Start);
         }

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/schedule_exchange.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/schedule_exchange.cpp
@@ -32,7 +32,7 @@ message_20::ScheduleExchangeRequest make_request(const SessionId& session) {
 
 void ScheduleExchange::enter() {
     logf_debug("Enter state: ScheduleExchange");
-    m_ctx.respond(make_request(m_ctx.get_session()));
+    m_ctx.send_request(make_request(m_ctx.get_session()));
 }
 
 Result ScheduleExchange::feed(Event ev) {
@@ -59,7 +59,7 @@ Result ScheduleExchange::feed(Event ev) {
     }
 
     // Processing::Ongoing: re-send the request and stay.
-    m_ctx.respond(make_request(m_ctx.get_session()));
+    m_ctx.send_request(make_request(m_ctx.get_session()));
     return {};
 }
 

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/service_detail.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/service_detail.cpp
@@ -125,7 +125,7 @@ void ServiceDetail::enter() {
     message_20::ServiceDetailRequest req;
     setup_header(req.header, m_ctx.get_session());
     req.service = message_20::to_underlying_value(m_ctx.selected_service());
-    m_ctx.respond(req);
+    m_ctx.send_request(req);
 }
 
 Result ServiceDetail::feed(Event ev) {

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/service_discovery.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/service_discovery.cpp
@@ -18,7 +18,7 @@ void ServiceDiscovery::enter() {
     setup_header(req.header, m_ctx.get_session());
     req.supported_service_ids =
         message_20::datatypes::ServiceIdList{message_20::to_underlying_value(m_ctx.selected_service())};
-    m_ctx.respond(req);
+    m_ctx.send_request(req);
 }
 
 Result ServiceDiscovery::feed(Event ev) {

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/service_selection.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/service_selection.cpp
@@ -34,7 +34,8 @@ Result ServiceSelection::feed(Event ev) {
 
     const auto service = m_ctx.selected_service();
 
-    if (service == message_20::datatypes::ServiceCategory::AC) {
+    if (service == message_20::datatypes::ServiceCategory::AC or
+        service == message_20::datatypes::ServiceCategory::AC_BPT) {
         return m_ctx.create_state<AC_ChargeParameterDiscovery>();
     }
 
@@ -42,7 +43,14 @@ Result ServiceSelection::feed(Event ev) {
         return m_ctx.create_state<AC_DER_IEC_ChargeParameterDiscovery>();
     }
 
-    return m_ctx.create_state<DC_ChargeParameterDiscovery>();
+    if (service == message_20::datatypes::ServiceCategory::DC or
+        service == message_20::datatypes::ServiceCategory::DC_BPT) {
+        return m_ctx.create_state<DC_ChargeParameterDiscovery>();
+    }
+
+    logf_error("selected service category is not supported by the EV");
+    m_ctx.stop_session();
+    return {};
 }
 
 } // namespace iso15118::ev::d20::state

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/service_selection.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/service_selection.cpp
@@ -17,7 +17,7 @@ void ServiceSelection::enter() {
     message_20::ServiceSelectionRequest req;
     setup_header(req.header, m_ctx.get_session());
     req.selected_energy_transfer_service = {m_ctx.selected_service(), m_parameter_set_id};
-    m_ctx.respond(req);
+    m_ctx.send_request(req);
 }
 
 Result ServiceSelection::feed(Event ev) {

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/session_setup.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/session_setup.cpp
@@ -50,7 +50,7 @@ void SessionSetup::enter() {
     message_20::SessionSetupRequest req{};
     setup_header(req.header, m_ctx.get_session());
     req.evccid = m_ctx.get_evcc_id();
-    m_ctx.respond(req);
+    m_ctx.send_request(req);
 }
 
 Result SessionSetup::feed(Event ev) {

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/session_stop.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/session_stop.cpp
@@ -12,7 +12,7 @@ void SessionStop::enter() {
     message_20::SessionStopRequest req;
     setup_header(req.header, m_ctx.get_session());
     req.charging_session = message_20::datatypes::ChargingSession::Terminate;
-    m_ctx.respond(req);
+    m_ctx.send_request(req);
 }
 
 Result SessionStop::feed(Event ev) {

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/supported_app_protocol.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/supported_app_protocol.cpp
@@ -21,7 +21,7 @@ void SupportedAppProtocol::enter() {
         req.app_protocol.push_back(ap);
     }
 
-    m_ctx.respond(req);
+    m_ctx.send_request(req);
 }
 
 Result SupportedAppProtocol::feed(Event ev) {

--- a/lib/everest/iso15118/src/iso15118/ev/session/feedback.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/session/feedback.cpp
@@ -45,6 +45,14 @@ void Feedback::ac_limits(const message_20::datatypes::AC_CPDResEnergyTransferMod
     call_if_available(callbacks.ac_limits, mode);
 }
 
+void Feedback::ac_bpt_limits(const message_20::datatypes::BPT_AC_CPDResEnergyTransferMode& mode) const {
+    call_if_available(callbacks.ac_bpt_limits, mode);
+}
+
+void Feedback::dc_bpt_limits(const message_20::datatypes::BPT_DC_CPDResEnergyTransferMode& mode) const {
+    call_if_available(callbacks.dc_bpt_limits, mode);
+}
+
 void Feedback::ac_target_power(const message_20::datatypes::Dynamic_AC_CLResControlMode& mode) const {
     call_if_available(callbacks.ac_target_power, mode);
 }

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/ac_charge_loop.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/ac_charge_loop.cpp
@@ -39,6 +39,30 @@ const auto seed_present_5000 = [](FsmStateHelper& helper) {
     helper.set_ac_params(p);
 };
 
+// A BPT session seeded with discharge limits alongside the charge params.
+const auto seed_bpt_present_5000 = [](FsmStateHelper& helper) {
+    helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::AC_BPT);
+    ev::AcChargeParams p{};
+    p.max_charge_power = 11000.0f;
+    p.min_charge_power = 1000.0f;
+    p.max_discharge_power = 9000.0f;
+    p.min_discharge_power = 500.0f;
+    p.present_active_power = 5000.0f;
+    helper.set_ac_params(p);
+};
+
+message_20::AC_ChargeLoopResponse make_bpt_res(const message_20::Header& header, ResponseCode code,
+                                               std::optional<message_20::datatypes::EvseStatus> status = std::nullopt) {
+    message_20::AC_ChargeLoopResponse res;
+    res.header = header;
+    res.response_code = code;
+    res.status = status;
+    message_20::datatypes::BPT_Dynamic_AC_CLResControlMode mode{};
+    mode.target_active_power = message_20::datatypes::from_float(7000.0f);
+    res.control_mode = mode;
+    return res;
+}
+
 // A stop_from_charger observer wired into the callbacks. Also records whether
 // ac_target_power fired, so stop paths can prove no setpoint was pushed.
 struct StopObserver {
@@ -267,6 +291,170 @@ SCENARIO("ISO15118-20 EV AC_ChargeLoop stops the session on a BPT_Dynamic contro
     REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::AC_ChargeLoop);
     REQUIRE(primed.ctx.is_session_stopped() == true);
     REQUIRE(fired == false);
+}
+
+SCENARIO("ISO15118-20 EV AC_ChargeLoop emits a BPT_Dynamic request with discharge limits for a BPT session") {
+    const ev::feedback::Callbacks callbacks{};
+    const auto seed_single = [](FsmStateHelper& helper) {
+        helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::AC_BPT);
+        ev::AcChargeParams p{};
+        p.max_charge_power = 11000.0f;
+        p.min_charge_power = 1000.0f;
+        p.max_discharge_power = 9000.0f;
+        p.min_discharge_power = 500.0f;
+        p.present_active_power = 5000.0f;
+        p.three_phase = false;
+        helper.set_ac_params(p);
+    };
+    PrimedState<ev::d20::state::AC_ChargeLoop> primed{callbacks, seed_single};
+
+    const auto requests = primed.take_requests();
+    const auto request_message = requests.get<message_20::AC_ChargeLoopRequest>();
+    REQUIRE(request_message.has_value());
+    REQUIRE(
+        std::holds_alternative<message_20::datatypes::BPT_Dynamic_AC_CLReqControlMode>(request_message->control_mode));
+    const auto& mode = std::get<message_20::datatypes::BPT_Dynamic_AC_CLReqControlMode>(request_message->control_mode);
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode.max_charge_power) == Catch::Approx(11000.0f));
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode.min_charge_power) == Catch::Approx(1000.0f));
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode.present_active_power) == Catch::Approx(5000.0f));
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode.max_discharge_power) == Catch::Approx(9000.0f));
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode.min_discharge_power) == Catch::Approx(500.0f));
+    // v2x energy request fields are deliberately omitted.
+    REQUIRE_FALSE(mode.max_v2x_energy_request.has_value());
+    REQUIRE_FALSE(mode.min_v2x_energy_request.has_value());
+    // Single-phase: no per-phase discharge fields.
+    REQUIRE_FALSE(mode.max_discharge_power_L2.has_value());
+    REQUIRE_FALSE(mode.max_discharge_power_L3.has_value());
+    REQUIRE_FALSE(mode.min_discharge_power_L2.has_value());
+    REQUIRE_FALSE(mode.min_discharge_power_L3.has_value());
+}
+
+SCENARIO("ISO15118-20 EV AC_ChargeLoop mirrors BPT discharge limits to L2/L3 when three_phase") {
+    const ev::feedback::Callbacks callbacks{};
+    const auto seed_three = [](FsmStateHelper& helper) {
+        helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::AC_BPT);
+        ev::AcChargeParams p{};
+        p.max_charge_power = 11000.0f;
+        p.min_charge_power = 1000.0f;
+        p.max_discharge_power = 9000.0f;
+        p.min_discharge_power = 500.0f;
+        p.present_active_power = 5000.0f;
+        p.three_phase = true;
+        helper.set_ac_params(p);
+    };
+    PrimedState<ev::d20::state::AC_ChargeLoop> primed{callbacks, seed_three};
+
+    const auto requests = primed.take_requests();
+    const auto request_message = requests.get<message_20::AC_ChargeLoopRequest>();
+    REQUIRE(request_message.has_value());
+    const auto& mode = std::get<message_20::datatypes::BPT_Dynamic_AC_CLReqControlMode>(request_message->control_mode);
+    REQUIRE(mode.max_discharge_power_L2.has_value());
+    REQUIRE(mode.max_discharge_power_L3.has_value());
+    REQUIRE(mode.min_discharge_power_L2.has_value());
+    REQUIRE(mode.min_discharge_power_L3.has_value());
+    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.max_discharge_power_L2) == Catch::Approx(9000.0f));
+    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.min_discharge_power_L3) == Catch::Approx(500.0f));
+}
+
+SCENARIO("ISO15118-20 EV AC_ChargeLoop fires ac_target_power on a BPT_Dynamic response for a BPT session") {
+    float reported = 0.0f;
+    bool fired = false;
+    ev::feedback::Callbacks callbacks{};
+    callbacks.ac_target_power = [&](const message_20::datatypes::Dynamic_AC_CLResControlMode& mode) {
+        fired = true;
+        reported = message_20::datatypes::from_RationalNumber(mode.target_active_power);
+    };
+    PrimedState<ev::d20::state::AC_ChargeLoop> primed{callbacks, seed_bpt_present_5000};
+
+    primed.handle_response(make_bpt_res(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(fired == true);
+    REQUIRE(reported == Catch::Approx(7000.0f));
+    REQUIRE(result.transitioned() == false);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::AC_ChargeLoop);
+}
+
+SCENARIO("ISO15118-20 EV AC_ChargeLoop stops a BPT session on a plain Dynamic reply it never requested") {
+    bool fired = false;
+    ev::feedback::Callbacks callbacks{};
+    callbacks.ac_target_power = [&](const message_20::datatypes::Dynamic_AC_CLResControlMode&) { fired = true; };
+    PrimedState<ev::d20::state::AC_ChargeLoop> primed{callbacks, seed_bpt_present_5000};
+
+    primed.handle_response(make_res(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == false);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::AC_ChargeLoop);
+    REQUIRE(primed.ctx.is_session_stopped() == true);
+    REQUIRE(fired == false);
+}
+
+SCENARIO("ISO15118-20 EV AC_ChargeLoop stops a BPT session on a Scheduled reply it never requested") {
+    bool fired = false;
+    ev::feedback::Callbacks callbacks{};
+    callbacks.ac_target_power = [&](const message_20::datatypes::Dynamic_AC_CLResControlMode&) { fired = true; };
+    PrimedState<ev::d20::state::AC_ChargeLoop> primed{callbacks, seed_bpt_present_5000};
+
+    auto res = make_bpt_res(SESSION_HEADER, ResponseCode::OK);
+    res.control_mode = message_20::datatypes::Scheduled_AC_CLResControlMode{};
+    primed.handle_response(res);
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == false);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::AC_ChargeLoop);
+    REQUIRE(primed.ctx.is_session_stopped() == true);
+    REQUIRE(fired == false);
+}
+
+SCENARIO("ISO15118-20 EV AC_ChargeLoop fires stop_from_charger and drives PowerDelivery(Stop) on Terminate for BPT") {
+    StopObserver obs;
+    PrimedState<ev::d20::state::AC_ChargeLoop> primed{obs.callbacks, seed_bpt_present_5000};
+
+    primed.handle_response(
+        make_bpt_res(SESSION_HEADER, ResponseCode::OK,
+                     message_20::datatypes::EvseStatus{0, message_20::datatypes::EvseNotification::Terminate}));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(obs.fired == true);
+    REQUIRE(obs.ac_target_fired == false);
+    REQUIRE(result.transitioned() == true);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::PowerDelivery);
+    REQUIRE(primed.ctx.is_session_stopped() == false);
+
+    const auto requests = primed.take_requests();
+    const auto pd_request = requests.get<message_20::PowerDeliveryRequest>();
+    REQUIRE(pd_request.has_value());
+    REQUIRE(pd_request->charge_progress == message_20::datatypes::Progress::Stop);
+}
+
+SCENARIO("ISO15118-20 EV AC_ChargeLoop honors a stop request set before the state was entered for AC_BPT") {
+    StopObserver obs;
+    const auto seed_latched_stop = [](FsmStateHelper& helper) {
+        helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::AC_BPT);
+        ev::AcChargeParams p{};
+        p.max_charge_power = 11000.0f;
+        p.min_charge_power = 1000.0f;
+        p.max_discharge_power = 9000.0f;
+        p.min_discharge_power = 500.0f;
+        p.present_active_power = 5000.0f;
+        helper.set_ac_params(p);
+        helper.get_context().set_stop_charging_requested(true);
+    };
+    PrimedState<ev::d20::state::AC_ChargeLoop> primed{obs.callbacks, seed_latched_stop};
+
+    primed.handle_response(make_bpt_res(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == true);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::PowerDelivery);
+    REQUIRE(obs.fired == false);
+    REQUIRE(obs.ac_target_fired == false);
+
+    const auto requests = primed.take_requests();
+    const auto pd_request = requests.get<message_20::PowerDeliveryRequest>();
+    REQUIRE(pd_request.has_value());
+    REQUIRE(pd_request->charge_progress == message_20::datatypes::Progress::Stop);
 }
 
 SCENARIO("ISO15118-20 EV AC_ChargeLoop rejects malformed responses") {

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/ac_charge_loop.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/ac_charge_loop.cpp
@@ -128,6 +128,35 @@ SCENARIO("ISO15118-20 EV AC_ChargeLoop fires ac_target_power on a Dynamic respon
     REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::AC_ChargeLoop);
 }
 
+SCENARIO("ISO15118-20 EV AC_ChargeLoop reports the dictated target as its present power") {
+    // Nothing feeds a measured present power yet, so the request approximates it with the
+    // target the SECC dictated rather than putting a zero on the wire.
+    StopObserver obs;
+    const auto seed_limits_only = [](FsmStateHelper& helper) {
+        ev::AcChargeParams p{};
+        p.max_charge_power = 11000.0f;
+        p.min_charge_power = 1000.0f;
+        helper.set_ac_params(p);
+    };
+    PrimedState<ev::d20::state::AC_ChargeLoop> primed{obs.callbacks, seed_limits_only};
+
+    // No target has been dictated at loop entry, so the first request reports no power.
+    const auto first = primed.take_requests();
+    const auto first_request = first.get<message_20::AC_ChargeLoopRequest>();
+    REQUIRE(first_request.has_value());
+    const auto& first_mode = std::get<message_20::datatypes::Dynamic_AC_CLReqControlMode>(first_request->control_mode);
+    REQUIRE(message_20::datatypes::from_RationalNumber(first_mode.present_active_power) == Catch::Approx(0.0f));
+
+    primed.handle_response(make_res(SESSION_HEADER, ResponseCode::OK));
+    REQUIRE(primed.feed(ev::d20::Event::V2GTP_MESSAGE).transitioned() == false);
+
+    const auto requests = primed.take_requests();
+    const auto request_message = requests.get<message_20::AC_ChargeLoopRequest>();
+    REQUIRE(request_message.has_value());
+    const auto& mode = std::get<message_20::datatypes::Dynamic_AC_CLReqControlMode>(request_message->control_mode);
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode.present_active_power) == Catch::Approx(7000.0f));
+}
+
 SCENARIO("ISO15118-20 EV AC_ChargeLoop stays and re-emits a request on a non-Terminate response") {
     StopObserver obs;
     PrimedState<ev::d20::state::AC_ChargeLoop> primed{obs.callbacks, seed_present_5000};

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/ac_charge_loop.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/ac_charge_loop.cpp
@@ -80,15 +80,7 @@ struct StopObserver {
 
 SCENARIO("ISO15118-20 EV AC_ChargeLoop emits a Dynamic AC_ChargeLoopRequest on enter") {
     const ev::feedback::Callbacks callbacks{};
-    const auto seed_single = [](FsmStateHelper& helper) {
-        ev::AcChargeParams p{};
-        p.max_charge_power = 11000.0f;
-        p.min_charge_power = 1000.0f;
-        p.present_active_power = 5000.0f;
-        p.three_phase = false;
-        helper.set_ac_params(p);
-    };
-    PrimedState<ev::d20::state::AC_ChargeLoop> primed{callbacks, seed_single};
+    PrimedState<ev::d20::state::AC_ChargeLoop> primed{callbacks, seed_present_5000};
 
     const auto requests = primed.take_requests();
     const auto request_message = requests.get<message_20::AC_ChargeLoopRequest>();
@@ -106,43 +98,13 @@ SCENARIO("ISO15118-20 EV AC_ChargeLoop emits a Dynamic AC_ChargeLoopRequest on e
     REQUIRE(message_20::datatypes::from_RationalNumber(mode.max_energy_request) == Catch::Approx(0.0f));
     REQUIRE(message_20::datatypes::from_RationalNumber(mode.min_energy_request) == Catch::Approx(0.0f));
     REQUIRE(message_20::datatypes::from_RationalNumber(mode.present_reactive_power) == Catch::Approx(0.0f));
-    // Single-phase: no per-phase fields.
+    // The power limits are three-phase totals: no per-phase field is advertised.
     REQUIRE_FALSE(mode.max_charge_power_L2.has_value());
     REQUIRE_FALSE(mode.max_charge_power_L3.has_value());
     REQUIRE_FALSE(mode.min_charge_power_L2.has_value());
     REQUIRE_FALSE(mode.min_charge_power_L3.has_value());
     REQUIRE_FALSE(mode.present_active_power_L2.has_value());
     REQUIRE_FALSE(mode.present_active_power_L3.has_value());
-    REQUIRE_FALSE(mode.present_reactive_power_L2.has_value());
-    REQUIRE_FALSE(mode.present_reactive_power_L3.has_value());
-}
-
-SCENARIO("ISO15118-20 EV AC_ChargeLoop emits per-phase fields when three_phase") {
-    const ev::feedback::Callbacks callbacks{};
-    const auto seed_three = [](FsmStateHelper& helper) {
-        ev::AcChargeParams p{};
-        p.max_charge_power = 11000.0f;
-        p.min_charge_power = 1000.0f;
-        p.present_active_power = 5000.0f;
-        p.three_phase = true;
-        helper.set_ac_params(p);
-    };
-    PrimedState<ev::d20::state::AC_ChargeLoop> primed{callbacks, seed_three};
-
-    const auto requests = primed.take_requests();
-    const auto request_message = requests.get<message_20::AC_ChargeLoopRequest>();
-    REQUIRE(request_message.has_value());
-    const auto& mode = std::get<message_20::datatypes::Dynamic_AC_CLReqControlMode>(request_message->control_mode);
-    REQUIRE(mode.max_charge_power_L2.has_value());
-    REQUIRE(mode.max_charge_power_L3.has_value());
-    REQUIRE(mode.min_charge_power_L2.has_value());
-    REQUIRE(mode.min_charge_power_L3.has_value());
-    REQUIRE(mode.present_active_power_L2.has_value());
-    REQUIRE(mode.present_active_power_L3.has_value());
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.max_charge_power_L2) == Catch::Approx(11000.0f));
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.min_charge_power_L3) == Catch::Approx(1000.0f));
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.present_active_power_L2) == Catch::Approx(5000.0f));
-    // Per-phase reactive power is never advertised, even three-phase.
     REQUIRE_FALSE(mode.present_reactive_power_L2.has_value());
     REQUIRE_FALSE(mode.present_reactive_power_L3.has_value());
 }
@@ -295,18 +257,7 @@ SCENARIO("ISO15118-20 EV AC_ChargeLoop stops the session on a BPT_Dynamic contro
 
 SCENARIO("ISO15118-20 EV AC_ChargeLoop emits a BPT_Dynamic request with discharge limits for a BPT session") {
     const ev::feedback::Callbacks callbacks{};
-    const auto seed_single = [](FsmStateHelper& helper) {
-        helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::AC_BPT);
-        ev::AcChargeParams p{};
-        p.max_charge_power = 11000.0f;
-        p.min_charge_power = 1000.0f;
-        p.max_discharge_power = 9000.0f;
-        p.min_discharge_power = 500.0f;
-        p.present_active_power = 5000.0f;
-        p.three_phase = false;
-        helper.set_ac_params(p);
-    };
-    PrimedState<ev::d20::state::AC_ChargeLoop> primed{callbacks, seed_single};
+    PrimedState<ev::d20::state::AC_ChargeLoop> primed{callbacks, seed_bpt_present_5000};
 
     const auto requests = primed.take_requests();
     const auto request_message = requests.get<message_20::AC_ChargeLoopRequest>();
@@ -322,38 +273,11 @@ SCENARIO("ISO15118-20 EV AC_ChargeLoop emits a BPT_Dynamic request with discharg
     // v2x energy request fields are deliberately omitted.
     REQUIRE_FALSE(mode.max_v2x_energy_request.has_value());
     REQUIRE_FALSE(mode.min_v2x_energy_request.has_value());
-    // Single-phase: no per-phase discharge fields.
+    // The discharge limits are three-phase totals: no per-phase field is advertised.
     REQUIRE_FALSE(mode.max_discharge_power_L2.has_value());
     REQUIRE_FALSE(mode.max_discharge_power_L3.has_value());
     REQUIRE_FALSE(mode.min_discharge_power_L2.has_value());
     REQUIRE_FALSE(mode.min_discharge_power_L3.has_value());
-}
-
-SCENARIO("ISO15118-20 EV AC_ChargeLoop mirrors BPT discharge limits to L2/L3 when three_phase") {
-    const ev::feedback::Callbacks callbacks{};
-    const auto seed_three = [](FsmStateHelper& helper) {
-        helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::AC_BPT);
-        ev::AcChargeParams p{};
-        p.max_charge_power = 11000.0f;
-        p.min_charge_power = 1000.0f;
-        p.max_discharge_power = 9000.0f;
-        p.min_discharge_power = 500.0f;
-        p.present_active_power = 5000.0f;
-        p.three_phase = true;
-        helper.set_ac_params(p);
-    };
-    PrimedState<ev::d20::state::AC_ChargeLoop> primed{callbacks, seed_three};
-
-    const auto requests = primed.take_requests();
-    const auto request_message = requests.get<message_20::AC_ChargeLoopRequest>();
-    REQUIRE(request_message.has_value());
-    const auto& mode = std::get<message_20::datatypes::BPT_Dynamic_AC_CLReqControlMode>(request_message->control_mode);
-    REQUIRE(mode.max_discharge_power_L2.has_value());
-    REQUIRE(mode.max_discharge_power_L3.has_value());
-    REQUIRE(mode.min_discharge_power_L2.has_value());
-    REQUIRE(mode.min_discharge_power_L3.has_value());
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.max_discharge_power_L2) == Catch::Approx(9000.0f));
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.min_discharge_power_L3) == Catch::Approx(500.0f));
 }
 
 SCENARIO("ISO15118-20 EV AC_ChargeLoop fires ac_target_power on a BPT_Dynamic response for a BPT session") {

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/ac_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/ac_charge_parameter_discovery.cpp
@@ -43,6 +43,42 @@ const auto seed_three_phase = [](FsmStateHelper& helper) {
     p.three_phase = true;
     helper.set_ac_params(p);
 };
+
+const auto seed_bpt_single_phase = [](FsmStateHelper& helper) {
+    helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::AC_BPT);
+    ev::AcChargeParams p{};
+    p.max_charge_power = 22000.0f;
+    p.min_charge_power = 1000.0f;
+    p.max_discharge_power = 15000.0f;
+    p.min_discharge_power = 800.0f;
+    p.three_phase = false;
+    helper.set_ac_params(p);
+};
+
+const auto seed_bpt_three_phase = [](FsmStateHelper& helper) {
+    helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::AC_BPT);
+    ev::AcChargeParams p{};
+    p.max_charge_power = 22000.0f;
+    p.min_charge_power = 1000.0f;
+    p.max_discharge_power = 15000.0f;
+    p.min_discharge_power = 800.0f;
+    p.three_phase = true;
+    helper.set_ac_params(p);
+};
+
+message_20::AC_ChargeParameterDiscoveryResponse make_bpt_response(const message_20::Header& header, ResponseCode code) {
+    message_20::AC_ChargeParameterDiscoveryResponse res{};
+    res.header = header;
+    res.response_code = code;
+    message_20::datatypes::BPT_AC_CPDResEnergyTransferMode mode{};
+    mode.max_charge_power = message_20::datatypes::from_float(15000.0f);
+    mode.min_charge_power = message_20::datatypes::from_float(500.0f);
+    mode.nominal_frequency = message_20::datatypes::from_float(50.0f);
+    mode.max_discharge_power = message_20::datatypes::from_float(12000.0f);
+    mode.min_discharge_power = message_20::datatypes::from_float(300.0f);
+    res.transfer_mode = mode;
+    return res;
+}
 } // namespace
 
 SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery emits a single-phase request built from the AC params on enter") {
@@ -128,6 +164,92 @@ SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery rejects a BPT transfer-mode
     res.transfer_mode = bpt_mode;
 
     primed.handle_response(res);
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == false);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::AC_ChargeParameterDiscovery);
+    REQUIRE(primed.ctx.is_session_stopped() == true);
+    REQUIRE(fired == false);
+}
+
+SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery emits a BPT request with discharge limits for a BPT session") {
+    const ev::feedback::Callbacks callbacks{};
+    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_bpt_single_phase};
+
+    const auto requests = primed.take_requests();
+    const auto request_message = requests.get<message_20::AC_ChargeParameterDiscoveryRequest>();
+    REQUIRE(request_message.has_value());
+
+    const auto* mode =
+        std::get_if<message_20::datatypes::BPT_AC_CPDReqEnergyTransferMode>(&request_message->transfer_mode);
+    REQUIRE(mode != nullptr);
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_charge_power) == 22000.0f);
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode->min_charge_power) == 1000.0f);
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_discharge_power) == 15000.0f);
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode->min_discharge_power) == 800.0f);
+    // Single-phase: no per-phase discharge limits.
+    REQUIRE_FALSE(mode->max_discharge_power_L2.has_value());
+    REQUIRE_FALSE(mode->max_discharge_power_L3.has_value());
+    REQUIRE_FALSE(mode->min_discharge_power_L2.has_value());
+    REQUIRE_FALSE(mode->min_discharge_power_L3.has_value());
+}
+
+SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery mirrors BPT discharge limits to L2/L3 when three_phase") {
+    const ev::feedback::Callbacks callbacks{};
+    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_bpt_three_phase};
+
+    const auto requests = primed.take_requests();
+    const auto request_message = requests.get<message_20::AC_ChargeParameterDiscoveryRequest>();
+    REQUIRE(request_message.has_value());
+
+    const auto* mode =
+        std::get_if<message_20::datatypes::BPT_AC_CPDReqEnergyTransferMode>(&request_message->transfer_mode);
+    REQUIRE(mode != nullptr);
+    // Charge limits mirrored the same way as the plain-AC three-phase convention.
+    REQUIRE(mode->max_charge_power_L2.has_value());
+    REQUIRE(mode->min_charge_power_L3.has_value());
+    // Discharge limits mirrored to L2/L3.
+    REQUIRE(mode->max_discharge_power_L2.has_value());
+    REQUIRE(mode->max_discharge_power_L3.has_value());
+    REQUIRE(mode->min_discharge_power_L2.has_value());
+    REQUIRE(mode->min_discharge_power_L3.has_value());
+    REQUIRE(message_20::datatypes::from_RationalNumber(*mode->max_discharge_power_L2) == 15000.0f);
+    REQUIRE(message_20::datatypes::from_RationalNumber(*mode->max_discharge_power_L3) == 15000.0f);
+    REQUIRE(message_20::datatypes::from_RationalNumber(*mode->min_discharge_power_L2) == 800.0f);
+    REQUIRE(message_20::datatypes::from_RationalNumber(*mode->min_discharge_power_L3) == 800.0f);
+}
+
+SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery transitions to ScheduleExchange and fires ac_bpt_limits on a "
+         "BPT reply") {
+    bool fired = false;
+    float reported_max_discharge = 0.0f;
+    float reported_min_discharge = 0.0f;
+    ev::feedback::Callbacks callbacks{};
+    callbacks.ac_bpt_limits = [&](const message_20::datatypes::BPT_AC_CPDResEnergyTransferMode& mode) {
+        fired = true;
+        reported_max_discharge = message_20::datatypes::from_RationalNumber(mode.max_discharge_power);
+        reported_min_discharge = message_20::datatypes::from_RationalNumber(mode.min_discharge_power);
+    };
+    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_bpt_single_phase};
+
+    primed.handle_response(make_bpt_response(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == true);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::ScheduleExchange);
+    REQUIRE(primed.ctx.is_session_stopped() == false);
+    REQUIRE(fired == true);
+    REQUIRE(reported_max_discharge == 12000.0f);
+    REQUIRE(reported_min_discharge == 300.0f);
+}
+
+SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery stops the session on a plain reply for a BPT session") {
+    bool fired = false;
+    ev::feedback::Callbacks callbacks{};
+    callbacks.ac_bpt_limits = [&](const message_20::datatypes::BPT_AC_CPDResEnergyTransferMode&) { fired = true; };
+    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_bpt_single_phase};
+
+    primed.handle_response(make_response(SESSION_HEADER, ResponseCode::OK));
     const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
 
     REQUIRE(result.transitioned() == false);

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/ac_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/ac_charge_parameter_discovery.cpp
@@ -28,41 +28,20 @@ message_20::AC_ChargeParameterDiscoveryResponse make_response(const message_20::
 }
 
 // AC_ChargeParameterDiscovery builds its request from the EV's AC charge params.
-const auto seed_single_phase = [](FsmStateHelper& helper) {
+const auto seed_charge_limits = [](FsmStateHelper& helper) {
     ev::AcChargeParams p{};
     p.max_charge_power = 22000.0f;
     p.min_charge_power = 1000.0f;
-    p.three_phase = false;
     helper.set_ac_params(p);
 };
 
-const auto seed_three_phase = [](FsmStateHelper& helper) {
-    ev::AcChargeParams p{};
-    p.max_charge_power = 22000.0f;
-    p.min_charge_power = 1000.0f;
-    p.three_phase = true;
-    helper.set_ac_params(p);
-};
-
-const auto seed_bpt_single_phase = [](FsmStateHelper& helper) {
+const auto seed_bpt_limits = [](FsmStateHelper& helper) {
     helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::AC_BPT);
     ev::AcChargeParams p{};
     p.max_charge_power = 22000.0f;
     p.min_charge_power = 1000.0f;
     p.max_discharge_power = 15000.0f;
     p.min_discharge_power = 800.0f;
-    p.three_phase = false;
-    helper.set_ac_params(p);
-};
-
-const auto seed_bpt_three_phase = [](FsmStateHelper& helper) {
-    helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::AC_BPT);
-    ev::AcChargeParams p{};
-    p.max_charge_power = 22000.0f;
-    p.min_charge_power = 1000.0f;
-    p.max_discharge_power = 15000.0f;
-    p.min_discharge_power = 800.0f;
-    p.three_phase = true;
     helper.set_ac_params(p);
 };
 
@@ -81,9 +60,9 @@ message_20::AC_ChargeParameterDiscoveryResponse make_bpt_response(const message_
 }
 } // namespace
 
-SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery emits a single-phase request built from the AC params on enter") {
+SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery emits a request built from the AC params on enter") {
     const ev::feedback::Callbacks callbacks{};
-    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_single_phase};
+    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_charge_limits};
 
     const auto requests = primed.take_requests();
     const auto request_message = requests.get<message_20::AC_ChargeParameterDiscoveryRequest>();
@@ -94,32 +73,11 @@ SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery emits a single-phase reques
     REQUIRE(mode != nullptr);
     REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_charge_power) == 22000.0f);
     REQUIRE(message_20::datatypes::from_RationalNumber(mode->min_charge_power) == 1000.0f);
-    // Single-phase: no per-phase limits.
+    // The power limits are three-phase totals: no per-phase field is advertised.
     REQUIRE_FALSE(mode->max_charge_power_L2.has_value());
     REQUIRE_FALSE(mode->max_charge_power_L3.has_value());
     REQUIRE_FALSE(mode->min_charge_power_L2.has_value());
     REQUIRE_FALSE(mode->min_charge_power_L3.has_value());
-}
-
-SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery emits per-phase limits when three_phase") {
-    const ev::feedback::Callbacks callbacks{};
-    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_three_phase};
-
-    const auto requests = primed.take_requests();
-    const auto request_message = requests.get<message_20::AC_ChargeParameterDiscoveryRequest>();
-    REQUIRE(request_message.has_value());
-
-    const auto* mode = std::get_if<message_20::datatypes::AC_CPDReqEnergyTransferMode>(&request_message->transfer_mode);
-    REQUIRE(mode != nullptr);
-    // Three-phase: L2/L3 present and carry the same per-phase value as the total.
-    REQUIRE(mode->max_charge_power_L2.has_value());
-    REQUIRE(mode->max_charge_power_L3.has_value());
-    REQUIRE(mode->min_charge_power_L2.has_value());
-    REQUIRE(mode->min_charge_power_L3.has_value());
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode->max_charge_power_L2) == 22000.0f);
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode->max_charge_power_L3) == 22000.0f);
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode->min_charge_power_L2) == 1000.0f);
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode->min_charge_power_L3) == 1000.0f);
 }
 
 SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery transitions to ScheduleExchange and fires ac_limits on OK") {
@@ -134,7 +92,7 @@ SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery transitions to ScheduleExch
         reported_max_charge_power = message_20::datatypes::from_RationalNumber(mode.max_charge_power);
         reported_min_charge_power = message_20::datatypes::from_RationalNumber(mode.min_charge_power);
     };
-    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_single_phase};
+    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_charge_limits};
 
     primed.handle_response(make_response(SESSION_HEADER, ResponseCode::OK));
     const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
@@ -152,7 +110,7 @@ SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery rejects a BPT transfer-mode
     bool fired = false;
     ev::feedback::Callbacks callbacks{};
     callbacks.ac_limits = [&](const message_20::datatypes::AC_CPDResEnergyTransferMode&) { fired = true; };
-    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_single_phase};
+    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_charge_limits};
 
     message_20::AC_ChargeParameterDiscoveryResponse res{};
     res.header = SESSION_HEADER;
@@ -174,7 +132,7 @@ SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery rejects a BPT transfer-mode
 
 SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery emits a BPT request with discharge limits for a BPT session") {
     const ev::feedback::Callbacks callbacks{};
-    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_bpt_single_phase};
+    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_bpt_limits};
 
     const auto requests = primed.take_requests();
     const auto request_message = requests.get<message_20::AC_ChargeParameterDiscoveryRequest>();
@@ -187,36 +145,15 @@ SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery emits a BPT request with di
     REQUIRE(message_20::datatypes::from_RationalNumber(mode->min_charge_power) == 1000.0f);
     REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_discharge_power) == 15000.0f);
     REQUIRE(message_20::datatypes::from_RationalNumber(mode->min_discharge_power) == 800.0f);
-    // Single-phase: no per-phase discharge limits.
+    // The limits are three-phase totals: no per-phase charge or discharge field is advertised.
+    REQUIRE_FALSE(mode->max_charge_power_L2.has_value());
+    REQUIRE_FALSE(mode->max_charge_power_L3.has_value());
+    REQUIRE_FALSE(mode->min_charge_power_L2.has_value());
+    REQUIRE_FALSE(mode->min_charge_power_L3.has_value());
     REQUIRE_FALSE(mode->max_discharge_power_L2.has_value());
     REQUIRE_FALSE(mode->max_discharge_power_L3.has_value());
     REQUIRE_FALSE(mode->min_discharge_power_L2.has_value());
     REQUIRE_FALSE(mode->min_discharge_power_L3.has_value());
-}
-
-SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery mirrors BPT discharge limits to L2/L3 when three_phase") {
-    const ev::feedback::Callbacks callbacks{};
-    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_bpt_three_phase};
-
-    const auto requests = primed.take_requests();
-    const auto request_message = requests.get<message_20::AC_ChargeParameterDiscoveryRequest>();
-    REQUIRE(request_message.has_value());
-
-    const auto* mode =
-        std::get_if<message_20::datatypes::BPT_AC_CPDReqEnergyTransferMode>(&request_message->transfer_mode);
-    REQUIRE(mode != nullptr);
-    // Charge limits mirrored the same way as the plain-AC three-phase convention.
-    REQUIRE(mode->max_charge_power_L2.has_value());
-    REQUIRE(mode->min_charge_power_L3.has_value());
-    // Discharge limits mirrored to L2/L3.
-    REQUIRE(mode->max_discharge_power_L2.has_value());
-    REQUIRE(mode->max_discharge_power_L3.has_value());
-    REQUIRE(mode->min_discharge_power_L2.has_value());
-    REQUIRE(mode->min_discharge_power_L3.has_value());
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode->max_discharge_power_L2) == 15000.0f);
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode->max_discharge_power_L3) == 15000.0f);
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode->min_discharge_power_L2) == 800.0f);
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode->min_discharge_power_L3) == 800.0f);
 }
 
 SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery transitions to ScheduleExchange and fires ac_bpt_limits on a "
@@ -230,7 +167,7 @@ SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery transitions to ScheduleExch
         reported_max_discharge = message_20::datatypes::from_RationalNumber(mode.max_discharge_power);
         reported_min_discharge = message_20::datatypes::from_RationalNumber(mode.min_discharge_power);
     };
-    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_bpt_single_phase};
+    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_bpt_limits};
 
     primed.handle_response(make_bpt_response(SESSION_HEADER, ResponseCode::OK));
     const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
@@ -247,7 +184,7 @@ SCENARIO("ISO15118-20 EV AC_ChargeParameterDiscovery stops the session on a plai
     bool fired = false;
     ev::feedback::Callbacks callbacks{};
     callbacks.ac_bpt_limits = [&](const message_20::datatypes::BPT_AC_CPDResEnergyTransferMode&) { fired = true; };
-    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_bpt_single_phase};
+    PrimedState<ev::d20::state::AC_ChargeParameterDiscovery> primed{callbacks, seed_bpt_limits};
 
     primed.handle_response(make_response(SESSION_HEADER, ResponseCode::OK));
     const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/ac_der_iec_charge_loop.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/ac_der_iec_charge_loop.cpp
@@ -59,15 +59,7 @@ struct StopObserver {
 
 SCENARIO("ISO15118-20 EV AC_DER_IEC_ChargeLoop emits a Dynamic DER_AC_ChargeLoopRequest on enter") {
     const ev::feedback::Callbacks callbacks{};
-    const auto seed_single = [](FsmStateHelper& helper) {
-        ev::AcChargeParams p{};
-        p.max_charge_power = 11000.0f;
-        p.min_charge_power = 1000.0f;
-        p.present_active_power = 5000.0f;
-        p.three_phase = false;
-        helper.set_ac_params(p);
-    };
-    PrimedState<ev::d20::state::AC_DER_IEC_ChargeLoop> primed{callbacks, seed_single};
+    PrimedState<ev::d20::state::AC_DER_IEC_ChargeLoop> primed{callbacks, seed_present_5000};
 
     const auto requests = primed.take_requests();
     const auto request_message = requests.get<message_20::DER_AC_ChargeLoopRequest>();
@@ -86,52 +78,17 @@ SCENARIO("ISO15118-20 EV AC_DER_IEC_ChargeLoop emits a Dynamic DER_AC_ChargeLoop
     REQUIRE(message_20::datatypes::from_RationalNumber(mode.min_discharge_power) == Catch::Approx(1000.0f));
     // No grid event asserted by the EV.
     REQUIRE(mode.grid_event_condition == 0);
-}
-
-SCENARIO("ISO15118-20 EV AC_DER_IEC_ChargeLoop emits per-phase charge and discharge limits when three_phase") {
-    const ev::feedback::Callbacks callbacks{};
-    const auto seed_three_phase = [](FsmStateHelper& helper) {
-        ev::AcChargeParams p{};
-        p.max_charge_power = 11000.0f;
-        p.min_charge_power = 1000.0f;
-        p.present_active_power = 5000.0f;
-        p.three_phase = true;
-        helper.set_ac_params(p);
-    };
-    PrimedState<ev::d20::state::AC_DER_IEC_ChargeLoop> primed{callbacks, seed_three_phase};
-
-    const auto requests = primed.take_requests();
-    const auto request_message = requests.get<message_20::DER_AC_ChargeLoopRequest>();
-    REQUIRE(request_message.has_value());
-    REQUIRE(
-        std::holds_alternative<message_20::datatypes::DER_Dynamic_AC_CLReqControlMode>(request_message->control_mode));
-    const auto& mode = std::get<message_20::datatypes::DER_Dynamic_AC_CLReqControlMode>(request_message->control_mode);
-
-    // Per-phase charge limits mirror the aggregate on L2 and L3.
-    REQUIRE(mode.max_charge_power_L2.has_value());
-    REQUIRE(mode.max_charge_power_L3.has_value());
-    REQUIRE(mode.min_charge_power_L2.has_value());
-    REQUIRE(mode.min_charge_power_L3.has_value());
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.max_charge_power_L2) == Catch::Approx(11000.0f));
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.max_charge_power_L3) == Catch::Approx(11000.0f));
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.min_charge_power_L2) == Catch::Approx(1000.0f));
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.min_charge_power_L3) == Catch::Approx(1000.0f));
-
-    // Present active power is reported per phase.
-    REQUIRE(mode.present_active_power_L2.has_value());
-    REQUIRE(mode.present_active_power_L3.has_value());
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.present_active_power_L2) == Catch::Approx(5000.0f));
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.present_active_power_L3) == Catch::Approx(5000.0f));
-
-    // Discharge capability is advertised per phase as well.
-    REQUIRE(mode.max_discharge_power_L2.has_value());
-    REQUIRE(mode.max_discharge_power_L3.has_value());
-    REQUIRE(mode.min_discharge_power_L2.has_value());
-    REQUIRE(mode.min_discharge_power_L3.has_value());
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.max_discharge_power_L2) == Catch::Approx(11000.0f));
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.max_discharge_power_L3) == Catch::Approx(11000.0f));
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.min_discharge_power_L2) == Catch::Approx(1000.0f));
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.min_discharge_power_L3) == Catch::Approx(1000.0f));
+    // The power limits are three-phase totals: no per-phase field is advertised.
+    REQUIRE_FALSE(mode.max_charge_power_L2.has_value());
+    REQUIRE_FALSE(mode.max_charge_power_L3.has_value());
+    REQUIRE_FALSE(mode.min_charge_power_L2.has_value());
+    REQUIRE_FALSE(mode.min_charge_power_L3.has_value());
+    REQUIRE_FALSE(mode.present_active_power_L2.has_value());
+    REQUIRE_FALSE(mode.present_active_power_L3.has_value());
+    REQUIRE_FALSE(mode.max_discharge_power_L2.has_value());
+    REQUIRE_FALSE(mode.max_discharge_power_L3.has_value());
+    REQUIRE_FALSE(mode.min_discharge_power_L2.has_value());
+    REQUIRE_FALSE(mode.min_discharge_power_L3.has_value());
 }
 
 SCENARIO("ISO15118-20 EV AC_DER_IEC_ChargeLoop fires der_control on a Dynamic response") {

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/ac_der_iec_charge_loop.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/ac_der_iec_charge_loop.cpp
@@ -34,10 +34,14 @@ message_20::DER_AC_ChargeLoopResponse make_res(const message_20::Header& header,
     return res;
 }
 
+// Discharge limits differ from the charge limits so a request that substitutes one for the
+// other fails rather than passing by coincidence.
 const auto seed_present_5000 = [](FsmStateHelper& helper) {
     ev::AcChargeParams p{};
     p.max_charge_power = 11000.0f;
     p.min_charge_power = 1000.0f;
+    p.max_discharge_power = 9000.0f;
+    p.min_discharge_power = 800.0f;
     p.present_active_power = 5000.0f;
     helper.set_ac_params(p);
 };
@@ -74,8 +78,8 @@ SCENARIO("ISO15118-20 EV AC_DER_IEC_ChargeLoop emits a Dynamic DER_AC_ChargeLoop
     REQUIRE(message_20::datatypes::from_RationalNumber(mode.min_charge_power) == Catch::Approx(1000.0f));
     REQUIRE(message_20::datatypes::from_RationalNumber(mode.present_active_power) == Catch::Approx(5000.0f));
     // Discharge capability advertised on every loop request.
-    REQUIRE(message_20::datatypes::from_RationalNumber(mode.max_discharge_power) == Catch::Approx(11000.0f));
-    REQUIRE(message_20::datatypes::from_RationalNumber(mode.min_discharge_power) == Catch::Approx(1000.0f));
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode.max_discharge_power) == Catch::Approx(9000.0f));
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode.min_discharge_power) == Catch::Approx(800.0f));
     // No grid event asserted by the EV.
     REQUIRE(mode.grid_event_condition == 0);
     // The power limits are three-phase totals: no per-phase field is advertised.
@@ -128,6 +132,34 @@ SCENARIO("ISO15118-20 EV AC_DER_IEC_ChargeLoop stays and re-emits a request on a
     const auto requests = primed.take_requests();
     REQUIRE(requests.get<message_20::DER_AC_ChargeLoopRequest>().has_value());
     REQUIRE_FALSE(requests.get<message_20::PowerDeliveryRequest>().has_value());
+}
+
+SCENARIO("ISO15118-20 EV AC_DER_IEC_ChargeLoop reports the dictated target as its present power") {
+    const ev::feedback::Callbacks callbacks{};
+    // No module-fed present power, so the approximation has to supply the mandatory field.
+    const auto seed_unfed_present = [](FsmStateHelper& helper) {
+        ev::AcChargeParams p{};
+        p.max_charge_power = 11000.0f;
+        p.min_charge_power = 1000.0f;
+        p.max_discharge_power = 9000.0f;
+        p.min_discharge_power = 800.0f;
+        helper.set_ac_params(p);
+    };
+    PrimedState<ev::d20::state::AC_DER_IEC_ChargeLoop> primed{callbacks, seed_unfed_present};
+
+    // Nothing has been dictated yet, so the first request has no better value than zero.
+    const auto first = primed.take_requests().get<message_20::DER_AC_ChargeLoopRequest>();
+    REQUIRE(first.has_value());
+    const auto& first_mode = std::get<message_20::datatypes::DER_Dynamic_AC_CLReqControlMode>(first->control_mode);
+    REQUIRE(message_20::datatypes::from_RationalNumber(first_mode.present_active_power) == Catch::Approx(0.0f));
+
+    primed.handle_response(make_res(SESSION_HEADER, ResponseCode::OK));
+    primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    const auto second = primed.take_requests().get<message_20::DER_AC_ChargeLoopRequest>();
+    REQUIRE(second.has_value());
+    const auto& second_mode = std::get<message_20::datatypes::DER_Dynamic_AC_CLReqControlMode>(second->control_mode);
+    REQUIRE(message_20::datatypes::from_RationalNumber(second_mode.present_active_power) == Catch::Approx(7000.0f));
 }
 
 SCENARIO("ISO15118-20 EV AC_DER_IEC_ChargeLoop fires stop_from_charger and drives PowerDelivery(Stop) on Terminate") {
@@ -184,6 +216,8 @@ SCENARIO("ISO15118-20 EV AC_DER_IEC_ChargeLoop honors a stop request set before 
         ev::AcChargeParams p{};
         p.max_charge_power = 11000.0f;
         p.min_charge_power = 1000.0f;
+        p.max_discharge_power = 9000.0f;
+        p.min_discharge_power = 800.0f;
         p.present_active_power = 5000.0f;
         helper.set_ac_params(p);
         helper.get_context().set_stop_charging_requested(true);

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/ac_der_iec_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/ac_der_iec_charge_parameter_discovery.cpp
@@ -31,26 +31,17 @@ message_20::DER_AC_ChargeParameterDiscoveryResponse make_response(const message_
 }
 
 // AC_DER_IEC_ChargeParameterDiscovery builds its request from the EV's AC charge params.
-const auto seed_single_phase = [](FsmStateHelper& helper) {
+const auto seed_charge_limits = [](FsmStateHelper& helper) {
     ev::AcChargeParams p{};
     p.max_charge_power = 22000.0f;
     p.min_charge_power = 1000.0f;
-    p.three_phase = false;
-    helper.set_ac_params(p);
-};
-
-const auto seed_three_phase = [](FsmStateHelper& helper) {
-    ev::AcChargeParams p{};
-    p.max_charge_power = 22000.0f;
-    p.min_charge_power = 1000.0f;
-    p.three_phase = true;
     helper.set_ac_params(p);
 };
 } // namespace
 
-SCENARIO("ISO15118-20 EV AC_DER_IEC_ChargeParameterDiscovery emits a single-phase DER request on enter") {
+SCENARIO("ISO15118-20 EV AC_DER_IEC_ChargeParameterDiscovery emits a DER request on enter") {
     const ev::feedback::Callbacks callbacks{};
-    PrimedState<ev::d20::state::AC_DER_IEC_ChargeParameterDiscovery> primed{callbacks, seed_single_phase};
+    PrimedState<ev::d20::state::AC_DER_IEC_ChargeParameterDiscovery> primed{callbacks, seed_charge_limits};
 
     const auto requests = primed.take_requests();
     const auto request_message = requests.get<message_20::DER_AC_ChargeParameterDiscoveryRequest>();
@@ -65,35 +56,15 @@ SCENARIO("ISO15118-20 EV AC_DER_IEC_ChargeParameterDiscovery emits a single-phas
     REQUIRE(message_20::datatypes::from_RationalNumber(mode.min_discharge_power) == Catch::Approx(1000.0f));
     // The EV drives a single discovery round: processing is Finished.
     REQUIRE(mode.processing == message_20::datatypes::Processing::Finished);
-    // Single-phase: no per-phase limits.
+    // The limits are three-phase totals: no per-phase charge or discharge field is advertised.
     REQUIRE_FALSE(mode.max_charge_power_L2.has_value());
     REQUIRE_FALSE(mode.max_charge_power_L3.has_value());
     REQUIRE_FALSE(mode.min_charge_power_L2.has_value());
     REQUIRE_FALSE(mode.min_charge_power_L3.has_value());
-}
-
-SCENARIO("ISO15118-20 EV AC_DER_IEC_ChargeParameterDiscovery emits per-phase limits when three_phase") {
-    const ev::feedback::Callbacks callbacks{};
-    PrimedState<ev::d20::state::AC_DER_IEC_ChargeParameterDiscovery> primed{callbacks, seed_three_phase};
-
-    const auto requests = primed.take_requests();
-    const auto request_message = requests.get<message_20::DER_AC_ChargeParameterDiscoveryRequest>();
-    REQUIRE(request_message.has_value());
-
-    const auto& mode = request_message->transfer_mode;
-    REQUIRE(mode.max_charge_power_L2.has_value());
-    REQUIRE(mode.max_charge_power_L3.has_value());
-    REQUIRE(mode.min_charge_power_L2.has_value());
-    REQUIRE(mode.min_charge_power_L3.has_value());
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.max_charge_power_L2) == Catch::Approx(22000.0f));
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.min_charge_power_L3) == Catch::Approx(1000.0f));
-    // Discharge capability is advertised per phase too.
-    REQUIRE(mode.max_discharge_power_L2.has_value());
-    REQUIRE(mode.max_discharge_power_L3.has_value());
-    REQUIRE(mode.min_discharge_power_L2.has_value());
-    REQUIRE(mode.min_discharge_power_L3.has_value());
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.max_discharge_power_L2) == Catch::Approx(22000.0f));
-    REQUIRE(message_20::datatypes::from_RationalNumber(*mode.min_discharge_power_L3) == Catch::Approx(1000.0f));
+    REQUIRE_FALSE(mode.max_discharge_power_L2.has_value());
+    REQUIRE_FALSE(mode.max_discharge_power_L3.has_value());
+    REQUIRE_FALSE(mode.min_discharge_power_L2.has_value());
+    REQUIRE_FALSE(mode.min_discharge_power_L3.has_value());
 }
 
 SCENARIO("ISO15118-20 EV AC_DER_IEC_ChargeParameterDiscovery transitions to ScheduleExchange and fires ac_limits") {
@@ -106,7 +77,7 @@ SCENARIO("ISO15118-20 EV AC_DER_IEC_ChargeParameterDiscovery transitions to Sche
         reported_frequency = message_20::datatypes::from_RationalNumber(mode.nominal_frequency);
         reported_max_charge_power = message_20::datatypes::from_RationalNumber(mode.max_charge_power);
     };
-    PrimedState<ev::d20::state::AC_DER_IEC_ChargeParameterDiscovery> primed{callbacks, seed_single_phase};
+    PrimedState<ev::d20::state::AC_DER_IEC_ChargeParameterDiscovery> primed{callbacks, seed_charge_limits};
 
     primed.handle_response(make_response(SESSION_HEADER, ResponseCode::OK));
     const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/context.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/context.cpp
@@ -212,10 +212,10 @@ SCENARIO("ISO15118-20 EV Context encodes a request that round-trips back to the 
         auto& ctx = helper.get_context();
         auto& mx = helper.get_message_exchange();
 
-        WHEN("The Context responds with a SessionSetupRequest") {
+        WHEN("The Context sends a SessionSetupRequest") {
 
             message_20::SessionSetupRequest req{message_20::Header{}, "EVTESTID01"};
-            ctx.respond(req);
+            ctx.send_request(req);
 
             THEN("The MessageExchange holds a pending request") {
                 REQUIRE(mx.has_request());

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/context.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/context.cpp
@@ -10,6 +10,7 @@
 
 #include <iso15118/d20/der_functions.hpp>
 #include <iso15118/ev/ac_charge_params.hpp>
+#include <iso15118/ev/dc_charge_params.hpp>
 #include <iso15118/ev/der_control_functions.hpp>
 
 using namespace iso15118;
@@ -24,6 +25,8 @@ SCENARIO("ISO15118-20 EV Context returns a locked-copy snapshot of the seeded AC
         ev::AcChargeParams params{};
         params.max_charge_power = 11000.0f;
         params.min_charge_power = 1000.0f;
+        params.max_discharge_power = 9000.0f;
+        params.min_discharge_power = 500.0f;
         params.three_phase = true;
         params.present_active_power = 5000.0f;
         helper.set_ac_params(params);
@@ -37,6 +40,8 @@ SCENARIO("ISO15118-20 EV Context returns a locked-copy snapshot of the seeded AC
             THEN("Every field matches the seeded params") {
                 REQUIRE(snapshot.max_charge_power == params.max_charge_power);
                 REQUIRE(snapshot.min_charge_power == params.min_charge_power);
+                REQUIRE(snapshot.max_discharge_power == params.max_discharge_power);
+                REQUIRE(snapshot.min_discharge_power == params.min_discharge_power);
                 REQUIRE(snapshot.three_phase == params.three_phase);
                 REQUIRE(snapshot.present_active_power == params.present_active_power);
             }
@@ -56,6 +61,38 @@ SCENARIO("ISO15118-20 EV Context returns a locked-copy snapshot of the seeded AC
                     REQUIRE(snapshot.max_charge_power == params.max_charge_power);
                     REQUIRE(snapshot.three_phase == params.three_phase);
                 }
+            }
+        }
+    }
+}
+
+SCENARIO("ISO15118-20 EV Context returns a locked-copy snapshot of the seeded DC discharge params") {
+
+    GIVEN("An EV d20 Context with a seeded DcChargeParams monitor carrying discharge limits") {
+
+        const ev::feedback::Callbacks callbacks{};
+        FsmStateHelper helper{callbacks};
+
+        ev::DcChargeParams params{};
+        params.max_charge_power = 150000.0f;
+        params.max_charge_current = 200.0f;
+        params.max_discharge_power = 120000.0f;
+        params.min_discharge_power = 1000.0f;
+        params.max_discharge_current = 180.0f;
+        helper.set_dc_params(params);
+
+        auto& ctx = helper.get_context();
+
+        WHEN("The DC params are read back through the Context getter") {
+
+            const auto snapshot = ctx.get_dc_params();
+
+            THEN("The discharge fields match the seeded params") {
+                REQUIRE(snapshot.max_charge_power == params.max_charge_power);
+                REQUIRE(snapshot.max_charge_current == params.max_charge_current);
+                REQUIRE(snapshot.max_discharge_power == params.max_discharge_power);
+                REQUIRE(snapshot.min_discharge_power == params.min_discharge_power);
+                REQUIRE(snapshot.max_discharge_current == params.max_discharge_current);
             }
         }
     }

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/context.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/context.cpp
@@ -27,7 +27,6 @@ SCENARIO("ISO15118-20 EV Context returns a locked-copy snapshot of the seeded AC
         params.min_charge_power = 1000.0f;
         params.max_discharge_power = 9000.0f;
         params.min_discharge_power = 500.0f;
-        params.three_phase = true;
         params.present_active_power = 5000.0f;
         helper.set_ac_params(params);
 
@@ -42,7 +41,6 @@ SCENARIO("ISO15118-20 EV Context returns a locked-copy snapshot of the seeded AC
                 REQUIRE(snapshot.min_charge_power == params.min_charge_power);
                 REQUIRE(snapshot.max_discharge_power == params.max_discharge_power);
                 REQUIRE(snapshot.min_discharge_power == params.min_discharge_power);
-                REQUIRE(snapshot.three_phase == params.three_phase);
                 REQUIRE(snapshot.present_active_power == params.present_active_power);
             }
         }
@@ -59,7 +57,7 @@ SCENARIO("ISO15118-20 EV Context returns a locked-copy snapshot of the seeded AC
 
                 AND_THEN("The static fields are unchanged") {
                     REQUIRE(snapshot.max_charge_power == params.max_charge_power);
-                    REQUIRE(snapshot.three_phase == params.three_phase);
+                    REQUIRE(snapshot.min_charge_power == params.min_charge_power);
                 }
             }
         }

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/dc_charge_loop.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/dc_charge_loop.cpp
@@ -30,9 +30,36 @@ message_20::DC_ChargeLoopResponse make_res(const message_20::Header& header, Res
     return res;
 }
 
+message_20::DC_ChargeLoopResponse make_bpt_res(const message_20::Header& header, ResponseCode code,
+                                               std::optional<message_20::datatypes::EvseStatus> status = std::nullopt) {
+    message_20::DC_ChargeLoopResponse res;
+    res.header = header;
+    res.response_code = code;
+    res.status = status;
+    res.present_voltage = message_20::datatypes::from_float(400.0f);
+    res.present_current = message_20::datatypes::from_float(10.0f);
+    res.control_mode = message_20::datatypes::BPT_Dynamic_DC_CLResControlMode{};
+    return res;
+}
+
 // DC_ChargeLoop reads present_voltage from the DC params for each loop request.
 const auto seed_present_400 = [](FsmStateHelper& helper) {
     ev::DcChargeParams params{};
+    params.present_voltage = 400.0f;
+    helper.set_dc_params(params);
+};
+
+// A BPT session seeded with discharge limits alongside the charge params.
+const auto seed_bpt_present_400 = [](FsmStateHelper& helper) {
+    helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::DC_BPT);
+    ev::DcChargeParams params{};
+    params.max_charge_power = 11000.0f;
+    params.max_charge_current = 200.0f;
+    params.max_voltage = 500.0f;
+    params.min_voltage = 200.0f;
+    params.max_discharge_power = 9000.0f;
+    params.min_discharge_power = 500.0f;
+    params.max_discharge_current = 180.0f;
     params.present_voltage = 400.0f;
     helper.set_dc_params(params);
 };
@@ -210,6 +237,117 @@ SCENARIO("ISO15118-20 EV DC_ChargeLoop honors a stop request set before the stat
     PrimedState<ev::d20::state::DC_ChargeLoop> primed{obs.callbacks, seed_stop_request};
 
     primed.handle_response(make_res(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == true);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::PowerDelivery);
+    REQUIRE(obs.fired == false);
+
+    const auto requests = primed.take_requests();
+    const auto pd_request = requests.get<message_20::PowerDeliveryRequest>();
+    REQUIRE(pd_request.has_value());
+    REQUIRE(pd_request->charge_progress == message_20::datatypes::Progress::Stop);
+}
+
+SCENARIO("ISO15118-20 EV DC_ChargeLoop emits a BPT_Dynamic request with discharge limits for a BPT session") {
+    const ev::feedback::Callbacks callbacks{};
+    PrimedState<ev::d20::state::DC_ChargeLoop> primed{callbacks, seed_bpt_present_400};
+
+    const auto requests = primed.take_requests();
+    const auto request_message = requests.get<message_20::DC_ChargeLoopRequest>();
+    REQUIRE(request_message.has_value());
+    REQUIRE(
+        std::holds_alternative<message_20::datatypes::BPT_Dynamic_DC_CLReqControlMode>(request_message->control_mode));
+    const auto& mode = std::get<message_20::datatypes::BPT_Dynamic_DC_CLReqControlMode>(request_message->control_mode);
+    // Charge-side fields carried over unchanged.
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode.max_charge_power) == Catch::Approx(11000.0f));
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode.max_charge_current) == Catch::Approx(200.0f));
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode.max_voltage) == Catch::Approx(500.0f));
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode.min_voltage) == Catch::Approx(200.0f));
+    // Discharge fields from the DC params.
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode.max_discharge_power) == Catch::Approx(9000.0f));
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode.min_discharge_power) == Catch::Approx(500.0f));
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode.max_discharge_current) == Catch::Approx(180.0f));
+    // v2x energy request fields are deliberately omitted.
+    REQUIRE_FALSE(mode.max_v2x_energy_request.has_value());
+    REQUIRE_FALSE(mode.min_v2x_energy_request.has_value());
+}
+
+SCENARIO("ISO15118-20 EV DC_ChargeLoop continues on a BPT_Dynamic response for a BPT session") {
+    StopObserver obs;
+    PrimedState<ev::d20::state::DC_ChargeLoop> primed{obs.callbacks, seed_bpt_present_400};
+
+    primed.handle_response(make_bpt_res(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == false);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::DC_ChargeLoop);
+    REQUIRE(primed.ctx.is_session_stopped() == false);
+    REQUIRE(obs.fired == false);
+
+    const auto requests = primed.take_requests();
+    REQUIRE(requests.get<message_20::DC_ChargeLoopRequest>().has_value());
+}
+
+SCENARIO("ISO15118-20 EV DC_ChargeLoop stops a BPT session on a plain Dynamic reply it never requested") {
+    StopObserver obs;
+    PrimedState<ev::d20::state::DC_ChargeLoop> primed{obs.callbacks, seed_bpt_present_400};
+
+    primed.handle_response(make_res(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == false);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::DC_ChargeLoop);
+    REQUIRE(primed.ctx.is_session_stopped() == true);
+    REQUIRE(obs.fired == false);
+}
+
+SCENARIO("ISO15118-20 EV DC_ChargeLoop stops a plain DC session on a BPT_Dynamic reply it never requested") {
+    StopObserver obs;
+    PrimedState<ev::d20::state::DC_ChargeLoop> primed{obs.callbacks, seed_present_400};
+
+    primed.handle_response(make_bpt_res(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == false);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::DC_ChargeLoop);
+    REQUIRE(primed.ctx.is_session_stopped() == true);
+    REQUIRE(obs.fired == false);
+}
+
+SCENARIO("ISO15118-20 EV DC_ChargeLoop fires stop_from_charger and drives PowerDelivery(Stop) on Terminate for BPT") {
+    StopObserver obs;
+    PrimedState<ev::d20::state::DC_ChargeLoop> primed{obs.callbacks, seed_bpt_present_400};
+
+    primed.handle_response(
+        make_bpt_res(SESSION_HEADER, ResponseCode::OK,
+                     message_20::datatypes::EvseStatus{0, message_20::datatypes::EvseNotification::Terminate}));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(obs.fired == true);
+    REQUIRE(result.transitioned() == true);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::PowerDelivery);
+    REQUIRE(primed.ctx.is_session_stopped() == false);
+
+    const auto requests = primed.take_requests();
+    const auto pd_request = requests.get<message_20::PowerDeliveryRequest>();
+    REQUIRE(pd_request.has_value());
+    REQUIRE(pd_request->charge_progress == message_20::datatypes::Progress::Stop);
+}
+
+SCENARIO("ISO15118-20 EV DC_ChargeLoop honors a stop request for a BPT session") {
+    StopObserver obs;
+    const auto seed_bpt_latched = [](FsmStateHelper& helper) {
+        helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::DC_BPT);
+        ev::DcChargeParams params{};
+        params.present_voltage = 400.0f;
+        params.max_discharge_power = 9000.0f;
+        helper.set_dc_params(params);
+        helper.get_context().set_stop_charging_requested(true);
+    };
+    PrimedState<ev::d20::state::DC_ChargeLoop> primed{obs.callbacks, seed_bpt_latched};
+
+    primed.handle_response(make_bpt_res(SESSION_HEADER, ResponseCode::OK));
     const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
 
     REQUIRE(result.transitioned() == true);

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/dc_charge_loop.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/dc_charge_loop.cpp
@@ -102,6 +102,85 @@ SCENARIO("ISO15118-20 EV DC_ChargeLoop emits a Dynamic DC_ChargeLoopRequest on e
     REQUIRE(message_20::datatypes::from_RationalNumber(mode.min_voltage) == Catch::Approx(200.0f));
 }
 
+SCENARIO("ISO15118-20 EV DC_ChargeLoop seeds present_voltage from the target voltage") {
+    // Nothing feeds a measured present voltage yet, so the first request approximates it
+    // with the voltage the EV asks for rather than putting a zero on the wire.
+    const ev::feedback::Callbacks callbacks{};
+    const auto seed_target_only = [](FsmStateHelper& helper) {
+        ev::DcChargeParams params{};
+        params.max_charge_power = 11000.0f;
+        params.max_voltage = 500.0f;
+        params.min_voltage = 200.0f;
+        params.target_voltage = 420.0f;
+        helper.set_dc_params(params);
+    };
+    PrimedState<ev::d20::state::DC_ChargeLoop> primed{callbacks, seed_target_only};
+
+    const auto requests = primed.take_requests();
+    const auto request_message = requests.get<message_20::DC_ChargeLoopRequest>();
+    REQUIRE(request_message.has_value());
+    REQUIRE(message_20::datatypes::from_RationalNumber(request_message->present_voltage) == Catch::Approx(420.0f));
+}
+
+SCENARIO("ISO15118-20 EV DC_ChargeLoop adopts the present voltage the SECC reports") {
+    // The SECC's reported present voltage is a better approximation than the EV's own
+    // target, so every loop iteration after the first carries it.
+    StopObserver obs;
+    const auto seed_target_only = [](FsmStateHelper& helper) {
+        ev::DcChargeParams params{};
+        params.max_charge_power = 11000.0f;
+        params.max_voltage = 500.0f;
+        params.min_voltage = 200.0f;
+        params.target_voltage = 420.0f;
+        helper.set_dc_params(params);
+    };
+    PrimedState<ev::d20::state::DC_ChargeLoop> primed{obs.callbacks, seed_target_only};
+
+    // The enter() request still carries the seed.
+    const auto seeded = primed.take_requests();
+    const auto seeded_request = seeded.get<message_20::DC_ChargeLoopRequest>();
+    REQUIRE(seeded_request.has_value());
+    REQUIRE(message_20::datatypes::from_RationalNumber(seeded_request->present_voltage) == Catch::Approx(420.0f));
+
+    auto res = make_res(SESSION_HEADER, ResponseCode::OK);
+    res.present_voltage = message_20::datatypes::from_float(390.0f);
+    primed.handle_response(res);
+    REQUIRE(primed.feed(ev::d20::Event::V2GTP_MESSAGE).transitioned() == false);
+
+    const auto requests = primed.take_requests();
+    const auto request_message = requests.get<message_20::DC_ChargeLoopRequest>();
+    REQUIRE(request_message.has_value());
+    REQUIRE(message_20::datatypes::from_RationalNumber(request_message->present_voltage) == Catch::Approx(390.0f));
+}
+
+SCENARIO("ISO15118-20 EV DC_ChargeLoop prefers a module-fed present voltage over the approximation") {
+    StopObserver obs;
+    const auto seed_measured = [](FsmStateHelper& helper) {
+        ev::DcChargeParams params{};
+        params.max_voltage = 500.0f;
+        params.min_voltage = 200.0f;
+        params.target_voltage = 420.0f;
+        params.present_voltage = 380.0f;
+        helper.set_dc_params(params);
+    };
+    PrimedState<ev::d20::state::DC_ChargeLoop> primed{obs.callbacks, seed_measured};
+
+    // The measured value wins over the target-voltage seed.
+    const auto seeded = primed.take_requests();
+    const auto seeded_request = seeded.get<message_20::DC_ChargeLoopRequest>();
+    REQUIRE(seeded_request.has_value());
+    REQUIRE(message_20::datatypes::from_RationalNumber(seeded_request->present_voltage) == Catch::Approx(380.0f));
+
+    // and over the voltage the SECC reports.
+    primed.handle_response(make_res(SESSION_HEADER, ResponseCode::OK));
+    REQUIRE(primed.feed(ev::d20::Event::V2GTP_MESSAGE).transitioned() == false);
+
+    const auto requests = primed.take_requests();
+    const auto request_message = requests.get<message_20::DC_ChargeLoopRequest>();
+    REQUIRE(request_message.has_value());
+    REQUIRE(message_20::datatypes::from_RationalNumber(request_message->present_voltage) == Catch::Approx(380.0f));
+}
+
 SCENARIO("ISO15118-20 EV DC_ChargeLoop stays and re-emits a request on a non-Terminate response") {
     StopObserver obs;
     PrimedState<ev::d20::state::DC_ChargeLoop> primed{obs.callbacks, seed_present_400};

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/dc_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/dc_charge_parameter_discovery.cpp
@@ -23,6 +23,19 @@ message_20::DC_ChargeParameterDiscoveryResponse make_response(const message_20::
     return res;
 }
 
+message_20::DC_ChargeParameterDiscoveryResponse make_bpt_response(const message_20::Header& header, ResponseCode code) {
+    message_20::DC_ChargeParameterDiscoveryResponse res{};
+    res.header = header;
+    res.response_code = code;
+    message_20::datatypes::BPT_DC_CPDResEnergyTransferMode mode{};
+    mode.max_charge_power = message_20::datatypes::from_float(15000.0f);
+    mode.max_discharge_power = message_20::datatypes::from_float(12000.0f);
+    mode.min_discharge_power = message_20::datatypes::from_float(300.0f);
+    mode.max_discharge_current = message_20::datatypes::from_float(150.0f);
+    res.transfer_mode = mode;
+    return res;
+}
+
 // DC_ChargeParameterDiscovery builds its request from the EV's DC charge params.
 const auto seed_params = [](FsmStateHelper& helper) {
     ev::DcChargeParams p{};
@@ -30,6 +43,19 @@ const auto seed_params = [](FsmStateHelper& helper) {
     p.max_charge_current = 200.0f;
     p.max_voltage = 500.0f;
     p.min_voltage = 150.0f;
+    helper.set_dc_params(p);
+};
+
+const auto seed_bpt_params = [](FsmStateHelper& helper) {
+    helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::DC_BPT);
+    ev::DcChargeParams p{};
+    p.max_charge_power = 11000.0f;
+    p.max_charge_current = 200.0f;
+    p.max_voltage = 500.0f;
+    p.min_voltage = 150.0f;
+    p.max_discharge_power = 9000.0f;
+    p.min_discharge_power = 500.0f;
+    p.max_discharge_current = 180.0f;
     helper.set_dc_params(p);
 };
 } // namespace
@@ -62,6 +88,86 @@ SCENARIO("ISO15118-20 EV DC_ChargeParameterDiscovery transitions to ScheduleExch
     REQUIRE(result.transitioned() == true);
     REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::ScheduleExchange);
     REQUIRE(primed.ctx.is_session_stopped() == false);
+}
+
+SCENARIO("ISO15118-20 EV DC_ChargeParameterDiscovery emits a BPT request with discharge limits for a BPT session") {
+    const ev::feedback::Callbacks callbacks{};
+    PrimedState<ev::d20::state::DC_ChargeParameterDiscovery> primed{callbacks, seed_bpt_params};
+
+    const auto requests = primed.take_requests();
+    const auto request_message = requests.get<message_20::DC_ChargeParameterDiscoveryRequest>();
+    REQUIRE(request_message.has_value());
+
+    const auto* mode =
+        std::get_if<message_20::datatypes::BPT_DC_CPDReqEnergyTransferMode>(&request_message->transfer_mode);
+    REQUIRE(mode != nullptr);
+    // Charge-side fields unchanged from the plain-DC conventions.
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_charge_power) == 11000.0f);
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode->min_charge_power) == 0.0f);
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_charge_current) == 200.0f);
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode->min_charge_current) == 0.0f);
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_voltage) == 500.0f);
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode->min_voltage) == 150.0f);
+    REQUIRE_FALSE(mode->target_soc.has_value());
+    // Discharge limits sourced from the DC params; min_discharge_current pinned to {0,0}.
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_discharge_power) == 9000.0f);
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode->min_discharge_power) == 500.0f);
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_discharge_current) == 180.0f);
+    REQUIRE(message_20::datatypes::from_RationalNumber(mode->min_discharge_current) == 0.0f);
+}
+
+SCENARIO("ISO15118-20 EV DC_ChargeParameterDiscovery transitions to ScheduleExchange and fires dc_bpt_limits on a "
+         "BPT reply") {
+    bool fired = false;
+    float reported_max_discharge = 0.0f;
+    float reported_min_discharge = 0.0f;
+    float reported_max_discharge_current = 0.0f;
+    ev::feedback::Callbacks callbacks{};
+    callbacks.dc_bpt_limits = [&](const message_20::datatypes::BPT_DC_CPDResEnergyTransferMode& mode) {
+        fired = true;
+        reported_max_discharge = message_20::datatypes::from_RationalNumber(mode.max_discharge_power);
+        reported_min_discharge = message_20::datatypes::from_RationalNumber(mode.min_discharge_power);
+        reported_max_discharge_current = message_20::datatypes::from_RationalNumber(mode.max_discharge_current);
+    };
+    PrimedState<ev::d20::state::DC_ChargeParameterDiscovery> primed{callbacks, seed_bpt_params};
+
+    primed.handle_response(make_bpt_response(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == true);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::ScheduleExchange);
+    REQUIRE(primed.ctx.is_session_stopped() == false);
+    REQUIRE(fired == true);
+    REQUIRE(reported_max_discharge == 12000.0f);
+    REQUIRE(reported_min_discharge == 300.0f);
+    REQUIRE(reported_max_discharge_current == 150.0f);
+}
+
+SCENARIO("ISO15118-20 EV DC_ChargeParameterDiscovery stops the session on a plain reply for a BPT session") {
+    bool fired = false;
+    ev::feedback::Callbacks callbacks{};
+    callbacks.dc_bpt_limits = [&](const message_20::datatypes::BPT_DC_CPDResEnergyTransferMode&) { fired = true; };
+    PrimedState<ev::d20::state::DC_ChargeParameterDiscovery> primed{callbacks, seed_bpt_params};
+
+    primed.handle_response(make_response(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == false);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::DC_ChargeParameterDiscovery);
+    REQUIRE(primed.ctx.is_session_stopped() == true);
+    REQUIRE(fired == false);
+}
+
+SCENARIO("ISO15118-20 EV DC_ChargeParameterDiscovery stops the session on a BPT reply for a plain DC session") {
+    const ev::feedback::Callbacks callbacks{};
+    PrimedState<ev::d20::state::DC_ChargeParameterDiscovery> primed{callbacks, seed_params};
+
+    primed.handle_response(make_bpt_response(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == false);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::DC_ChargeParameterDiscovery);
+    REQUIRE(primed.ctx.is_session_stopped() == true);
 }
 
 SCENARIO("ISO15118-20 EV DC_ChargeParameterDiscovery rejects malformed responses") {

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/power_delivery.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/power_delivery.cpp
@@ -58,6 +58,36 @@ SCENARIO("ISO15118-20 EV PowerDelivery transitions to DC_WeldingDetection on Sto
     REQUIRE(primed.ctx.is_session_stopped() == false);
 }
 
+SCENARIO("ISO15118-20 EV PowerDelivery transitions to DC_ChargeLoop on OK response for DC_BPT") {
+    const ev::feedback::Callbacks callbacks{};
+    const auto seed_dc_bpt = [](FsmStateHelper& helper) {
+        helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::DC_BPT);
+    };
+    PrimedState<ev::d20::state::PowerDelivery> primed{callbacks, seed_dc_bpt, Progress::Start};
+
+    primed.handle_response(make_pd_res(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == true);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::DC_ChargeLoop);
+    REQUIRE(primed.ctx.is_session_stopped() == false);
+}
+
+SCENARIO("ISO15118-20 EV PowerDelivery transitions to DC_WeldingDetection on Stop for DC_BPT") {
+    const ev::feedback::Callbacks callbacks{};
+    const auto seed_dc_bpt = [](FsmStateHelper& helper) {
+        helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::DC_BPT);
+    };
+    PrimedState<ev::d20::state::PowerDelivery> primed{callbacks, seed_dc_bpt, Progress::Stop};
+
+    primed.handle_response(make_pd_res(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == true);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::DC_WeldingDetection);
+    REQUIRE(primed.ctx.is_session_stopped() == false);
+}
+
 SCENARIO("ISO15118-20 EV PowerDelivery transitions to AC_ChargeLoop on OK response for AC") {
     const ev::feedback::Callbacks callbacks{};
     const auto seed_ac = [](FsmStateHelper& helper) {
@@ -79,6 +109,36 @@ SCENARIO("ISO15118-20 EV PowerDelivery transitions to SessionStop on Stop for AC
         helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::AC);
     };
     PrimedState<ev::d20::state::PowerDelivery> primed{callbacks, seed_ac, Progress::Stop};
+
+    primed.handle_response(make_pd_res(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == true);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::SessionStop);
+    REQUIRE(primed.ctx.is_session_stopped() == false);
+}
+
+SCENARIO("ISO15118-20 EV PowerDelivery transitions to AC_ChargeLoop on OK response for AC_BPT") {
+    const ev::feedback::Callbacks callbacks{};
+    const auto seed_ac_bpt = [](FsmStateHelper& helper) {
+        helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::AC_BPT);
+    };
+    PrimedState<ev::d20::state::PowerDelivery> primed{callbacks, seed_ac_bpt, Progress::Start};
+
+    primed.handle_response(make_pd_res(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == true);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::AC_ChargeLoop);
+    REQUIRE(primed.ctx.is_session_stopped() == false);
+}
+
+SCENARIO("ISO15118-20 EV PowerDelivery transitions to SessionStop on Stop for AC_BPT") {
+    const ev::feedback::Callbacks callbacks{};
+    const auto seed_ac_bpt = [](FsmStateHelper& helper) {
+        helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::AC_BPT);
+    };
+    PrimedState<ev::d20::state::PowerDelivery> primed{callbacks, seed_ac_bpt, Progress::Stop};
 
     primed.handle_response(make_pd_res(SESSION_HEADER, ResponseCode::OK));
     const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/schedule_exchange.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/schedule_exchange.cpp
@@ -51,6 +51,25 @@ SCENARIO("ISO15118-20 EV ScheduleExchange fires ev_power_ready and transitions t
     REQUIRE(primed.ctx.is_session_stopped() == false);
 }
 
+SCENARIO(
+    "ISO15118-20 EV ScheduleExchange fires ev_power_ready and transitions to DC_CableCheck on Finished for DC_BPT") {
+    bool ev_power_ready_fired = false;
+    ev::feedback::Callbacks callbacks{};
+    callbacks.ev_power_ready = [&ev_power_ready_fired]() { ev_power_ready_fired = true; };
+    const auto seed_dc_bpt = [](FsmStateHelper& helper) {
+        helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::DC_BPT);
+    };
+    PrimedState<ev::d20::state::ScheduleExchange> primed{callbacks, seed_dc_bpt};
+
+    primed.handle_response(make_response(SESSION_HEADER, ResponseCode::OK, Processing::Finished));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(ev_power_ready_fired == true);
+    REQUIRE(result.transitioned() == true);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::DC_CableCheck);
+    REQUIRE(primed.ctx.is_session_stopped() == false);
+}
+
 SCENARIO("ISO15118-20 EV ScheduleExchange fires ev_power_ready and transitions to PowerDelivery on Finished for AC") {
     bool ev_power_ready_fired = false;
     ev::feedback::Callbacks callbacks{};
@@ -59,6 +78,25 @@ SCENARIO("ISO15118-20 EV ScheduleExchange fires ev_power_ready and transitions t
         helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::AC);
     };
     PrimedState<ev::d20::state::ScheduleExchange> primed{callbacks, seed_ac};
+
+    primed.handle_response(make_response(SESSION_HEADER, ResponseCode::OK, Processing::Finished));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(ev_power_ready_fired == true);
+    REQUIRE(result.transitioned() == true);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::PowerDelivery);
+    REQUIRE(primed.ctx.is_session_stopped() == false);
+}
+
+SCENARIO(
+    "ISO15118-20 EV ScheduleExchange fires ev_power_ready and transitions to PowerDelivery on Finished for AC_BPT") {
+    bool ev_power_ready_fired = false;
+    ev::feedback::Callbacks callbacks{};
+    callbacks.ev_power_ready = [&ev_power_ready_fired]() { ev_power_ready_fired = true; };
+    const auto seed_ac_bpt = [](FsmStateHelper& helper) {
+        helper.get_context().set_selected_service(message_20::datatypes::ServiceCategory::AC_BPT);
+    };
+    PrimedState<ev::d20::state::ScheduleExchange> primed{callbacks, seed_ac_bpt};
 
     primed.handle_response(make_response(SESSION_HEADER, ResponseCode::OK, Processing::Finished));
     const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/service_selection.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/service_selection.cpp
@@ -23,9 +23,16 @@ message_20::ServiceSelectionResponse make_response(const message_20::Header& hea
 }
 
 const auto seed_ac = [](FsmStateHelper& helper) { helper.get_context().set_selected_service(ServiceCategory::AC); };
+const auto seed_ac_bpt = [](FsmStateHelper& helper) {
+    helper.get_context().set_selected_service(ServiceCategory::AC_BPT);
+};
 const auto seed_ac_der_iec = [](FsmStateHelper& helper) {
     helper.get_context().set_selected_service(ServiceCategory::AC_DER_IEC);
 };
+const auto seed_dc_bpt = [](FsmStateHelper& helper) {
+    helper.get_context().set_selected_service(ServiceCategory::DC_BPT);
+};
+const auto seed_wpt = [](FsmStateHelper& helper) { helper.get_context().set_selected_service(ServiceCategory::WPT); };
 } // namespace
 
 SCENARIO("ISO15118-20 EV ServiceSelection emits a DC ServiceSelectionRequest on enter") {
@@ -77,6 +84,54 @@ SCENARIO("ISO15118-20 EV ServiceSelection transitions to AC_ChargeParameterDisco
     REQUIRE(primed.ctx.selected_service() == ServiceCategory::AC);
 }
 
+SCENARIO("ISO15118-20 EV ServiceSelection emits an AC_BPT ServiceSelectionRequest on enter") {
+    const ev::feedback::Callbacks callbacks{};
+    PrimedState<ev::d20::state::ServiceSelection> primed{callbacks, seed_ac_bpt, uint16_t{5}};
+
+    const auto requests = primed.take_requests();
+    const auto request_message = requests.get<message_20::ServiceSelectionRequest>();
+    REQUIRE(request_message.has_value());
+    REQUIRE(request_message->selected_energy_transfer_service.service_id == ServiceCategory::AC_BPT);
+    REQUIRE(request_message->selected_energy_transfer_service.parameter_set_id == 5);
+}
+
+SCENARIO("ISO15118-20 EV ServiceSelection transitions to AC_ChargeParameterDiscovery on OK for AC_BPT") {
+    const ev::feedback::Callbacks callbacks{};
+    PrimedState<ev::d20::state::ServiceSelection> primed{callbacks, seed_ac_bpt, uint16_t{1}};
+
+    primed.handle_response(make_response(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == true);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::AC_ChargeParameterDiscovery);
+    REQUIRE(primed.ctx.is_session_stopped() == false);
+    REQUIRE(primed.ctx.selected_service() == ServiceCategory::AC_BPT);
+}
+
+SCENARIO("ISO15118-20 EV ServiceSelection emits a DC_BPT ServiceSelectionRequest on enter") {
+    const ev::feedback::Callbacks callbacks{};
+    PrimedState<ev::d20::state::ServiceSelection> primed{callbacks, seed_dc_bpt, uint16_t{7}};
+
+    const auto requests = primed.take_requests();
+    const auto request_message = requests.get<message_20::ServiceSelectionRequest>();
+    REQUIRE(request_message.has_value());
+    REQUIRE(request_message->selected_energy_transfer_service.service_id == ServiceCategory::DC_BPT);
+    REQUIRE(request_message->selected_energy_transfer_service.parameter_set_id == 7);
+}
+
+SCENARIO("ISO15118-20 EV ServiceSelection transitions to DC_ChargeParameterDiscovery on OK for DC_BPT") {
+    const ev::feedback::Callbacks callbacks{};
+    PrimedState<ev::d20::state::ServiceSelection> primed{callbacks, seed_dc_bpt, uint16_t{1}};
+
+    primed.handle_response(make_response(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == true);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::DC_ChargeParameterDiscovery);
+    REQUIRE(primed.ctx.is_session_stopped() == false);
+    REQUIRE(primed.ctx.selected_service() == ServiceCategory::DC_BPT);
+}
+
 SCENARIO("ISO15118-20 EV ServiceSelection emits an AC_DER_IEC ServiceSelectionRequest on enter") {
     const ev::feedback::Callbacks callbacks{};
     PrimedState<ev::d20::state::ServiceSelection> primed{callbacks, seed_ac_der_iec, uint16_t{5}};
@@ -99,6 +154,18 @@ SCENARIO("ISO15118-20 EV ServiceSelection transitions to AC_DER_IEC_ChargeParame
     REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::AC_DER_IEC_ChargeParameterDiscovery);
     REQUIRE(primed.ctx.is_session_stopped() == false);
     REQUIRE(primed.ctx.selected_service() == ServiceCategory::AC_DER_IEC);
+}
+
+SCENARIO("ISO15118-20 EV ServiceSelection stops the session on an unsupported service category") {
+    const ev::feedback::Callbacks callbacks{};
+    PrimedState<ev::d20::state::ServiceSelection> primed{callbacks, seed_wpt, uint16_t{1}};
+
+    primed.handle_response(make_response(SESSION_HEADER, ResponseCode::OK));
+    const auto result = primed.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == false);
+    REQUIRE(primed.fsm.get_current_state_id() == ev::d20::StateID::ServiceSelection);
+    REQUIRE(primed.ctx.is_session_stopped() == true);
 }
 
 SCENARIO("ISO15118-20 EV ServiceSelection rejects malformed responses") {

--- a/lib/everest/iso15118/test/iso15118/ev/session/integration_walk.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/session/integration_walk.cpp
@@ -95,6 +95,21 @@ constexpr float AC_MIN_CHARGE_POWER = 1000.0f;
 constexpr float AC_PRESENT_ACTIVE_POWER = 5000.0f;
 constexpr float AC_TARGET_ACTIVE_POWER = 7000.0f;
 
+// Discharge limits seeded for the AC_BPT walk; asserted on the AC_BPT CPD and
+// charge-loop requests.
+constexpr float AC_MAX_DISCHARGE_POWER = 15000.0f;
+constexpr float AC_MIN_DISCHARGE_POWER = 500.0f;
+
+// DC limits seeded into the DC_BPT fixture; charge fields drive the plain DC
+// request slice, discharge fields the BPT extension.
+constexpr float DC_MAX_CHARGE_POWER = 50000.0f;
+constexpr float DC_MAX_CHARGE_CURRENT = 125.0f;
+constexpr float DC_MAX_VOLTAGE = 900.0f;
+constexpr float DC_MIN_VOLTAGE = 200.0f;
+constexpr float DC_MAX_DISCHARGE_POWER = 30000.0f;
+constexpr float DC_MIN_DISCHARGE_POWER = 1000.0f;
+constexpr float DC_MAX_DISCHARGE_CURRENT = 80.0f;
+
 // A ServiceDetail parameter set carrying a named ControlMode, mirroring the SECC's
 // EXI encoding the EV honest-selects on. The ServiceDetail state requires a Dynamic
 // set to advance.
@@ -647,6 +662,370 @@ message_20::DER_AC_ChargeLoopResponse make_der_loop_res(const message_20::dataty
 }
 
 // Walk an AC_DER_IEC-configured ev::Session from start() up to the emitted
+ev::AcChargeParams ac_bpt_seed_params() {
+    auto p = ac_seed_params();
+    p.max_discharge_power = AC_MAX_DISCHARGE_POWER;
+    p.min_discharge_power = AC_MIN_DISCHARGE_POWER;
+    return p;
+}
+
+// DC charge params seeded with charge and discharge fields for the DC_BPT walk.
+// target_voltage matches the injected DC_PreChargeResponse present voltage so
+// precharge converges in one step, mirroring the plain-DC walk.
+ev::DcChargeParams dc_bpt_seed_params() {
+    ev::DcChargeParams p{};
+    p.max_charge_power = DC_MAX_CHARGE_POWER;
+    p.max_charge_current = DC_MAX_CHARGE_CURRENT;
+    p.max_voltage = DC_MAX_VOLTAGE;
+    p.min_voltage = DC_MIN_VOLTAGE;
+    p.max_discharge_power = DC_MAX_DISCHARGE_POWER;
+    p.min_discharge_power = DC_MIN_DISCHARGE_POWER;
+    p.max_discharge_current = DC_MAX_DISCHARGE_CURRENT;
+    p.target_voltage = 400.0f;
+    return p;
+}
+
+// Walk an AC_BPT-configured ev::Session from start() through the first BPT AC_ChargeLoop
+// request. Service id 5 routes through AC parameter-discovery and charge-loop states with
+// the BPT request variants, past the DC-only path exactly like plain AC:
+// ScheduleExchange -> PowerDelivery(Start) -> AC_ChargeLoop (BPT). Returns the session id.
+message_20::datatypes::SessionId walk_to_ac_bpt_charge_loop(SessionFixture& fx) {
+    const auto sid = WALK_SESSION_ID;
+    using SC = message_20::datatypes::ServiceCategory;
+
+    fx.session.start();
+    REQUIRE(run_reactor_until(
+        fx.reactor, [&]() { return fx.captured.size() >= 1; }, 1s));
+    REQUIRE(decode_frame(fx.captured.back()).get_if<message_20::SupportedAppProtocolRequest>() != nullptr);
+
+    inject_then_expect<message_20::SessionSetupRequest>(
+        fx, "SAP -> SessionSetup",
+        message_20::SupportedAppProtocolResponse{
+            message_20::SupportedAppProtocolResponse::ResponseCode::OK_SuccessfulNegotiation, 1},
+        PT::SAP);
+
+    message_20::SessionSetupResponse setup_res{};
+    setup_res.response_code = ResponseCode::OK_NewSessionEstablished;
+    setup_res.header.session_id = sid;
+    setup_res.evseid = "DE*PNX*E12345";
+    inject_then_expect<message_20::AuthorizationSetupRequest>(fx, "SessionSetup -> AuthorizationSetup", setup_res,
+                                                              PT::Part20Main);
+
+    message_20::AuthorizationSetupResponse auth_setup_res{};
+    auth_setup_res.header.session_id = sid;
+    auth_setup_res.response_code = ResponseCode::OK;
+    auth_setup_res.authorization_services = {message_20::datatypes::Authorization::EIM};
+    auth_setup_res.certificate_installation_service = false;
+    auth_setup_res.authorization_mode = message_20::datatypes::EIM_ASResAuthorizationMode{};
+    inject_then_expect<message_20::AuthorizationRequest>(fx, "AuthorizationSetup -> Authorization", auth_setup_res,
+                                                         PT::Part20Main);
+
+    message_20::AuthorizationResponse auth_res{};
+    auth_res.header.session_id = sid;
+    auth_res.response_code = ResponseCode::OK;
+    auth_res.evse_processing = Processing::Finished;
+    inject_then_expect<message_20::ServiceDiscoveryRequest>(fx, "Authorization -> ServiceDiscovery", auth_res,
+                                                            PT::Part20Main);
+
+    // ServiceDiscoveryResponse offering the AC_BPT service (id 5) -> ServiceDetailRequest.
+    message_20::ServiceDiscoveryResponse discovery_res{};
+    discovery_res.header.session_id = sid;
+    discovery_res.response_code = ResponseCode::OK;
+    discovery_res.energy_transfer_service_list = {{SC::AC_BPT, false}};
+    {
+        const auto req = inject_then_expect<message_20::ServiceDetailRequest>(fx, "ServiceDiscovery -> ServiceDetail",
+                                                                              discovery_res, PT::Part20Main);
+        REQUIRE(req.service == message_20::to_underlying_value(SC::AC_BPT));
+    }
+
+    // ServiceDetailResponse with a Dynamic parameter set -> ServiceSelectionRequest.
+    message_20::ServiceDetailResponse detail_res{};
+    detail_res.header.session_id = sid;
+    detail_res.response_code = ResponseCode::OK;
+    detail_res.service = message_20::to_underlying_value(SC::AC_BPT);
+    detail_res.service_parameter_list = {make_param_set(5, ControlMode::Dynamic)};
+    {
+        const auto req = inject_then_expect<message_20::ServiceSelectionRequest>(
+            fx, "ServiceDetail -> ServiceSelection", detail_res, PT::Part20Main);
+        REQUIRE(req.selected_energy_transfer_service.service_id == SC::AC_BPT);
+        REQUIRE(req.selected_energy_transfer_service.parameter_set_id == 5);
+    }
+
+    // ServiceSelectionResponse(OK) -> AC_ChargeParameterDiscoveryRequest carrying the BPT
+    // request variant with the seeded charge and discharge limits.
+    message_20::ServiceSelectionResponse selection_res{};
+    selection_res.header.session_id = sid;
+    selection_res.response_code = ResponseCode::OK;
+    {
+        const auto req = inject_then_expect<message_20::AC_ChargeParameterDiscoveryRequest>(
+            fx, "ServiceSelection -> AC_ChargeParameterDiscovery", selection_res, PT::Part20Main);
+        REQUIRE(req.header.session_id == sid);
+        const auto* mode = std::get_if<message_20::datatypes::BPT_AC_CPDReqEnergyTransferMode>(&req.transfer_mode);
+        REQUIRE(mode != nullptr);
+        REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_charge_power) ==
+                Catch::Approx(AC_MAX_CHARGE_POWER));
+        REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_discharge_power) ==
+                Catch::Approx(AC_MAX_DISCHARGE_POWER));
+        REQUIRE(message_20::datatypes::from_RationalNumber(mode->min_discharge_power) ==
+                Catch::Approx(AC_MIN_DISCHARGE_POWER));
+    }
+
+    // BPT AC_ChargeParameterDiscoveryResponse(OK) -> ScheduleExchangeRequest; fires ac_bpt_limits.
+    REQUIRE_FALSE(fx.ac_bpt_limits);
+    message_20::AC_ChargeParameterDiscoveryResponse cpd_res{};
+    cpd_res.header.session_id = sid;
+    cpd_res.response_code = ResponseCode::OK;
+    {
+        message_20::datatypes::BPT_AC_CPDResEnergyTransferMode mode{};
+        mode.max_charge_power = message_20::datatypes::from_float(AC_MAX_CHARGE_POWER);
+        mode.min_charge_power = message_20::datatypes::from_float(AC_MIN_CHARGE_POWER);
+        mode.nominal_frequency = message_20::datatypes::from_float(50.0f);
+        mode.max_discharge_power = message_20::datatypes::from_float(AC_MAX_DISCHARGE_POWER);
+        mode.min_discharge_power = message_20::datatypes::from_float(AC_MIN_DISCHARGE_POWER);
+        cpd_res.transfer_mode = mode;
+    }
+    {
+        const auto req = inject_then_expect<message_20::ScheduleExchangeRequest>(
+            fx, "AC_ChargeParameterDiscovery -> ScheduleExchange", cpd_res, PT::Part20AC);
+        REQUIRE(req.header.session_id == sid);
+    }
+    REQUIRE(fx.ac_bpt_limits);
+    REQUIRE_FALSE(fx.ac_limits);
+
+    // ScheduleExchangeResponse(OK, Finished) -> PowerDeliveryRequest(Start); the Start
+    // progress (not a DC_CableCheckRequest) is the AC routing assertion.
+    message_20::ScheduleExchangeResponse schedule_res{};
+    schedule_res.header.session_id = sid;
+    schedule_res.response_code = ResponseCode::OK;
+    schedule_res.processing = Processing::Finished;
+    {
+        const auto req = inject_then_expect<message_20::PowerDeliveryRequest>(
+            fx, "ScheduleExchange -> PowerDelivery(Start)", schedule_res, PT::Part20Main);
+        REQUIRE(req.charge_progress == message_20::datatypes::Progress::Start);
+    }
+
+    // PowerDeliveryResponse(OK) -> AC_ChargeLoopRequest carrying the BPT Dynamic control mode.
+    message_20::PowerDeliveryResponse power_delivery_res{};
+    power_delivery_res.header.session_id = sid;
+    power_delivery_res.response_code = ResponseCode::OK;
+    {
+        const auto req = inject_then_expect<message_20::AC_ChargeLoopRequest>(fx, "PowerDelivery -> AC_ChargeLoop",
+                                                                              power_delivery_res, PT::Part20Main);
+        REQUIRE(req.header.session_id == sid);
+        const auto* mode = std::get_if<message_20::datatypes::BPT_Dynamic_AC_CLReqControlMode>(&req.control_mode);
+        REQUIRE(mode != nullptr);
+        REQUIRE(message_20::datatypes::from_RationalNumber(mode->present_active_power) ==
+                Catch::Approx(AC_PRESENT_ACTIVE_POWER));
+        REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_discharge_power) ==
+                Catch::Approx(AC_MAX_DISCHARGE_POWER));
+    }
+
+    return sid;
+}
+
+// A BPT AC_ChargeLoopResponse carrying a BPT Dynamic control mode with a target set so the
+// ac_target_power feedback (reading the base Dynamic slice) is meaningful.
+message_20::AC_ChargeLoopResponse make_ac_bpt_loop_res(const message_20::datatypes::SessionId& sid) {
+    message_20::AC_ChargeLoopResponse res{};
+    res.header.session_id = sid;
+    res.response_code = ResponseCode::OK;
+    message_20::datatypes::BPT_Dynamic_AC_CLResControlMode mode{};
+    mode.target_active_power = message_20::datatypes::from_float(AC_TARGET_ACTIVE_POWER);
+    res.control_mode = mode;
+    return res;
+}
+
+// Walk a DC_BPT-configured ev::Session from start() through the first BPT DC_ChargeLoop
+// request. Service id 6 uses the BPT request variants for parameter discovery and the
+// charge loop; cable-check and precharge stay the plain DC requests: ScheduleExchange ->
+// DC_CableCheck -> DC_PreCharge -> PowerDelivery(Start) -> DC_ChargeLoop (BPT).
+message_20::datatypes::SessionId walk_to_dc_bpt_charge_loop(SessionFixture& fx) {
+    const auto sid = WALK_SESSION_ID;
+    using SC = message_20::datatypes::ServiceCategory;
+
+    fx.session.start();
+    REQUIRE(run_reactor_until(
+        fx.reactor, [&]() { return fx.captured.size() >= 1; }, 1s));
+    REQUIRE(decode_frame(fx.captured.back()).get_if<message_20::SupportedAppProtocolRequest>() != nullptr);
+
+    inject_then_expect<message_20::SessionSetupRequest>(
+        fx, "SAP -> SessionSetup",
+        message_20::SupportedAppProtocolResponse{
+            message_20::SupportedAppProtocolResponse::ResponseCode::OK_SuccessfulNegotiation, 1},
+        PT::SAP);
+
+    message_20::SessionSetupResponse setup_res{};
+    setup_res.response_code = ResponseCode::OK_NewSessionEstablished;
+    setup_res.header.session_id = sid;
+    setup_res.evseid = "DE*PNX*E12345";
+    inject_then_expect<message_20::AuthorizationSetupRequest>(fx, "SessionSetup -> AuthorizationSetup", setup_res,
+                                                              PT::Part20Main);
+
+    message_20::AuthorizationSetupResponse auth_setup_res{};
+    auth_setup_res.header.session_id = sid;
+    auth_setup_res.response_code = ResponseCode::OK;
+    auth_setup_res.authorization_services = {message_20::datatypes::Authorization::EIM};
+    auth_setup_res.certificate_installation_service = false;
+    auth_setup_res.authorization_mode = message_20::datatypes::EIM_ASResAuthorizationMode{};
+    inject_then_expect<message_20::AuthorizationRequest>(fx, "AuthorizationSetup -> Authorization", auth_setup_res,
+                                                         PT::Part20Main);
+
+    message_20::AuthorizationResponse auth_res{};
+    auth_res.header.session_id = sid;
+    auth_res.response_code = ResponseCode::OK;
+    auth_res.evse_processing = Processing::Finished;
+    inject_then_expect<message_20::ServiceDiscoveryRequest>(fx, "Authorization -> ServiceDiscovery", auth_res,
+                                                            PT::Part20Main);
+
+    // ServiceDiscoveryResponse offering the DC_BPT service (id 6) -> ServiceDetailRequest.
+    message_20::ServiceDiscoveryResponse discovery_res{};
+    discovery_res.header.session_id = sid;
+    discovery_res.response_code = ResponseCode::OK;
+    discovery_res.energy_transfer_service_list = {{SC::DC_BPT, false}};
+    {
+        const auto req = inject_then_expect<message_20::ServiceDetailRequest>(fx, "ServiceDiscovery -> ServiceDetail",
+                                                                              discovery_res, PT::Part20Main);
+        REQUIRE(req.service == message_20::to_underlying_value(SC::DC_BPT));
+    }
+
+    // ServiceDetailResponse with a Dynamic parameter set -> ServiceSelectionRequest.
+    message_20::ServiceDetailResponse detail_res{};
+    detail_res.header.session_id = sid;
+    detail_res.response_code = ResponseCode::OK;
+    detail_res.service = message_20::to_underlying_value(SC::DC_BPT);
+    detail_res.service_parameter_list = {make_param_set(6, ControlMode::Dynamic)};
+    {
+        const auto req = inject_then_expect<message_20::ServiceSelectionRequest>(
+            fx, "ServiceDetail -> ServiceSelection", detail_res, PT::Part20Main);
+        REQUIRE(req.selected_energy_transfer_service.service_id == SC::DC_BPT);
+        REQUIRE(req.selected_energy_transfer_service.parameter_set_id == 6);
+    }
+
+    // ServiceSelectionResponse(OK) -> DC_ChargeParameterDiscoveryRequest carrying the BPT
+    // request variant with the seeded charge and discharge limits.
+    message_20::ServiceSelectionResponse selection_res{};
+    selection_res.header.session_id = sid;
+    selection_res.response_code = ResponseCode::OK;
+    {
+        const auto req = inject_then_expect<message_20::DC_ChargeParameterDiscoveryRequest>(
+            fx, "ServiceSelection -> DC_ChargeParameterDiscovery", selection_res, PT::Part20Main);
+        REQUIRE(req.header.session_id == sid);
+        const auto* mode = std::get_if<message_20::datatypes::BPT_DC_CPDReqEnergyTransferMode>(&req.transfer_mode);
+        REQUIRE(mode != nullptr);
+        REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_charge_power) ==
+                Catch::Approx(DC_MAX_CHARGE_POWER));
+        REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_charge_current) ==
+                Catch::Approx(DC_MAX_CHARGE_CURRENT));
+        REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_voltage) == Catch::Approx(DC_MAX_VOLTAGE));
+        REQUIRE(message_20::datatypes::from_RationalNumber(mode->min_voltage) == Catch::Approx(DC_MIN_VOLTAGE));
+        REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_discharge_power) ==
+                Catch::Approx(DC_MAX_DISCHARGE_POWER));
+        REQUIRE(message_20::datatypes::from_RationalNumber(mode->min_discharge_power) ==
+                Catch::Approx(DC_MIN_DISCHARGE_POWER));
+        REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_discharge_current) ==
+                Catch::Approx(DC_MAX_DISCHARGE_CURRENT));
+    }
+
+    // BPT DC_ChargeParameterDiscoveryResponse(OK) -> ScheduleExchangeRequest; fires dc_bpt_limits.
+    REQUIRE_FALSE(fx.dc_bpt_limits);
+    message_20::DC_ChargeParameterDiscoveryResponse cpd_res{};
+    cpd_res.header.session_id = sid;
+    cpd_res.response_code = ResponseCode::OK;
+    {
+        message_20::datatypes::BPT_DC_CPDResEnergyTransferMode mode{};
+        mode.max_charge_power = message_20::datatypes::from_float(DC_MAX_CHARGE_POWER);
+        mode.min_charge_power = message_20::datatypes::from_float(0.0f);
+        mode.max_charge_current = message_20::datatypes::from_float(DC_MAX_CHARGE_CURRENT);
+        mode.min_charge_current = message_20::datatypes::from_float(0.0f);
+        mode.max_voltage = message_20::datatypes::from_float(DC_MAX_VOLTAGE);
+        mode.min_voltage = message_20::datatypes::from_float(DC_MIN_VOLTAGE);
+        mode.max_discharge_power = message_20::datatypes::from_float(DC_MAX_DISCHARGE_POWER);
+        mode.min_discharge_power = message_20::datatypes::from_float(DC_MIN_DISCHARGE_POWER);
+        mode.max_discharge_current = message_20::datatypes::from_float(DC_MAX_DISCHARGE_CURRENT);
+        mode.min_discharge_current = message_20::datatypes::from_float(0.0f);
+        cpd_res.transfer_mode = mode;
+    }
+    {
+        const auto req = inject_then_expect<message_20::ScheduleExchangeRequest>(
+            fx, "DC_ChargeParameterDiscovery -> ScheduleExchange", cpd_res, PT::Part20DC);
+        REQUIRE(req.header.session_id == sid);
+    }
+    REQUIRE(fx.dc_bpt_limits);
+    REQUIRE_FALSE(fx.ac_bpt_limits);
+
+    // ScheduleExchangeResponse(OK, Finished) -> DC_CableCheckRequest.
+    message_20::ScheduleExchangeResponse schedule_res{};
+    schedule_res.header.session_id = sid;
+    schedule_res.response_code = ResponseCode::OK;
+    schedule_res.processing = Processing::Finished;
+    {
+        const auto req = inject_then_expect<message_20::DC_CableCheckRequest>(fx, "ScheduleExchange -> DC_CableCheck",
+                                                                              schedule_res, PT::Part20Main);
+        REQUIRE(req.header.session_id == sid);
+    }
+
+    // DC_CableCheckResponse(OK, Finished) -> DC_PreChargeRequest(Ongoing).
+    message_20::DC_CableCheckResponse cable_check_res{};
+    cable_check_res.header.session_id = sid;
+    cable_check_res.response_code = ResponseCode::OK;
+    cable_check_res.processing = Processing::Finished;
+    {
+        const auto req = inject_then_expect<message_20::DC_PreChargeRequest>(fx, "DC_CableCheck -> DC_PreCharge",
+                                                                             cable_check_res, PT::Part20DC);
+        REQUIRE(req.header.session_id == sid);
+        REQUIRE(req.processing == Processing::Ongoing);
+    }
+
+    // DC_PreChargeResponse(OK, in-tolerance) -> PowerDeliveryRequest(Start).
+    message_20::DC_PreChargeResponse pre_charge_res{};
+    pre_charge_res.header.session_id = sid;
+    pre_charge_res.response_code = ResponseCode::OK;
+    pre_charge_res.present_voltage = message_20::datatypes::from_float(400.0f);
+    {
+        const auto req = inject_then_expect<message_20::PowerDeliveryRequest>(
+            fx, "DC_PreCharge -> PowerDelivery(Start)", pre_charge_res, PT::Part20DC);
+        REQUIRE(req.header.session_id == sid);
+        REQUIRE(req.charge_progress == message_20::datatypes::Progress::Start);
+    }
+
+    // PowerDeliveryResponse(OK) -> DC_ChargeLoopRequest carrying the BPT Dynamic control mode.
+    message_20::PowerDeliveryResponse power_delivery_res{};
+    power_delivery_res.header.session_id = sid;
+    power_delivery_res.response_code = ResponseCode::OK;
+    {
+        const auto req = inject_then_expect<message_20::DC_ChargeLoopRequest>(fx, "PowerDelivery -> DC_ChargeLoop",
+                                                                              power_delivery_res, PT::Part20Main);
+        REQUIRE(req.header.session_id == sid);
+        const auto* mode = std::get_if<message_20::datatypes::BPT_Dynamic_DC_CLReqControlMode>(&req.control_mode);
+        REQUIRE(mode != nullptr);
+        REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_discharge_power) ==
+                Catch::Approx(DC_MAX_DISCHARGE_POWER));
+        REQUIRE(message_20::datatypes::from_RationalNumber(mode->max_discharge_current) ==
+                Catch::Approx(DC_MAX_DISCHARGE_CURRENT));
+    }
+
+    return sid;
+}
+
+// A BPT DC_ChargeLoopResponse carrying a BPT Dynamic control mode. The DC loop fires no
+// per-response feedback; the variant match is what advances the walk.
+message_20::DC_ChargeLoopResponse make_dc_bpt_loop_res(const message_20::datatypes::SessionId& sid) {
+    message_20::DC_ChargeLoopResponse res{};
+    res.header.session_id = sid;
+    res.response_code = ResponseCode::OK;
+    message_20::datatypes::BPT_Dynamic_DC_CLResControlMode mode{};
+    mode.max_charge_power = message_20::datatypes::from_float(DC_MAX_CHARGE_POWER);
+    mode.min_charge_power = message_20::datatypes::from_float(0.0f);
+    mode.max_charge_current = message_20::datatypes::from_float(DC_MAX_CHARGE_CURRENT);
+    mode.max_voltage = message_20::datatypes::from_float(DC_MAX_VOLTAGE);
+    mode.min_voltage = message_20::datatypes::from_float(DC_MIN_VOLTAGE);
+    mode.max_discharge_power = message_20::datatypes::from_float(DC_MAX_DISCHARGE_POWER);
+    mode.min_discharge_power = message_20::datatypes::from_float(DC_MIN_DISCHARGE_POWER);
+    mode.max_discharge_current = message_20::datatypes::from_float(DC_MAX_DISCHARGE_CURRENT);
+    res.control_mode = mode;
+    return res;
+}
+
 // ServiceDetailRequest, so a scenario can then inject a tailored ServiceDetailResponse.
 message_20::datatypes::SessionId walk_to_ac_der_iec_service_detail(SessionFixture& fx) {
     const auto sid = WALK_SESSION_ID;
@@ -949,6 +1328,87 @@ SCENARIO("ISO15118-20 EV Session stops cleanly when the only AC_DER_IEC set dema
                 REQUIRE(fx.session.is_finished());
                 REQUIRE_FALSE(fx.timed_out);
                 REQUIRE(fx.captured.size() == before);
+            }
+        }
+    }
+}
+
+SCENARIO("ISO15118-20 EV Session drives a full AC_BPT session through the BPT charge loop to SessionStop") {
+
+    GIVEN("An AC_BPT-configured Session bound to a reactor with short send-delay and watchdog timers") {
+        SessionFixture fx{"EVTESTID01",
+                       ev::SessionTiming{5ms, 100ms},
+                       ev::DcChargeParams{},
+                       default_advertised_ac_app_protocols(),
+                       message_20::datatypes::ServiceCategory::AC_BPT,
+                       ac_bpt_seed_params()};
+
+        WHEN("the session is walked to an active BPT AC_ChargeLoop and the SECC then signals Terminate") {
+            const auto sid = walk_to_ac_bpt_charge_loop(fx);
+
+            REQUIRE(fx.captured.size() == 11);
+            REQUIRE_FALSE(fx.session.is_finished());
+            REQUIRE_FALSE(fx.timed_out);
+
+            // BPT AC_ChargeLoopResponse(OK, Dynamic target) -> AC_ChargeLoopRequest; fires ac_target_power.
+            REQUIRE_FALSE(fx.ac_target_power);
+            inject_then_expect<message_20::AC_ChargeLoopRequest>(fx, "AC_ChargeLoop OK -> AC_ChargeLoop",
+                                                                 make_ac_bpt_loop_res(sid), PT::Part20AC);
+            REQUIRE(fx.ac_target_power);
+            REQUIRE_FALSE(fx.stop_from_charger);
+
+            // BPT AC_ChargeLoopResponse(OK, Terminate) -> PowerDeliveryRequest(Stop); fires stop_from_charger.
+            auto loop_terminate = make_ac_bpt_loop_res(sid);
+            loop_terminate.status =
+                message_20::datatypes::EvseStatus{0, message_20::datatypes::EvseNotification::Terminate};
+            {
+                const auto req = inject_then_expect<message_20::PowerDeliveryRequest>(
+                    fx, "AC_ChargeLoop Terminate -> PowerDelivery(Stop)", loop_terminate, PT::Part20AC);
+                REQUIRE(req.charge_progress == message_20::datatypes::Progress::Stop);
+            }
+            REQUIRE(fx.stop_from_charger);
+
+            THEN("PowerDelivery(Stop) walks straight to SessionStop, skipping WeldingDetection") {
+                walk_ac_stop_to_finish(fx, sid);
+                REQUIRE(fx.stop_from_charger);
+            }
+        }
+    }
+}
+
+SCENARIO("ISO15118-20 EV Session drives a full DC_BPT session through the BPT charge loop to SessionStop") {
+
+    GIVEN("A DC_BPT-configured Session bound to a reactor with short send-delay and watchdog timers") {
+        SessionFixture fx{"EVTESTID01", ev::SessionTiming{5ms, 100ms}, dc_bpt_seed_params(),
+                       default_advertised_app_protocols(), message_20::datatypes::ServiceCategory::DC_BPT};
+
+        WHEN("the session is walked to an active BPT DC_ChargeLoop and the SECC then signals Terminate") {
+            const auto sid = walk_to_dc_bpt_charge_loop(fx);
+
+            REQUIRE(fx.captured.size() == 13);
+            REQUIRE_FALSE(fx.session.is_finished());
+            REQUIRE_FALSE(fx.timed_out);
+
+            // BPT DC_ChargeLoopResponse(OK, no Terminate) -> DC_ChargeLoopRequest (loop continues).
+            REQUIRE_FALSE(fx.stop_from_charger);
+            inject_then_expect<message_20::DC_ChargeLoopRequest>(fx, "DC_ChargeLoop OK -> DC_ChargeLoop",
+                                                                 make_dc_bpt_loop_res(sid), PT::Part20DC);
+            REQUIRE_FALSE(fx.stop_from_charger);
+
+            // BPT DC_ChargeLoopResponse(OK, Terminate) -> PowerDeliveryRequest(Stop); fires stop_from_charger.
+            auto loop_terminate = make_dc_bpt_loop_res(sid);
+            loop_terminate.status =
+                message_20::datatypes::EvseStatus{0, message_20::datatypes::EvseNotification::Terminate};
+            {
+                const auto req = inject_then_expect<message_20::PowerDeliveryRequest>(
+                    fx, "DC_ChargeLoop Terminate -> PowerDelivery(Stop)", loop_terminate, PT::Part20DC);
+                REQUIRE(req.charge_progress == message_20::datatypes::Progress::Stop);
+            }
+            REQUIRE(fx.stop_from_charger);
+
+            THEN("PowerDelivery(Stop) walks through DC_WeldingDetection to a clean SessionStop") {
+                walk_stop_to_finish(fx, sid);
+                REQUIRE(fx.stop_from_charger);
             }
         }
     }

--- a/lib/everest/iso15118/test/iso15118/ev/session/integration_walk.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/session/integration_walk.cpp
@@ -1337,11 +1337,11 @@ SCENARIO("ISO15118-20 EV Session drives a full AC_BPT session through the BPT ch
 
     GIVEN("An AC_BPT-configured Session bound to a reactor with short send-delay and watchdog timers") {
         SessionFixture fx{"EVTESTID01",
-                       ev::SessionTiming{5ms, 100ms},
-                       ev::DcChargeParams{},
-                       default_advertised_ac_app_protocols(),
-                       message_20::datatypes::ServiceCategory::AC_BPT,
-                       ac_bpt_seed_params()};
+                          ev::SessionTiming{5ms, 100ms},
+                          ev::DcChargeParams{},
+                          default_advertised_ac_app_protocols(),
+                          message_20::datatypes::ServiceCategory::AC_BPT,
+                          ac_bpt_seed_params()};
 
         WHEN("the session is walked to an active BPT AC_ChargeLoop and the SECC then signals Terminate") {
             const auto sid = walk_to_ac_bpt_charge_loop(fx);
@@ -1380,7 +1380,7 @@ SCENARIO("ISO15118-20 EV Session drives a full DC_BPT session through the BPT ch
 
     GIVEN("A DC_BPT-configured Session bound to a reactor with short send-delay and watchdog timers") {
         SessionFixture fx{"EVTESTID01", ev::SessionTiming{5ms, 100ms}, dc_bpt_seed_params(),
-                       default_advertised_app_protocols(), message_20::datatypes::ServiceCategory::DC_BPT};
+                          default_advertised_app_protocols(), message_20::datatypes::ServiceCategory::DC_BPT};
 
         WHEN("the session is walked to an active BPT DC_ChargeLoop and the SECC then signals Terminate") {
             const auto sid = walk_to_dc_bpt_charge_loop(fx);

--- a/lib/everest/iso15118/test/iso15118/ev/session/test_support.hpp
+++ b/lib/everest/iso15118/test/iso15118/ev/session/test_support.hpp
@@ -137,6 +137,8 @@ public:
     bool dc_power_on = false;
     bool stop_from_charger = false;
     bool ac_limits = false;
+    bool ac_bpt_limits = false;
+    bool dc_bpt_limits = false;
     bool ac_target_power = false;
     bool der_control = false;
 
@@ -169,6 +171,12 @@ private:
         cb.dc_power_on = [this]() { dc_power_on = true; };
         cb.stop_from_charger = [this]() { stop_from_charger = true; };
         cb.ac_limits = [this](const message_20::datatypes::AC_CPDResEnergyTransferMode&) { ac_limits = true; };
+        cb.ac_bpt_limits = [this](const message_20::datatypes::BPT_AC_CPDResEnergyTransferMode&) {
+            ac_bpt_limits = true;
+        };
+        cb.dc_bpt_limits = [this](const message_20::datatypes::BPT_DC_CPDResEnergyTransferMode&) {
+            dc_bpt_limits = true;
+        };
         cb.ac_target_power = [this](const message_20::datatypes::Dynamic_AC_CLResControlMode&) {
             ac_target_power = true;
         };

--- a/modules/EV/EvIso15118D20/EvIso15118D20.hpp
+++ b/modules/EV/EvIso15118D20/EvIso15118D20.hpp
@@ -38,6 +38,11 @@ struct Conf {
     bool der_over_voltage_fault_ride_through_mode;
     bool der_under_voltage_fault_ride_through_mode;
     bool der_stop_on_unsupported_functions;
+    double ac_max_discharge_power_w;
+    double ac_min_discharge_power_w;
+    double dc_max_discharge_power_w;
+    double dc_min_discharge_power_w;
+    double dc_max_discharge_current_a;
 };
 
 class EvIso15118D20 : public Everest::ModuleBase {

--- a/modules/EV/EvIso15118D20/docs/index.rst
+++ b/modules/EV/EvIso15118D20/docs/index.rst
@@ -13,6 +13,13 @@ identification means (EIM) authorization. The AC DER IEC service is also
 negotiated (assuming a three-phase inverter relay); received DER directives are
 logged only, as ``ISO15118_ev`` has no DER variable to publish them on.
 
+Bidirectional power transfer (BPT) is negotiated for both AC_BPT and DC_BPT in
+Dynamic control mode. The advertised discharge limits come from the ``*_discharge_*``
+config knobs; ``set_bpt_dc_params`` overrides the DC discharge power and current at
+runtime. AC_BPT assumes a three-phase inverter relay. Reverse power flow itself is
+driven entirely by the SECC's target-power directives; the EVSE's advertised
+discharge limits are logged for visibility.
+
 Configuration
 -------------
 
@@ -78,6 +85,21 @@ Configuration
    * - ``der_stop_on_unsupported_functions``
      - ``true``
      - Stop the session if no AC_DER_IEC parameter set fits the supported DER functions.
+   * - ``ac_max_discharge_power_w``
+     - ``11040``
+     - Advertised AC maximum discharge power in watts (BPT).
+   * - ``ac_min_discharge_power_w``
+     - ``1380``
+     - Advertised AC minimum discharge power in watts (BPT).
+   * - ``dc_max_discharge_power_w``
+     - ``150000``
+     - Advertised DC maximum discharge power in watts (BPT).
+   * - ``dc_min_discharge_power_w``
+     - ``0``
+     - Advertised DC minimum discharge power in watts (BPT).
+   * - ``dc_max_discharge_current_a``
+     - ``300``
+     - Advertised DC maximum discharge current in amperes (BPT).
 
 DER control function negotiation
 --------------------------------
@@ -101,16 +123,18 @@ Limitations
 
 The implementation has a deliberately narrow scope:
 
-- **DC and AC only.** ``start_charging`` accepts DC, AC single/three-phase, and
-  AC DER IEC energy-transfer modes; WPT and MCS sessions are not supported.
+- **DC and AC only.** ``start_charging`` accepts DC, DC BPT, AC single/three-phase,
+  AC BPT, and AC DER IEC energy-transfer modes; WPT and MCS sessions are not
+  supported.
 - **DER directives are log-only.** AC DER IEC directives (target active power,
   DSO Q and cos phi setpoints) are logged, not published, pending an interface
   variable. The three-phase inverter relay use case is assumed.
 - **No TLS.** The session advertises ``NO_TRANSPORT_SECURITY``; Plug & Charge and
   TLS are out of scope.
 - **No pause/resume.** ``pause_charging`` is a no-op.
-- **No BPT / SAE.** Bidirectional power transfer (``set_bpt_dc_params``) and
-  SAE J2847/2 (``enable_sae_j2847_v2g_v2h``) are not implemented.
+- **Dynamic BPT only.** BPT is negotiated in Dynamic control mode; reverse power
+  flow follows SECC targets. SAE J2847/2 (``enable_sae_j2847_v2g_v2h``) is not
+  implemented.
 
 Threading
 ---------

--- a/modules/EV/EvIso15118D20/docs/index.rst
+++ b/modules/EV/EvIso15118D20/docs/index.rst
@@ -42,10 +42,12 @@ Configuration
      - Response watchdog timeout in milliseconds.
    * - ``ac_max_charge_power_w``
      - ``11040``
-     - Advertised AC maximum charge power in watts.
+     - Advertised AC maximum charge power in watts, as a three-phase total. The
+       default is 16 A x 230 V x 3.
    * - ``ac_min_charge_power_w``
-     - ``1380``
-     - Advertised AC minimum charge power in watts.
+     - ``4140``
+     - Advertised AC minimum charge power in watts, as a three-phase total. The
+       default is 6 A x 230 V x 3.
    * - ``der_over_frequency_watt_mode``
      - ``false``
      - Declare support for the IEC OverFrequencyWattMode DER control function.
@@ -87,10 +89,12 @@ Configuration
      - Stop the session if no AC_DER_IEC parameter set fits the supported DER functions.
    * - ``ac_max_discharge_power_w``
      - ``11040``
-     - Advertised AC maximum discharge power in watts (BPT).
+     - Advertised AC maximum discharge power in watts (BPT), as a three-phase
+       total. The default is 16 A x 230 V x 3.
    * - ``ac_min_discharge_power_w``
-     - ``1380``
-     - Advertised AC minimum discharge power in watts (BPT).
+     - ``4140``
+     - Advertised AC minimum discharge power in watts (BPT), as a three-phase
+       total. The default is 6 A x 230 V x 3.
    * - ``dc_max_discharge_power_w``
      - ``150000``
      - Advertised DC maximum discharge power in watts (BPT).

--- a/modules/EV/EvIso15118D20/ev/ISO15118_evImpl.cpp
+++ b/modules/EV/EvIso15118D20/ev/ISO15118_evImpl.cpp
@@ -256,33 +256,26 @@ bool ISO15118_evImpl::handle_start_charging(types::iso15118::EnergyTransferMode&
     EVLOG_info << "EvIso15118D20: start_charging requested (negotiation arguments ignored)";
 
     auto energy_service = iso15118::message_20::datatypes::ServiceCategory::DC;
-    bool three_phase = false;
     switch (EnergyTransferMode) {
     case types::iso15118::EnergyTransferMode::DC:
     case types::iso15118::EnergyTransferMode::DC_core:
     case types::iso15118::EnergyTransferMode::DC_extended:
         energy_service = iso15118::message_20::datatypes::ServiceCategory::DC;
         break;
+    // The advertised AC power limits are three-phase totals either way, so the
+    // single-phase and three-phase modes select the same service.
     case types::iso15118::EnergyTransferMode::AC_single_phase_core:
-        energy_service = iso15118::message_20::datatypes::ServiceCategory::AC;
-        three_phase = false;
-        break;
     case types::iso15118::EnergyTransferMode::AC_three_phase_core:
         energy_service = iso15118::message_20::datatypes::ServiceCategory::AC;
-        three_phase = true;
         break;
     case types::iso15118::EnergyTransferMode::AC_BPT:
-        // AC_BPT carries no phase count; assume a three-phase inverter relay
         energy_service = iso15118::message_20::datatypes::ServiceCategory::AC_BPT;
-        three_phase = true;
         break;
     case types::iso15118::EnergyTransferMode::DC_BPT:
         energy_service = iso15118::message_20::datatypes::ServiceCategory::DC_BPT;
         break;
     case types::iso15118::EnergyTransferMode::AC_DER_IEC:
-        // AC_DER_IEC carries no phase count; assume a three-phase inverter relay
         energy_service = iso15118::message_20::datatypes::ServiceCategory::AC_DER_IEC;
-        three_phase = true;
         break;
     default:
         EVLOG_warning << "EvIso15118D20: rejecting start_charging with unsupported EnergyTransferMode '"
@@ -303,7 +296,6 @@ bool ISO15118_evImpl::handle_start_charging(types::iso15118::EnergyTransferMode&
         if (is_ac) {
             (*h).ac_params.max_charge_power = static_cast<float>(mod->config.ac_max_charge_power_w);
             (*h).ac_params.min_charge_power = static_cast<float>(mod->config.ac_min_charge_power_w);
-            (*h).ac_params.three_phase = three_phase;
         }
         if (energy_service == dt::ServiceCategory::AC_BPT) {
             (*h).ac_params.max_discharge_power = static_cast<float>(mod->config.ac_max_discharge_power_w);

--- a/modules/EV/EvIso15118D20/ev/ISO15118_evImpl.cpp
+++ b/modules/EV/EvIso15118D20/ev/ISO15118_evImpl.cpp
@@ -85,10 +85,15 @@ ISO15118_evImpl::make_ev_config(iso15118::message_20::datatypes::ServiceCategory
     ev_config.advertised_security = iso15118::io::v2gtp::Security::NO_TRANSPORT_SECURITY;
     ev_config.discover = true;
 
+    namespace dt = iso15118::message_20::datatypes;
     ev_config.energy_service = energy_service;
-    if (energy_service == iso15118::message_20::datatypes::ServiceCategory::AC ||
-        energy_service == iso15118::message_20::datatypes::ServiceCategory::AC_DER_IEC) {
+    const bool ac_family = energy_service == dt::ServiceCategory::AC || energy_service == dt::ServiceCategory::AC_BPT ||
+                           energy_service == dt::ServiceCategory::AC_DER_IEC;
+    const bool dc_family = energy_service == dt::ServiceCategory::DC || energy_service == dt::ServiceCategory::DC_BPT;
+    if (ac_family) {
         ev_config.advertised_app_protocols = {{"urn:iso:std:iso:15118:-20:AC", 1, 0, 1, 1}};
+    } else if (dc_family) {
+        ev_config.advertised_app_protocols = {{"urn:iso:std:iso:15118:-20:DC", 1, 0, 1, 1}};
     }
 
     if (energy_service == iso15118::message_20::datatypes::ServiceCategory::AC_DER_IEC) {
@@ -139,6 +144,20 @@ iso15118::ev::feedback::Callbacks ISO15118_evImpl::make_callbacks() {
         EVLOG_info << "EvIso15118D20: AC EVSE limits: max charge power "
                    << dt::from_RationalNumber(limits.max_charge_power) << " W, min charge power "
                    << dt::from_RationalNumber(limits.min_charge_power) << " W";
+    };
+
+    callbacks.ac_bpt_limits = [](const iso15118::message_20::datatypes::BPT_AC_CPDResEnergyTransferMode& limits) {
+        namespace dt = iso15118::message_20::datatypes;
+        EVLOG_info << "EvIso15118D20: AC BPT EVSE limits: max discharge power "
+                   << dt::from_RationalNumber(limits.max_discharge_power) << " W, min discharge power "
+                   << dt::from_RationalNumber(limits.min_discharge_power) << " W";
+    };
+
+    callbacks.dc_bpt_limits = [](const iso15118::message_20::datatypes::BPT_DC_CPDResEnergyTransferMode& limits) {
+        namespace dt = iso15118::message_20::datatypes;
+        EVLOG_info << "EvIso15118D20: DC BPT EVSE limits: max discharge power "
+                   << dt::from_RationalNumber(limits.max_discharge_power) << " W, min discharge power "
+                   << dt::from_RationalNumber(limits.min_discharge_power) << " W";
     };
 
     callbacks.ac_target_power = [this](const iso15118::message_20::datatypes::Dynamic_AC_CLResControlMode& control) {
@@ -252,6 +271,14 @@ bool ISO15118_evImpl::handle_start_charging(types::iso15118::EnergyTransferMode&
         energy_service = iso15118::message_20::datatypes::ServiceCategory::AC;
         three_phase = true;
         break;
+    case types::iso15118::EnergyTransferMode::AC_BPT:
+        // AC_BPT carries no phase count; assume a three-phase inverter relay
+        energy_service = iso15118::message_20::datatypes::ServiceCategory::AC_BPT;
+        three_phase = true;
+        break;
+    case types::iso15118::EnergyTransferMode::DC_BPT:
+        energy_service = iso15118::message_20::datatypes::ServiceCategory::DC_BPT;
+        break;
     case types::iso15118::EnergyTransferMode::AC_DER_IEC:
         // AC_DER_IEC carries no phase count; assume a three-phase inverter relay
         energy_service = iso15118::message_20::datatypes::ServiceCategory::AC_DER_IEC;
@@ -260,7 +287,7 @@ bool ISO15118_evImpl::handle_start_charging(types::iso15118::EnergyTransferMode&
     default:
         EVLOG_warning << "EvIso15118D20: rejecting start_charging with unsupported EnergyTransferMode '"
                       << types::iso15118::energy_transfer_mode_to_string(EnergyTransferMode)
-                      << "'; only DC, AC single/three-phase and AC DER IEC are supported";
+                      << "'; only DC, DC BPT, AC single/three-phase, AC BPT and AC DER IEC are supported";
         return false;
     }
     {
@@ -270,12 +297,23 @@ bool ISO15118_evImpl::handle_start_charging(types::iso15118::EnergyTransferMode&
             return false;
         }
         (*h).energy_service = energy_service;
-        const bool is_ac = energy_service == iso15118::message_20::datatypes::ServiceCategory::AC ||
-                           energy_service == iso15118::message_20::datatypes::ServiceCategory::AC_DER_IEC;
+        namespace dt = iso15118::message_20::datatypes;
+        const bool is_ac = energy_service == dt::ServiceCategory::AC || energy_service == dt::ServiceCategory::AC_BPT ||
+                           energy_service == dt::ServiceCategory::AC_DER_IEC;
         if (is_ac) {
             (*h).ac_params.max_charge_power = static_cast<float>(mod->config.ac_max_charge_power_w);
             (*h).ac_params.min_charge_power = static_cast<float>(mod->config.ac_min_charge_power_w);
             (*h).ac_params.three_phase = three_phase;
+        }
+        if (energy_service == dt::ServiceCategory::AC_BPT) {
+            (*h).ac_params.max_discharge_power = static_cast<float>(mod->config.ac_max_discharge_power_w);
+            (*h).ac_params.min_discharge_power = static_cast<float>(mod->config.ac_min_discharge_power_w);
+        }
+        if (energy_service == dt::ServiceCategory::DC_BPT and not(*h).bpt_dc_params_set) {
+            // set_bpt_dc_params discharge limits win; config knobs are the fallback
+            (*h).dc_params.max_discharge_power = static_cast<float>(mod->config.dc_max_discharge_power_w);
+            (*h).dc_params.min_discharge_power = static_cast<float>(mod->config.dc_min_discharge_power_w);
+            (*h).dc_params.max_discharge_current = static_cast<float>(mod->config.dc_max_discharge_current_a);
         }
         (*h).phase = SessionPhase::requested;
     }
@@ -340,7 +378,42 @@ void ISO15118_evImpl::handle_set_dc_params(types::iso15118::DcEvParameters& EvPa
 }
 
 void ISO15118_evImpl::handle_set_bpt_dc_params(types::iso15118::DcEvBPTParameters& EvBPTParameters) {
-    EVLOG_info << "EvIso15118D20: set_bpt_dc_params: deferred to M1+";
+    EVLOG_info << "EvIso15118D20: set_bpt_dc_params";
+
+    std::string missing;
+    const auto note_missing = [&missing](const char* name, bool present) {
+        if (not present) {
+            missing.append(missing.empty() ? "" : ", ").append(name);
+        }
+    };
+    note_missing("discharge_max_power_limit", EvBPTParameters.discharge_max_power_limit.has_value());
+    note_missing("discharge_max_current_limit", EvBPTParameters.discharge_max_current_limit.has_value());
+    if (not missing.empty()) {
+        EVLOG_warning << "EvIso15118D20: set_bpt_dc_params missing " << missing
+                      << "; keeping configured discharge knobs";
+    }
+
+    // discharge_target_current / discharge_minimal_soc are not consumed by the -20
+    // Dynamic BPT request (reverse power flow is driven by SECC targets); log only
+    if (EvBPTParameters.discharge_target_current) {
+        EVLOG_debug << "EvIso15118D20: ignoring discharge_target_current " << *EvBPTParameters.discharge_target_current
+                    << " A (SECC-target-driven)";
+    }
+    if (EvBPTParameters.discharge_minimal_soc) {
+        EVLOG_debug << "EvIso15118D20: ignoring discharge_minimal_soc " << *EvBPTParameters.discharge_minimal_soc
+                    << " % (SECC-target-driven)";
+    }
+
+    // command values override the config knobs seeded at start_charging
+    auto h = session.handle();
+    (*h).bpt_dc_params_set = true;
+    auto& params = (*h).dc_params;
+    if (EvBPTParameters.discharge_max_power_limit) {
+        params.max_discharge_power = static_cast<float>(*EvBPTParameters.discharge_max_power_limit);
+    }
+    if (EvBPTParameters.discharge_max_current_limit) {
+        params.max_discharge_current = static_cast<float>(*EvBPTParameters.discharge_max_current_limit);
+    }
 }
 
 void ISO15118_evImpl::handle_enable_sae_j2847_v2g_v2h() {

--- a/modules/EV/EvIso15118D20/ev/ISO15118_evImpl.cpp
+++ b/modules/EV/EvIso15118D20/ev/ISO15118_evImpl.cpp
@@ -297,7 +297,8 @@ bool ISO15118_evImpl::handle_start_charging(types::iso15118::EnergyTransferMode&
             (*h).ac_params.max_charge_power = static_cast<float>(mod->config.ac_max_charge_power_w);
             (*h).ac_params.min_charge_power = static_cast<float>(mod->config.ac_min_charge_power_w);
         }
-        if (energy_service == dt::ServiceCategory::AC_BPT) {
+        // AC_DER_IEC carries mandatory discharge limits on the wire just as AC_BPT does.
+        if (energy_service == dt::ServiceCategory::AC_BPT or energy_service == dt::ServiceCategory::AC_DER_IEC) {
             (*h).ac_params.max_discharge_power = static_cast<float>(mod->config.ac_max_discharge_power_w);
             (*h).ac_params.min_discharge_power = static_cast<float>(mod->config.ac_min_discharge_power_w);
         }

--- a/modules/EV/EvIso15118D20/ev/ISO15118_evImpl.hpp
+++ b/modules/EV/EvIso15118D20/ev/ISO15118_evImpl.hpp
@@ -75,6 +75,7 @@ private:
         bool shutting_down{false};
         iso15118::ev::Controller* current{nullptr};
         iso15118::ev::DcChargeParams dc_params;
+        bool bpt_dc_params_set{false};
         iso15118::ev::AcChargeParams ac_params;
         iso15118::message_20::datatypes::ServiceCategory energy_service{
             iso15118::message_20::datatypes::ServiceCategory::DC};

--- a/modules/EV/EvIso15118D20/manifest.yaml
+++ b/modules/EV/EvIso15118D20/manifest.yaml
@@ -16,15 +16,19 @@ config:
     minimum: 1
     default: 20000
   ac_max_charge_power_w:
-    description: Advertised AC maximum charge power in watts.
+    description:
+      Advertised AC maximum charge power in watts, as a three-phase total. The
+      default is 16 A x 230 V x 3.
     type: number
     minimum: 0
     default: 11040
   ac_min_charge_power_w:
-    description: Advertised AC minimum charge power in watts.
+    description:
+      Advertised AC minimum charge power in watts, as a three-phase total. The
+      default is 6 A x 230 V x 3.
     type: number
     minimum: 0
-    default: 1380
+    default: 4140
   der_over_frequency_watt_mode:
     description: Declare support for the IEC OverFrequencyWattMode DER control function.
     type: boolean
@@ -78,13 +82,17 @@ config:
     type: boolean
     default: true
   ac_max_discharge_power_w:
-    description: Advertised AC maximum discharge power in watts (BPT).
+    description:
+      Advertised AC maximum discharge power in watts (BPT), as a three-phase
+      total. The default is 16 A x 230 V x 3.
     type: number
     default: 11040
   ac_min_discharge_power_w:
-    description: Advertised AC minimum discharge power in watts (BPT).
+    description:
+      Advertised AC minimum discharge power in watts (BPT), as a three-phase
+      total. The default is 6 A x 230 V x 3.
     type: number
-    default: 1380
+    default: 4140
   dc_max_discharge_power_w:
     description: Advertised DC maximum discharge power in watts (BPT).
     type: number

--- a/modules/EV/EvIso15118D20/manifest.yaml
+++ b/modules/EV/EvIso15118D20/manifest.yaml
@@ -77,6 +77,26 @@ config:
     description: Stop the session if no AC_DER_IEC parameter set fits the supported DER functions.
     type: boolean
     default: true
+  ac_max_discharge_power_w:
+    description: Advertised AC maximum discharge power in watts (BPT).
+    type: number
+    default: 11040
+  ac_min_discharge_power_w:
+    description: Advertised AC minimum discharge power in watts (BPT).
+    type: number
+    default: 1380
+  dc_max_discharge_power_w:
+    description: Advertised DC maximum discharge power in watts (BPT).
+    type: number
+    default: 150000
+  dc_min_discharge_power_w:
+    description: Advertised DC minimum discharge power in watts (BPT).
+    type: number
+    default: 0
+  dc_max_discharge_current_a:
+    description: Advertised DC maximum discharge current in amperes (BPT).
+    type: number
+    default: 300
 provides:
   ev:
     interface: ISO15118_ev

--- a/modules/EV/EvIso15118D20/manifest.yaml
+++ b/modules/EV/EvIso15118D20/manifest.yaml
@@ -86,24 +86,29 @@ config:
       Advertised AC maximum discharge power in watts (BPT), as a three-phase
       total. The default is 16 A x 230 V x 3.
     type: number
+    minimum: 0
     default: 11040
   ac_min_discharge_power_w:
     description:
       Advertised AC minimum discharge power in watts (BPT), as a three-phase
       total. The default is 6 A x 230 V x 3.
     type: number
+    minimum: 0
     default: 4140
   dc_max_discharge_power_w:
     description: Advertised DC maximum discharge power in watts (BPT).
     type: number
+    minimum: 0
     default: 150000
   dc_min_discharge_power_w:
     description: Advertised DC minimum discharge power in watts (BPT).
     type: number
+    minimum: 0
     default: 0
   dc_max_discharge_current_a:
     description: Advertised DC maximum discharge current in amperes (BPT).
     type: number
+    minimum: 0
     default: 300
 provides:
   ev:

--- a/modules/EV/EvManager/main/car_simulation.cpp
+++ b/modules/EV/EvManager/main/car_simulation.cpp
@@ -287,7 +287,8 @@ bool CarSimulation::iso_dc_power_on(const CmdArguments& arguments) {
         EVLOG_info << "Charger wants to pause the session";
         r_ev_board_support->call_allow_power_on(false);
 
-        // NOTE(sl): Change when the Energymode has more then 2 values
+        // NOTE(sl): Change when the Energymode has more then 2 values; BPT sessions resume as
+        // non-BPT here; the internal enum reuse loses the BPT flag.
         const std::string energy_mode = (sim_data.energy_mode == EnergyMode::AC) ? "AC" : "DC";
         const std::string iso_start_v2g_session = "iso_start_v2g_session " + energy_mode + ";";
 
@@ -344,10 +345,20 @@ bool CarSimulation::iso_start_v2g_session(const CmdArguments& arguments, bool th
                                          selected_payment_option, departure_time, e_amount);
             charge_mode = ChargeMode::ACThreePhase;
         }
+    } else if (energy_mode == constants::AC_BPT) {
+        sim_data.energy_mode = EnergyMode::AC;
+        r_ev[0]->call_start_charging(types::iso15118::EnergyTransferMode::AC_BPT, selected_payment_option,
+                                     departure_time, e_amount);
+        charge_mode = ChargeMode::AC;
     } else if (energy_mode == constants::DC) {
         r_ev[0]->call_start_charging(types::iso15118::EnergyTransferMode::DC_extended, selected_payment_option,
                                      departure_time, e_amount);
         sim_data.energy_mode = EnergyMode::DC;
+        charge_mode = ChargeMode::DC;
+    } else if (energy_mode == constants::DC_BPT) {
+        sim_data.energy_mode = EnergyMode::DC;
+        r_ev[0]->call_start_charging(types::iso15118::EnergyTransferMode::DC_BPT, selected_payment_option,
+                                     departure_time, e_amount);
         charge_mode = ChargeMode::DC;
     } else {
         return false;
@@ -410,7 +421,8 @@ bool CarSimulation::iso_wait_for_stop(const CmdArguments& arguments, size_t loop
         EVLOG_info << "Charger wants to pause the session";
         r_ev_board_support->call_allow_power_on(false);
 
-        // NOTE(sl): Change when the Energymode has more then 2 values
+        // NOTE(sl): Change when the Energymode has more then 2 values; BPT sessions resume as
+        // non-BPT here; the internal enum reuse loses the BPT flag.
         const std::string energy_mode = (sim_data.energy_mode == EnergyMode::AC) ? "AC" : "DC";
         const std::string iso_start_v2g_session = "iso_start_v2g_session " + energy_mode + ";";
 

--- a/modules/EV/EvManager/main/constants.hpp
+++ b/modules/EV/EvManager/main/constants.hpp
@@ -7,4 +7,6 @@ static constexpr auto THREE_PHASES{"3"};
 static constexpr auto DEFAULT_LOOP_INTERVAL_MS{250};
 static constexpr auto AC{"ac"};
 static constexpr auto DC{"dc"};
+static constexpr auto AC_BPT{"ac_bpt"};
+static constexpr auto DC_BPT{"dc_bpt"};
 } // namespace constants

--- a/tests/core_tests/ev_iso15118d20_bpt_module_test.py
+++ b/tests/core_tests/ev_iso15118d20_bpt_module_test.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Pionix GmbH and Contributors to EVerest
+
+import asyncio
+import logging
+import os
+from copy import deepcopy
+from typing import Dict, List
+from unittest.mock import Mock
+
+import pytest
+
+from everest.testing.core_utils.common import Requirement
+from everest.testing.core_utils.fixtures import *
+from everest.testing.core_utils.controller.test_controller_interface import (
+    TestController,
+)
+from everest.testing.core_utils.everest_core import EverestCore
+from everest.testing.core_utils.probe_module import ProbeModule
+
+from smoke_tests import NetworkInterfaceConfigAdjustmentStrategy
+
+
+# The SECC publishes these literals for any negotiated AC / DC ISO 15118-20 namespace.
+D20_AC_PROTOCOL = "ISO15118-20:AC and similar"
+D20_DC_PROTOCOL = "ISO15118-20:DC"
+
+# EvIso15118D20 logs these only after the SECC returns BPT limits in the CPD
+# exchange, i.e. only when a BPT service was negotiated. Grepping the manager log
+# capture for them distinguishes a BPT session from a plain (unidirectional) one.
+AC_BPT_LIMITS_LOG = "AC BPT EVSE limits"
+DC_BPT_LIMITS_LOG = "DC BPT EVSE limits"
+
+
+class EvAutoExecAdjustmentStrategy(EverestConfigAdjustmentStrategy):
+    """Drive the EvManager through a complete ISO 15118-20 BPT session via auto_exec."""
+
+    def __init__(self, auto_exec_commands: str):
+        self.auto_exec_commands = auto_exec_commands
+
+    def adjust_everest_configuration(self, everest_config: Dict) -> Dict:
+        adjusted_config = deepcopy(everest_config)
+        ev_manager = adjusted_config["active_modules"]["ev_manager"]["config_module"]
+        ev_manager["auto_exec"] = True
+        ev_manager["auto_exec_commands"] = self.auto_exec_commands
+        return adjusted_config
+
+
+def _ev_config_adaptions(auto_exec_commands: str) -> List[EverestConfigAdjustmentStrategy]:
+    """Auto_exec strategy plus, when EVEREST_V2G_DEVICE is set, a device override.
+
+    CI leaves EVEREST_V2G_DEVICE unset (device stays ``auto``, the network-isolation
+    plugin picks the per-worker veth); a developer host sets it to e.g. ``v2g0``.
+    """
+    adaptions: List[EverestConfigAdjustmentStrategy] = [EvAutoExecAdjustmentStrategy(auto_exec_commands)]
+    local_device = os.environ.get("EVEREST_V2G_DEVICE")
+    if local_device:
+        adaptions.append(NetworkInterfaceConfigAdjustmentStrategy(local_device))
+    return adaptions
+
+
+async def wait_for_call(mock: Mock, timeout: float = 30.0):
+    """Wait until mock has been called at least once. Raises TimeoutError otherwise."""
+    start_time = asyncio.get_event_loop().time()
+    while asyncio.get_event_loop().time() - start_time < timeout:
+        if mock.call_count > 0:
+            return
+        await asyncio.sleep(0.1)
+    raise TimeoutError("Timeout waiting for variable publication.")
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group(name="ISO15118")
+@pytest.mark.probe_module(
+    connections={
+        "charger": [Requirement("iso15118_charger", "charger")],
+        "ev": [Requirement("iso15118_car", "ev")],
+    }
+)
+@pytest.mark.everest_core_config("config-sil-ac-bpt-d20-evcpp.yaml")
+@pytest.mark.everest_config_adaptions(
+    *_ev_config_adaptions(
+        # sleep 1: let the modules reach steady state before SLAC matching starts.
+        # The rest of the chain is event-gated (iso_wait_*), so no further sleeps.
+        "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC_BPT;"
+        "iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 10;"
+        "iso_wait_v2g_session_stopped;unplug"
+    )
+)
+async def test_ev_iso15118d20_ac_bpt_session(
+    test_controller: TestController, everest_core: EverestCore, caplog
+):
+    """SIL gate: EvIso15118D20 negotiates an AC ISO 15118-20 BPT session.
+
+    The gate proves BPT NEGOTIATION happened, not reverse power flow: the EV
+    selects the AC_BPT service and the SECC returns BPT AC limits in the CPD
+    exchange (logged by the EV module). The SIL charge loop still moves power
+    in the charge direction; only the negotiated service is bidirectional.
+    """
+    caplog.set_level(logging.DEBUG)
+    test_controller.start()
+    probe_module = ProbeModule(everest_core.get_runtime_session())
+
+    selected_protocol_mock = Mock()
+    power_ready_mock = Mock()
+    ac_target_power_mock = Mock()
+    finished_mock = Mock()
+
+    probe_module.subscribe_variable("charger", "selected_protocol", selected_protocol_mock)
+    probe_module.subscribe_variable("ev", "ev_power_ready", power_ready_mock)
+    probe_module.subscribe_variable("ev", "ac_evse_target_power", ac_target_power_mock)
+    probe_module.subscribe_variable("ev", "v2g_session_finished", finished_mock)
+
+    probe_module.start()
+    await probe_module.wait_to_be_ready()
+
+    await wait_for_call(selected_protocol_mock, timeout=30)
+    selected_protocol = selected_protocol_mock.call_args[0][0]
+    assert selected_protocol == D20_AC_PROTOCOL, (
+        f"selected_protocol '{selected_protocol}' != expected "
+        f"ISO 15118-20 AC protocol literal '{D20_AC_PROTOCOL}'"
+    )
+
+    await wait_for_call(power_ready_mock, timeout=30)
+    assert power_ready_mock.call_args[0][0] is True, "ev_power_ready published without a true value"
+
+    await wait_for_call(ac_target_power_mock, timeout=30)
+
+    await wait_for_call(finished_mock, timeout=40)
+
+    assert AC_BPT_LIMITS_LOG in caplog.text, (
+        f"'{AC_BPT_LIMITS_LOG}' not found in the manager log capture; the AC BPT "
+        "CPD exchange did not happen, so BPT was not negotiated"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group(name="ISO15118")
+@pytest.mark.probe_module(
+    connections={
+        "charger": [Requirement("iso15118_charger", "charger")],
+        "ev": [Requirement("iso15118_car", "ev")],
+    }
+)
+@pytest.mark.everest_core_config("config-sil-dc-bpt-d20-evcpp.yaml")
+@pytest.mark.everest_config_adaptions(
+    *_ev_config_adaptions(
+        # sleep 1: let the modules reach steady state before SLAC matching starts.
+        # The rest of the chain is event-gated (iso_wait_*), so no further sleeps.
+        "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC_BPT;"
+        "iso_wait_pwr_ready;iso_dc_power_on;iso_wait_for_stop 10;"
+        "iso_wait_v2g_session_stopped;unplug"
+    )
+)
+async def test_ev_iso15118d20_dc_bpt_session(
+    test_controller: TestController, everest_core: EverestCore, caplog
+):
+    """SIL gate: EvIso15118D20 negotiates a DC ISO 15118-20 BPT session.
+
+    The gate proves BPT NEGOTIATION happened, not reverse power flow: the EV
+    selects the DC_BPT service and the SECC returns BPT DC limits in the CPD
+    exchange (logged by the EV module). iso_dc_power_on blocks the auto_exec
+    chain until dc_power_on is published, so the chain only advances once the
+    DC charge loop has run on both sides. Power still flows in the charge
+    direction; only the negotiated service is bidirectional.
+    """
+    caplog.set_level(logging.DEBUG)
+    test_controller.start()
+    probe_module = ProbeModule(everest_core.get_runtime_session())
+
+    selected_protocol_mock = Mock()
+    power_ready_mock = Mock()
+    dc_power_on_mock = Mock()
+    finished_mock = Mock()
+
+    probe_module.subscribe_variable("charger", "selected_protocol", selected_protocol_mock)
+    probe_module.subscribe_variable("ev", "ev_power_ready", power_ready_mock)
+    probe_module.subscribe_variable("ev", "dc_power_on", dc_power_on_mock)
+    probe_module.subscribe_variable("ev", "v2g_session_finished", finished_mock)
+
+    probe_module.start()
+    await probe_module.wait_to_be_ready()
+
+    await wait_for_call(selected_protocol_mock, timeout=30)
+    selected_protocol = selected_protocol_mock.call_args[0][0]
+    assert selected_protocol == D20_DC_PROTOCOL, (
+        f"selected_protocol '{selected_protocol}' != expected "
+        f"ISO 15118-20 DC protocol literal '{D20_DC_PROTOCOL}'"
+    )
+
+    await wait_for_call(power_ready_mock, timeout=30)
+    assert power_ready_mock.call_args[0][0] is True, "ev_power_ready published without a true value"
+
+    await wait_for_call(dc_power_on_mock, timeout=30)
+
+    await wait_for_call(finished_mock, timeout=40)
+
+    assert DC_BPT_LIMITS_LOG in caplog.text, (
+        f"'{DC_BPT_LIMITS_LOG}' not found in the manager log capture; the DC BPT "
+        "CPD exchange did not happen, so BPT was not negotiated"
+    )


### PR DESCRIPTION
Part of the EV-side libiso15118 stack (5/8). Each PR compares against the one below it; review bottom-up.

**Stack (bottom to top):**
1. Foundation — #2577
2. DC module + session — #2578
3. AC charging — #2579
4. AC_DER_IEC — #2580
5. BPT (AC + DC) — #2581 ⬅️ **this PR**
6. Fixes + test coverage — #2582
7. Three-phase AC — #2583
8. State outcomes refactor — #2584

## Describe your changes

Bidirectional power transfer for both AC and DC. Discharge limits ride on the existing
charge-params types, and the BPT request and response variants are handled inside the AC and DC
states already there, keyed on the selected service, so there is no parallel BPT state set.

Two wire-level fixes came out of testing it: the three_phase flag was copying one aggregate into
all three per-phase fields, so those optional fields are no longer emitted, and the mandatory
present voltage and power went out as a constant zero, which a charger reads as measured and uses
to disable its HLC power clamp.
