### PR TITLE
feat(OCPPmulti): Use EVerest Device Model also in OCPP1.6

### DIFF
--- a/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/device_model/composed_device_model_storage.hpp
+++ b/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/device_model/composed_device_model_storage.hpp
@@ -20,6 +20,9 @@ public:
     ComposedDeviceModelStorage() = default;
 
     /// \brief Register a device model storage.
+    /// If a component/variable combination is already provided by a previously registered storage, the storage
+    /// registered last takes precedence for that variable and a warning is logged. The integrator is responsible
+    /// for avoiding such overlaps.
     /// \param device_model_storage_id   The id of the device model storage. Component variable combinations can be
     /// used to map to this id to identify which device model is adressed for certain requests.
     /// \param  device_model_storage The device model storage to register.
@@ -59,4 +62,17 @@ private:
     ///
     std::string get_variable_source(const ocpp::v2::Component& component, const ocpp::v2::Variable& variable);
 };
+
+/// \brief Builds the module-standard composed device model storage: \p ocpp_storage registered under
+/// source id "OCPP" (the default source) and \p everest_storage under "EVEREST". For component/variable
+/// combinations defined in both storages, the EVerest device model takes precedence and a warning is
+/// logged; the integrator is responsible for avoiding overlaps.
+/// \param ocpp_storage     Must have a fully seeded backing database, because registration snapshots
+///                         get_device_model() to build the per-variable source map. A null pointer
+///                         raises std::invalid_argument.
+/// \param everest_storage  Registered under "EVEREST"; a null pointer is skipped with a warning.
+/// \return The composed storage with both sources registered.
+std::unique_ptr<ComposedDeviceModelStorage>
+make_composed_device_model_storage(std::shared_ptr<ocpp::v2::DeviceModelStorageInterface> ocpp_storage,
+                                   std::shared_ptr<ocpp::v2::DeviceModelStorageInterface> everest_storage);
 } // namespace ocpp_module_common::device_model

--- a/lib/everest/ocpp_module_common/src/device_model/composed_device_model_storage.cpp
+++ b/lib/everest/ocpp_module_common/src/device_model/composed_device_model_storage.cpp
@@ -3,7 +3,10 @@
 
 #include <everest/ocpp_module_common/device_model/composed_device_model_storage.hpp>
 
+#include <stdexcept>
+
 static constexpr auto VARIABLE_SOURCE_OCPP = "OCPP";
+static constexpr auto VARIABLE_SOURCE_EVEREST = "EVEREST";
 
 namespace ocpp_module_common::device_model {
 
@@ -17,17 +20,21 @@ bool ComposedDeviceModelStorage::register_device_model_storage(
     // store the sources of each variable to be able to lookup requests to the device model storage
     for (const auto& [component, variable_map] : device_model_map) {
         for (const auto& [variable, variable_meta] : variable_map) {
-            // check if component variable source is already exist in the map
-            if (this->component_variable_source_map.find(component) != this->component_variable_source_map.end() &&
-                this->component_variable_source_map.at(component).find(variable) !=
-                    this->component_variable_source_map.at(component).end()) {
-                EVLOG_warning << "Component variable source already exists for component: " << component.name
-                              << ", variable: " << variable.name << ". Fix your device model configuration.";
+            // Note: Source should not be optional, should be changed in libocpp
+            const auto source = variable_meta.source.value_or(VARIABLE_SOURCE_OCPP);
+
+            // On overlap, the storage registered last takes precedence. The integrator is responsible for
+            // avoiding overlaps.
+            const auto component_it = this->component_variable_source_map.find(component);
+            if (component_it != this->component_variable_source_map.end() &&
+                component_it->second.find(variable) != component_it->second.end()) {
+                EVLOG_warning << "Variable " << variable.name << " of component " << component.name
+                              << " is defined in multiple device model storages; source " << source
+                              << " takes precedence. The integrator is responsible for avoiding overlapping "
+                                 "device model definitions.";
             }
 
-            // Note: Source should not be optional, should be changed in libocpp
-            this->component_variable_source_map[component][variable] =
-                variable_meta.source.value_or(VARIABLE_SOURCE_OCPP);
+            this->component_variable_source_map[component][variable] = source;
         }
     }
 
@@ -37,8 +44,17 @@ bool ComposedDeviceModelStorage::register_device_model_storage(
 
 ocpp::v2::DeviceModelMap ComposedDeviceModelStorage::get_device_model() {
     ocpp::v2::DeviceModelMap device_model_map;
-    for (const auto& [name, device_model_storage] : this->device_model_storages) {
-        device_model_map.merge(device_model_storage->get_device_model());
+    // Merge per variable, not per component: each variable is contributed only by the storage that owns it
+    // according to the source map, so the merged model is consistent with request routing when storages
+    // define overlapping components or variables.
+    for (const auto& [storage_id, device_model_storage] : this->device_model_storages) {
+        for (auto& [component, variable_map] : device_model_storage->get_device_model()) {
+            for (auto& [variable, variable_meta] : variable_map) {
+                if (get_variable_source(component, variable) == storage_id) {
+                    device_model_map[component].insert_or_assign(variable, std::move(variable_meta));
+                }
+            }
+        }
     }
     return device_model_map;
 }
@@ -158,6 +174,26 @@ ocpp_module_common::device_model::ComposedDeviceModelStorage::get_variable_sourc
         return VARIABLE_SOURCE_OCPP; // default source
     }
     return variable_map.at(variable);
+}
+
+std::unique_ptr<ComposedDeviceModelStorage>
+make_composed_device_model_storage(std::shared_ptr<ocpp::v2::DeviceModelStorageInterface> ocpp_storage,
+                                   std::shared_ptr<ocpp::v2::DeviceModelStorageInterface> everest_storage) {
+    if (ocpp_storage == nullptr) {
+        throw std::invalid_argument("Cannot compose device model storage: the OCPP device model storage is null");
+    }
+
+    auto composed_device_model_storage = std::make_unique<ComposedDeviceModelStorage>();
+    // note - registration snapshots get_device_model(), which causes a slight delay; scope for performance tuning
+    composed_device_model_storage->register_device_model_storage(VARIABLE_SOURCE_OCPP, std::move(ocpp_storage));
+    if (everest_storage != nullptr) {
+        composed_device_model_storage->register_device_model_storage(VARIABLE_SOURCE_EVEREST,
+                                                                     std::move(everest_storage));
+    } else {
+        EVLOG_warning << "No EVerest device model storage provided; composed device model contains only the "
+                         "OCPP source";
+    }
+    return composed_device_model_storage;
 }
 
 } // namespace ocpp_module_common::device_model

--- a/lib/everest/ocpp_module_common/tests/CMakeLists.txt
+++ b/lib/everest/ocpp_module_common/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(${TEST_TARGET_NAME})
 
 target_sources(${TEST_TARGET_NAME}
     PRIVATE
+    composed_device_model_storage_test.cpp
     data_transfer_conversions_test.cpp
     error_handling_tests.cpp
     everest_device_model_storage_test.cpp

--- a/lib/everest/ocpp_module_common/tests/composed_device_model_storage_test.cpp
+++ b/lib/everest/ocpp_module_common/tests/composed_device_model_storage_test.cpp
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <everest/ocpp_module_common/device_model/composed_device_model_storage.hpp>
+
+namespace {
+
+using ocpp_module_common::device_model::make_composed_device_model_storage;
+
+ocpp::v2::Component make_component(const std::string& name) {
+    ocpp::v2::Component component;
+    component.name = name;
+    return component;
+}
+
+ocpp::v2::Variable make_variable(const std::string& name) {
+    ocpp::v2::Variable variable;
+    variable.name = name;
+    return variable;
+}
+
+// In-memory storage exposing a fixed device model map; records writes so tests can assert routing.
+class FakeDeviceModelStorage : public ocpp::v2::DeviceModelStorageInterface {
+public:
+    FakeDeviceModelStorage(ocpp::v2::DeviceModelMap device_model_map, std::string attribute_value) :
+        device_model_map(std::move(device_model_map)), attribute_value(std::move(attribute_value)) {
+    }
+
+    ocpp::v2::DeviceModelMap get_device_model() override {
+        return this->device_model_map;
+    }
+
+    std::optional<ocpp::v2::VariableAttribute> get_variable_attribute(const ocpp::v2::Component& component_id,
+                                                                      const ocpp::v2::Variable& variable_id,
+                                                                      const ocpp::v2::AttributeEnum&) override {
+        const auto component_it = this->device_model_map.find(component_id);
+        if (component_it == this->device_model_map.end() ||
+            component_it->second.find(variable_id) == component_it->second.end()) {
+            return std::nullopt;
+        }
+        ocpp::v2::VariableAttribute attribute;
+        attribute.value = this->attribute_value;
+        return attribute;
+    }
+
+    std::vector<ocpp::v2::VariableAttribute>
+    get_variable_attributes(const ocpp::v2::Component& component_id, const ocpp::v2::Variable& variable_id,
+                            const std::optional<ocpp::v2::AttributeEnum>& attribute_enum) override {
+        const auto attribute =
+            get_variable_attribute(component_id, variable_id, attribute_enum.value_or(ocpp::v2::AttributeEnum::Actual));
+        if (!attribute.has_value()) {
+            return {};
+        }
+        return {attribute.value()};
+    }
+
+    ocpp::v2::SetVariableStatusEnum set_variable_attribute_value(const ocpp::v2::Component& component_id,
+                                                                 const ocpp::v2::Variable& variable_id,
+                                                                 const ocpp::v2::AttributeEnum&,
+                                                                 const std::string& value,
+                                                                 const std::string&) override {
+        this->last_set_component = component_id.name.get();
+        this->last_set_variable = variable_id.name.get();
+        this->last_set_value = value;
+        return ocpp::v2::SetVariableStatusEnum::Accepted;
+    }
+
+    std::optional<ocpp::v2::VariableMonitoringMeta> set_monitoring_data(const ocpp::v2::SetMonitoringData&,
+                                                                        const ocpp::v2::VariableMonitorType) override {
+        return std::nullopt;
+    }
+
+    bool update_monitoring_reference(const std::int32_t, const std::string&) override {
+        return false;
+    }
+
+    std::vector<ocpp::v2::VariableMonitoringMeta>
+    get_monitoring_data(const std::vector<ocpp::v2::MonitoringCriterionEnum>&, const ocpp::v2::Component&,
+                        const ocpp::v2::Variable&) override {
+        return {};
+    }
+
+    ocpp::v2::ClearMonitoringStatusEnum clear_variable_monitor(int, bool) override {
+        return ocpp::v2::ClearMonitoringStatusEnum::NotFound;
+    }
+
+    std::int32_t clear_custom_variable_monitors() override {
+        return 0;
+    }
+
+    void check_integrity() override {
+    }
+
+    ocpp::v2::DeviceModelMap device_model_map;
+    std::string attribute_value;
+    std::optional<std::string> last_set_component;
+    std::optional<std::string> last_set_variable;
+    std::optional<std::string> last_set_value;
+};
+
+ocpp::v2::VariableMetaData make_meta(const std::optional<std::string>& source) {
+    ocpp::v2::VariableMetaData meta;
+    meta.characteristics.dataType = ocpp::v2::DataEnum::string;
+    meta.characteristics.supportsMonitoring = false;
+    meta.source = source;
+    return meta;
+}
+
+ocpp::v2::DeviceModelMap make_device_model_map(const std::string& component_name, const std::string& variable_name,
+                                               const std::optional<std::string>& source) {
+    ocpp::v2::DeviceModelMap map;
+    map[make_component(component_name)][make_variable(variable_name)] = make_meta(source);
+    return map;
+}
+
+class ComposedDeviceModelStorageFactoryTest : public ::testing::Test {
+protected:
+    // OCPP-side variable carries no source (defaults to "OCPP"); EVerest-side variable is tagged "EVEREST".
+    std::shared_ptr<FakeDeviceModelStorage> ocpp_storage = std::make_shared<FakeDeviceModelStorage>(
+        make_device_model_map("OCPPCommCtrlr", "HeartbeatInterval", std::nullopt), "ocpp-value");
+    std::shared_ptr<FakeDeviceModelStorage> everest_storage = std::make_shared<FakeDeviceModelStorage>(
+        make_device_model_map("ConnectedEV", "VehicleId", "EVEREST"), "everest-value");
+};
+
+TEST_F(ComposedDeviceModelStorageFactoryTest, EverestSourcedVariableRoutesToEverestStorage) {
+    const auto composed = make_composed_device_model_storage(ocpp_storage, everest_storage);
+
+    const auto attribute = composed->get_variable_attribute(make_component("ConnectedEV"), make_variable("VehicleId"),
+                                                            ocpp::v2::AttributeEnum::Actual);
+    ASSERT_TRUE(attribute.has_value());
+    ASSERT_TRUE(attribute->value.has_value());
+    EXPECT_EQ(attribute->value.value().get(), "everest-value");
+
+    const auto status = composed->set_variable_attribute_value(
+        make_component("ConnectedEV"), make_variable("VehicleId"), ocpp::v2::AttributeEnum::Actual, "WMI123", "test");
+    EXPECT_EQ(status, ocpp::v2::SetVariableStatusEnum::Accepted);
+    EXPECT_EQ(everest_storage->last_set_value, "WMI123");
+    EXPECT_FALSE(ocpp_storage->last_set_value.has_value());
+}
+
+TEST_F(ComposedDeviceModelStorageFactoryTest, UnsourcedVariableDefaultsToOcppStorage) {
+    const auto composed = make_composed_device_model_storage(ocpp_storage, everest_storage);
+
+    const auto attribute = composed->get_variable_attribute(
+        make_component("OCPPCommCtrlr"), make_variable("HeartbeatInterval"), ocpp::v2::AttributeEnum::Actual);
+    ASSERT_TRUE(attribute.has_value());
+    ASSERT_TRUE(attribute->value.has_value());
+    EXPECT_EQ(attribute->value.value().get(), "ocpp-value");
+
+    const auto status =
+        composed->set_variable_attribute_value(make_component("OCPPCommCtrlr"), make_variable("HeartbeatInterval"),
+                                               ocpp::v2::AttributeEnum::Actual, "42", "test");
+    EXPECT_EQ(status, ocpp::v2::SetVariableStatusEnum::Accepted);
+    EXPECT_EQ(ocpp_storage->last_set_value, "42");
+    EXPECT_FALSE(everest_storage->last_set_value.has_value());
+}
+
+TEST_F(ComposedDeviceModelStorageFactoryTest, GetDeviceModelMergesBothSources) {
+    const auto composed = make_composed_device_model_storage(ocpp_storage, everest_storage);
+
+    const auto device_model_map = composed->get_device_model();
+    EXPECT_EQ(device_model_map.size(), 2u);
+    EXPECT_NE(device_model_map.find(make_component("OCPPCommCtrlr")), device_model_map.end());
+    EXPECT_NE(device_model_map.find(make_component("ConnectedEV")), device_model_map.end());
+}
+
+TEST_F(ComposedDeviceModelStorageFactoryTest, OverlappingVariablePrefersEverestSource) {
+    // The EVSE component exists in both storages: "Power" overlaps, "AllowReset" is OCPP-only.
+    auto ocpp_map = make_device_model_map("EVSE", "Power", std::nullopt);
+    ocpp_map[make_component("EVSE")][make_variable("AllowReset")] = make_meta(std::nullopt);
+    const auto overlapping_ocpp_storage = std::make_shared<FakeDeviceModelStorage>(std::move(ocpp_map), "ocpp-value");
+    const auto overlapping_everest_storage =
+        std::make_shared<FakeDeviceModelStorage>(make_device_model_map("EVSE", "Power", "EVEREST"), "everest-value");
+
+    const auto composed = make_composed_device_model_storage(overlapping_ocpp_storage, overlapping_everest_storage);
+
+    // The merged model contains the component once, with the overlapping variable owned by EVEREST and the
+    // disjoint OCPP variable preserved.
+    const auto device_model_map = composed->get_device_model();
+    const auto evse_it = device_model_map.find(make_component("EVSE"));
+    ASSERT_NE(evse_it, device_model_map.end());
+    EXPECT_EQ(evse_it->second.size(), 2u);
+    ASSERT_NE(evse_it->second.find(make_variable("AllowReset")), evse_it->second.end());
+    ASSERT_NE(evse_it->second.find(make_variable("Power")), evse_it->second.end());
+    EXPECT_EQ(evse_it->second.at(make_variable("Power")).source, "EVEREST");
+
+    // Reads and writes of the overlapping variable go to the EVerest storage.
+    const auto power = composed->get_variable_attribute(make_component("EVSE"), make_variable("Power"),
+                                                        ocpp::v2::AttributeEnum::Actual);
+    ASSERT_TRUE(power.has_value());
+    ASSERT_TRUE(power->value.has_value());
+    EXPECT_EQ(power->value.value().get(), "everest-value");
+
+    const auto status = composed->set_variable_attribute_value(make_component("EVSE"), make_variable("Power"),
+                                                               ocpp::v2::AttributeEnum::Actual, "11000", "test");
+    EXPECT_EQ(status, ocpp::v2::SetVariableStatusEnum::Accepted);
+    EXPECT_EQ(overlapping_everest_storage->last_set_value, "11000");
+    EXPECT_FALSE(overlapping_ocpp_storage->last_set_value.has_value());
+
+    // The disjoint variable of the same component still routes to the OCPP storage.
+    const auto allow_reset = composed->get_variable_attribute(make_component("EVSE"), make_variable("AllowReset"),
+                                                              ocpp::v2::AttributeEnum::Actual);
+    ASSERT_TRUE(allow_reset.has_value());
+    ASSERT_TRUE(allow_reset->value.has_value());
+    EXPECT_EQ(allow_reset->value.value().get(), "ocpp-value");
+}
+
+TEST_F(ComposedDeviceModelStorageFactoryTest, NullOcppStorageThrows) {
+    EXPECT_THROW(make_composed_device_model_storage(nullptr, everest_storage), std::invalid_argument);
+}
+
+TEST_F(ComposedDeviceModelStorageFactoryTest, EverestSourcedVariableWithoutEverestStorageIsRejected) {
+    // The OCPP storage declares a variable whose metadata routes to "EVEREST", but no EVEREST storage is
+    // registered: lookups must fail gracefully and the variable must not appear in the merged model.
+    const auto orphan_storage = std::make_shared<FakeDeviceModelStorage>(
+        make_device_model_map("ConnectedEV", "VehicleId", "EVEREST"), "ocpp-value");
+    const auto composed = make_composed_device_model_storage(orphan_storage, nullptr);
+
+    EXPECT_EQ(composed->get_variable_attribute(make_component("ConnectedEV"), make_variable("VehicleId"),
+                                               ocpp::v2::AttributeEnum::Actual),
+              std::nullopt);
+    EXPECT_EQ(composed->set_variable_attribute_value(make_component("ConnectedEV"), make_variable("VehicleId"),
+                                                     ocpp::v2::AttributeEnum::Actual, "WMI123", "test"),
+              ocpp::v2::SetVariableStatusEnum::Rejected);
+    EXPECT_TRUE(composed->get_device_model().empty());
+}
+
+TEST_F(ComposedDeviceModelStorageFactoryTest, NullEverestStorageIsSkipped) {
+    const auto composed = make_composed_device_model_storage(ocpp_storage, nullptr);
+
+    const auto device_model_map = composed->get_device_model();
+    EXPECT_EQ(device_model_map.size(), 1u);
+
+    const auto attribute = composed->get_variable_attribute(
+        make_component("OCPPCommCtrlr"), make_variable("HeartbeatInterval"), ocpp::v2::AttributeEnum::Actual);
+    ASSERT_TRUE(attribute.has_value());
+    ASSERT_TRUE(attribute->value.has_value());
+    EXPECT_EQ(attribute->value.value().get(), "ocpp-value");
+
+    // EVEREST-sourced lookups have no registered storage and must not crash.
+    EXPECT_EQ(composed->get_variable_attribute(make_component("ConnectedEV"), make_variable("VehicleId"),
+                                               ocpp::v2::AttributeEnum::Actual),
+              std::nullopt);
+}
+
+} // namespace

--- a/modules/EVSE/OCPPmulti/charge_point_config_factory_v16.cpp
+++ b/modules/EVSE/OCPPmulti/charge_point_config_factory_v16.cpp
@@ -11,6 +11,8 @@
 #include <fmt/core.h>
 #include <nlohmann/json.hpp>
 
+#include <everest/ocpp_module_common/device_model/composed_device_model_storage.hpp>
+
 #include <ocpp/v16/charge_point_configuration.hpp>
 #include <ocpp/v16/charge_point_configuration_devicemodel.hpp>
 #include <ocpp/v2/ctrlr_component_variables.hpp>
@@ -173,11 +175,15 @@ void initialize_device_model_with_migration(const fs::path& ocpp_share_path, con
     EVLOG_info << "Successfully migrated OCPP1.6 configuration to device model database at " << context.database_path;
 }
 
-config_factory_result_t
-create_device_model_charge_point_configuration(const fs::path& ocpp_share_path,
-                                               const DeviceModelInitializationContext& context) {
-    auto device_model_storage = std::make_unique<ocpp::v2::DeviceModelStorageSqlite>(context.database_path);
-    auto device_model = std::make_unique<ocpp::v2::DeviceModel>(std::move(device_model_storage));
+config_factory_result_t create_device_model_charge_point_configuration(
+    const fs::path& ocpp_share_path, const DeviceModelInitializationContext& context,
+    std::shared_ptr<ocpp::v2::DeviceModelStorageInterface> everest_device_model) {
+    // The database is pre-seeded by initialize_device_model_* above, so the 1-arg ctor is correct here.
+    auto ocpp_device_model_storage = std::make_shared<ocpp::v2::DeviceModelStorageSqlite>(context.database_path);
+    // Same composition as the OCPP 2.x path (ChargePointV2::init): sources "OCPP" + "EVEREST".
+    auto composed_device_model_storage = ocpp_module_common::device_model::make_composed_device_model_storage(
+        std::move(ocpp_device_model_storage), std::move(everest_device_model));
+    auto device_model = std::make_unique<ocpp::v2::DeviceModel>(std::move(composed_device_model_storage));
 
     // One-time migration, mirroring the v2 path (ocpp::v2::ChargePoint::initialize)
     ocpp::v2::NetworkConfigurationComponentVariables::migrate_from_blob_if_needed(*device_model);
@@ -234,8 +240,10 @@ std::string load_charge_point_config_json(const fs::path& configured_config_path
 
 } // namespace
 
-config_factory_result_t create_charge_point_configuration(const fs::path& ocpp_share_path,
-                                                          const Ocpp16DeviceModelParams& config, std::int32_t n_evse) {
+config_factory_result_t
+create_charge_point_configuration(const fs::path& ocpp_share_path, const Ocpp16DeviceModelParams& config,
+                                  std::int32_t n_evse,
+                                  std::shared_ptr<ocpp::v2::DeviceModelStorageInterface> everest_device_model) {
     const auto context = resolve_device_model_initialization_context(ocpp_share_path, config);
 
     const bool db_initialized =
@@ -265,7 +273,8 @@ config_factory_result_t create_charge_point_configuration(const fs::path& ocpp_s
         initialize_device_model_direct(context, n_evse);
     }
 
-    auto result = create_device_model_charge_point_configuration(ocpp_share_path, context);
+    auto result =
+        create_device_model_charge_point_configuration(ocpp_share_path, context, std::move(everest_device_model));
     result.configuration->check_integrity(n_evse);
     return result;
 }

--- a/modules/EVSE/OCPPmulti/charge_point_config_factory_v16.hpp
+++ b/modules/EVSE/OCPPmulti/charge_point_config_factory_v16.hpp
@@ -11,6 +11,7 @@
 #include <everest/logging.hpp>
 
 #include <ocpp/v16/charge_point_configuration_devicemodel.hpp>
+#include <ocpp/v2/device_model_storage_interface.hpp>
 #include <ocpp/v2/ocpp16_custom_config_mappings.hpp>
 
 namespace module::config_factory_v16 {
@@ -48,11 +49,18 @@ struct config_factory_result_t {
 /// Initializes the device model database from the component configs, optionally performing a one-time
 /// migration from the legacy OCPP 1.6 JSON config on the first startup (see \ref Ocpp16DeviceModelParams),
 /// then returns a device-model-backed configuration after an integrity check.
+/// The returned configuration is backed by the composed device model storage: the SQLite device model
+/// database as source "OCPP" and \p everest_device_model as source "EVEREST" — the same composition the
+/// OCPP 2.x path provides to its ChargePoint.
 /// \param ocpp_share_path The share path of the OCPP module, used to resolve relative paths in the config.
 /// \param config The OCPP 1.6 device-model configuration parameters.
 /// \param n_evse The number of EVSEs, used for the device model integrity check.
+/// \param everest_device_model Registered as source "EVEREST" in the composed device model storage; must be
+///        fully constructed (components/variables created) before this call.
 /// \return The configuration and the custom config mappings it uses.
-config_factory_result_t create_charge_point_configuration(const std::filesystem::path& ocpp_share_path,
-                                                          const Ocpp16DeviceModelParams& config, std::int32_t n_evse);
+config_factory_result_t
+create_charge_point_configuration(const std::filesystem::path& ocpp_share_path, const Ocpp16DeviceModelParams& config,
+                                  std::int32_t n_evse,
+                                  std::shared_ptr<ocpp::v2::DeviceModelStorageInterface> everest_device_model);
 
 } // namespace module::config_factory_v16

--- a/modules/EVSE/OCPPmulti/docs/index.rst
+++ b/modules/EVSE/OCPPmulti/docs/index.rst
@@ -209,6 +209,19 @@ The module composes two device model storages behind libocpp's ``DeviceModelStor
 The ``ComposedDeviceModelStorage`` routes each variable access to its owning storage by the variable's ``source``
 field, which defaults to ``OCPP``.
 
+The composed storage backs **both** protocol paths: in OCPP 2.x it is the device model of the libocpp
+``ChargePoint``, and in OCPP 1.6 it backs the device-model-based charge point configuration. Variables of both
+sources are therefore visible and settable through the EVerest ``ocpp`` interface (``get_variables`` /
+``set_variables``, e.g. via the ``ocpp_consumer_API`` module) regardless of the active protocol version. Note that
+an OCPP 1.6 **CSMS** still cannot address EVerest device model variables directly: ``GetConfiguration`` /
+``ChangeConfiguration`` are key-based, and only keys with a device model mapping (built-in or via
+``DeviceModelConfigMappings``) reach the device model. Also note that variables of source ``EVEREST`` are updated
+by the module at runtime directly in the ``EverestDeviceModelStorage``; such updates do not trigger
+``monitor_variables`` events on the ``ocpp`` interface (in either protocol version) — only writes performed through
+the OCPP stack or the ``ocpp`` interface do. If a component/variable is defined in both storages, the EVerest
+device model takes precedence for that variable and a warning is logged at startup; the integrator is
+responsible for avoiding such overlaps.
+
 .. mermaid::
 
    classDiagram

--- a/modules/EVSE/OCPPmulti/tests/CMakeLists.txt
+++ b/modules/EVSE/OCPPmulti/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(${TEST_TARGET_NAME}
     systemIntf_tests.cpp
 
     # general
+    charge_point_config_factory_v16_tests.cpp
     generic_ocpp_tests.cpp
     grid_support_der_tests.cpp
     grid_support_state_test.cpp
@@ -63,6 +64,10 @@ target_sources(${TEST_TARGET_NAME}
 target_compile_definitions(${TEST_TARGET_NAME}
     PRIVATE
     UNIT_TESTS
+    # The factory tests seed a real device model database from the shipped libocpp component configs
+    # and migrations - the same sources the installed module runs against.
+    LIBOCPP_COMPONENT_CONFIG_DIR="${PROJECT_SOURCE_DIR}/lib/everest/ocpp/config/common/component_config"
+    LIBOCPP_DEVICE_MODEL_MIGRATIONS_DIR="${PROJECT_SOURCE_DIR}/lib/everest/ocpp/config/common/device_model_migrations"
 )
 
 target_link_libraries(${TEST_TARGET_NAME}

--- a/modules/EVSE/OCPPmulti/tests/charge_point_config_factory_v16_tests.cpp
+++ b/modules/EVSE/OCPPmulti/tests/charge_point_config_factory_v16_tests.cpp
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+/// \file charge_point_config_factory_v16_tests.cpp
+/// \brief Tests that the OCPP 1.6 config factory backs the configuration with the composed device model
+/// storage: variables supplied by an EVerest device model storage (source "EVEREST") are readable and
+/// writable through the returned configuration, next to the SQLite-backed OCPP source — the same
+/// composition the OCPP 2.x path provides to its ChargePoint.
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <ocpp/v2/comparators.hpp>
+#include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v2/device_model_storage_interface.hpp>
+
+#include "charge_point_config_factory_v16.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+
+ocpp::v2::Component make_component(const std::string& name) {
+    ocpp::v2::Component component;
+    component.name = name;
+    return component;
+}
+
+ocpp::v2::Variable make_variable(const std::string& name) {
+    ocpp::v2::Variable variable;
+    variable.name = name;
+    return variable;
+}
+
+// In-memory stand-in for the EVerest device model storage: one ReadWrite string variable tagged with
+// source "EVEREST"; records writes so tests can assert routing.
+class FakeEverestDeviceModelStorage : public ocpp::v2::DeviceModelStorageInterface {
+public:
+    FakeEverestDeviceModelStorage(const std::string& component_name, const std::string& variable_name,
+                                  const std::string& value) :
+        component(make_component(component_name)), variable(make_variable(variable_name)), value(value) {
+    }
+
+    ocpp::v2::DeviceModelMap get_device_model() override {
+        ocpp::v2::VariableMetaData meta;
+        meta.characteristics.dataType = ocpp::v2::DataEnum::string;
+        meta.characteristics.supportsMonitoring = false;
+        meta.source = "EVEREST";
+        ocpp::v2::DeviceModelMap map;
+        map[this->component][this->variable] = meta;
+        return map;
+    }
+
+    std::optional<ocpp::v2::VariableAttribute> get_variable_attribute(const ocpp::v2::Component& component_id,
+                                                                      const ocpp::v2::Variable& variable_id,
+                                                                      const ocpp::v2::AttributeEnum&) override {
+        if (!(component_id == this->component) || !(variable_id == this->variable)) {
+            return std::nullopt;
+        }
+        ocpp::v2::VariableAttribute attribute;
+        attribute.value = this->value;
+        attribute.mutability = ocpp::v2::MutabilityEnum::ReadWrite;
+        return attribute;
+    }
+
+    std::vector<ocpp::v2::VariableAttribute>
+    get_variable_attributes(const ocpp::v2::Component& component_id, const ocpp::v2::Variable& variable_id,
+                            const std::optional<ocpp::v2::AttributeEnum>& attribute_enum) override {
+        const auto attribute =
+            get_variable_attribute(component_id, variable_id, attribute_enum.value_or(ocpp::v2::AttributeEnum::Actual));
+        if (!attribute.has_value()) {
+            return {};
+        }
+        return {attribute.value()};
+    }
+
+    ocpp::v2::SetVariableStatusEnum set_variable_attribute_value(const ocpp::v2::Component& component_id,
+                                                                 const ocpp::v2::Variable& variable_id,
+                                                                 const ocpp::v2::AttributeEnum&,
+                                                                 const std::string& new_value,
+                                                                 const std::string&) override {
+        if (!(component_id == this->component) || !(variable_id == this->variable)) {
+            return ocpp::v2::SetVariableStatusEnum::Rejected;
+        }
+        this->value = new_value;
+        this->last_set_value = new_value;
+        return ocpp::v2::SetVariableStatusEnum::Accepted;
+    }
+
+    std::optional<ocpp::v2::VariableMonitoringMeta> set_monitoring_data(const ocpp::v2::SetMonitoringData&,
+                                                                        const ocpp::v2::VariableMonitorType) override {
+        return std::nullopt;
+    }
+
+    bool update_monitoring_reference(const std::int32_t, const std::string&) override {
+        return false;
+    }
+
+    std::vector<ocpp::v2::VariableMonitoringMeta>
+    get_monitoring_data(const std::vector<ocpp::v2::MonitoringCriterionEnum>&, const ocpp::v2::Component&,
+                        const ocpp::v2::Variable&) override {
+        return {};
+    }
+
+    ocpp::v2::ClearMonitoringStatusEnum clear_variable_monitor(int, bool) override {
+        return ocpp::v2::ClearMonitoringStatusEnum::NotFound;
+    }
+
+    std::int32_t clear_custom_variable_monitors() override {
+        return 0;
+    }
+
+    void check_integrity() override {
+    }
+
+    ocpp::v2::Component component;
+    ocpp::v2::Variable variable;
+    std::string value;
+    std::optional<std::string> last_set_value;
+};
+
+class ChargePointConfigFactoryV16Test : public ::testing::Test {
+protected:
+    void SetUp() override {
+        work_dir = fs::temp_directory_path() / "ocppmulti_factory_v16_tests" /
+                   ::testing::UnitTest::GetInstance()->current_test_info()->name();
+        fs::remove_all(work_dir);
+        fs::create_directories(work_dir);
+    }
+
+    void TearDown() override {
+        fs::remove_all(work_dir);
+    }
+
+    module::config_factory_v16::Ocpp16DeviceModelParams make_params() const {
+        return {
+            (work_dir / "device_model_storage.db").string(), // DeviceModelDatabasePath
+            LIBOCPP_DEVICE_MODEL_MIGRATIONS_DIR,             // DeviceModelDatabaseMigrationPath
+            LIBOCPP_COMPONENT_CONFIG_DIR,                    // DeviceModelConfigPath
+            "",                                              // DeviceModelConfigMappings
+            1,                                               // Ocpp16NetworkConfigSlot
+            false,                                           // EnableLegacyConfigMigration
+            "",                                              // ChargePointConfigPath
+            "",                                              // UserConfigPath
+        };
+    }
+
+    // The shipped custom component configs define two EVSEs.
+    static constexpr std::int32_t n_evse = 2;
+
+    fs::path work_dir;
+};
+
+TEST_F(ChargePointConfigFactoryV16Test, EverestSourcedVariableIsReadableAndWritable) {
+    auto everest_storage = std::make_shared<FakeEverestDeviceModelStorage>("ConnectedEV", "VehicleId", "everest-value");
+
+    auto result =
+        module::config_factory_v16::create_charge_point_configuration(work_dir, make_params(), n_evse, everest_storage);
+    ASSERT_NE(result.configuration, nullptr);
+    auto& device_model = result.configuration->get_device_model();
+
+    std::string value;
+    const auto get_status = device_model.get_variable(make_component("ConnectedEV"), make_variable("VehicleId"),
+                                                      ocpp::v2::AttributeEnum::Actual, value);
+    EXPECT_EQ(get_status, ocpp::v2::GetVariableStatusEnum::Accepted);
+    EXPECT_EQ(value, "everest-value");
+
+    const auto set_status = device_model.set_value(make_component("ConnectedEV"), make_variable("VehicleId"),
+                                                   ocpp::v2::AttributeEnum::Actual, "WMI999", "test");
+    EXPECT_EQ(set_status, ocpp::v2::SetVariableStatusEnum::Accepted);
+    EXPECT_EQ(everest_storage->last_set_value, "WMI999");
+}
+
+TEST_F(ChargePointConfigFactoryV16Test, OcppSourcedVariableStillResolves) {
+    auto everest_storage = std::make_shared<FakeEverestDeviceModelStorage>("ConnectedEV", "VehicleId", "everest-value");
+
+    auto result =
+        module::config_factory_v16::create_charge_point_configuration(work_dir, make_params(), n_evse, everest_storage);
+    ASSERT_NE(result.configuration, nullptr);
+    auto& device_model = result.configuration->get_device_model();
+
+    const auto& heartbeat_interval = ocpp::v2::ControllerComponentVariables::HeartbeatInterval;
+    ASSERT_TRUE(heartbeat_interval.variable.has_value());
+    std::string value;
+    const auto get_status = device_model.get_variable(heartbeat_interval.component, heartbeat_interval.variable.value(),
+                                                      ocpp::v2::AttributeEnum::Actual, value);
+    EXPECT_EQ(get_status, ocpp::v2::GetVariableStatusEnum::Accepted);
+    EXPECT_FALSE(value.empty());
+
+    // The write must not leak into the EVerest storage.
+    EXPECT_FALSE(everest_storage->last_set_value.has_value());
+}
+
+// The factory is also used in setups without an EVerest device model storage (e.g. tests); it must
+// degrade to the OCPP-only device model instead of crashing.
+TEST_F(ChargePointConfigFactoryV16Test, NullEverestStorageDegradesToOcppOnly) {
+    auto result =
+        module::config_factory_v16::create_charge_point_configuration(work_dir, make_params(), n_evse, nullptr);
+    ASSERT_NE(result.configuration, nullptr);
+    auto& device_model = result.configuration->get_device_model();
+
+    std::string value;
+    EXPECT_EQ(device_model.get_variable(make_component("ConnectedEV"), make_variable("VehicleId"),
+                                        ocpp::v2::AttributeEnum::Actual, value),
+              ocpp::v2::GetVariableStatusEnum::UnknownComponent);
+
+    const auto& heartbeat_interval = ocpp::v2::ControllerComponentVariables::HeartbeatInterval;
+    ASSERT_TRUE(heartbeat_interval.variable.has_value());
+    EXPECT_EQ(device_model.get_variable(heartbeat_interval.component, heartbeat_interval.variable.value(),
+                                        ocpp::v2::AttributeEnum::Actual, value),
+              ocpp::v2::GetVariableStatusEnum::Accepted);
+}
+
+} // namespace

--- a/modules/EVSE/OCPPmulti/v16_chargepoint.cpp
+++ b/modules/EVSE/OCPPmulti/v16_chargepoint.cpp
@@ -573,7 +573,7 @@ void ChargePointV16::configure_data_model(const config_info_t& config) {
     };
 
     auto factory_result = module::config_factory_v16::create_charge_point_configuration(
-        ocpp_share_path, params, static_cast<int32_t>(config.number_of_connectors));
+        ocpp_share_path, params, static_cast<int32_t>(config.number_of_connectors), config.everest_device_model);
     m_charge_point_configuration = std::move(factory_result.configuration);
     m_custom_mappings = std::move(factory_result.custom_mappings);
 
@@ -634,6 +634,7 @@ void ChargePointV16::init(init_args_t& args) {
         args.v16_device_model_config_mappings,
         args.v16_ocpp16_network_config_slot,
         args.v16_enable_legacy_config_migration,
+        args.everest_device_model,
     };
 
     configure_data_model(config);

--- a/modules/EVSE/OCPPmulti/v16_chargepoint.hpp
+++ b/modules/EVSE/OCPPmulti/v16_chargepoint.hpp
@@ -53,6 +53,9 @@ private:
         std::string device_model_config_mappings;
         std::int32_t ocpp16_network_config_slot;
         bool enable_legacy_config_migration;
+        // Registered as source "EVEREST" in the composed device model storage, next to the SQLite-backed
+        // "OCPP" source; same composition as the OCPP 2.x path.
+        std::shared_ptr<ocpp_module_common::device_model::EverestDeviceModelStorage> everest_device_model;
     };
 
     void check_configured(const std::string_view& fn);

--- a/modules/EVSE/OCPPmulti/v2_chargepoint.cpp
+++ b/modules/EVSE/OCPPmulti/v2_chargepoint.cpp
@@ -460,12 +460,8 @@ void ChargePointV2::init(init_args_t& args) {
         args.v2_device_model_config_path);
 
     // initialise composed device model, this will be provided to the ChargePoint constructor
-    auto composed_device_model_storage = std::make_unique<module::device_model::ComposedDeviceModelStorage>();
-
-    // register both device model storages
-    // note - this processing causes a slight delay, scope for performance tuning
-    composed_device_model_storage->register_device_model_storage("OCPP", std::move(libocpp_device_model_storage));
-    composed_device_model_storage->register_device_model_storage("EVEREST", args.everest_device_model);
+    auto composed_device_model_storage = module::device_model::make_composed_device_model_storage(
+        std::move(libocpp_device_model_storage), args.everest_device_model);
 
     const auto ocpp_share_path = args.share_path / "OCPP201";
     const auto sql_init_path = ocpp_share_path / SQL_CORE_MIGRATIONS;


### PR DESCRIPTION
## Describe your changes

Register the EVerest device model storage (source EVEREST) next to the SQLite-backed OCPP source in the OCPP 1.6 path of OCPPmulti, mirroring the OCPP 2.x composition. EVerest-supplied components (EVSE, Connector,
ConnectedEV, DER controllers, module configs) are now readable and writable through the ocpp interface (e.g. via ocpp_consumer_API) in 1.6 mode as well.

The composition is factored into a shared make_composed_device_model_storage helper in ocpp_module_common, also used by the 2.x path.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

