### PR TITLE
test(Auth): plug in sequentially in invalid-rfid test

### DIFF
--- a/modules/EVSE/Auth/tests/auth_tests.cpp
+++ b/modules/EVSE/Auth/tests/auth_tests.cpp
@@ -753,8 +753,10 @@ TEST_F(AuthTest, test_two_plugins_with_invalid_rfid) {
 
     SessionEvent session_event = get_session_started_event(types::evse_manager::StartSessionReason::EVConnected);
 
-    std::thread t1([this, session_event]() { this->auth_handler->handle_session_event(1, session_event); });
-    std::thread t2([this, session_event]() { this->auth_handler->handle_session_event(2, session_event); });
+    // PlugEvents authorizes the earliest plug in, so racing the two events leaves it undefined which
+    // evse the valid token starts. Plug in sequentially so the order is deterministic.
+    this->auth_handler->handle_session_event(1, session_event);
+    this->auth_handler->handle_session_event(2, session_event);
 
     std::vector<int32_t> connectors{1, 2};
     ProvidedIdToken provided_token_1 = get_provided_token(VALID_TOKEN_1, connectors);
@@ -771,8 +773,6 @@ TEST_F(AuthTest, test_two_plugins_with_invalid_rfid) {
                 Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token), TokenValidationStatus::UsedToStart));
     EXPECT_CALL(mock_publish_token_validation_status_callback,
                 Call(Field(&ProvidedIdToken::id_token, provided_token_2.id_token), TokenValidationStatus::Rejected));
-    t1.join();
-    t2.join();
     std::thread t3([this, provided_token_1, &result1]() { result1 = this->auth_handler->on_token(provided_token_1); });
     t3.join();
 


### PR DESCRIPTION
## Describe your changes

`AuthTest.test_two_plugins_with_invalid_rfid` is the long-suspected `everest-core_auth_tests` flake.
Measured on this branch's parent: 12 failures in 20 iterations under full CPU load, 0 failures in 50
iterations on an idle machine. That load sensitivity is why it has survived, a re-run on a quiet
machine always passes.

The test started two `std::thread`s that each called `handle_session_event` for evse 1 and evse 2.
Both land in `AuthHandler::handle_session_event`, which appends to `plug_in_queue` under
`event_mutex`. The locking is correct, but which thread reaches the `push_back` first is not
ordered. With the `PlugEvents` algorithm the authorization goes to the *earliest* plug in
(`AuthHandler::get_oldest_plugin`), so the winner is whichever thread happened to get there first.
The test then asserted `get_authorization(0)`, hardcoding that evse 1 won. `t1.join(); t2.join()`
only guarantees both events were applied, not the order they were applied in.

The fix plugs the two EVSEs in sequentially on the test thread, which is what the sibling test
`test_plug_events_selects_first_plugin` immediately below already does, with the same reasoning in
its comment. No production code changed: `AuthHandler` behaves correctly, the test asserted a
guarantee it never made.

Note on the failure signature: the ctest log for this flake shows three failures, at
`auth_tests.cpp:765`, `:772` and `:780`. There is only one root failure, at line 780. That
`ASSERT_TRUE` is fatal, so the test body returns early, the thread driving the second token never
runs, and gmock reports the two now-unsatisfied `EXPECT_CALL`s at teardown.

The two other tests that race plug-in events, `test_two_id_tokens` and `test_two_plugins`, are
deliberately left alone: they assert that *both* EVSEs were authorized, so plug-in order does not
change their outcome.

Testing, all under the same 16-core busy-loop load used to characterize the flake:
- `AuthTest.test_two_plugins_with_invalid_rfid` with `--gtest_repeat=50`: 50/50 pass (was 12/20
  failing before the change).
- Full `everest-core_auth_tests`: 103/103 pass.

## Issue ticket number and link

n/a

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
