### PR TITLE
fix(OCPP): re-arm connection callbacks on start

### DIFF
--- a/lib/everest/ocpp/include/ocpp/common/connectivity_manager.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/connectivity_manager.hpp
@@ -161,6 +161,13 @@ public:
     /// blocks until any in-flight callback returns, then suppresses all further ones.
     virtual void disarm_connection_callbacks() = 0;
 
+    /// \brief Resume delivering connected/disconnected notifications to the registered callbacks.
+    ///
+    /// Counterpart of disarm_connection_callbacks(), called from ChargePoint::start(). A restart
+    /// reuses the same ConnectivityManager, so the suppression set up by the preceding stop() has
+    /// to be lifted before the connection state can be reported again.
+    virtual void arm_connection_callbacks() = 0;
+
     /// \brief Suppress automatic reconnection without closing the current websocket.
     ///
     /// Unlike disconnect(), this does NOT close the live websocket: it only clears the internal
@@ -233,7 +240,8 @@ private:
     Everest::SteadyTimer websocket_timer;
 
     // Serializes invocation of the connected/disconnected callbacks (websocket thread) with
-    // disarm_connection_callbacks() (teardown thread). Once disarmed, the callbacks are suppressed.
+    // disarm_connection_callbacks() (teardown thread) and arm_connection_callbacks() (start thread).
+    // While disarmed, the callbacks are suppressed.
     std::mutex connection_callbacks_mutex;
     bool connection_callbacks_disarmed{false};
     // Written from the OCPP message-handler thread (suppress_reconnect/disconnect) and read from the
@@ -298,6 +306,7 @@ public:
     void connect(std::optional<std::int32_t> network_profile_slot = std::nullopt) override;
     void disconnect() override;
     void disarm_connection_callbacks() override;
+    void arm_connection_callbacks() override;
     void suppress_reconnect() override;
     bool send_to_websocket(const std::string& message) override;
     void on_network_disconnected(ocpp::v2::OCPPInterfaceEnum ocpp_interface) override;

--- a/lib/everest/ocpp/lib/ocpp/common/connectivity_manager.cpp
+++ b/lib/everest/ocpp/lib/ocpp/common/connectivity_manager.cpp
@@ -236,6 +236,11 @@ void ConnectivityManager::disarm_connection_callbacks() {
     this->connection_callbacks_disarmed = true;
 }
 
+void ConnectivityManager::arm_connection_callbacks() {
+    std::lock_guard<std::mutex> lock(this->connection_callbacks_mutex);
+    this->connection_callbacks_disarmed = false;
+}
+
 void ConnectivityManager::suppress_reconnect() {
     // Like disconnect() this clears the connect intent and cancels any pending reconnect timer, but
     // leaves the live socket open so queued messages can still flush. The websocket's own internal

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -1155,6 +1155,8 @@ bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_st
         init(connector_status_map, resuming_session_ids);
     }
     this->bootreason = bootreason;
+    // Lift the suppression a preceding stop() put in place, so the connection state is reported again.
+    this->connectivity_manager->arm_connection_callbacks();
     // Publish the initial default price before connecting (offline state at startup).
     this->publish_default_price(true);
     this->connectivity_manager->set_message_callback(

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
@@ -107,6 +107,8 @@ ChargePoint::ChargePoint(const std::map<std::int32_t, std::int32_t>& evse_connec
 ChargePoint::~ChargePoint() = default;
 
 void ChargePoint::start(BootReasonEnum bootreason, bool start_connecting) {
+    // Lift the suppression a preceding stop() put in place, so the connection state is reported again.
+    this->connectivity_manager->arm_connection_callbacks();
     this->connectivity_manager->set_message_callback(
         std::bind(&ChargePoint::message_callback, this, std::placeholders::_1));
     this->message_queue->start();

--- a/lib/everest/ocpp/tests/lib/ocpp/common/mocks/connectivity_manager_mock.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/common/mocks/connectivity_manager_mock.hpp
@@ -31,6 +31,7 @@ public:
     MOCK_METHOD(void, connect, (std::optional<std::int32_t> network_profile_slot));
     MOCK_METHOD(void, disconnect, ());
     MOCK_METHOD(void, disarm_connection_callbacks, ());
+    MOCK_METHOD(void, arm_connection_callbacks, ());
     MOCK_METHOD(void, suppress_reconnect, ());
     MOCK_METHOD(bool, send_to_websocket, (const std::string& message));
     MOCK_METHOD(void, on_network_disconnected, (ocpp::v2::OCPPInterfaceEnum ocpp_interface));

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/test_charge_point_connectivity.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/test_charge_point_connectivity.cpp
@@ -145,6 +145,24 @@ TEST_F(ChargePointConnectivityTest, StopDisarmsConnectionCallbacksAfterDisconnec
     charge_point->stop();
 }
 
+// A restart reuses the same ConnectivityManager, so start() must arm the connection callbacks that the
+// preceding stop() disarmed. Otherwise the connection state stays suppressed after the first stop().
+TEST_F(ChargePointConnectivityTest, RestartArmsConnectionCallbacksAgain) {
+    ON_CALL(*this->connectivity_manager, is_websocket_connected()).WillByDefault(Return(false));
+
+    const ::testing::InSequence seq;
+    EXPECT_CALL(*this->connectivity_manager, arm_connection_callbacks()).Times(1);
+    EXPECT_CALL(*this->connectivity_manager, disarm_connection_callbacks()).Times(1);
+    EXPECT_CALL(*this->connectivity_manager, arm_connection_callbacks()).Times(1);
+    EXPECT_CALL(*this->connectivity_manager, disarm_connection_callbacks()).Times(1);
+
+    auto charge_point = make_charge_point();
+    charge_point->start({}, BootReasonEnum::PowerUp, {});
+    charge_point->stop();
+    EXPECT_TRUE(charge_point->restart({}, BootReasonEnum::ApplicationReset));
+    charge_point->stop();
+}
+
 // Once the charge point observes a successful connection (connected callback -> message queue resume), queued
 // outgoing OCPP messages such as the BootNotification.req are handed to the websocket via send_to_websocket().
 TEST_F(ChargePointConnectivityTest, OutgoingMessageGoesToSendToWebsocket) {

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_charge_point.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_charge_point.cpp
@@ -2,6 +2,7 @@
 // Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
 
 #include "comparators.hpp"
+#include "connectivity_manager_mock.hpp"
 #include "device_model_test_helper.hpp"
 #include "everest/logging.hpp"
 #include "evse_security_mock.hpp"
@@ -1002,5 +1003,29 @@ TEST_F(ChargePointConstructorTestFixtureV2, DerBlock_NotBuiltAtBoot_WhenNoEnable
                                        create_message_queue(database_handler), "/tmp", evse_security, callbacks);
 
     EXPECT_EQ(this->der_active_directives_emit_count, 0);
+}
+
+// stop() disarms the connection callbacks so a late websocket-thread callback cannot reach a charge point
+// being torn down. A restart calls start() again on the same ConnectivityManager, so start() must arm them
+// again; otherwise the connection state stays suppressed after the first stop().
+TEST_F(ChargePointConstructorTestFixtureV2, StartArmsConnectionCallbacks) {
+    configure_callbacks_with_mocks();
+
+    auto connectivity_manager = std::make_shared<::testing::NiceMock<ConnectivityManagerMock>>();
+    ON_CALL(*connectivity_manager, is_websocket_connected()).WillByDefault(::testing::Return(false));
+
+    const ::testing::InSequence seq;
+    EXPECT_CALL(*connectivity_manager, arm_connection_callbacks()).Times(1);
+    EXPECT_CALL(*connectivity_manager, disarm_connection_callbacks()).Times(1);
+    EXPECT_CALL(*connectivity_manager, arm_connection_callbacks()).Times(1);
+    EXPECT_CALL(*connectivity_manager, disarm_connection_callbacks()).Times(1);
+
+    ocpp::v2::ChargePoint charge_point(evse_connector_structure, device_model, database_handler, evse_security,
+                                       connectivity_manager, "/tmp", callbacks);
+
+    charge_point.start(BootReasonEnum::PowerUp);
+    charge_point.stop();
+    charge_point.start(BootReasonEnum::ApplicationReset);
+    charge_point.stop();
 }
 } // namespace ocpp::v2

--- a/tests/ocpp_tests/test_sets/ocpp16/ocpp_generic_interface_integration_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/ocpp_generic_interface_integration_tests.py
@@ -723,10 +723,11 @@ class TestOCPP16GenericInterfaceIntegration:
         _env.probe_module.subscribe_variable(
             "ocpp", "is_connected", subscription_mock)
 
+        # Await the disconnect before restarting
         assert await _env.probe_module.call_command("ocpp", "stop", None)
-        assert await _env.probe_module.call_command("ocpp", "restart", None)
-
         await wait_for_mock_called(subscription_mock, mock_call(False))
+
+        assert await _env.probe_module.call_command("ocpp", "restart", None)
         await wait_for_mock_called(subscription_mock, mock_call(True))
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Describe your changes

disarm_connection_callbacks() was introduced to keep a late websocket-thread callback from reaching a ChargePoint under teardown by https://github.com/EVerest/EVerest/pull/2475, but the flag was never cleared. Since stop()/start() also back the external stop/restart control of the OCPP communication, and a restart reuses the same ConnectivityManager, the connection state was never reported again after the first stop().

Add arm_connection_callbacks() as its counterpart and call it in v16 ChargePointImpl::start() and v2 ChargePoint::start(), the funnel all restart paths go through.

Fixes test_subscribe_is_connected, which now awaits the disconnect before restarting so each transition is asserted on its own.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

