### PR TITLE
OCPP: disarm connection callbacks at destruction, not stop()

### DIFF
--- a/lib/everest/ocpp/include/ocpp/common/connectivity_manager.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/connectivity_manager.hpp
@@ -154,19 +154,14 @@ public:
     ///
     virtual void disconnect() = 0;
 
-    /// \brief Stop delivering connected/disconnected notifications to the registered callbacks.
+    /// \brief Permanently suppress the connected/disconnected callbacks.
     ///
-    /// Called during teardown after disconnect(). A late websocket-thread callback would otherwise
-    /// reach into a ChargePoint whose members are already being destroyed (use-after-free). This
-    /// blocks until any in-flight callback returns, then suppresses all further ones.
+    /// Called from the ChargePoint destructor: the websocket delivers these from a deferred thread, so
+    /// one can be in flight while members are destroyed (use-after-free). Blocks on an in-flight call.
+    ///
+    /// One-way by design, never call it on the stop()/restart() path: the owner is still entitled to
+    /// the connection state there.
     virtual void disarm_connection_callbacks() = 0;
-
-    /// \brief Resume delivering connected/disconnected notifications to the registered callbacks.
-    ///
-    /// Counterpart of disarm_connection_callbacks(), called from ChargePoint::start(). A restart
-    /// reuses the same ConnectivityManager, so the suppression set up by the preceding stop() has
-    /// to be lifted before the connection state can be reported again.
-    virtual void arm_connection_callbacks() = 0;
 
     /// \brief Suppress automatic reconnection without closing the current websocket.
     ///
@@ -239,9 +234,8 @@ private:
 
     Everest::SteadyTimer websocket_timer;
 
-    // Serializes invocation of the connected/disconnected callbacks (websocket thread) with
-    // disarm_connection_callbacks() (teardown thread) and arm_connection_callbacks() (start thread).
-    // While disarmed, the callbacks are suppressed.
+    // Serializes the connected/disconnected callbacks (websocket deferred thread) with
+    // disarm_connection_callbacks() (destroying thread). Disarming is permanent.
     std::mutex connection_callbacks_mutex;
     bool connection_callbacks_disarmed{false};
     // Written from the OCPP message-handler thread (suppress_reconnect/disconnect) and read from the
@@ -306,7 +300,6 @@ public:
     void connect(std::optional<std::int32_t> network_profile_slot = std::nullopt) override;
     void disconnect() override;
     void disarm_connection_callbacks() override;
-    void arm_connection_callbacks() override;
     void suppress_reconnect() override;
     bool send_to_websocket(const std::string& message) override;
     void on_network_disconnected(ocpp::v2::OCPPInterfaceEnum ocpp_interface) override;

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
@@ -457,7 +457,9 @@ public:
         const std::optional<SecurityConfiguration>& security_configuration,
         const std::function<void(const std::string& message, MessageDirection direction)>& message_callback);
 
-    virtual ~ChargePointImpl() override = default;
+    /// \brief Disarms the connection callbacks so a deferred websocket callback cannot reach a
+    /// partly destroyed charge point.
+    virtual ~ChargePointImpl() override;
 
     /// \brief Allow to update the ChargePoint core information which will be sent in BootNotification.req
     void update_chargepoint_information(const std::string& vendor, const std::string& model,

--- a/lib/everest/ocpp/lib/ocpp/common/connectivity_manager.cpp
+++ b/lib/everest/ocpp/lib/ocpp/common/connectivity_manager.cpp
@@ -236,11 +236,6 @@ void ConnectivityManager::disarm_connection_callbacks() {
     this->connection_callbacks_disarmed = true;
 }
 
-void ConnectivityManager::arm_connection_callbacks() {
-    std::lock_guard<std::mutex> lock(this->connection_callbacks_mutex);
-    this->connection_callbacks_disarmed = false;
-}
-
 void ConnectivityManager::suppress_reconnect() {
     // Like disconnect() this clears the connect intent and cancels any pending reconnect timer, but
     // leaves the live socket open so queued messages can still flush. The websocket's own internal

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -260,6 +260,11 @@ ChargePointImpl::ChargePointImpl(
     this->connectivity_manager->set_logging(this->logging);
 }
 
+ChargePointImpl::~ChargePointImpl() {
+    // Suppress deferred websocket callbacks before any member is destroyed.
+    this->connectivity_manager->disarm_connection_callbacks();
+}
+
 std::unique_ptr<ocpp::MessageQueue<v16::MessageType>> ChargePointImpl::create_message_queue() {
 
     // The StartTransaction.conf handler attempts to get the transaction based on the message id. The message id changes
@@ -1155,8 +1160,6 @@ bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_st
         init(connector_status_map, resuming_session_ids);
     }
     this->bootreason = bootreason;
-    // Lift the suppression a preceding stop() put in place, so the connection state is reported again.
-    this->connectivity_manager->arm_connection_callbacks();
     // Publish the initial default price before connecting (offline state at startup).
     this->publish_default_price(true);
     this->connectivity_manager->set_message_callback(
@@ -1299,10 +1302,9 @@ bool ChargePointImpl::stop() {
         this->stop_all_transactions();
 
         this->database_handler->close_connection();
+        // Callbacks stay armed: this only queues the disconnected notification the owner waits for.
+        // ~ChargePointImpl() disarms.
         this->connectivity_manager->disconnect();
-        // Disarm before tearing down the message queue: a late websocket-thread disconnect callback
-        // must not reach into members being destroyed.
-        this->connectivity_manager->disarm_connection_callbacks();
         this->message_queue->stop();
 
         this->stopped = true;

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
@@ -104,11 +104,12 @@ ChargePoint::ChargePoint(const std::map<std::int32_t, std::int32_t>& evse_connec
                 ocpp_main_path, core_database_path, sql_init_path, message_log_path, evse_security, callbacks) {
 }
 
-ChargePoint::~ChargePoint() = default;
+ChargePoint::~ChargePoint() {
+    // Suppress deferred websocket callbacks before any member is destroyed.
+    this->connectivity_manager->disarm_connection_callbacks();
+}
 
 void ChargePoint::start(BootReasonEnum bootreason, bool start_connecting) {
-    // Lift the suppression a preceding stop() put in place, so the connection state is reported again.
-    this->connectivity_manager->arm_connection_callbacks();
     this->connectivity_manager->set_message_callback(
         std::bind(&ChargePoint::message_callback, this, std::placeholders::_1));
     this->message_queue->start();
@@ -163,10 +164,9 @@ void ChargePoint::stop() {
     this->ocsp_updater.stop();
     this->availability->stop_heartbeat_timer();
     this->provisioning->stop_bootnotification_timer();
+    // Callbacks stay armed: this only queues the disconnected notification the owner waits for.
+    // ~ChargePoint() disarms.
     this->connectivity_manager->disconnect();
-    // Disarm before tearing down the message queue: a late websocket-thread disconnect callback
-    // must not reach into members being destroyed.
-    this->connectivity_manager->disarm_connection_callbacks();
     this->security->stop_certificate_expiration_check_timers();
     this->diagnostics->stop_monitoring();
     this->message_queue->stop();

--- a/lib/everest/ocpp/tests/lib/ocpp/common/mocks/connectivity_manager_mock.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/common/mocks/connectivity_manager_mock.hpp
@@ -31,7 +31,6 @@ public:
     MOCK_METHOD(void, connect, (std::optional<std::int32_t> network_profile_slot));
     MOCK_METHOD(void, disconnect, ());
     MOCK_METHOD(void, disarm_connection_callbacks, ());
-    MOCK_METHOD(void, arm_connection_callbacks, ());
     MOCK_METHOD(void, suppress_reconnect, ());
     MOCK_METHOD(bool, send_to_websocket, (const std::string& message));
     MOCK_METHOD(void, on_network_disconnected, (ocpp::v2::OCPPInterfaceEnum ocpp_interface));

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/test_charge_point_connectivity.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/test_charge_point_connectivity.cpp
@@ -8,7 +8,9 @@
 /// ConnectivityManager, and assert observable interactions only:
 ///   * that an injected manager is NOT auto-wired for the websocket lifecycle at construction (only set_logging),
 ///     and that the message callback is registered later in start(),
-///   * that the drive surface (start/stop/outgoing message/offline query) hits the manager, and
+///   * that the drive surface (start/stop/outgoing message/offline query) hits the manager,
+///   * that the connection callbacks stay armed for the whole lifetime and are disarmed only at
+///     destruction, and
 ///   * the security-profile switch + revert behaviour orchestrated via the manager and the
 ///     internal websocket revert timer.
 
@@ -130,37 +132,50 @@ TEST_F(ChargePointConnectivityTest, StartConnectsStopDisconnects) {
     charge_point->stop();
 }
 
-// Closing the socket is not enough: a disconnect callback already in flight on the websocket thread would
-// still reach on_websocket_disconnected() and touch the message queue and timers that stop() is about to
-// tear down. stop() therefore disarms the connection callbacks right after disconnect().
-TEST_F(ChargePointConnectivityTest, StopDisarmsConnectionCallbacksAfterDisconnect) {
+// stop() is the external "stop OCPP communication" control, not destruction: the charge point stays alive
+// and restartable, and its owner still gets the disconnect notification. Disarming here raced the deferred
+// delivery of that notification and swallowed it.
+TEST_F(ChargePointConnectivityTest, StopKeepsConnectionCallbacksArmed) {
     ON_CALL(*this->connectivity_manager, is_websocket_connected()).WillByDefault(Return(false));
 
-    const ::testing::InSequence seq;
     EXPECT_CALL(*this->connectivity_manager, disconnect()).Times(AtLeast(1));
-    EXPECT_CALL(*this->connectivity_manager, disarm_connection_callbacks()).Times(1);
+    EXPECT_CALL(*this->connectivity_manager, disarm_connection_callbacks()).Times(0);
 
     auto charge_point = make_charge_point();
     charge_point->start({}, BootReasonEnum::PowerUp, {});
     charge_point->stop();
+
+    // Verify while still alive: destruction is the only disarm site.
+    testing::Mock::VerifyAndClearExpectations(this->connectivity_manager.get());
 }
 
-// A restart reuses the same ConnectivityManager, so start() must arm the connection callbacks that the
-// preceding stop() disarmed. Otherwise the connection state stays suppressed after the first stop().
-TEST_F(ChargePointConnectivityTest, RestartArmsConnectionCallbacksAgain) {
+// Neither half the owner waits for (offline after stop(), online after restart()) survives a disarm.
+TEST_F(ChargePointConnectivityTest, StopRestartCycleNeverDisarms) {
     ON_CALL(*this->connectivity_manager, is_websocket_connected()).WillByDefault(Return(false));
 
-    const ::testing::InSequence seq;
-    EXPECT_CALL(*this->connectivity_manager, arm_connection_callbacks()).Times(1);
-    EXPECT_CALL(*this->connectivity_manager, disarm_connection_callbacks()).Times(1);
-    EXPECT_CALL(*this->connectivity_manager, arm_connection_callbacks()).Times(1);
-    EXPECT_CALL(*this->connectivity_manager, disarm_connection_callbacks()).Times(1);
+    EXPECT_CALL(*this->connectivity_manager, connect(_)).Times(AtLeast(2));
+    EXPECT_CALL(*this->connectivity_manager, disarm_connection_callbacks()).Times(0);
 
     auto charge_point = make_charge_point();
     charge_point->start({}, BootReasonEnum::PowerUp, {});
     charge_point->stop();
     EXPECT_TRUE(charge_point->restart({}, BootReasonEnum::ApplicationReset));
     charge_point->stop();
+
+    testing::Mock::VerifyAndClearExpectations(this->connectivity_manager.get());
+}
+
+// The use-after-free is at destruction: a deferred callback landing while members are destroyed. The
+// destructor body runs before any member is gone and blocks on an in-flight callback.
+TEST_F(ChargePointConnectivityTest, DestructionDisarmsConnectionCallbacks) {
+    ON_CALL(*this->connectivity_manager, is_websocket_connected()).WillByDefault(Return(false));
+
+    auto charge_point = make_charge_point();
+    charge_point->start({}, BootReasonEnum::PowerUp, {});
+    charge_point->stop();
+
+    EXPECT_CALL(*this->connectivity_manager, disarm_connection_callbacks()).Times(1);
+    charge_point.reset();
 }
 
 // Once the charge point observes a successful connection (connected callback -> message queue resume), queued

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_charge_point.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_charge_point.cpp
@@ -1005,20 +1005,16 @@ TEST_F(ChargePointConstructorTestFixtureV2, DerBlock_NotBuiltAtBoot_WhenNoEnable
     EXPECT_EQ(this->der_active_directives_emit_count, 0);
 }
 
-// stop() disarms the connection callbacks so a late websocket-thread callback cannot reach a charge point
-// being torn down. A restart calls start() again on the same ConnectivityManager, so start() must arm them
-// again; otherwise the connection state stays suppressed after the first stop().
-TEST_F(ChargePointConstructorTestFixtureV2, StartArmsConnectionCallbacks) {
+// stop() is the external "stop OCPP communication" control, not destruction: the charge point stays alive
+// and restartable, and its owner still gets the disconnect notification. Disarming here raced the deferred
+// delivery of that notification and swallowed it.
+TEST_F(ChargePointConstructorTestFixtureV2, StopKeepsConnectionCallbacksArmed) {
     configure_callbacks_with_mocks();
 
     auto connectivity_manager = std::make_shared<::testing::NiceMock<ConnectivityManagerMock>>();
     ON_CALL(*connectivity_manager, is_websocket_connected()).WillByDefault(::testing::Return(false));
 
-    const ::testing::InSequence seq;
-    EXPECT_CALL(*connectivity_manager, arm_connection_callbacks()).Times(1);
-    EXPECT_CALL(*connectivity_manager, disarm_connection_callbacks()).Times(1);
-    EXPECT_CALL(*connectivity_manager, arm_connection_callbacks()).Times(1);
-    EXPECT_CALL(*connectivity_manager, disarm_connection_callbacks()).Times(1);
+    EXPECT_CALL(*connectivity_manager, disarm_connection_callbacks()).Times(0);
 
     ocpp::v2::ChargePoint charge_point(evse_connector_structure, device_model, database_handler, evse_security,
                                        connectivity_manager, "/tmp", callbacks);
@@ -1027,5 +1023,26 @@ TEST_F(ChargePointConstructorTestFixtureV2, StartArmsConnectionCallbacks) {
     charge_point.stop();
     charge_point.start(BootReasonEnum::ApplicationReset);
     charge_point.stop();
+
+    // Verify while still alive: destruction is the only disarm site.
+    ::testing::Mock::VerifyAndClearExpectations(connectivity_manager.get());
+}
+
+// The use-after-free is at destruction: a deferred callback landing while members are destroyed. The
+// destructor body runs before any member is gone and blocks on an in-flight callback.
+TEST_F(ChargePointConstructorTestFixtureV2, DestructionDisarmsConnectionCallbacks) {
+    configure_callbacks_with_mocks();
+
+    auto connectivity_manager = std::make_shared<::testing::NiceMock<ConnectivityManagerMock>>();
+    ON_CALL(*connectivity_manager, is_websocket_connected()).WillByDefault(::testing::Return(false));
+
+    {
+        ocpp::v2::ChargePoint charge_point(evse_connector_structure, device_model, database_handler, evse_security,
+                                           connectivity_manager, "/tmp", callbacks);
+        charge_point.start(BootReasonEnum::PowerUp);
+        charge_point.stop();
+
+        EXPECT_CALL(*connectivity_manager, disarm_connection_callbacks()).Times(1);
+    }
 }
 } // namespace ocpp::v2


### PR DESCRIPTION
## Describe your changes

`test_subscribe_is_connected` flakes on `main`, both `[legacy]` and `[multi]`, timing out waiting for
`is_connected(false)` after `stop`.

Cause: that notification comes only from the websocket's disconnected callback, delivered from a deferred
callback thread that `disconnect()` does not join. `stop()` then disarmed the connection callbacks
immediately, and `on_websocket_disconnected()` drops them while disarmed. CI logs show a 16-70us race window.

Fix: the use-after-free the disarm guards against is at destruction, not at `stop()`, which destroys nothing
and leaves the charge point restartable. Moved to `~ChargePointImpl()` / `~ChargePoint()`, which run before
any member is gone and block on an in-flight callback. Also covers destruction without a preceding `stop()`.

`arm_connection_callbacks()` then has nothing to lift and is removed with its `start()` call sites. #2599
added it for the restart half of this same test; with the disarm out of `stop()` both halves are
deterministic.

Staying armed between `stop()` and destruction is safe: a late callback pauses an already-stopped
`MessageQueue` and stops still-live timers.

### Tests

Five new unit tests, all failing before the change: `stop()` disconnects but does not disarm, a full
stop/restart cycle never disarms, and destruction does disarm (v16 and v2). They replace
`StopDisarmsConnectionCallbacksAfterDisconnect`, `RestartArmsConnectionCallbacksAgain` and
`StartArmsConnectionCallbacks`, which asserted the old placement. libocpp suite 7/7.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
