### PR TITLE
test(ocpp): give each process its own temp paths

### DIFF
--- a/lib/everest/ocpp/tests/lib/ocpp/test_temp_paths.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/test_temp_paths.hpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <atomic>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <unistd.h>
+
+namespace libocpp_test {
+
+/// \brief a temporary path no other process can be using
+/// \param[in] stem descriptive part of the name, so a leftover file says which test made it
+/// \param[in] extension appended unchanged, include the dot
+/// \return <tmp>/<stem>_<pid>_<n><extension>
+///
+/// Test databases and message log directories under a fixed path are shared by every
+/// libocpp_unit_tests process on the machine. Two runs at once (several build trees, or
+/// concurrent jobs on one CI host) then delete and re-create each other's databases, which
+/// surfaces as unrelated migration and query failures.
+inline std::filesystem::path unique_temp_path(std::string_view stem, std::string_view extension = {}) {
+    static std::atomic<unsigned> sequence{0};
+    return std::filesystem::temp_directory_path() /
+           (std::string{stem} + "_" + std::to_string(::getpid()) + "_" +
+            std::to_string(sequence.fetch_add(1, std::memory_order_relaxed)) + std::string{extension});
+}
+
+/// \brief unique_temp_path() plus the directory itself
+/// \note the caller owns removal, TearDown is the usual place
+inline std::filesystem::path unique_temp_directory(std::string_view stem) {
+    const auto path = unique_temp_path(stem);
+    std::filesystem::create_directories(path);
+    return path;
+}
+
+} // namespace libocpp_test

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/database_stub.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/database_stub.hpp
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#include <test_temp_paths.hpp>
+
 #include <ocpp/v16/charge_point_configuration.hpp>
 #include <ocpp/v16/connector.hpp>
 #include <ocpp/v16/database_handler.hpp>
@@ -143,9 +145,8 @@ struct DatabaseConnectionTest : public ConnectionInterface {
 class DbTestBase : public testing::Test {
 protected:
     const std::string chargepoint_id = "12345678";
-    const fs::path database_path = "/tmp/";
     const fs::path init_script_path = "./core_migrations";
-    const fs::path db_filename = database_path / (chargepoint_id + ".db");
+    const fs::path db_filename = libocpp_test::unique_temp_path("ocpp16_" + chargepoint_id, ".db");
 
     std::map<std::int32_t, std::shared_ptr<Connector>> connectors;
     std::shared_ptr<stubs::DatabaseHandlerTest> database_handler;

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/test_charge_point_connectivity.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/test_charge_point_connectivity.cpp
@@ -23,6 +23,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
+#include <test_temp_paths.hpp>
 
 #include <ocpp/common/connectivity_manager.hpp>
 #include <ocpp/v16/charge_point_configuration.hpp>
@@ -55,9 +56,7 @@ protected:
             std::make_unique<ChargePointConfiguration>(config_file, CONFIG_DIR_V16, USER_CONFIG_FILE_LOCATION_V16);
 
         // Each test gets its own temporary directory so the on-disk sqlite db and message logs do not collide.
-        this->tmp_dir = fs::temp_directory_path() /
-                        ("ocpp_v16_connectivity_test_" + std::to_string(reinterpret_cast<std::uintptr_t>(this)));
-        fs::create_directories(this->tmp_dir);
+        this->tmp_dir = libocpp_test::unique_temp_directory("ocpp_v16_connectivity_test");
     }
 
     void TearDown() override {

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_smart_charging.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_smart_charging.cpp
@@ -5,6 +5,7 @@
 #include "date/tz.h"
 #include "everest/logging.hpp"
 #include "lib/ocpp/common/database_testing_utils.hpp"
+#include "lib/ocpp/test_temp_paths.hpp"
 #include "message_dispatcher_mock.hpp"
 #include "ocpp/common/types.hpp"
 #include "ocpp/v2/ctrlr_component_variables.hpp"
@@ -83,7 +84,7 @@ protected:
 
     TestSmartCharging create_smart_charging(const std::optional<std::string> ac_phase_switching_supported = "true") {
         std::unique_ptr<everest::db::sqlite::Connection> database_connection =
-            std::make_unique<everest::db::sqlite::Connection>(fs::path("/tmp/ocpp201") / "cp.db");
+            std::make_unique<everest::db::sqlite::Connection>(libocpp_test::unique_temp_path("ocpp201_cp", ".db"));
         database_handler =
             std::make_shared<DatabaseHandler>(std::move(database_connection), MIGRATION_FILES_LOCATION_V2);
         database_handler->open_connection();

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/smart_charging_test_utils.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/smart_charging_test_utils.cpp
@@ -3,6 +3,7 @@
 
 #include <ocpp/v2/device_model.hpp>
 #include <smart_charging_test_utils.hpp>
+#include <test_temp_paths.hpp>
 
 #include "ocpp/v2/ctrlr_component_variables.hpp"
 
@@ -472,7 +473,7 @@ std::unique_ptr<TestSmartCharging>
 CompositeScheduleTestFixtureV2::create_smart_charging_handler(const OcppProtocolVersion ocpp_version) {
     this->ocpp_version = ocpp_version;
     std::unique_ptr<everest::db::sqlite::Connection> database_connection =
-        std::make_unique<everest::db::sqlite::Connection>(fs::path("/tmp/ocpp201") / "cp.db");
+        std::make_unique<everest::db::sqlite::Connection>(libocpp_test::unique_temp_path("ocpp201_cp", ".db"));
     this->database_handler =
         std::make_unique<DatabaseHandlerFake>(std::move(database_connection), MIGRATION_FILES_LOCATION_V2);
     database_handler->open_connection();

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_charge_point.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_charge_point.cpp
@@ -19,6 +19,7 @@
 #include "ocpp/v21/messages/NotifyDERAlarm.hpp"
 #include "ocpp/v21/messages/SetDERControl.hpp"
 #include "smart_charging_test_utils.hpp"
+#include "test_temp_paths.hpp"
 
 #include "gmock/gmock.h"
 #include <boost/uuid/uuid_generators.hpp>
@@ -29,7 +30,7 @@
 
 static const ocpp::v2::AddChargingProfileSource DEFAULT_REQUEST_TO_ADD_PROFILE_SOURCE =
     ocpp::v2::AddChargingProfileSource::SetChargingProfile;
-static const std::string TEMP_OUTPUT_PATH = "/tmp/ocpp201";
+static const std::string TEMP_OUTPUT_PATH = libocpp_test::unique_temp_directory("ocpp201_message_log").string();
 static const std::string DEFAULT_TX_ID = "10c75ff7-74f5-44f5-9d01-f649f3ac7b78";
 
 namespace ocpp::v2 {
@@ -151,7 +152,7 @@ public:
 
     std::shared_ptr<DatabaseHandler> create_database_handler() {
         auto database_connection =
-            std::make_unique<everest::db::sqlite::Connection>(fs::path("/tmp/ocpp201") / "cp.db");
+            std::make_unique<everest::db::sqlite::Connection>(libocpp_test::unique_temp_path("ocpp201_cp", ".db"));
         return std::make_shared<DatabaseHandler>(std::move(database_connection), MIGRATION_FILES_LOCATION_V2);
     }
 

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_network_config_sync.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_network_config_sync.cpp
@@ -36,6 +36,7 @@
 #include <ocpp/v2/messages/SetNetworkProfile.hpp>
 #include <ocpp/v2/ocpp_types.hpp>
 #include <ocsp_updater_mock.hpp>
+#include <test_temp_paths.hpp>
 
 using json = nlohmann::json;
 
@@ -1822,7 +1823,7 @@ protected:
 
     void SetUp() override {
         const std::string unique = ::testing::UnitTest::GetInstance()->current_test_info()->name();
-        db_path = std::filesystem::temp_directory_path() / ("libocpp_no_prune_" + unique + ".db");
+        db_path = libocpp_test::unique_temp_path("libocpp_no_prune_" + unique, ".db");
         std::error_code ec;
         std::filesystem::remove(db_path, ec);
     }

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_ocpp16_custom_config_mappings.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_ocpp16_custom_config_mappings.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 
 #include <ocpp/v2/ocpp16_custom_config_mappings.hpp>
+#include <test_temp_paths.hpp>
 
 namespace ocpp::v2 {
 
@@ -15,8 +16,7 @@ protected:
     std::filesystem::path test_dir;
 
     void SetUp() override {
-        test_dir = std::filesystem::temp_directory_path() / "ocpp16_custom_mapping_tests";
-        std::filesystem::create_directories(test_dir);
+        test_dir = libocpp_test::unique_temp_directory("ocpp16_custom_mapping_tests");
     }
 
     void TearDown() override {


### PR DESCRIPTION
## Describe your changes

Several `libocpp_unit_tests` fixtures write to fixed absolute paths: `/tmp/ocpp201/cp.db`,
`/tmp/12345678.db`, `/tmp/ocpp16_custom_mapping_tests`, and `/tmp/libocpp_no_prune_<testname>.db`
(unique per test *name*, not per process). Every `libocpp_unit_tests` process on the machine shares
them, so two runs at once (several build trees, or concurrent jobs on one CI host) delete and
re-create each other's databases. The result is assertion failures in tests unrelated to whatever
either run was actually exercising.

This adds `tests/lib/ocpp/test_temp_paths.hpp` with `unique_temp_path(stem, extension)` and
`unique_temp_directory(stem)`, which compose temp dir + stem + pid + sequence number, and converts
the fixed-path sites to use them.

It also removes a hidden ordering dependency. Nothing ever created `/tmp/ocpp201`, so opening
`cp.db` under it only worked because an earlier test's message logger had created the directory, or
because it survived from a previous run. The message log path is now created explicitly by
`unique_temp_directory`.

Testing, two build trees of this branch running the suite concurrently:
- Before: 4 of 4 runs failed, every time in `MigrationWithoutJsonTest.*`.
- After: 4 of 4 runs pass.
- Solo run after the change: 1502 tests, 0 failures.

Known limitation, deliberately not addressed here: two instances launched from the *same* build
directory still share that tree's writable v16 user-config fixture, which showed up once as
`ConfigurationTester.BooleanKeyAcceptsValidLiterals` failing on an empty-file JSON parse. That is a
different shared resource and does not affect the separate-build-tree case this PR is about.

## Issue ticket number and link

n/a

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
