### PR TITLE
EvseManager: Add WaitingForReplug state

### DIFF
--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -123,7 +123,9 @@ void Charger::error_thread() {
         if (error_thread_handle.shouldExit()) {
             break;
         }
-        auto events = error_handling_event_queue.wait();
+        // Use a bounded wait: a plain wait() can miss the shutdown when the destructor's
+        // wake-up event is consumed before the exit flag is set, blocking the join forever.
+        auto events = error_handling_event_queue.wait_for(std::chrono::seconds(1));
         if (!events.empty()) {
             Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_signal_loop);
             for (auto& event : events) {
@@ -1037,13 +1039,22 @@ void Charger::run_state_machine() {
                 break;
             }
 
-            // If the only stop reason is the unplug and a replug timeout is configured, give the
-            // user a grace period to replug and continue the still active transaction.
-            if (not shared_context.flag_ev_plugged_in and config_context.replug_timeout_s > 0 and
-                shared_context.flag_transaction_active and shared_context.flag_authorized and
-                not shared_context.flag_disable_requested and shared_context.shutdown_type == ShutdownType::None) {
-                set_state(EvseState::WaitingForReplug);
-                break;
+            {
+                // The grace period only applies while the transaction is "young"; 0 means no limit.
+                const bool young_transaction =
+                    config_context.replug_max_transaction_age_s <= 0 or
+                    std::chrono::steady_clock::now() - shared_context.flag_transaction_active_since <
+                        std::chrono::seconds(config_context.replug_max_transaction_age_s);
+
+                // If the only stop reason is the unplug and a replug timeout is configured, give the
+                // user a grace period to replug and continue the still active transaction.
+                if (not shared_context.flag_ev_plugged_in and config_context.replug_timeout_s > 0 and
+                    young_transaction and shared_context.flag_transaction_active and
+                    shared_context.flag_authorized and not shared_context.flag_disable_requested and
+                    shared_context.shutdown_type == ShutdownType::None) {
+                    set_state(EvseState::WaitingForReplug);
+                    break;
+                }
             }
 
             // Those are fatal, so we can not recover without replugging.
@@ -1502,6 +1513,7 @@ bool Charger::start_transaction() {
 
     store->store_session(shared_context.session_uuid);
     signal_transaction_started_event(shared_context.id_token);
+    shared_context.flag_transaction_active_since = std::chrono::steady_clock::now();
     shared_context.flag_transaction_active = true;
     return true;
 }
@@ -1615,7 +1627,8 @@ void Charger::setup(bool has_ventilation, const ChargeMode _charge_mode, bool _a
                     const int _soft_over_current_timeout_ms, const int _state_F_after_fault_ms,
                     const bool fail_on_powermeter_errors, const bool raise_mrec9,
                     const int sleep_before_enabling_pwm_hlc_mode_ms, const utils::SessionIdType session_id_type,
-                    const int hlc_charge_loop_without_energy_timeout_s, const int replug_timeout_s) {
+                    const int hlc_charge_loop_without_energy_timeout_s, const int replug_timeout_s,
+                    const int replug_max_transaction_age_s) {
     // set up board support package
     bsp->setup(has_ventilation);
 
@@ -1641,6 +1654,7 @@ void Charger::setup(bool has_ventilation, const ChargeMode _charge_mode, bool _a
     config_context.session_id_type = session_id_type;
     config_context.hlc_charge_loop_without_energy_timeout_s = hlc_charge_loop_without_energy_timeout_s;
     config_context.replug_timeout_s = replug_timeout_s;
+    config_context.replug_max_transaction_age_s = replug_max_transaction_age_s;
 
     if (config_context.charge_mode == ChargeMode::AC and config_context.ac_hlc_enabled)
         EVLOG_info << "AC HLC mode enabled.";

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -1037,6 +1037,15 @@ void Charger::run_state_machine() {
                 break;
             }
 
+            // If the only stop reason is the unplug and a replug timeout is configured, give the
+            // user a grace period to replug and continue the still active transaction.
+            if (not shared_context.flag_ev_plugged_in and config_context.replug_timeout_s > 0 and
+                shared_context.flag_transaction_active and shared_context.flag_authorized and
+                not shared_context.flag_disable_requested and shared_context.shutdown_type == ShutdownType::None) {
+                set_state(EvseState::WaitingForReplug);
+                break;
+            }
+
             // Those are fatal, so we can not recover without replugging.
             if (not shared_context.flag_transaction_active or not shared_context.flag_ev_plugged_in or
                 not shared_context.flag_authorized or shared_context.flag_disable_requested) {
@@ -1053,6 +1062,50 @@ void Charger::run_state_machine() {
             } else {
                 // If the reason was not the EVSE, go to paused by EV
                 set_state(EvseState::ChargingPausedEV);
+            }
+            break;
+
+        // Grace period after the EV was unplugged while the transaction was otherwise still
+        // intact. If the EV is replugged within replug_timeout_s, the session and transaction
+        // continue (via WaitingForAuthentication, see process_cp_events_state). Otherwise the
+        // session is torn down in Finished as if the grace period did not exist.
+        case EvseState::WaitingForReplug:
+            if (initialize_state) {
+                session_log.evse(false, fmt::format("Waiting {} s for replug to continue the session",
+                                                    config_context.replug_timeout_s));
+                // Reset all state related to the previous car connection, similar to Idle,
+                // but keep the session, transaction and authorization untouched.
+                bcb_toggle_reset();
+                shared_context.iec_allow_close_contactor = false;
+                if (config_context.charge_mode == ChargeMode::AC) {
+                    shared_context.hlc_charging_active = false;
+                } else {
+                    shared_context.hlc_charging_active = true;
+                }
+                shared_context.hlc_allow_close_contactor = false;
+                // A different cable may be used on replug, force a re-read of the PP ampacity
+                shared_context.max_current_cable.reset();
+                shared_context.hlc_charging_terminate_pause = HlcTerminatePause::Unknown;
+                shared_context.legacy_wakeup_done = false;
+                shared_context.hlc_d20_active = false;
+                cp_state_X1();
+                clear_errors_on_unplug();
+            }
+
+            // The same conditions that route StoppingCharging to Finished, except the unplug itself
+            {
+                const bool fatal_error = stop_charging_on_fatal_error_internal();
+                if (fatal_error or not shared_context.flag_transaction_active or not shared_context.flag_authorized or
+                    shared_context.flag_disable_requested) {
+                    session_log.evse(false, fmt::format("Stop waiting for replug: {}", stop_reason_flags(fatal_error)));
+                    set_state(EvseState::Finished);
+                    break;
+                }
+            }
+
+            if (time_in_current_state >= config_context.replug_timeout_s * 1000) {
+                session_log.evse(false, "Replug timeout expired, finishing session");
+                set_state(EvseState::Finished);
             }
             break;
 
@@ -1186,6 +1239,17 @@ void Charger::process_cp_events_state(CPEvent cp_event) {
             } else if (cp_event == CPEvent::CarRequestedStopPower) {
                 bcb_toggle_detect_stop_pulse();
             }
+        }
+        break;
+
+    case EvseState::WaitingForReplug:
+        if (cp_event == CPEvent::CarPluggedIn) {
+            session_log.evse(false, "EV replugged within grace period, continuing session");
+            shared_context.flag_ev_plugged_in = true;
+            // Authorization and transaction are still active, so WaitingForAuthentication
+            // will directly proceed to PrepareCharging with the proper PWM/t_step handling
+            // and re-read the PP ampacity for socket type connectors.
+            shared_context.current_state = EvseState::WaitingForAuthentication;
         }
         break;
 
@@ -1551,7 +1615,7 @@ void Charger::setup(bool has_ventilation, const ChargeMode _charge_mode, bool _a
                     const int _soft_over_current_timeout_ms, const int _state_F_after_fault_ms,
                     const bool fail_on_powermeter_errors, const bool raise_mrec9,
                     const int sleep_before_enabling_pwm_hlc_mode_ms, const utils::SessionIdType session_id_type,
-                    const int hlc_charge_loop_without_energy_timeout_s) {
+                    const int hlc_charge_loop_without_energy_timeout_s, const int replug_timeout_s) {
     // set up board support package
     bsp->setup(has_ventilation);
 
@@ -1576,6 +1640,7 @@ void Charger::setup(bool has_ventilation, const ChargeMode _charge_mode, bool _a
     config_context.sleep_before_enabling_pwm_hlc_mode_ms = sleep_before_enabling_pwm_hlc_mode_ms;
     config_context.session_id_type = session_id_type;
     config_context.hlc_charge_loop_without_energy_timeout_s = hlc_charge_loop_without_energy_timeout_s;
+    config_context.replug_timeout_s = replug_timeout_s;
 
     if (config_context.charge_mode == ChargeMode::AC and config_context.ac_hlc_enabled)
         EVLOG_info << "AC HLC mode enabled.";
@@ -1905,6 +1970,9 @@ std::string Charger::evse_state_to_string(EvseState s) {
         break;
     case EvseState::SwitchPhases:
         return ("SwitchPhases");
+        break;
+    case EvseState::WaitingForReplug:
+        return ("Wait for Replug");
         break;
     }
     return "Invalid";

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -107,7 +107,8 @@ public:
                const std::string switch_3ph1ph_cp_state, const int soft_over_current_timeout_ms,
                const int _state_F_after_fault_ms, const bool fail_on_powermeter_errors, const bool raise_mrec9,
                const int sleep_before_enabling_pwm_hlc_mode_ms, const utils::SessionIdType session_id_type,
-               const int hlc_charge_loop_without_energy_timeout_s, const int replug_timeout_s);
+               const int hlc_charge_loop_without_energy_timeout_s, const int replug_timeout_s,
+               const int replug_max_transaction_age_s);
 
     void enable_disable_initial_state_publish();
     bool enable_disable(int connector_id, const types::evse_manager::EnableDisableSource& source);
@@ -326,12 +327,14 @@ private:
         std::atomic_bool flag_paused_by_evse{false};
         std::atomic_bool flag_ev_plugged_in{false};
         // set to true if auth is from PnC, otherwise to false (EIM)
-        bool authorized_pnc;
+        bool authorized_pnc{false};
         bool matching_started;
         float max_current;
         std::chrono::time_point<std::chrono::steady_clock> max_current_valid_until;
         std::optional<double> max_current_cable;
         std::atomic_bool flag_transaction_active;
+        // Time the current transaction started; limits the replug grace period to young transactions
+        std::chrono::time_point<std::chrono::steady_clock> flag_transaction_active_since;
         bool session_active;
         std::string session_uuid;
         bool connector_enabled;
@@ -345,9 +348,9 @@ private:
         float current_drawn_by_vehicle[3];
         ShutdownType shutdown_type{ShutdownType::None};
         ShutdownType last_shutdown_type{ShutdownType::None};
-        int ac_with_soc_timer;
+        int ac_with_soc_timer{3600000};
         // non standard compliant option: time out after a while and switch back to DC to get SoC update
-        bool ac_with_soc_timeout;
+        bool ac_with_soc_timeout{false};
         bool contactor_welded{false};
         bool switch_3ph1ph_threephase{false};
         bool switch_3ph1ph_threephase_ongoing{false};
@@ -359,12 +362,13 @@ private:
     } shared_context;
 
     struct ConfigContext {
+        // Defaults mirror the manifest; all values are overwritten by setup()
         // non standard compliant option to enforce HLC in AC mode
-        bool ac_enforce_hlc;
+        bool ac_enforce_hlc{false};
         // Config option to use 5 percent PWM in HLC AC mode
-        bool ac_hlc_use_5percent;
+        bool ac_hlc_use_5percent{true};
         // Config option to enable HLC in AC mode
-        bool ac_hlc_enabled;
+        bool ac_hlc_enabled{false};
         // AC or DC
         ChargeMode charge_mode{0};
         // Delay when switching from 1ph to 3ph or 3ph to 1ph
@@ -376,9 +380,9 @@ private:
         // Switch to F for configured ms after a fatal error
         int state_F_after_fault_ms{300};
         // Fail on powermeter errors
-        bool fail_on_powermeter_errors;
+        bool fail_on_powermeter_errors{true};
         // Raise MREC9 authorization timeout error
-        bool raise_mrec9;
+        bool raise_mrec9{false};
         // sleep before enabling pwm in hlc mode
         int sleep_before_enabling_pwm_hlc_mode_ms{1000};
         // type used to generate session ids
@@ -389,6 +393,10 @@ private:
         // Grace period in seconds to continue an active transaction after the EV was unplugged.
         // 0 disables the grace period and finishes the transaction immediately on unplug.
         int replug_timeout_s{0};
+        // The replug grace period only applies if the EV is unplugged within this many seconds
+        // after the transaction started. Later unplugs finish the transaction immediately.
+        // 0 means no limit.
+        int replug_max_transaction_age_s{300};
     } config_context;
 
     // Used by different threads, but requires no complete state machine locking

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -79,7 +79,8 @@ public:
         Finished,
         T_step_EF,
         T_step_X1,
-        SwitchPhases
+        SwitchPhases,
+        WaitingForReplug
     };
 
     enum class HlcTerminatePause {
@@ -106,7 +107,7 @@ public:
                const std::string switch_3ph1ph_cp_state, const int soft_over_current_timeout_ms,
                const int _state_F_after_fault_ms, const bool fail_on_powermeter_errors, const bool raise_mrec9,
                const int sleep_before_enabling_pwm_hlc_mode_ms, const utils::SessionIdType session_id_type,
-               const int hlc_charge_loop_without_energy_timeout_s);
+               const int hlc_charge_loop_without_energy_timeout_s, const int replug_timeout_s);
 
     void enable_disable_initial_state_publish();
     bool enable_disable(int connector_id, const types::evse_manager::EnableDisableSource& source);
@@ -274,8 +275,6 @@ private:
     bool start_transaction();
     void stop_transaction();
 
-    void process_event(CPEvent event);
-
     void set_state(EvseState s);
 
     // This mutex locks all variables related to the state machine
@@ -387,6 +386,9 @@ private:
         // Timeout in seconds that defines for how long the EVSE allows the ISO charge loop (AC: ChargingStatus, DC:
         // CurrentDemand)
         int hlc_charge_loop_without_energy_timeout_s{300};
+        // Grace period in seconds to continue an active transaction after the EV was unplugged.
+        // 0 disables the grace period and finishes the transaction immediately on unplug.
+        int replug_timeout_s{0};
     } config_context;
 
     // Used by different threads, but requires no complete state machine locking
@@ -500,8 +502,15 @@ private:
 protected:
     // provide access for unit tests
     void run_state_machine();
+    void process_event(CPEvent event);
     constexpr auto& get_shared_context() {
         return shared_context;
+    }
+    constexpr auto& get_config_context() {
+        return config_context;
+    }
+    constexpr auto& get_internal_context() {
+        return internal_context;
     }
     constexpr const auto& get_enable_disable_source_table() const {
         return enable_disable_source_table;

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -1360,7 +1360,8 @@ void EvseManager::ready() {
                        config.state_F_after_fault_ms, config.fail_on_powermeter_errors, config.raise_mrec9,
                        config.sleep_before_enabling_pwm_hlc_mode_ms,
                        utils::get_session_id_type_from_string(config.session_id_type),
-                       config.hlc_charge_loop_without_energy_timeout_s, config.replug_timeout_s);
+                       config.hlc_charge_loop_without_energy_timeout_s, config.replug_timeout_s,
+                       config.replug_max_transaction_age_s);
     }
 
     telemetryThreadHandle = std::thread([this]() {
@@ -1549,7 +1550,8 @@ void EvseManager::setup_fake_DC_mode() {
                    config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms, config.state_F_after_fault_ms,
                    config.fail_on_powermeter_errors, config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
                    utils::get_session_id_type_from_string(config.session_id_type),
-                   config.hlc_charge_loop_without_energy_timeout_s, config.replug_timeout_s);
+                   config.hlc_charge_loop_without_energy_timeout_s, config.replug_timeout_s,
+                   config.replug_max_transaction_age_s);
 
     types::iso15118::EVSEID evseid = {config.evse_id, config.evse_id_din};
 
@@ -1592,7 +1594,8 @@ void EvseManager::setup_AC_mode() {
                    config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms, config.state_F_after_fault_ms,
                    config.fail_on_powermeter_errors, config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
                    utils::get_session_id_type_from_string(config.session_id_type),
-                   config.hlc_charge_loop_without_energy_timeout_s, config.replug_timeout_s);
+                   config.hlc_charge_loop_without_energy_timeout_s, config.replug_timeout_s,
+                   config.replug_max_transaction_age_s);
 
     types::iso15118::EVSEID evseid = {config.evse_id, config.evse_id_din};
 

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -1360,7 +1360,7 @@ void EvseManager::ready() {
                        config.state_F_after_fault_ms, config.fail_on_powermeter_errors, config.raise_mrec9,
                        config.sleep_before_enabling_pwm_hlc_mode_ms,
                        utils::get_session_id_type_from_string(config.session_id_type),
-                       config.hlc_charge_loop_without_energy_timeout_s);
+                       config.hlc_charge_loop_without_energy_timeout_s, config.replug_timeout_s);
     }
 
     telemetryThreadHandle = std::thread([this]() {
@@ -1549,7 +1549,7 @@ void EvseManager::setup_fake_DC_mode() {
                    config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms, config.state_F_after_fault_ms,
                    config.fail_on_powermeter_errors, config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
                    utils::get_session_id_type_from_string(config.session_id_type),
-                   config.hlc_charge_loop_without_energy_timeout_s);
+                   config.hlc_charge_loop_without_energy_timeout_s, config.replug_timeout_s);
 
     types::iso15118::EVSEID evseid = {config.evse_id, config.evse_id_din};
 
@@ -1592,7 +1592,7 @@ void EvseManager::setup_AC_mode() {
                    config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms, config.state_F_after_fault_ms,
                    config.fail_on_powermeter_errors, config.raise_mrec9, config.sleep_before_enabling_pwm_hlc_mode_ms,
                    utils::get_session_id_type_from_string(config.session_id_type),
-                   config.hlc_charge_loop_without_energy_timeout_s);
+                   config.hlc_charge_loop_without_energy_timeout_s, config.replug_timeout_s);
 
     types::iso15118::EVSEID evseid = {config.evse_id, config.evse_id_din};
 
@@ -2540,12 +2540,13 @@ void EvseManager::fail_cable_check(const std::string& reason) {
     }
     // Raising a cable check fault should not happen if:
     // - a cancel_transaction (DeAuthorized) is triggered during cable check
-    // - the car has already been unplugged (Idle/Finished), which prevents a race condition
+    // - the car has already been unplugged (Idle/Finished/WaitingForReplug), which prevents a race condition
     //   where the detached cable check thread raises an error after clear_errors_on_unplug()
     //   has already run, leaving the charger permanently inoperative (see GitHub issue #1392)
     const auto current_state = charger->get_current_state();
     const auto last_stop_transaction_reason = charger->get_last_stop_transaction_reason();
-    if (current_state == Charger::EvseState::Idle || current_state == Charger::EvseState::Finished) {
+    if (current_state == Charger::EvseState::Idle || current_state == Charger::EvseState::Finished ||
+        current_state == Charger::EvseState::WaitingForReplug) {
         EVLOG_info << "Cable check failed due to: " << reason
                    << ", but session already ended (car unplugged). Not raising cable check fault error.";
     } else if (not last_stop_transaction_reason.has_value() or

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -126,6 +126,7 @@ struct Conf {
     std::string bpt_grid_code_island_method;
     int hlc_charge_loop_without_energy_timeout_s;
     int dc_ramp_ampere_per_second;
+    int replug_timeout_s;
 };
 
 class EvseManager : public Everest::ModuleBase {

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -127,6 +127,7 @@ struct Conf {
     int hlc_charge_loop_without_energy_timeout_s;
     int dc_ramp_ampere_per_second;
     int replug_timeout_s;
+    int replug_max_transaction_age_s;
 };
 
 class EvseManager : public Everest::ModuleBase {

--- a/modules/EVSE/EvseManager/docs/index.rst
+++ b/modules/EVSE/EvseManager/docs/index.rst
@@ -133,6 +133,11 @@ Charging State Machine
        %% Post-Stop logic
        StoppingCharging --> ChargingPausedEV : EV-initiated pause
 
+       %% Replug grace period (replug_timeout_s > 0)
+       StoppingCharging --> WaitingForReplug : EV unplugged, transaction still active
+       WaitingForReplug --> WaitingForAuthentication : EV replugged in time
+       WaitingForReplug --> Finished : Timeout, deauth, disable or fatal error
+
 State Transitions
 -----------------
 
@@ -151,6 +156,17 @@ State Transitions
 * ``ChargingPausedEV`` -> ``ChargingPausedEVSE``: No power available (AC BASIC only).
 * ``ChargingPausedEVSE`` -> ``PrepareCharging``: Power available, no EVSE pause and errors cleared.
 * ``StoppingCharging`` -> ``ChargingPausedEV``: EV-initiated pause after stop sequence.
+
+**Replug Grace Period**
+
+Only active when the ``replug_timeout_s`` config option is greater than 0.
+
+* ``StoppingCharging`` -> ``WaitingForReplug``: EV unplugged while transaction and authorization
+  are otherwise still intact. The transaction stays open during the grace period.
+* ``WaitingForReplug`` -> ``WaitingForAuthentication``: EV replugged within ``replug_timeout_s``;
+  the session and transaction continue without a new authorization.
+* ``WaitingForReplug`` -> ``Finished``: ``replug_timeout_s`` expired, deauthorization, disable
+  request or fatal error.
 
 **Stop Conditions**
 

--- a/modules/EVSE/EvseManager/docs/index.rst
+++ b/modules/EVSE/EvseManager/docs/index.rst
@@ -159,7 +159,10 @@ State Transitions
 
 **Replug Grace Period**
 
-Only active when the ``replug_timeout_s`` config option is greater than 0.
+Only active when the ``replug_timeout_s`` config option is greater than 0 and the transaction is
+younger than ``replug_max_transaction_age_s`` (0 = no limit). An unplug later in the transaction
+is treated as the user ending it — some EVs briefly pulse CP state A for exactly that — and
+finishes the transaction immediately.
 
 * ``StoppingCharging`` -> ``WaitingForReplug``: EV unplugged while transaction and authorization
   are otherwise still intact. The transaction stays open during the grace period.

--- a/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
+++ b/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
@@ -175,6 +175,9 @@ types::energy::EvseState to_energy_evse_state(const Charger::EvseState charger_s
     case Charger::EvseState::SwitchPhases:
         return types::energy::EvseState::Charging;
         break;
+    case Charger::EvseState::WaitingForReplug:
+        return types::energy::EvseState::Finished;
+        break;
     }
     return types::energy::EvseState::Disabled;
 }

--- a/modules/EVSE/EvseManager/manifest.yaml
+++ b/modules/EVSE/EvseManager/manifest.yaml
@@ -454,6 +454,13 @@ config:
       finished as usual. Set to 0 to finish the transaction immediately on unplug.
     type: integer
     default: 0
+  replug_max_transaction_age_s:
+    description: >-
+      Maximum transaction age in seconds for the `replug_timeout_s` to apply. If the EV is
+      unplugged later than this into the transaction, the `replug_timeout_s` takes no effect.
+      Setting it to 0 or less disables the age limit.
+    type: integer
+    default: 300
 provides:
   evse:
     interface: evse_manager

--- a/modules/EVSE/EvseManager/manifest.yaml
+++ b/modules/EVSE/EvseManager/manifest.yaml
@@ -446,6 +446,14 @@ config:
       Maximum ampere per second limit for up/down ramping of current in charging loop.
     type: integer
     default: 25
+  replug_timeout_s:
+    description: >-
+      Grace period in seconds to continue an active transaction after the EV was unplugged.
+      If the EV is plugged in again within this period, the charging session and transaction
+      continue without a new authorization. When the period expires, the transaction is
+      finished as usual. Set to 0 to finish the transaction immediately on unplug.
+    type: integer
+    default: 0
 provides:
   evse:
     interface: evse_manager

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -97,6 +97,7 @@ struct ChargerTest : public testing::Test {
         ctx.current_state = Charger::EvseState::StoppingCharging;
         ctx.flag_transaction_active = true;
         ctx.session_active = true;
+        ctx.flag_transaction_active_since = std::chrono::steady_clock::now();
         ctx.flag_authorized = true;
         ctx.contactor_open = true;
         ctx.flag_ev_plugged_in = false;
@@ -808,6 +809,39 @@ TEST_F(ChargerTest, UnplugWithReplugTimeoutEntersWaitingForReplug) {
     EXPECT_TRUE(ctx.flag_transaction_active);
     EXPECT_TRUE(ctx.session_active);
     EXPECT_TRUE(ctx.flag_authorized);
+}
+
+TEST_F(ChargerTest, UnplugAfterReplugMaxTransactionAgeFinishesImmediately) {
+    auto& ctx = charger->get_shared_context();
+    charger->get_config_context().replug_timeout_s = 30;
+    charger->get_config_context().replug_max_transaction_age_s = 300;
+    simulate_unplug_during_transaction();
+    // The transaction is older than the replug window
+    ctx.flag_transaction_active_since = std::chrono::steady_clock::now() - std::chrono::seconds(301);
+
+    charger->run_state_machine();
+
+    // Too old for the grace period: finish immediately as if it was not configured
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::Idle);
+    EXPECT_FALSE(ctx.flag_transaction_active);
+    EXPECT_FALSE(ctx.session_active);
+    EXPECT_EQ(last_event, SessionEventEnum::SessionFinished);
+    EXPECT_EQ(ctx.last_stop_transaction_reason, StopTransactionReason::EVDisconnected);
+}
+
+TEST_F(ChargerTest, ReplugMaxTransactionAgeZeroAppliesGraceToOldTransactions) {
+    auto& ctx = charger->get_shared_context();
+    charger->get_config_context().replug_timeout_s = 30;
+    charger->get_config_context().replug_max_transaction_age_s = 0;
+    simulate_unplug_during_transaction();
+    ctx.flag_transaction_active_since = std::chrono::steady_clock::now() - std::chrono::hours(10);
+
+    charger->run_state_machine();
+
+    // 0 means no session age limit
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::WaitingForReplug);
+    EXPECT_TRUE(ctx.flag_transaction_active);
+    EXPECT_TRUE(ctx.session_active);
 }
 
 TEST_F(ChargerTest, ReplugWithinTimeoutContinuesSession) {

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -18,8 +18,11 @@ using namespace types::evse_manager;
 // class that provides access to internal state from the Charger class
 struct ChargerDerived : public Charger {
     using Charger::Charger;
+    using Charger::get_config_context;
     using Charger::get_enable_disable_source_table;
+    using Charger::get_internal_context;
     using Charger::get_shared_context;
+    using Charger::process_event;
     using Charger::run_state_machine;
 
     // updated when a non-zero connector is used to enable_disable()
@@ -46,6 +49,7 @@ struct ChargerTest : public testing::Test {
     std::unique_ptr<IECStateMachine> charger_bsp;
     std::unique_ptr<ErrorHandling> charger_error_handling;
     std::vector<std::unique_ptr<powermeterIntf>> charger_powermeter_billing;
+    std::vector<std::unique_ptr<kvsIntf>> charger_kvs;
     std::unique_ptr<PersistentStore> charger_store;
 
     // error handling requirements
@@ -71,6 +75,7 @@ struct ChargerTest : public testing::Test {
 
     void SetUp() override {
         reset_last_event();
+        charger_store = std::make_unique<PersistentStore>(charger_kvs, "EVSETEST");
         charger = std::make_unique<ChargerDerived>(
             charger_bsp, charger_error_handling, charger_powermeter_billing, charger_store,
             types::evse_board_support::Connector_type::IEC62196Type2Socket, "EVSETEST");
@@ -83,6 +88,18 @@ struct ChargerTest : public testing::Test {
 
     void session_event(SessionEventEnum event) {
         last_event = event;
+    }
+
+    // Simulate the situation right after an unplug during an active transaction:
+    // all charging states funnel into StoppingCharging and the contactors have opened.
+    void simulate_unplug_during_transaction() {
+        auto& ctx = charger->get_shared_context();
+        ctx.current_state = Charger::EvseState::StoppingCharging;
+        ctx.flag_transaction_active = true;
+        ctx.session_active = true;
+        ctx.flag_authorized = true;
+        ctx.contactor_open = true;
+        ctx.flag_ev_plugged_in = false;
     }
 
     static constexpr SessionEventEnum default_event{SessionEventEnum::SessionFinished};
@@ -758,6 +775,137 @@ TEST_F(ChargerTest, DisableDuringIdle) {
 
     // Must immediately transition to Disabled
     EXPECT_EQ(ctx.current_state, Charger::EvseState::Disabled);
+    EXPECT_EQ(last_event, SessionEventEnum::Disabled);
+}
+
+// ----------------------------------------------------------------------------
+// tests for the replug grace period (WaitingForReplug)
+
+TEST_F(ChargerTest, UnplugWithoutReplugTimeoutFinishesImmediately) {
+    auto& ctx = charger->get_shared_context();
+    simulate_unplug_during_transaction();
+
+    charger->run_state_machine();
+
+    // With replug_timeout_s = 0 (default) the session is torn down as before:
+    // StoppingCharging -> Finished -> Idle
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::Idle);
+    EXPECT_FALSE(ctx.flag_transaction_active);
+    EXPECT_FALSE(ctx.session_active);
+    EXPECT_EQ(last_event, SessionEventEnum::SessionFinished);
+    EXPECT_EQ(ctx.last_stop_transaction_reason, StopTransactionReason::EVDisconnected);
+}
+
+TEST_F(ChargerTest, UnplugWithReplugTimeoutEntersWaitingForReplug) {
+    auto& ctx = charger->get_shared_context();
+    charger->get_config_context().replug_timeout_s = 30;
+    simulate_unplug_during_transaction();
+
+    charger->run_state_machine();
+
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::WaitingForReplug);
+    // Session, transaction and authorization stay untouched during the grace period
+    EXPECT_TRUE(ctx.flag_transaction_active);
+    EXPECT_TRUE(ctx.session_active);
+    EXPECT_TRUE(ctx.flag_authorized);
+}
+
+TEST_F(ChargerTest, ReplugWithinTimeoutContinuesSession) {
+    auto& ctx = charger->get_shared_context();
+    charger->get_config_context().replug_timeout_s = 30;
+    charger->get_config_context().ac_hlc_enabled = false;
+    simulate_unplug_during_transaction();
+    ctx.session_uuid = "SESSION_UNDER_TEST";
+
+    charger->run_state_machine();
+    ASSERT_EQ(ctx.current_state, Charger::EvseState::WaitingForReplug);
+
+    charger->process_event(CPEvent::CarPluggedIn);
+
+    // Authorization and transaction are still valid, so the state machine proceeds
+    // through WaitingForAuthentication without starting a new session or transaction.
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::WaitingForAuthentication);
+    EXPECT_TRUE(ctx.flag_ev_plugged_in);
+    EXPECT_TRUE(ctx.flag_transaction_active);
+    EXPECT_TRUE(ctx.session_active);
+    EXPECT_TRUE(ctx.flag_authorized);
+    EXPECT_EQ(ctx.session_uuid, "SESSION_UNDER_TEST");
+}
+
+TEST_F(ChargerTest, ReplugTimeoutExpiryFinishesSession) {
+    auto& ctx = charger->get_shared_context();
+    charger->get_config_context().replug_timeout_s = 30;
+    simulate_unplug_during_transaction();
+
+    charger->run_state_machine();
+    ASSERT_EQ(ctx.current_state, Charger::EvseState::WaitingForReplug);
+
+    // Simulate the expiry of the grace period
+    charger->get_internal_context().current_state_started -= std::chrono::seconds(31);
+    charger->run_state_machine();
+
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::Idle);
+    EXPECT_FALSE(ctx.flag_transaction_active);
+    EXPECT_FALSE(ctx.session_active);
+    EXPECT_EQ(last_event, SessionEventEnum::SessionFinished);
+    EXPECT_EQ(ctx.last_stop_transaction_reason, StopTransactionReason::EVDisconnected);
+}
+
+TEST_F(ChargerTest, AuthorizeFalseDuringReplugGraceFinishesSession) {
+    auto& ctx = charger->get_shared_context();
+    charger->get_config_context().replug_timeout_s = 30;
+    simulate_unplug_during_transaction();
+
+    charger->run_state_machine();
+    ASSERT_EQ(ctx.current_state, Charger::EvseState::WaitingForReplug);
+
+    // Deauthorization stops the session right away, no replug grace period applies
+    types::authorization::ProvidedIdToken token;
+    types::authorization::ValidationResult validation_result;
+    charger->authorize(false, token, validation_result);
+    charger->run_state_machine();
+
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::Idle);
+    EXPECT_FALSE(ctx.flag_transaction_active);
+    EXPECT_FALSE(ctx.session_active);
+}
+
+TEST_F(ChargerTest, CancelTransactionDuringReplugGraceFinishesSession) {
+    auto& ctx = charger->get_shared_context();
+    charger->get_config_context().replug_timeout_s = 30;
+    simulate_unplug_during_transaction();
+
+    charger->run_state_machine();
+    ASSERT_EQ(ctx.current_state, Charger::EvseState::WaitingForReplug);
+
+    types::evse_manager::StopTransactionRequest stop_request;
+    stop_request.reason = StopTransactionReason::Remote;
+    EXPECT_TRUE(charger->cancel_transaction(stop_request));
+    charger->run_state_machine();
+
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::Idle);
+    EXPECT_FALSE(ctx.flag_transaction_active);
+    EXPECT_FALSE(ctx.session_active);
+    EXPECT_EQ(ctx.last_stop_transaction_reason, StopTransactionReason::Remote);
+}
+
+TEST_F(ChargerTest, DisableDuringReplugGraceGoesToDisabled) {
+    constexpr EnableDisableSource disable_source{Enable_source::CSMS, Enable_state::Disable, 100};
+
+    auto& ctx = charger->get_shared_context();
+    charger->get_config_context().replug_timeout_s = 30;
+    simulate_unplug_during_transaction();
+
+    charger->run_state_machine();
+    ASSERT_EQ(ctx.current_state, Charger::EvseState::WaitingForReplug);
+
+    // enable_disable calls run_state_machine synchronously:
+    // WaitingForReplug -> Finished -> Disabled
+    EXPECT_FALSE(charger->enable_disable(1, disable_source));
+
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::Disabled);
+    EXPECT_FALSE(ctx.flag_transaction_active);
+    EXPECT_FALSE(ctx.session_active);
     EXPECT_EQ(last_event, SessionEventEnum::Disabled);
 }
 


### PR DESCRIPTION
We analyzed our user data an observed that its seems to be a common issue that especially during the first 30 secs of a session the cp signal can drop for a view seconds from B to A and then to back to B. This right now ends the sessions, leading to a not ideal experience. 

To deal with that we add a new `WaitingForReplug` state (I know that we had a similar naming for a slightly different concept) - during that state we allow users to reconnect their car without stopping the session/transaction. 


Our data also showed that the majority of these toggles happen within the first 5mins of the session. Later toggles are more likely to be legit attempts from users to stop their session. Therefore we also added the `replug_max_transaction_age_s` defaulting to 5min - after this time the replug logic is deactivated

