### PR TITLE
fix(libiso15118): Decreased ac contactor close timeout 

### DIFF
--- a/lib/everest/iso15118/src/iso15118/d20/state/power_delivery.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/power_delivery.cpp
@@ -15,6 +15,10 @@
 
 namespace iso15118::d20::state {
 
+// Secc performance timer for PowerDelivery is 1.5s.
+// 100ms is resevered for polling timeout and sending the response.
+constexpr uint32_t AC_CLOSE_CONTACTOR_TIMEOUT = 1400;
+
 namespace dt = message_20::datatypes;
 
 message_20::PowerDeliveryResponse handle_request(const message_20::PowerDeliveryRequest& req,
@@ -95,6 +99,8 @@ Result PowerDelivery::feed(Event ev) {
     if (ev == Event::TIMEOUT) {
         const auto timeout = m_ctx.get_active_timeout();
         if (timeout and *timeout == d20::TimeoutType::CONTACTOR) {
+            logf_error("AC contactor is not closed within %ums, sending failure response code and stop the session",
+                       AC_CLOSE_CONTACTOR_TIMEOUT);
             // TODO(SL): Check if value_or is the correct way
             const auto& res =
                 handle_request(previous_req.value_or(message_20::PowerDeliveryRequest{}), m_ctx.session, true, false);
@@ -126,7 +132,7 @@ Result PowerDelivery::feed(Event ev) {
                 previous_req = *req;
                 // Close the AC contactor so that charging can start
                 m_ctx.feedback.signal(session::feedback::Signal::AC_CLOSE_CONTACTOR);
-                m_ctx.start_timeout(d20::TimeoutType::CONTACTOR, 3000);
+                m_ctx.start_timeout(d20::TimeoutType::CONTACTOR, AC_CLOSE_CONTACTOR_TIMEOUT);
                 logf_info("Waiting for contactor is closed");
                 return {};
             }


### PR DESCRIPTION
## Describe your changes
The timeout is set to a value under the PowerDelivery performance timer.

## Issue ticket number and link
The current Timeout value is too large (3000ms). The Evcc timeout is for PowerDelivery 2seconds. That's why it can happen that the EV terminates the session even though the EVSE hasn't sent a response yet

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
