### PR TITLE
fix(EnergyNode): Do not call_enforce_limits for all children

### DIFF
--- a/modules/EnergyManagement/EnergyNode/energy_grid/energyImpl.cpp
+++ b/modules/EnergyManagement/EnergyNode/energy_grid/energyImpl.cpp
@@ -7,8 +7,10 @@
 #include <chrono>
 #include <date/date.h>
 #include <date/tz.h>
+#include <string>
 #include <string_view>
 #include <utils/date.hpp>
+#include <vector>
 
 namespace module {
 namespace energy_grid {
@@ -25,23 +27,9 @@ void energyImpl::init() {
     energy_state_handle->energy_flow_request.schedule_import = get_local_schedule();
     energy_state_handle->energy_flow_request.schedule_export = get_local_schedule();
 
-    for (auto& entry : mod->r_energy_consumer) {
-        entry->subscribe_energy_flow_request([this](types::energy::EnergyFlowRequest const& e) {
-            // Received new energy_flow_request object from a child. Update in the cached object and republish.
-            auto energy_state_handle = energy_state.handle();
-
-            auto& children = energy_state_handle->energy_flow_request.children;
-            auto children_it = std::find_if(children.begin(), children.end(), [&e](const auto& child) {
-                return std::string_view{child.uuid} == std::string_view{e.uuid};
-            });
-            if (children_it != children.end()) {
-                *children_it = e;
-            } else {
-                children.push_back(std::move(e));
-            }
-
-            publish_complete_energy_object(*energy_state_handle);
-        });
+    for (auto const& consumer : mod->r_energy_consumer) {
+        consumer->subscribe_energy_flow_request(
+            [this, connection = consumer.get()](auto const& e) { update_child_energy_flow_request(connection, e); });
     }
 
     if (!mod->r_powermeter.empty()) {
@@ -62,6 +50,37 @@ void energyImpl::init() {
                 publish_complete_energy_object(*energy_state_handle);
             });
     }
+}
+
+void energyImpl::update_child_energy_flow_request(energyIntf* connection,
+                                                  const types::energy::EnergyFlowRequest& request) {
+    // Received new energy_flow_request object from a child. Update in the cached object and republish.
+    auto energy_state_handle = energy_state.handle();
+
+    auto& children = energy_state_handle->energy_flow_request.children;
+    auto children_it = std::find_if(children.begin(), children.end(), [&request](auto const& child) {
+        return std::string_view{child.uuid} == std::string_view{request.uuid};
+    });
+    if (children_it != children.end()) {
+        *children_it = request;
+    } else {
+        children.push_back(request);
+    }
+    energy_state_handle->child_connections[request.uuid] = connection;
+
+    publish_complete_energy_object(*energy_state_handle);
+}
+
+std::vector<energyIntf*> energyImpl::find_target_connections(const EnergyState& state, std::string_view uuid) {
+    std::vector<energyIntf*> connections;
+
+    for (auto const& child : state.energy_flow_request.children) {
+        if (energy_flow_request_contains_uuid(child, uuid)) {
+            connections.push_back(state.child_connections.at(child.uuid));
+        }
+    }
+
+    return connections;
 }
 
 types::energy::ScheduleReqEntry energyImpl::get_local_schedule_req_entry() {
@@ -178,14 +197,28 @@ void energyImpl::ready() {
 }
 
 void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
-    auto energy_state_handle = energy_state.handle();
+    std::vector<energyIntf*> target_connections;
 
-    // route to children if it is not for me
-    // FIXME: this sends it to all children, we could do a lookup on which branch it actually is
-    if (value.uuid != energy_state_handle->energy_flow_request.uuid) {
-        for (auto& entry : mod->r_energy_consumer) {
-            entry->call_enforce_limits(value);
+    {
+        auto energy_state_handle = energy_state.handle();
+
+        // it is for this node itself, no need to route it to children
+        if (value.uuid == energy_state_handle->energy_flow_request.uuid) {
+            return;
         }
+
+        target_connections = find_target_connections(*energy_state_handle, value.uuid);
+    }
+
+    if (target_connections.empty()) {
+        // Unknown uuid (e.g. no energy_flow_request received from that child yet): send to all children
+        for (auto const& consumer : mod->r_energy_consumer) {
+            target_connections.push_back(consumer.get());
+        }
+    }
+
+    for (auto const connection : target_connections) {
+        connection->call_enforce_limits(value);
     }
 };
 

--- a/modules/EnergyManagement/EnergyNode/energy_grid/energyImpl.hpp
+++ b/modules/EnergyManagement/EnergyNode/energy_grid/energyImpl.hpp
@@ -15,6 +15,10 @@
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 // insert your custom include headers here
 #include <everest/util/async/monitor.hpp>
+#include <map>
+#include <string>
+#include <string_view>
+#include <vector>
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 
 namespace module {
@@ -55,12 +59,22 @@ private:
 
         // contains only the pricing informations last update
         types::energy_price_information::EnergyPriceSchedule energy_pricing;
+
+        // the energy_consumer connection each child subtree (keyed by its root uuid) was
+        // received from, so enforce_limits can be routed to its branch
+        std::map<std::string, energyIntf*> child_connections;
     };
 
     everest::lib::util::monitor<EnergyState> energy_state;
 
     types::energy::ScheduleReqEntry get_local_schedule_req_entry();
     std::vector<types::energy::ScheduleReqEntry> get_local_schedule();
+
+    // Updates the cached energy flow request of the child it was received from and republishes
+    void update_child_energy_flow_request(energyIntf* connection, const types::energy::EnergyFlowRequest& request);
+
+    // Returns the connections of all child branches whose cached subtree contains the uuid
+    static std::vector<energyIntf*> find_target_connections(const EnergyState& state, std::string_view uuid);
 
     void publish_complete_energy_object(const EnergyState& state);
     void set_external_limits(types::energy::ExternalLimits& l);

--- a/modules/EnergyManagement/EnergyNode/energy_grid/energy_schedule_utils.cpp
+++ b/modules/EnergyManagement/EnergyNode/energy_grid/energy_schedule_utils.cpp
@@ -3,8 +3,18 @@
 
 #include "energy_schedule_utils.hpp"
 
+#include <algorithm>
+
 namespace module {
 namespace energy_grid {
+
+bool energy_flow_request_contains_uuid(const types::energy::EnergyFlowRequest& request, std::string_view uuid) {
+    if (std::string_view{request.uuid} == uuid) {
+        return true;
+    }
+    return std::any_of(request.children.begin(), request.children.end(),
+                       [uuid](const auto& child) { return energy_flow_request_contains_uuid(child, uuid); });
+}
 
 void process_schedule_with_limits(std::vector<types::energy::ScheduleReqEntry>& schedule, const std::string& source,
                                   double fuse_limit_A, int phase_count, double nominal_voltage_V,

--- a/modules/EnergyManagement/EnergyNode/energy_grid/energy_schedule_utils.hpp
+++ b/modules/EnergyManagement/EnergyNode/energy_grid/energy_schedule_utils.hpp
@@ -6,6 +6,7 @@
 
 #include <generated/types/energy.hpp>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace module {
@@ -27,6 +28,15 @@ namespace energy_grid {
 void process_schedule_with_limits(std::vector<types::energy::ScheduleReqEntry>& schedule, const std::string& source,
                                   double fuse_limit_A, int phase_count, double nominal_voltage_V,
                                   bool enhance_with_current_limits);
+
+/**
+ * @brief Checks whether an energy flow request tree contains a node with the given uuid
+ *
+ * @param request The root of the (sub)tree to search
+ * @param uuid The uuid to search for
+ * @return true if the request itself or any of its descendants has the given uuid
+ */
+bool energy_flow_request_contains_uuid(const types::energy::EnergyFlowRequest& request, std::string_view uuid);
 
 } // namespace energy_grid
 } // namespace module

--- a/modules/EnergyManagement/EnergyNode/tests/energy_node_tests.cpp
+++ b/modules/EnergyManagement/EnergyNode/tests/energy_node_tests.cpp
@@ -226,3 +226,37 @@ TEST_F(EnergyNodeTest, TestConfigurableVoltage240V) {
     EXPECT_TRUE(schedule[0].limits_to_root.ac_max_current_A.has_value());
     EXPECT_EQ(schedule[0].limits_to_root.ac_max_current_A->value, expected_current);
 }
+
+// Helper to create an energy flow request node with a given uuid
+static types::energy::EnergyFlowRequest create_energy_flow_request(const std::string& uuid) {
+    types::energy::EnergyFlowRequest request;
+    request.uuid = uuid;
+    request.node_type = types::energy::NodeType::Generic;
+    return request;
+}
+
+/// Test uuid containment on a single node without children
+TEST_F(EnergyNodeTest, TestContainsUuidSingleNode) {
+    auto request = create_energy_flow_request("root");
+
+    EXPECT_TRUE(module::energy_grid::energy_flow_request_contains_uuid(request, "root"));
+    EXPECT_FALSE(module::energy_grid::energy_flow_request_contains_uuid(request, "other"));
+}
+
+/// Test uuid containment finds all nested descendants but not nodes of other branches
+TEST_F(EnergyNodeTest, TestContainsUuidNestedTree) {
+    auto request = create_energy_flow_request("root");
+    auto child = create_energy_flow_request("child");
+    child.children.push_back(create_energy_flow_request("grandchild"));
+    request.children.push_back(child);
+    request.children.push_back(create_energy_flow_request("sibling"));
+
+    EXPECT_TRUE(module::energy_grid::energy_flow_request_contains_uuid(request, "root"));
+    EXPECT_TRUE(module::energy_grid::energy_flow_request_contains_uuid(request, "child"));
+    EXPECT_TRUE(module::energy_grid::energy_flow_request_contains_uuid(request, "grandchild"));
+    EXPECT_TRUE(module::energy_grid::energy_flow_request_contains_uuid(request, "sibling"));
+    EXPECT_FALSE(module::energy_grid::energy_flow_request_contains_uuid(request, "unknown"));
+
+    // A branch does not contain nodes of its sibling branch
+    EXPECT_FALSE(module::energy_grid::energy_flow_request_contains_uuid(request.children[0], "sibling"));
+}


### PR DESCRIPTION

## Describe your changes

route enforce_limits only to the branch containing the target node

Previously every EnforcedLimits was broadcast to all children at each tree level, flooding the whole tree with one command call per node and recipient per optimizer run (resolves the FIXME in handle_enforce_limits).

Record for each cached child subtree which energy_consumer connection it was received from, and deliver limits only to the branches whose subtree contains the target uuid. Unknown uuids (e.g. no energy_flow_request received from a child yet) still fall back to broadcasting to all children.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

