### PR TITLE
OCPP: guard the remote start id map against concurrent access

### DIFF
--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/transaction.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/transaction.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <everest/util/async/monitor.hpp>
+
 #include <ocpp/v2/message_handler.hpp>
 
 namespace ocpp::v2 {
@@ -128,7 +130,9 @@ private:
     std::optional<TransactionEventResponseCallback> transaction_event_response_callback;
     ResetCallback reset_callback;
 
-    std::map<std::int32_t, std::pair<IdToken, std::int32_t>> remote_start_id_per_evse;
+    /// \brief Written by the message-handler thread (handle_remote_start_transaction_request), read and
+    /// erased by the EVerest module thread (on_authorized / on_charging_state_changed via transaction_event_req).
+    everest::lib::util::monitor<std::map<std::int32_t, std::pair<IdToken, std::int32_t>>> remote_start_id_per_evse;
     /// \brief Used when an 'OnIdle' reset is requested, to perform the reset after the charging has stopped.
     bool reset_scheduled;
     /// \brief If `reset_scheduled` is true and the reset is for a specific evse id, it will be stored in this member.

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/transaction.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/transaction.cpp
@@ -264,31 +264,36 @@ void TransactionBlock::transaction_event_req(const TransactionEventEnum& event_t
 
     ocpp::Call<TransactionEventRequest> call(req);
 
-    // Check if id token is in the remote start map, because when a remote
-    // start request is done, the first transaction event request should
-    // always contain trigger reason 'RemoteStart'.
-    auto it = std::find_if(
-        remote_start_id_per_evse.begin(), remote_start_id_per_evse.end(),
-        [&id_token, &evse](const std::pair<std::int32_t, std::pair<IdToken, std::int32_t>>& remote_start_per_evse) {
-            if (id_token.has_value() and remote_start_per_evse.second.first.idToken == id_token.value().idToken) {
+    {
+        // Check if id token is in the remote start map, because when a remote
+        // start request is done, the first transaction event request should
+        // always contain trigger reason 'RemoteStart'.
+        // Handle spans find-then-erase so the two form one atomic critical section; it is
+        // released (end of this block) before dispatch_call to avoid holding the lock while dispatching.
+        auto handle = this->remote_start_id_per_evse.handle();
+        auto it = std::find_if(
+            handle->begin(), handle->end(),
+            [&id_token, &evse](const std::pair<std::int32_t, std::pair<IdToken, std::int32_t>>& remote_start_per_evse) {
+                if (id_token.has_value() and remote_start_per_evse.second.first.idToken == id_token.value().idToken) {
 
-                if (remote_start_per_evse.first == 0) {
-                    return true;
+                    if (remote_start_per_evse.first == 0) {
+                        return true;
+                    }
+
+                    if (evse.has_value() and evse.value().id == remote_start_per_evse.first) {
+                        return true;
+                    }
                 }
+                return false;
+            });
 
-                if (evse.has_value() and evse.value().id == remote_start_per_evse.first) {
-                    return true;
-                }
-            }
-            return false;
-        });
+        if (it != handle->end()) {
+            // Found remote start. Set remote start id and the trigger reason.
+            call.msg.triggerReason = TriggerReasonEnum::RemoteStart;
+            call.msg.transactionInfo.remoteStartId = it->second.second;
 
-    if (it != remote_start_id_per_evse.end()) {
-        // Found remote start. Set remote start id and the trigger reason.
-        call.msg.triggerReason = TriggerReasonEnum::RemoteStart;
-        call.msg.transactionInfo.remoteStartId = it->second.second;
-
-        remote_start_id_per_evse.erase(it);
+            handle->erase(it);
+        }
     }
 
     this->context.message_dispatcher.dispatch_call(call, initiated_by_trigger_message);
@@ -300,7 +305,8 @@ void TransactionBlock::transaction_event_req(const TransactionEventEnum& event_t
 
 void TransactionBlock::set_remote_start_id_for_evse(const std::int32_t evse_id, const IdToken id_token,
                                                     const std::int32_t remote_start_id) {
-    remote_start_id_per_evse[evse_id] = {id_token, remote_start_id};
+    auto handle = this->remote_start_id_per_evse.handle();
+    (*handle)[evse_id] = {id_token, remote_start_id};
 }
 
 void TransactionBlock::schedule_reset(const std::optional<std::int32_t> reset_scheduled_evseid) {


### PR DESCRIPTION
## Describe your changes

`TransactionBlock::remote_start_id_per_evse` is reached from two threads with no
synchronization:

- **Writer**, message-handler thread: `RemoteTransactionControl::handle_remote_start_transaction_request`
  → `set_remote_start_id_for_evse`, which inserts into the map.
- **Reader and eraser**, EVerest module thread: `ChargePoint::on_authorized` and
  `ChargePoint::on_charging_state_changed` → `transaction_event_req`, which runs a
  `std::find_if` over the map and then erases the match.

A concurrent `insert` with `find_if` / `erase` on a `std::map` is undefined
behavior. In practice the window is narrow (it needs a RequestStartTransaction to
land while a transaction event is being built), which is presumably why it has
gone unnoticed.

Wraps the map in `everest::lib::util::monitor`, matching the existing use in
`dynamic_schedule_manager.hpp`. Two details worth noting for review:

- The handle in `transaction_event_req` spans find-then-erase, so the lookup and
  the erase are one critical section rather than two.
- It is scoped to end before `message_dispatcher.dispatch_call`, so the lock is
  not held while dispatching.

No behavior change: the match predicate (including the `evse_id == 0` "any EVSE"
case), the insertion, and the erase-on-match are all untouched.

Found while rescoping #2479, but independent of it.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

### Verification

`ctest` in a libocpp-only build: 158/158 passed, unchanged from the baseline on
`main`.

No new tests. A data race of this shape cannot be meaningfully unit-tested; the
justification is the call-path analysis above. `functional_blocks/transaction.hpp`
is not included outside `lib/everest/ocpp`, so the added include has no reach
beyond libocpp.
