### PR TITLE
fix(ocpp1.6): make StopTransactionOnEVSideDisconnect writable

### DIFF
--- a/lib/everest/ocpp/config/v16/profile_schemas/Core.json
+++ b/lib/everest/ocpp/config/v16/profile_schemas/Core.json
@@ -133,7 +133,7 @@
         },
         "StopTransactionOnEVSideDisconnect": {
             "type": "boolean",
-            "readOnly": true
+            "readOnly": false
         },
         "StopTransactionOnInvalidId": {
             "type": "boolean",

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
@@ -1547,7 +1547,7 @@ std::optional<KeyValue> ChargePointConfiguration::getStopTransactionOnEVSideDisc
     if (stop_transaction_on_ev_side_disconnect != std::nullopt) {
         KeyValue kv;
         kv.key = "StopTransactionOnEVSideDisconnect";
-        kv.readonly = true;
+        kv.readonly = false;
         kv.value.emplace(ocpp::conversions::bool_to_string(stop_transaction_on_ev_side_disconnect.value()));
         stop_transaction_on_ev_side_disconnect_kv.emplace(kv);
     }
@@ -3991,6 +3991,14 @@ std::optional<ConfigurationStatus> ChargePointConfiguration::set(const CiString<
     } else if (key == "StopTransactionOnInvalidId") {
         if (isBool(value.get())) {
             this->setStopTransactionOnInvalidId(ocpp::conversions::string_to_bool(value.get()));
+        } else {
+            return ConfigurationStatus::Rejected;
+        }
+    } else if (key == "StopTransactionOnEVSideDisconnect") {
+        if (isBool(value.get())) {
+            this->config["Core"]["StopTransactionOnEVSideDisconnect"] = ocpp::conversions::string_to_bool(value.get());
+            this->setInUserConfig("Core", "StopTransactionOnEVSideDisconnect",
+                                   ocpp::conversions::string_to_bool(value.get()));
         } else {
             return ConfigurationStatus::Rejected;
         }

--- a/lib/everest/ocpp/lib/ocpp/v16/known_keys.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/known_keys.cpp
@@ -60,7 +60,6 @@ using ocpp::v16::keys::valid_keys;
     key(MeterValuesSampledDataMaxLength) \
     key(NumberOfConnectors) \
     key(ReserveConnectorZeroSupported) \
-    key(StopTransactionOnEVSideDisconnect) \
     key(StopTxnAlignedDataMaxLength) \
     key(StopTxnSampledDataMaxLength) \
     key(SupportedFeatureProfiles) \

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_core.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_core.cpp
@@ -436,7 +436,7 @@ TEST_P(Configuration, StopTransactionOnEVSideDisconnect) {
     ASSERT_TRUE(kv.has_value());
     EXPECT_EQ(kv.value().key, "StopTransactionOnEVSideDisconnect");
     EXPECT_EQ(kv.value().value, "true");
-    EXPECT_TRUE(kv.value().readonly);
+    EXPECT_FALSE(kv.value().readonly);
 }
 
 TEST_P(Configuration, ConnectorPhaseRotationMaxLength) {


### PR DESCRIPTION
Per the OCPP 1.6 Core spec this key is RW. OCTT fails (TC_005_3_CS) a ChangeConfiguration.req for this key with "Not  able to set config with key 'StopTransactionOnEVSideDisconnect'". Updated the existing unit test to match.

## Describe your changes

## Issue ticket number and link:N/A

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

