### PR TITLE
fix(tls): bind tests to an ephemeral port

### DIFF
--- a/lib/everest/tls/include/everest/tls/tls.hpp
+++ b/lib/everest/tls/include/everest/tls/tls.hpp
@@ -658,6 +658,14 @@ public:
     }
 
     /**
+     * \brief the port the listen socket is bound to
+     * \return the bound port in host byte order, 0 when there is no bound socket
+     * \note the only way to learn the port when config_t::service is "0", which
+     *       asks the operating system for an ephemeral port
+     */
+    [[nodiscard]] std::uint16_t bound_port() const;
+
+    /**
      * \brief wrap an externally-accepted TCP socket as a TLS server connection
      * \param[in] soc accepted TCP socket file descriptor
      * \param[in] ip peer IP address string (may be nullptr)

--- a/lib/everest/tls/src/tls.cpp
+++ b/lib/everest/tls/src/tls.cpp
@@ -1063,6 +1063,27 @@ bool Server::init_socket(const config_t& cfg) {
     return result;
 }
 
+std::uint16_t Server::bound_port() const {
+    if (m_socket == INVALID_SOCKET) {
+        return 0;
+    }
+
+    sockaddr_storage addr{};
+    socklen_t addr_len = sizeof(addr);
+    if (::getsockname(m_socket, reinterpret_cast<sockaddr*>(&addr), &addr_len) != 0) {
+        return 0;
+    }
+
+    switch (addr.ss_family) {
+    case AF_INET:
+        return ntohs(reinterpret_cast<const sockaddr_in*>(&addr)->sin_port);
+    case AF_INET6:
+        return ntohs(reinterpret_cast<const sockaddr_in6*>(&addr)->sin6_port);
+    default:
+        return 0;
+    }
+}
+
 int Server::handle_tls_1_3_verify_upgrade(SSL* ssl, int* /*alert*/) {
     // The verify upgrade only takes effect when the negotiated protocol will be
     // TLS 1.3. Both sides must allow it: the client must advertise TLS 1.3 in

--- a/lib/everest/tls/tests/tls_connection_test.cpp
+++ b/lib/everest/tls/tests/tls_connection_test.cpp
@@ -49,7 +49,8 @@ tls::Server::OptionalConfig ssl_init() {
     ref.trust_anchor_file = "server_root_cert.pem";
     ref.ocsp_response_files = {"ocsp_response.der", "ocsp_response.der"};
     server_config->host = "127.0.0.1";
-    server_config->service = "8444";
+    // update() does not change the listen socket, so this is never bound
+    server_config->service = "0";
     server_config->ipv6_only = false;
     server_config->verify_client = false;
     server_config->io_timeout_ms = 500;
@@ -69,6 +70,14 @@ TEST_F(TlsTest, StartStop) {
     if (server_thread.joinable()) {
         server_thread.join();
     }
+}
+
+TEST_F(TlsTest, BoundPortReportsEphemeralPort) {
+    // Without this the fixture cannot tell the client where to connect, since
+    // the OS picks the port.
+    EXPECT_EQ(server.bound_port(), 0); // nothing bound yet
+    start();
+    EXPECT_NE(server.bound_port(), 0);
 }
 
 TEST_F(TlsTest, StartConnectDisconnect) {
@@ -865,7 +874,7 @@ TEST_F(TlsTest, TCKeysInvalid) {
     client.reset();
     // localhost works in some cases but not in the CI pipeline for IPv6
     // use ip6-localhost
-    auto connection = client.connect("127.0.0.1", "8444", false, 1000);
+    auto connection = client.connect("127.0.0.1", server_service().c_str(), false, 1000);
     if (connection) {
         if (connection->connect() == result_t::success) {
             set(ClientTest::flags_t::connected);

--- a/lib/everest/tls/tests/tls_connection_test.hpp
+++ b/lib/everest/tls/tests/tls_connection_test.hpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 #include <memory>
 #include <openssl/ssl.h>
+#include <string>
 #include <thread>
 #include <tuple>
 #include <unistd.h>
@@ -312,7 +313,10 @@ protected:
         ref1.ocsp_response_files = {"ocsp_response.der", "ocsp_response.der"};
         // server_config.verify_locations_file = "client_root_cert.pem";
         server_config.host = "127.0.0.1";
-        server_config.service = "8444";
+        // "0" asks the OS for a free port. A fixed port collides with any other
+        // build tree or CI job running these tests at the same time, and the
+        // collision presents as a hang rather than a bind error.
+        server_config.service = "0";
         server_config.ipv6_only = false;
         server_config.verify_client = false;
         server_config.io_timeout_ms = 1000; // no lower than 200ms, valgrind need much higher
@@ -355,12 +359,17 @@ protected:
         }
     }
 
+    // The port the server actually bound. Only valid after start().
+    [[nodiscard]] std::string server_service() const {
+        return std::to_string(server.bound_port());
+    }
+
     void connect(const std::function<void(tls::Client::ConnectionPtr& con)>& handler = nullptr) {
         client.init(client_config);
         client.reset();
         // localhost works in some cases but not in the CI pipeline for IPv6
         // use ip6-localhost
-        auto connection = client.connect("127.0.0.1", "8444", false, 1000);
+        auto connection = client.connect("127.0.0.1", server_service().c_str(), false, 1000);
         if (handler == nullptr) {
             if (connection) {
                 if (connection->connect() == tls::Connection::result_t::success) {
@@ -431,7 +440,10 @@ protected:
         // ref1.trust_anchor_file = "alt_server_root_cert.pem";
         // ref1.ocsp_response_files = {"ocsp_response.der", "ocsp_response.der"};
         server_config.host = "127.0.0.1";
-        server_config.service = "8444";
+        // "0" asks the OS for a free port. A fixed port collides with any other
+        // build tree or CI job running these tests at the same time, and the
+        // collision presents as a hang rather than a bind error.
+        server_config.service = "0";
         server_config.ipv6_only = false;
         server_config.verify_client = false;
         server_config.io_timeout_ms = 1000; // no lower than 200ms, valgrind need much higher


### PR DESCRIPTION
## Describe your changes

The `TlsTest` fixture bound the server to a fixed port 8444, so two `tls_test` runs on the same
machine collide. That happens routinely with multiple build trees, and it also affects any CI setup
that runs test binaries concurrently on one host. The collision does not fail cleanly: one process
gets `BIO_bind: Address already in use` and the other can hang, because each process's client
reaches the *other* process's server, whose PKI fixture was generated independently.

This change binds the fixture to port 0 (the OS picks a free port) and adds
`tls::Server::bound_port()` so the client can learn which port was picked. `bound_port()` is
`getsockname` on the listen socket and returns 0 when nothing is bound; it is the only way to
recover the port once `config_t::service` is `"0"`.

The standalone `tls_server` / `tls_client` manual test tools keep 8444: they are a matched pair
meant to interoperate, and they are not part of the `tls_test` gtest target.

Testing, two `tls_test` instances started concurrently:
- Before, round 1: one instance `BIO_bind: Address already in use`, the other 4 failed tests.
  Round 2: one bind failure, the other hung until a 120 s external timeout inside
  `TlsTest.ClientWriteTimeout`.
- After: 3 rounds, 127/127 pass in both instances every round.

Also `ctest` over the whole tls/util/evse_security tree: 151/151 pass. New coverage:
`TlsTest.BoundPortReportsEphemeralPort` asserts 0 before `start()` and non-zero after.

## Issue ticket number and link

n/a

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
