### PR TITLE
fix(OCPP): prevent DataTransfer issues on non-string data

### DIFF
--- a/lib/everest/ocpp_module_common/src/conversions.cpp
+++ b/lib/everest/ocpp_module_common/src/conversions.cpp
@@ -100,16 +100,27 @@ ocpp::v2::DataTransferResponse to_ocpp_data_transfer_response(types::ocpp::DataT
     ocpp::v2::DataTransferResponse ocpp_response;
     ocpp_response.status = conversions::to_ocpp_data_transfer_status_enum(response.status);
     if (response.data.has_value()) {
-        ocpp_response.data = json::parse(response.data.value());
+        try {
+            ocpp_response.data = json::parse(response.data.value());
+        } catch (const json::exception&) {
+            // Modules may answer with plain text; pass it on as a json string instead of dropping it.
+            ocpp_response.data = json(response.data.value());
+        }
     }
     if (response.custom_data.has_value()) {
         auto custom_data = response.custom_data.value();
-        json custom_data_json = json::parse(custom_data.data);
-        if (not custom_data_json.contains("vendorId")) {
-            EVLOG_warning << "DataTransferResponse custom_data.data does not contain vendorId, automatically adding it";
-            custom_data_json["vendorId"] = custom_data.vendor_id;
+        try {
+            json custom_data_json = json::parse(custom_data.data);
+            if (not custom_data_json.contains("vendorId")) {
+                EVLOG_warning
+                    << "DataTransferResponse custom_data.data does not contain vendorId, automatically adding it";
+                custom_data_json["vendorId"] = custom_data.vendor_id;
+            }
+            ocpp_response.customData = custom_data_json;
+        } catch (const json::exception& e) {
+            EVLOG_error << "Parsing of data transfer response custom_data json failed because: "
+                        << "(" << e.what() << ")";
         }
-        ocpp_response.customData = custom_data_json;
     }
     return ocpp_response;
 }

--- a/lib/everest/ocpp_module_common/tests/CMakeLists.txt
+++ b/lib/everest/ocpp_module_common/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(${TEST_TARGET_NAME})
 
 target_sources(${TEST_TARGET_NAME}
     PRIVATE
+    data_transfer_conversions_test.cpp
     error_handling_tests.cpp
     everest_device_model_storage_test.cpp
     grid_support_conversions_test.cpp

--- a/lib/everest/ocpp_module_common/tests/data_transfer_conversions_test.cpp
+++ b/lib/everest/ocpp_module_common/tests/data_transfer_conversions_test.cpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gtest/gtest.h>
+
+#include <nlohmann/json.hpp>
+
+#include <everest/ocpp_module_common/conversions.hpp>
+
+namespace {
+
+using ocpp_module_common::conversions::to_ocpp_data_transfer_response;
+
+TEST(DataTransferConversions, response_json_data_is_parsed) {
+    types::ocpp::DataTransferResponse response;
+    response.status = types::ocpp::DataTransferStatus::Accepted;
+    response.data = R"({"emergencyACLimit": 32})";
+
+    const auto result = to_ocpp_data_transfer_response(response);
+    EXPECT_EQ(result.status, ocpp::v2::DataTransferStatusEnum::Accepted);
+    ASSERT_TRUE(result.data.has_value());
+    EXPECT_EQ(result.data.value(), nlohmann::json::parse(R"({"emergencyACLimit": 32})"));
+}
+
+TEST(DataTransferConversions, response_plain_text_data_is_kept_as_json_string) {
+    types::ocpp::DataTransferResponse response;
+    response.status = types::ocpp::DataTransferStatus::Accepted;
+    response.data = "plain text, not json";
+
+    const auto result = to_ocpp_data_transfer_response(response);
+    ASSERT_TRUE(result.data.has_value());
+    ASSERT_TRUE(result.data.value().is_string());
+    EXPECT_EQ(result.data.value().get<std::string>(), "plain text, not json");
+}
+
+TEST(DataTransferConversions, response_invalid_custom_data_is_dropped) {
+    types::ocpp::DataTransferResponse response;
+    response.status = types::ocpp::DataTransferStatus::Accepted;
+    response.custom_data = types::ocpp::CustomData{"Pionix", "not json"};
+
+    const auto result = to_ocpp_data_transfer_response(response);
+    EXPECT_FALSE(result.customData.has_value());
+}
+
+} // namespace

--- a/modules/EVSE/OCPPmulti/tests/data_transfer_tests.cpp
+++ b/modules/EVSE/OCPPmulti/tests/data_transfer_tests.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <generic_ocpp.hpp>
+#include <v16_conversions.hpp>
 
 #include "stubs/generic_ocpp_stub.hpp"
 
@@ -103,6 +104,34 @@ TEST(GenericOcppProvides, dataTransferOffline) {
     const auto result = ocpp.handle_data_transfer(request);
     EXPECT_EQ(result.status, DataTransferStatus::Offline);
     EXPECT_FALSE(result.data.has_value());
+}
+
+TEST(V16Conversions, dataTransferResponseObjectData) {
+    ocpp::v2::DataTransferResponse response;
+    response.status = DataTransferStatusEnum::Accepted;
+    response.data = R"({"emergencyACLimit": 32})"_json;
+
+    const auto result = ocpp_multi::v16_conversions::convert(response);
+    EXPECT_EQ(result.status, ocpp::v16::DataTransferStatus::Accepted);
+    ASSERT_TRUE(result.data.has_value());
+    EXPECT_EQ(result.data.value(), "{\"emergencyACLimit\":32}");
+}
+
+TEST(V16Conversions, dataTransferResponseStringData) {
+    ocpp::v2::DataTransferResponse response;
+    response.status = DataTransferStatusEnum::Accepted;
+    response.data = nlohmann::json("OK");
+
+    const auto result = ocpp_multi::v16_conversions::convert(response);
+    ASSERT_TRUE(result.data.has_value());
+    EXPECT_EQ(result.data.value(), "OK");
+}
+
+TEST(V16Conversions, toV16DataString) {
+    using ocpp_multi::v16_conversions::to_v16_data_string;
+    EXPECT_FALSE(to_v16_data_string(std::nullopt).has_value());
+    EXPECT_EQ(to_v16_data_string(nlohmann::json("text")).value(), "text");
+    EXPECT_EQ(to_v16_data_string(nlohmann::json::array({1, 2})).value(), "[1,2]");
 }
 
 } // namespace

--- a/modules/EVSE/OCPPmulti/v16_chargepoint.cpp
+++ b/modules/EVSE/OCPPmulti/v16_chargepoint.cpp
@@ -666,7 +666,8 @@ void ChargePointV16::stop() {
 std::optional<ocpp::v2::DataTransferResponse>
 ChargePointV16::data_transfer_req(const ocpp::v2::DataTransferRequest& request) {
     check_configured("data_transfer_req");
-    const auto res = m_charge_point->data_transfer(request.vendorId, request.messageId, request.data);
+    const auto res =
+        m_charge_point->data_transfer(request.vendorId, request.messageId, to_v16_data_string(request.data));
     std::optional<ocpp::v2::DataTransferResponse> result;
     if (res) {
         ocpp::v2::DataTransferResponse response;

--- a/modules/EVSE/OCPPmulti/v16_conversions.cpp
+++ b/modules/EVSE/OCPPmulti/v16_conversions.cpp
@@ -121,8 +121,15 @@ ocpp::v16::DataTransferResponse convert(const ocpp::v2::DataTransferResponse& va
         result.status = ocpp::v16::DataTransferStatus::UnknownVendorId;
         break;
     }
-    result.data = value.data;
+    result.data = to_v16_data_string(value.data);
     return result;
+}
+
+std::optional<std::string> to_v16_data_string(const std::optional<nlohmann::json>& data) {
+    if (!data.has_value()) {
+        return std::nullopt;
+    }
+    return data->is_string() ? data->get<std::string>() : data->dump();
 }
 
 ocpp::v2::DataTransferStatusEnum convert(ocpp::v16::DataTransferStatus value) {

--- a/modules/EVSE/OCPPmulti/v16_conversions.hpp
+++ b/modules/EVSE/OCPPmulti/v16_conversions.hpp
@@ -32,4 +32,9 @@ ocpp::v2::UpdateFirmwareRequest convert(const ocpp::v16::UpdateFirmwareRequest& 
 ocpp::v2::UpdateFirmwareRequest convert(const ocpp::v16::SignedUpdateFirmwareRequest& value);
 ocpp::v16::UpdateFirmwareStatusEnumType convert(const ocpp::v2::UpdateFirmwareResponse& value);
 
+// OCPP 2.x carries DataTransfer `data` as anyType (json); OCPP 1.6 requires a string. Returns the
+// raw string for json strings and the serialized json otherwise, instead of relying on nlohmann's
+// implicit conversion, which throws type_error.302 on objects and arrays.
+std::optional<std::string> to_v16_data_string(const std::optional<nlohmann::json>& data);
+
 } // namespace ocpp_multi::v16_conversions


### PR DESCRIPTION

## Describe your changes

Convert OCPP 2.x json  to the OCPP 1.6 string form explicitly in OCPPmulti instead of relying on nlohmann's implicit conversion, which throws on objects/arrays; harden to_ocpp_data_transfer_response in ocpp_module_common against non-json module responses (affects OCPP201 and both OCPPmulti paths). Add unit tests for both conversion layers.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

