### PR TITLE
feat(ocpp1.6): add extensibility hooks for Custom-profile config keys

### DIFF
--- a/lib/everest/ocpp/include/ocpp/v16/charge_point.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point.hpp
@@ -641,6 +641,18 @@ public:
     void
     register_generic_configuration_key_changed_callback(const std::function<void(const KeyValue& key_value)>& callback);
 
+    /// \brief registers a \p callback that can veto a ChangeConfiguration before it is applied (e.g.
+    /// based on runtime charge-point state), for both Core and Custom-profile keys
+    /// \param callback returns true to allow the change, false to reject it
+    void register_custom_key_validation_callback(
+        const std::function<bool(const std::string& key, const std::string& value)>& callback);
+
+    /// \brief force-writes a Custom key's value, bypassing its readOnly flag (see
+    /// ChargePointConfigurationInterface::set_custom_key_forced for details)
+    /// \param key
+    /// \param value
+    ConfigurationStatus set_custom_key_forced(const CiString<50>& key, const CiString<500>& value);
+
     /// \brief registers a \p callback function that can be used to react to a security event callback. This callback is
     /// called only if the SecurityEvent occured internally within libocpp
     void register_security_event_callback(

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration.hpp
@@ -3,6 +3,7 @@
 #ifndef OCPP_V16_CHARGE_POINT_CONFIGURATION_HPP
 #define OCPP_V16_CHARGE_POINT_CONFIGURATION_HPP
 
+#include <functional>
 #include <map>
 #include <mutex>
 #include <optional>
@@ -554,6 +555,8 @@ public:
     std::vector<KeyValue> get_all_key_value() override;
 
     std::optional<ConfigurationStatus> set(const CiString<50>& key, const CiString<500>& value) override;
+
+    ConfigurationStatus set_custom_key_forced(const CiString<50>& key, const CiString<500>& value) override;
 };
 
 } // namespace v16

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_interface.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_interface.hpp
@@ -4,6 +4,7 @@
 #define OCPP_V16_CHARGE_POINT_CONFIGURATION_INTERFACE_HPP
 
 #include <cstdint>
+#include <functional>
 #include <optional>
 #include <set>
 #include <string>
@@ -453,6 +454,17 @@ public:
     ///
     /// The default implementation is a no-op (the JSON-backed class validates at construction time).
     virtual void check_integrity(int32_t expected_number_of_connectors){};
+
+    /// \brief force-writes a Custom key's value, bypassing its readOnly flag. Intended for
+    /// internal/backend-driven updates only (e.g. a hardware event pushing a fresh value)
+    /// never for CSMS-initiated ChangeConfiguration, which must keep respecting readOnly.
+    /// Default implementation is a no-op returning NotSupported.
+    /// \param key
+    /// \param value
+    /// \return Accepted if written, NotSupported if the key does not exist in the Custom profile.
+    virtual ConfigurationStatus set_custom_key_forced(const CiString<50>& key, const CiString<500>& value) {
+        return ConfigurationStatus::NotSupported;
+    };
 };
 
 } // namespace ocpp::v16

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
@@ -146,6 +146,7 @@ private:
     std::mutex data_transfer_callbacks_mutex;
     std::map<CiString<50>, std::function<void(const KeyValue& key_value)>> configuration_key_changed_callbacks;
     std::function<void(const KeyValue& key_value)> generic_configuration_key_changed_callback;
+    std::function<bool(const std::string& key, const std::string& value)> custom_key_validation_callback;
 
     std::mutex stop_transaction_mutex;
     std::condition_variable stop_transaction_cv;
@@ -962,6 +963,20 @@ public:
     /// \param callback executed when this configuration key changed
     void
     register_generic_configuration_key_changed_callback(const std::function<void(const KeyValue& key_value)>& callback);
+
+    /// \brief registers a \p callback that can veto a ChangeConfiguration before it is applied (e.g.
+    /// based on runtime charge-point state), for both Core and Custom-profile keys. Invoked from
+    /// set_configuration_key_internal, so it applies regardless of which ChargePointConfigurationInterface
+    /// implementation is in use.
+    /// \param callback returns true to allow the change, false to reject it
+    void register_custom_key_validation_callback(
+        const std::function<bool(const std::string& key, const std::string& value)>& callback);
+
+    /// \brief force-writes a Custom key's value, bypassing its readOnly flag (see
+    /// ChargePointConfigurationInterface::set_custom_key_forced for details)
+    /// \param key
+    /// \param value
+    ConfigurationStatus set_custom_key_forced(const CiString<50>& key, const CiString<500>& value);
 
     /// \brief registers a \p callback function that can be used to react to a security event callback. This callback is
     /// called only if the SecurityEvent occured internally within libocpp

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point.cpp
@@ -387,6 +387,15 @@ void ChargePoint::register_generic_configuration_key_changed_callback(
     this->charge_point->register_generic_configuration_key_changed_callback(callback);
 }
 
+void ChargePoint::register_custom_key_validation_callback(
+    const std::function<bool(const std::string& key, const std::string& value)>& callback) {
+    this->charge_point->register_custom_key_validation_callback(callback);
+}
+
+ConfigurationStatus ChargePoint::set_custom_key_forced(const CiString<50>& key, const CiString<500>& value) {
+    return this->charge_point->set_custom_key_forced(key, value);
+}
+
 void ChargePoint::register_security_event_callback(
     const std::function<void(const std::string& type, const std::string& tech_info)>& callback) {
     this->charge_point->register_security_event_callback(callback);

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
@@ -3139,7 +3139,7 @@ std::optional<KeyValue> ChargePointConfiguration::getLanguageKeyValue() {
 // Custom
 std::optional<KeyValue> ChargePointConfiguration::getCustomKeyValue(const CiString<50>& key) {
     std::lock_guard<std::recursive_mutex> lock(this->configuration_mutex);
-    if (!this->config["Custom"].contains(key.get())) {
+    if (!this->config.contains("Custom") or !this->config["Custom"].contains(key.get())) {
         return std::nullopt;
     }
 
@@ -4302,6 +4302,15 @@ std::optional<ConfigurationStatus> ChargePointConfiguration::set(const CiString<
     }
 
     return ConfigurationStatus::Accepted;
+}
+
+ConfigurationStatus ChargePointConfiguration::set_custom_key_forced(const CiString<50>& key,
+                                                                    const CiString<500>& value) {
+    std::lock_guard<std::recursive_mutex> lock(this->configuration_mutex);
+    if (!this->config.contains("Custom") or !this->config["Custom"].contains(key.get())) {
+        return ConfigurationStatus::NotSupported;
+    }
+    return this->setCustomKey(key, value, /*force=*/true);
 }
 
 } // namespace ocpp::v16

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -1868,6 +1868,9 @@ ChargePointImpl::set_configuration_key_internal(CiString<50> key, CiString<500> 
         if (key != "AuthorizationKey" && kv.value().readonly) {
             // supported but could not be changed
             result = ConfigurationStatus::Rejected;
+        } else if (this->custom_key_validation_callback and
+                   not this->custom_key_validation_callback(key.get(), value.get())) {
+            result = ConfigurationStatus::Rejected;
         } else {
             // TODO(kai): how to signal RebootRequired? or what does need reboot required?
 
@@ -4945,6 +4948,15 @@ void ChargePointImpl::register_configuration_key_changed_callback(
 void ChargePointImpl::register_generic_configuration_key_changed_callback(
     const std::function<void(const KeyValue& key_value)>& callback) {
     this->generic_configuration_key_changed_callback = callback;
+}
+
+void ChargePointImpl::register_custom_key_validation_callback(
+    const std::function<bool(const std::string& key, const std::string& value)>& callback) {
+    this->custom_key_validation_callback = callback;
+}
+
+ConfigurationStatus ChargePointImpl::set_custom_key_forced(const CiString<50>& key, const CiString<500>& value) {
+    return this->configuration.set_custom_key_forced(key, value);
 }
 
 void ChargePointImpl::register_security_event_callback(

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(libocpp_unit_tests PRIVATE
         test_config_validation.cpp
         utils_tests.cpp
         test_configuration.cpp
+        test_custom_key_hooks.cpp
         test_utils.cpp
         test_variable_resolver.cpp
 )

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/test_custom_key_hooks.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/test_custom_key_hooks.cpp
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+/// \file test_custom_key_hooks.cpp
+/// \brief Tests for the ChargePointConfigurationInterface extensibility hooks:
+///   * set_custom_key_forced() bypassing readOnly on an existing Custom key, and returning
+///     NotSupported for a key that isn't defined in the Custom profile.
+///   * the ChargePointImpl-level custom_key_validation_callback vetoing a ChangeConfiguration,
+///     exercised through the public set_configuration_key() entry point so both the readonly
+///     gate and the veto gate in set_configuration_key_internal() are covered end to end.
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <ocpp/v16/charge_point_configuration.hpp>
+#include <ocpp/v16/charge_point_impl.hpp>
+
+#include "connectivity_manager_mock.hpp"
+#include "evse_security_mock.hpp"
+
+namespace fs = std::filesystem;
+
+using ::testing::NiceMock;
+
+namespace ocpp {
+namespace v16 {
+
+namespace {
+
+/// \brief config-full.json only defines Internal/Core/../CostAndPrice - there is no Custom
+/// profile in the stock v16 config fixtures (Custom is an application-defined extension point).
+/// To exercise set_custom_key_forced() against a real, schema-backed Custom key we copy the
+/// stock v16 config directory into a temp dir, add a small Custom.json schema there, wire it
+/// into Config.json's additionalProperties:false property list, and inject a matching "Custom"
+/// object into the config JSON before constructing ChargePointConfiguration.
+fs::path make_custom_profile_config_dir(const fs::path& base_dir) {
+    const fs::path dst = base_dir / "config_with_custom_profile";
+    fs::create_directories(dst);
+    fs::copy(fs::path(CONFIG_DIR_V16), dst, fs::copy_options::recursive | fs::copy_options::overwrite_existing);
+
+    const fs::path custom_schema_path = dst / "profile_schemas" / "Custom.json";
+    std::ofstream custom_schema_ofs(custom_schema_path);
+    custom_schema_ofs << R"({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+            "TestReadOnlyKey": { "type": "string", "readOnly": true },
+            "TestWritableKey": { "type": "string", "readOnly": false }
+        },
+        "additionalProperties": false
+    })";
+    custom_schema_ofs.close();
+
+    const fs::path config_schema_path = dst / "profile_schemas" / "Config.json";
+    std::ifstream config_schema_ifs(config_schema_path);
+    json config_schema = json::parse(config_schema_ifs);
+    config_schema_ifs.close();
+    config_schema["properties"]["Custom"] = {{"type", "object"}, {"$ref", "Custom.json"}};
+    std::ofstream config_schema_ofs(config_schema_path);
+    config_schema_ofs << config_schema.dump();
+    config_schema_ofs.close();
+
+    return dst;
+}
+
+std::string read_file(const fs::path& path) {
+    std::ifstream ifs(path);
+    return std::string((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
+}
+
+} // namespace
+
+class CustomKeyHooksTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        this->tmp_dir = fs::temp_directory_path() /
+                        ("ocpp_v16_custom_key_hooks_test_" + std::to_string(reinterpret_cast<std::uintptr_t>(this)));
+        fs::create_directories(this->tmp_dir);
+
+        const fs::path config_dir = make_custom_profile_config_dir(this->tmp_dir);
+
+        json config_json = json::parse(read_file(fs::path(CONFIG_FILE_LOCATION_V16)));
+        config_json["Custom"] = {{"TestReadOnlyKey", "initial-ro"}, {"TestWritableKey", "initial-rw"}};
+
+        this->configuration = std::make_unique<ChargePointConfiguration>(config_json.dump(), config_dir,
+                                                                         fs::path(USER_CONFIG_FILE_LOCATION_V16));
+    }
+
+    void TearDown() override {
+        std::error_code ec;
+        fs::remove_all(this->tmp_dir, ec);
+    }
+
+    std::unique_ptr<ChargePointConfiguration> configuration;
+    fs::path tmp_dir;
+};
+
+TEST_F(CustomKeyHooksTest, SetCustomKeyForcedBypassesReadOnly) {
+    // Confirm the key really is readOnly through the normal path first.
+    auto before = configuration->get("TestReadOnlyKey");
+    ASSERT_TRUE(before.has_value());
+    EXPECT_TRUE(before.value().readonly);
+
+    auto normal_set = configuration->set("TestReadOnlyKey", "should-be-rejected");
+    ASSERT_TRUE(normal_set.has_value());
+    EXPECT_EQ(normal_set.value(), ConfigurationStatus::Rejected);
+
+    const auto forced_result = configuration->set_custom_key_forced("TestReadOnlyKey", "forced-value");
+    EXPECT_EQ(forced_result, ConfigurationStatus::Accepted);
+
+    auto after = configuration->get("TestReadOnlyKey");
+    ASSERT_TRUE(after.has_value());
+    ASSERT_TRUE(after.value().value.has_value());
+    EXPECT_EQ(after.value().value.value(), "forced-value");
+}
+
+TEST_F(CustomKeyHooksTest, SetCustomKeyForcedRejectsMissingKey) {
+    const auto result = configuration->set_custom_key_forced("DoesNotExist", "x");
+    EXPECT_EQ(result, ConfigurationStatus::NotSupported);
+}
+
+class CustomKeyValidationCallbackTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        this->evse_security = std::make_shared<NiceMock<EvseSecurityMock>>();
+        this->connectivity_manager = std::make_shared<NiceMock<ConnectivityManagerMock>>();
+
+        this->configuration = std::make_unique<ChargePointConfiguration>(read_file(fs::path(CONFIG_FILE_LOCATION_V16)),
+                                                                         fs::path(CONFIG_DIR_V16),
+                                                                         fs::path(USER_CONFIG_FILE_LOCATION_V16));
+
+        this->tmp_dir = fs::temp_directory_path() / ("ocpp_v16_custom_key_validation_test_" +
+                                                     std::to_string(reinterpret_cast<std::uintptr_t>(this)));
+        fs::create_directories(this->tmp_dir);
+
+        this->charge_point = std::make_unique<ChargePointImpl>(
+            *this->configuration, /*share_path=*/fs::path(CONFIG_DIR_V16), /*database_path=*/this->tmp_dir,
+            /*sql_init_path=*/fs::path(MIGRATION_FILES_LOCATION_V16), /*message_log_path=*/this->tmp_dir,
+            this->evse_security, this->connectivity_manager, /*security_configuration=*/std::nullopt,
+            /*message_callback=*/nullptr);
+    }
+
+    void TearDown() override {
+        std::error_code ec;
+        fs::remove_all(this->tmp_dir, ec);
+    }
+
+    std::shared_ptr<NiceMock<EvseSecurityMock>> evse_security;
+    std::shared_ptr<NiceMock<ConnectivityManagerMock>> connectivity_manager;
+    std::unique_ptr<ChargePointConfiguration> configuration;
+    std::unique_ptr<ChargePointImpl> charge_point;
+    fs::path tmp_dir;
+};
+
+TEST_F(CustomKeyValidationCallbackTest, VetoRejectsChangeConfiguration) {
+    charge_point->register_custom_key_validation_callback(
+        [](const std::string& key, const std::string& value) { return false; });
+
+    const auto result = charge_point->set_configuration_key("HeartbeatInterval", "100");
+    EXPECT_EQ(result, ConfigurationStatus::Rejected);
+}
+
+TEST_F(CustomKeyValidationCallbackTest, ApprovingCallbackAllowsChangeConfiguration) {
+    charge_point->register_custom_key_validation_callback(
+        [](const std::string& key, const std::string& value) { return true; });
+
+    const auto result = charge_point->set_configuration_key("HeartbeatInterval", "100");
+    EXPECT_EQ(result, ConfigurationStatus::Accepted);
+}
+
+TEST_F(CustomKeyValidationCallbackTest, NoCallbackRegisteredBehavesAsBefore) {
+    const auto result = charge_point->set_configuration_key("HeartbeatInterval", "100");
+    EXPECT_EQ(result, ConfigurationStatus::Accepted);
+}
+
+} // namespace v16
+} // namespace ocpp


### PR DESCRIPTION
Adds two opt-in, inert-by-default hooks to ChargePointConfigurationInterface: a validation callback that can veto a ChangeConfiguration before it is applied (e.g. based on runtime charge-point state), and a forced-write path that bypasses readOnly for internal/backend-driven updates only (never for CSMS-initiated changes). The validation callback lives in ChargePointImpl::set_configuration_key_internal (mirroring register_configuration_key_changed_callback), so it applies to both config backends (legacy JSON and DeviceModel) and to any key - Custom or Core - without needing key-specific wiring (this is also why LightIntensity no longer needs a hardcoded hook).
There is no read callback: applications should push fresh values in via set_custom_key_forced() directly. An earlier read-callback design re-entered getCustomKeyValue() via setCustomKey() when  refreshing a readOnly key, causing infinite recursion - dropped for that reason. set_custom_key_forced() now locks configuration_mutex and guards against a missing "Custom" section.

Adds tests for veto, forced write on readOnly, and missing keys.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

