### PR TITLE
fix(ocpp1.6): report every InvalidCentralSystemCertificate failure.

### DIFF
--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
@@ -93,7 +93,6 @@ private:
     ChargePointConfigurationInterface& configuration;
     BootReasonEnum bootreason{BootReasonEnum::PowerUp};
     bool initialized{false};
-    bool InvalidCSMSCertificate_logged{false};
     ChargePointConnectionState connection_state{ChargePointConnectionState::Disconnected};
     std::atomic<RegistrationStatus> registration_status{RegistrationStatus::Pending};
     DiagnosticsStatus diagnostics_status{DiagnosticsStatus::Idle};

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -320,10 +320,6 @@ void ChargePointImpl::on_websocket_connected(const int /*configuration_slot*/,
     this->message_queue->resume(this->message_queue_resume_delay);
     this->connected_callback();
 
-    // There has been a successful connection so a subsequent
-    // InvalidCSMSCertificate should be logged
-    InvalidCSMSCertificate_logged = false;
-
     // signal_set_charging_profiles_callback since composite schedule could have changed if
     // IgnoredProfilePurposesOffline are configured when becoming online
     if (this->signal_set_charging_profiles_callback != nullptr and
@@ -362,14 +358,8 @@ void ChargePointImpl::on_websocket_connection_failed(ocpp::ConnectionFailedReaso
                                         true);
     }
     if (reason == ocpp::ConnectionFailedReason::InvalidCSMSCertificate) {
-        if (InvalidCSMSCertificate_logged) {
-            EVLOG_warning << "Connection failed: InvalidCSMSCertificate";
-        } else {
-            // This event is forced to accommodate TC_078_CS despite this event being not critical
-            this->securityEventNotification(CiString<50>(ocpp::security_events::INVALIDCENTRALSYSTEMCERTIFICATE),
-                                            std::nullopt, true, true);
-            InvalidCSMSCertificate_logged = true;
-        }
+        this->securityEventNotification(CiString<50>(ocpp::security_events::INVALIDCENTRALSYSTEMCERTIFICATE),
+                                        std::nullopt, true, true);
     }
 }
 


### PR DESCRIPTION
Previously a logged flag suppressed all but the first InvalidCSMSCertificate SecurityEventNotification until a successful connection, so consecutive bad-certificate attempts after the first were only logged, not reported to the CSMS. OCTT's TC_078_CS walks through several distinct invalid-certificate scenarios back to back without a successful connection in between and expects a notification for each one.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

