### PR TITLE
Fix(API): error id typo in evse_board_support_API

### DIFF
--- a/modules/API/EVerestAPI/evse_board_support_API/evse_board_support_API.cpp
+++ b/modules/API/EVerestAPI/evse_board_support_API/evse_board_support_API.cpp
@@ -206,7 +206,7 @@ evse_board_support_API::ErrorHandler evse_board_support_API::make_error_handler(
     case ErrorEnum::Selftest:
     case ErrorEnum::DC:
     case ErrorEnum::AC:
-        error_id = "acd_rcd/" + error_str;
+        error_id = "ac_rcd/" + error_str;
         result.raiser = [this, sub_type_str, message_str, error_id]() {
             auto ev_error =
                 p_rcd->error_factory->create_error(error_id, sub_type_str, message_str, Everest::error::Severity::High);


### PR DESCRIPTION
## Describe your changes

The error_id for "ac_rcd" was wrong. Likely no errors were ever emitted by this module (on the internal interfaces).

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

