### PR TITLE
fix(libocpp): use real reason codes on cert install reject

### DIFF
--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/security.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/security.hpp
@@ -7,6 +7,7 @@
 #include <variant>
 
 #include <ocpp/v2/message_handler.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
 #include <ocpp/v2/ocsp_updater.hpp>
 
 namespace ocpp {
@@ -113,8 +114,8 @@ private:
 
     /// \brief Helper function to determine if a certificate installation should be allowed
     /// \param cert_type is the certificate type to be checked
-    /// \return true if it should be allowed
-    bool should_allow_certificate_install(InstallCertificateUseEnum cert_type) const;
+    /// \return std::nullopt if it should be allowed, otherwise the StatusInfo describing why it was refused
+    std::optional<StatusInfo> check_certificate_install_allowed(InstallCertificateUseEnum cert_type) const;
     void scheduled_check_client_certificate_expiration();
     void scheduled_check_v2g_certificate_expiration();
 };

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/security.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/security.cpp
@@ -28,6 +28,7 @@ namespace ocpp::v2 {
 namespace {
 const CiString<20> reason_code_missing_device_model_info{"MissingDevModelInfo"};
 const CiString<20> reason_code_unspecified{"Unspecified"};
+const CiString<20> reason_code_unsupported_request{"UnsupportedRequest"};
 
 StatusInfo make_status_info(const CiString<20>& reason_code, const std::string& additional_info) {
     StatusInfo status_info;
@@ -441,11 +442,9 @@ void Security::handle_install_certificate_req(Call<InstallCertificateRequest> ca
     const auto msg = call.msg;
     InstallCertificateResponse response;
 
-    if (!should_allow_certificate_install(msg.certificateType)) {
+    if (auto refusal = check_certificate_install_allowed(msg.certificateType); refusal.has_value()) {
         response.status = InstallCertificateStatusEnum::Rejected;
-        response.statusInfo = StatusInfo();
-        response.statusInfo->reasonCode = "UnsecureConnection";
-        response.statusInfo->additionalInfo = "CertificateInstallationNotAllowedWithUnsecureConnection";
+        response.statusInfo = std::move(refusal);
     } else {
         const auto result = this->context.evse_security.install_ca_certificate(
             msg.certificate.get(), ocpp::evse_security_conversions::from_ocpp_v2(msg.certificateType));
@@ -486,31 +485,45 @@ void Security::handle_delete_certificate_req(Call<DeleteCertificateRequest> call
     this->context.message_dispatcher.dispatch_call_result(call_result);
 }
 
-bool Security::should_allow_certificate_install(InstallCertificateUseEnum cert_type) const {
+std::optional<StatusInfo> Security::check_certificate_install_allowed(InstallCertificateUseEnum cert_type) const {
+    if (cert_type == InstallCertificateUseEnum::OEMRootCertificate) {
+        // FIXME: Implement OEMRootCertificate. Refused independently of the security profile, because the conversion
+        // towards evse_security has no OEM equivalent and throws.
+        return make_status_info(reason_code_unsupported_request, "OEMRootCertificateInstallationNotSupported");
+    }
+
     const int security_profile =
         this->context.device_model.get_value<int>(ControllerComponentVariables::SecurityProfile);
 
     if (security_profile > 1) {
-        return true;
+        return std::nullopt;
     }
+
     switch (cert_type) {
     case InstallCertificateUseEnum::CSMSRootCertificate:
-        return this->context.device_model
-            .get_optional_value<bool>(ControllerComponentVariables::AllowCSMSRootCertInstallWithUnsecureConnection)
-            .value_or(true);
-
+        if (!this->context.device_model
+                 .get_optional_value<bool>(ControllerComponentVariables::AllowCSMSRootCertInstallWithUnsecureConnection)
+                 .value_or(true)) {
+            return make_status_info(reason_code_unspecified,
+                                    "CSMSRootCertificateInstallationNotAllowedWithUnsecureConnection");
+        }
+        return std::nullopt;
     case InstallCertificateUseEnum::ManufacturerRootCertificate:
-        return this->context.device_model
-            .get_optional_value<bool>(ControllerComponentVariables::AllowMFRootCertInstallWithUnsecureConnection)
-            .value_or(true);
+        if (!this->context.device_model
+                 .get_optional_value<bool>(ControllerComponentVariables::AllowMFRootCertInstallWithUnsecureConnection)
+                 .value_or(true)) {
+            return make_status_info(reason_code_unspecified,
+                                    "ManufacturerRootCertificateInstallationNotAllowedWithUnsecureConnection");
+        }
+        return std::nullopt;
     case InstallCertificateUseEnum::MORootCertificate:
     case InstallCertificateUseEnum::V2GRootCertificate:
-        return true;
+        return std::nullopt;
     case InstallCertificateUseEnum::OEMRootCertificate:
-        // FIXME: Implement OEMRootCertificate
-        return false;
+        break; // handled above
     }
-    return false;
+    // Unknown certificate types stay refused, as they were before.
+    return make_status_info(reason_code_unsupported_request, "CertificateTypeNotSupported");
 }
 
 void Security::scheduled_check_client_certificate_expiration() {

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_security.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_security.cpp
@@ -12,6 +12,7 @@
 #include <ocpp/v2/functional_blocks/security.hpp>
 #undef private
 #include <ocpp/v2/messages/CertificateSigned.hpp>
+#include <ocpp/v2/messages/InstallCertificate.hpp>
 #include <ocpp/v2/messages/Reset.hpp>
 #include <ocpp/v2/messages/SecurityEventNotification.hpp>
 #include <ocpp/v2/messages/SignCertificate.hpp>
@@ -134,6 +135,24 @@ protected: // Functions
         this->device_model->set_value(ControllerComponentVariables::UseTPM.component,
                                       ControllerComponentVariables::UseTPM.variable.value(), AttributeEnum::Actual,
                                       "false", "test", true);
+    }
+
+    ocpp::EnhancedMessage<MessageType>
+    create_example_install_certificate_request(const InstallCertificateUseEnum certificate_type) {
+        InstallCertificateRequest request;
+        request.certificateType = certificate_type;
+        request.certificate = "";
+        ocpp::Call<InstallCertificateRequest> call(request);
+        ocpp::EnhancedMessage<MessageType> enhanced_message;
+        enhanced_message.messageType = MessageType::InstallCertificate;
+        enhanced_message.message = call;
+        return enhanced_message;
+    }
+
+    void set_bool_variable(DeviceModel* device_model, const ComponentVariable& component_variable, const bool value) {
+        EXPECT_EQ(device_model->set_value(component_variable.component, component_variable.variable.value(),
+                                          AttributeEnum::Actual, value ? "true" : "false", "default", true),
+                  SetVariableStatusEnum::Accepted);
     }
 
     void set_security_profile(DeviceModel* device_model, const int profile) {
@@ -271,6 +290,96 @@ TEST_F(SecurityTest, handle_message_certificate_signed_chargingstationcertificat
 
     // When no certificate type is given, charging station certificate type is used.
     security.handle_message(create_example_certificate_signed_request("", std::nullopt));
+}
+
+TEST_F(SecurityTest, handle_message_install_certificate_csms_root_not_allowed_on_unsecure_connection) {
+    set_security_profile(this->device_model, 1);
+    set_bool_variable(this->device_model, ControllerComponentVariables::AllowCSMSRootCertInstallWithUnsecureConnection,
+                      false);
+
+    // The certificate is never looked at.
+    EXPECT_CALL(evse_security, install_ca_certificate(_, _)).Times(0);
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<InstallCertificateResponse>();
+        EXPECT_EQ(response.status, InstallCertificateStatusEnum::Rejected);
+        ASSERT_TRUE(response.statusInfo.has_value());
+        EXPECT_EQ(response.statusInfo->reasonCode.get(), "Unspecified");
+        ASSERT_TRUE(response.statusInfo->additionalInfo.has_value());
+        EXPECT_EQ(response.statusInfo->additionalInfo->get(),
+                  "CSMSRootCertificateInstallationNotAllowedWithUnsecureConnection");
+    }));
+
+    security.handle_message(create_example_install_certificate_request(InstallCertificateUseEnum::CSMSRootCertificate));
+}
+
+TEST_F(SecurityTest, handle_message_install_certificate_manufacturer_root_not_allowed_on_unsecure_connection) {
+    set_security_profile(this->device_model, 1);
+    set_bool_variable(this->device_model, ControllerComponentVariables::AllowMFRootCertInstallWithUnsecureConnection,
+                      false);
+
+    EXPECT_CALL(evse_security, install_ca_certificate(_, _)).Times(0);
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<InstallCertificateResponse>();
+        EXPECT_EQ(response.status, InstallCertificateStatusEnum::Rejected);
+        ASSERT_TRUE(response.statusInfo.has_value());
+        EXPECT_EQ(response.statusInfo->reasonCode.get(), "Unspecified");
+        ASSERT_TRUE(response.statusInfo->additionalInfo.has_value());
+        EXPECT_EQ(response.statusInfo->additionalInfo->get(),
+                  "ManufacturerRootCertificateInstallationNotAllowedWithUnsecureConnection");
+    }));
+
+    security.handle_message(
+        create_example_install_certificate_request(InstallCertificateUseEnum::ManufacturerRootCertificate));
+}
+
+TEST_F(SecurityTest, handle_message_install_certificate_csms_root_allowed_on_unsecure_connection) {
+    set_security_profile(this->device_model, 1);
+    set_bool_variable(this->device_model, ControllerComponentVariables::AllowCSMSRootCertInstallWithUnsecureConnection,
+                      true);
+
+    EXPECT_CALL(evse_security, install_ca_certificate("", ocpp::CaCertificateType::CSMS))
+        .WillOnce(Return(ocpp::InstallCertificateResult::Accepted));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<InstallCertificateResponse>();
+        EXPECT_EQ(response.status, InstallCertificateStatusEnum::Accepted);
+        EXPECT_FALSE(response.statusInfo.has_value());
+    }));
+    EXPECT_CALL(security_event_callback_mock, Call(CiString<50>("ReconfigurationOfSecurityParameters"), _));
+
+    security.handle_message(create_example_install_certificate_request(InstallCertificateUseEnum::CSMSRootCertificate));
+}
+
+TEST_F(SecurityTest, handle_message_install_certificate_oem_root_not_supported_unsecure_connection) {
+    set_security_profile(this->device_model, 1);
+
+    // Installing an OEM root certificate is not implemented, the refusal has nothing to do with the connection.
+    EXPECT_CALL(evse_security, install_ca_certificate(_, _)).Times(0);
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<InstallCertificateResponse>();
+        EXPECT_EQ(response.status, InstallCertificateStatusEnum::Rejected);
+        ASSERT_TRUE(response.statusInfo.has_value());
+        EXPECT_EQ(response.statusInfo->reasonCode.get(), "UnsupportedRequest");
+        ASSERT_TRUE(response.statusInfo->additionalInfo.has_value());
+        EXPECT_EQ(response.statusInfo->additionalInfo->get(), "OEMRootCertificateInstallationNotSupported");
+    }));
+
+    security.handle_message(create_example_install_certificate_request(InstallCertificateUseEnum::OEMRootCertificate));
+}
+
+TEST_F(SecurityTest, handle_message_install_certificate_oem_root_not_supported_secure_connection) {
+    set_security_profile(this->device_model, 3);
+
+    // On a secure connection the request used to reach evse_security, where the conversion of the OEM certificate
+    // type throws. It has to be rejected before that.
+    EXPECT_CALL(evse_security, install_ca_certificate(_, _)).Times(0);
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<InstallCertificateResponse>();
+        EXPECT_EQ(response.status, InstallCertificateStatusEnum::Rejected);
+        ASSERT_TRUE(response.statusInfo.has_value());
+        EXPECT_EQ(response.statusInfo->reasonCode.get(), "UnsupportedRequest");
+    }));
+
+    security.handle_message(create_example_install_certificate_request(InstallCertificateUseEnum::OEMRootCertificate));
 }
 
 TEST_F(SecurityTest, sign_certificate_request_accepted) {


### PR DESCRIPTION
## Describe your changes

`InstallCertificateResponse` rejections carried the invented `statusInfo.reasonCode`
`"UnsecureConnection"` for three unrelated causes. `Security::should_allow_certificate_install`
returned a bare bool, so the handler had one string for all of them.

It now returns the refusal instead of a bool (`check_certificate_install_allowed` ->
`std::optional<StatusInfo>`), with OCPP 2.1 Appendix 5 codes and a cause-specific
`additionalInfo`:

| Cause | reasonCode | additionalInfo |
|---|---|---|
| CSMS root, SecurityProfile <= 1, `AllowCSMSRootCertInstallWithUnsecureConnection` false | `Unspecified` | `CSMSRootCertificateInstallationNotAllowedWithUnsecureConnection` |
| Manufacturer root, same shape with `AllowMFRootCertInstallWithUnsecureConnection` | `Unspecified` | `ManufacturerRootCertificateInstallationNotAllowedWithUnsecureConnection` |
| OEM root, any profile | `UnsupportedRequest` | `OEMRootCertificateInstallationNotSupported` |
| Unhandled certificate type | `UnsupportedRequest` | `CertificateTypeNotSupported` |

`Unspecified` rather than a more specific code because Appendix 5 is informative, Part 3 puts no
`enum` on `reasonCode`, and neither the 2.0.1 Edition 4 nor the 2.1 Edition 2 Part 6 test cases
assert `reasonCode` on `InstallCertificateResponse` (`TC_M_07_CS` / `TC_M_09_CS` check
`status must be Rejected` only). The cause is carried by `additionalInfo`.

Also a functional fix: `OEMRootCertificate` is refused before the `SecurityProfile > 1` early
return. Above profile 1 the request used to reach `evse_security`, where
`from_ocpp(CaCertificateType::OEM)` throws `EnumConversionException`
(`lib/everest/ocpp/lib/ocpp/common/evse_security_impl.cpp:371`), so no CallResult was dispatched
at all. The `// FIXME: Implement OEMRootCertificate` gap itself is untouched.

The previously unreachable post-switch fallthrough now refuses rather than allows, keeping the
old deny-by-default if an enum value is added.

## Issue ticket number and link

n/a

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation - no module docs cover
      `InstallCertificate` reason codes
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

## How to verify it

- [x] `ctest -R libocpp --output-on-failure` - 7/7 passed, including `libocpp_test_security`
- [x] Full suite of the libs-only build (`EVEREST_INCLUDE_LIBS=ocpp`, `BUILD_TESTING=ON`) - 158/158 passed
- [x] Red-phase check: with the implementation reverted, 4 of the 5 new tests fail
      (`"UnsecureConnection"` vs `"Unspecified"` / `"UnsupportedRequest"`, and the profile-3 OEM
      case shows `install_ca_certificate` called once); the positive-path guard stays green

Five tests added in `lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_security.cpp`,
covering each refusal cause plus a guard that a CSMS root install at profile 1 with the variable
true still installs. There was no previous coverage of the reject path.
