### PR TITLE
fix(cbv2g): stop the bitstream writer one byte short of the end

### DIFF
--- a/lib/everest/cbv2g/lib/cbv2g/common/exi_bitstream.c
+++ b/lib/everest/cbv2g/lib/cbv2g/common/exi_bitstream.c
@@ -30,7 +30,10 @@ static int exi_bitstream_has_overflow(exi_bitstream_t* stream)
 {
     if (stream->bit_count == EXI_BITSTREAM_MAX_BIT_COUNT)
     {
-        if (stream->byte_pos < stream->data_size)
+        /* The current byte is full, so advance only if the NEXT index is still inside the
+           buffer. Comparing byte_pos itself lets it reach data_size, after which the caller
+           writes one past the end. */
+        if (stream->byte_pos + 1 < stream->data_size)
         {
             stream->byte_pos++;
             stream->bit_count = 0;

--- a/lib/everest/cbv2g/tests/CMakeLists.txt
+++ b/lib/everest/cbv2g/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ include(Catch)
 # source helper functions and library
 add_subdirectory(test_utils)
 
+add_subdirectory(common)
 add_subdirectory(app_handshake)
 add_subdirectory(din)
 add_subdirectory(iso20)

--- a/lib/everest/cbv2g/tests/common/CMakeLists.txt
+++ b/lib/everest/cbv2g/tests/common/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_codec_test(bitstream_bounds)

--- a/lib/everest/cbv2g/tests/common/bitstream_bounds.cpp
+++ b/lib/everest/cbv2g/tests/common/bitstream_bounds.cpp
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#include <array>
+#include <cstring>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cbv2g/common/exi_bitstream.h>
+#include <cbv2g/common/exi_error_codes.h>
+
+// The writer must stop at the end of the buffer it was handed. Callers size that buffer from
+// exi_bitstream_init, so an encoder that walks past it corrupts whatever the caller put next.
+SCENARIO("cbv2g bitstream writer respects the output buffer bound") {
+
+    GIVEN("A four byte output buffer with a guard region immediately after it") {
+        struct Framed {
+            std::array<uint8_t, 4> buffer;
+            std::array<uint8_t, 4> guard;
+        };
+        Framed framed{};
+        framed.buffer.fill(0x00);
+        framed.guard.fill(0xAA);
+
+        exi_bitstream_t stream;
+        exi_bitstream_init(&stream, framed.buffer.data(), framed.buffer.size(), 0, nullptr);
+
+        WHEN("exactly as many bits as the buffer holds are written") {
+            int error = EXI_ERROR__NO_ERROR;
+            for (size_t i = 0; i < framed.buffer.size() * 8 and error == EXI_ERROR__NO_ERROR; ++i) {
+                error = exi_bitstream_write_bits(&stream, 1, 1);
+            }
+
+            THEN("every one of them is accepted, so the bound costs no capacity") {
+                REQUIRE(error == EXI_ERROR__NO_ERROR);
+                REQUIRE(framed.buffer[3] == 0xFF);
+            }
+
+            AND_WHEN("one more bit is written") {
+                const auto error_past_end = exi_bitstream_write_bits(&stream, 1, 1);
+
+                THEN("it is reported as an overflow rather than silently accepted") {
+                    REQUIRE(error_past_end == EXI_ERROR__BITSTREAM_OVERFLOW);
+                }
+
+                THEN("the guard region is untouched") {
+                    REQUIRE(framed.guard[0] == 0xAA);
+                    REQUIRE(framed.guard[1] == 0xAA);
+                    REQUIRE(framed.guard[2] == 0xAA);
+                    REQUIRE(framed.guard[3] == 0xAA);
+                }
+
+                THEN("the write position never points past the buffer") {
+                    REQUIRE(stream.byte_pos < framed.buffer.size());
+                }
+            }
+        }
+
+        WHEN("a multi-bit write straddles the end of the buffer") {
+            int error = EXI_ERROR__NO_ERROR;
+            for (size_t i = 0; i < 3 and error == EXI_ERROR__NO_ERROR; ++i) {
+                error = exi_bitstream_write_bits(&stream, 8, 0xFF);
+            }
+            REQUIRE(error == EXI_ERROR__NO_ERROR);
+
+            // 8 bits still fit, then a 32 bit write cannot.
+            REQUIRE(exi_bitstream_write_bits(&stream, 8, 0xFF) == EXI_ERROR__NO_ERROR);
+            const auto error_past_end = exi_bitstream_write_bits(&stream, 32, 0xFFFFFFFF);
+
+            THEN("the overflow is reported and nothing past the buffer is written") {
+                REQUIRE(error_past_end == EXI_ERROR__BITSTREAM_OVERFLOW);
+                REQUIRE(framed.guard[0] == 0xAA);
+            }
+        }
+
+        WHEN("a single byte buffer is filled and then overrun") {
+            std::array<uint8_t, 1> one{};
+            uint8_t guard = 0xAA;
+            exi_bitstream_t tight;
+            exi_bitstream_init(&tight, one.data(), one.size(), 0, nullptr);
+
+            int error = EXI_ERROR__NO_ERROR;
+            for (size_t i = 0; i < 8 and error == EXI_ERROR__NO_ERROR; ++i) {
+                error = exi_bitstream_write_bits(&tight, 1, 1);
+            }
+
+            THEN("the byte fills, the next bit overflows, and the guard survives") {
+                REQUIRE(error == EXI_ERROR__NO_ERROR);
+                REQUIRE(one[0] == 0xFF);
+                REQUIRE(exi_bitstream_write_bits(&tight, 1, 1) == EXI_ERROR__BITSTREAM_OVERFLOW);
+                REQUIRE(guard == 0xAA);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Describe your changes

`exi_bitstream_has_overflow` in `lib/everest/cbv2g/lib/cbv2g/common/exi_bitstream.c` used the wrong bound when rolling the writer over to the next byte. Once the current byte was full (`bit_count == EXI_BITSTREAM_MAX_BIT_COUNT`) it compared `byte_pos < data_size`, so at the last byte of the buffer it happily advanced `byte_pos` to `data_size` and reported no error.

The failure mode is a silent buffer overrun. The caller sizes the output buffer through `exi_bitstream_init`, and after that rollover the next write lands at `data + data_size`, one byte past the end, corrupting whatever the caller placed after the buffer. Nothing reports an error, so the encoder looks like it succeeded.

The fix compares `byte_pos + 1 < data_size` instead, so the writer only advances while the next index is still inside the buffer and otherwise returns `EXI_ERROR__BITSTREAM_OVERFLOW`. No capacity is lost: a buffer of N bytes still accepts exactly 8N bits, and only bit 8N+1 is rejected.

A new test, `lib/everest/cbv2g/tests/common/bitstream_bounds.cpp`, pins the behavior. It places a guard region immediately after the output buffer and asserts that filling the buffer bit by bit is fully accepted, that the very next bit returns `EXI_ERROR__BITSTREAM_OVERFLOW`, that a multi-bit write straddling the end is rejected rather than truncated, that a one byte buffer behaves the same way, that `byte_pos` never points past the buffer, and that the guard bytes are untouched throughout. The `common` test directory is added to `lib/everest/cbv2g/tests/CMakeLists.txt`. Note that these tests only build under `CB_V2G_BUILD_TESTS`, which everest-core does not set.

This is a prerequisite for #2584. That PR drops a defensive struct layout guard that was only safe to remove once this encoder bound was correct, so this one has to merge first.

## Issue ticket number and link

None. Prerequisite for #2584.

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
