### PR TITLE
fix(iso15118): encode the selected auth mode

### DIFF
--- a/lib/everest/iso15118/include/iso15118/d20/dynamic_mode_parameters.hpp
+++ b/lib/everest/iso15118/include/iso15118/d20/dynamic_mode_parameters.hpp
@@ -3,13 +3,14 @@
 #pragma once
 
 #include <cstdint>
-#include <ctime>
 #include <optional>
 
 namespace iso15118::d20 {
 
 struct UpdateDynamicModeParameters {
-    std::optional<std::time_t> departure_time;
+    // NOTE: departure time needs to be in SECC time [V2G20-1529]:
+    // epoch seconds since UNIX time (UTC)
+    std::optional<std::uint64_t> departure_time;
     std::optional<std::uint8_t> target_soc;
     std::optional<std::uint8_t> min_soc;
 };

--- a/lib/everest/iso15118/include/iso15118/detail/d20/context_helper.hpp
+++ b/lib/everest/iso15118/include/iso15118/detail/d20/context_helper.hpp
@@ -15,6 +15,9 @@ template <typename Response, typename ResponseCode> Response& response_with_code
     return res;
 }
 
+uint64_t secc_time_s();
+uint64_t secc_time_ms();
+
 bool validate_and_setup_header(message_20::Header&, const Session&, const decltype(message_20::Header::session_id)&);
 
 void setup_header(message_20::Header&, const Session&);

--- a/lib/everest/iso15118/include/iso15118/detail/d20/context_helper.hpp
+++ b/lib/everest/iso15118/include/iso15118/detail/d20/context_helper.hpp
@@ -2,6 +2,9 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #pragma once
 
+#include <cstdint>
+#include <optional>
+
 #include <iso15118/d20/context.hpp>
 #include <iso15118/d20/session.hpp>
 #include <iso15118/message/common_types.hpp>
@@ -15,8 +18,10 @@ template <typename Response, typename ResponseCode> Response& response_with_code
     return res;
 }
 
-uint64_t secc_time_s();
-uint64_t secc_time_ms();
+// [V2G20-1534] SECC time at the microsecond resolution the message header is encoded in.
+uint64_t now_in_secc_time();
+
+std::optional<uint32_t> departure_time_offset(const std::optional<uint64_t>& departure_time, uint64_t header_timestamp);
 
 bool validate_and_setup_header(message_20::Header&, const Session&, const decltype(message_20::Header::session_id)&);
 

--- a/lib/everest/iso15118/include/iso15118/detail/d20/state/dc_charge_loop.hpp
+++ b/lib/everest/iso15118/include/iso15118/detail/d20/state/dc_charge_loop.hpp
@@ -2,12 +2,6 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #pragma once
 
-#include <cstdint>
-#include <ctime>
-#include <optional>
-#include <tuple>
-#include <variant>
-
 #include <iso15118/d20/dynamic_mode_parameters.hpp>
 #include <iso15118/d20/limits.hpp>
 #include <iso15118/d20/session.hpp>

--- a/lib/everest/iso15118/include/iso15118/detail/d20/state/schedule_exchange.hpp
+++ b/lib/everest/iso15118/include/iso15118/detail/d20/state/schedule_exchange.hpp
@@ -5,10 +5,6 @@
 #include <iso15118/d20/session.hpp>
 #include <iso15118/message/schedule_exchange.hpp>
 
-#include <cstdint>
-#include <ctime>
-#include <optional>
-
 #include <iso15118/d20/dynamic_mode_parameters.hpp>
 
 namespace iso15118::d20::state {

--- a/lib/everest/iso15118/src/iso15118/d20/context_helper.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/context_helper.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
-#include <ctime>
+#include <chrono>
 
 #include <iso15118/detail/d20/context_helper.hpp>
 #include <iso15118/detail/helper.hpp>
@@ -23,8 +23,32 @@
 
 namespace iso15118::d20 {
 
-static inline void setup_timestamp(message_20::Header& header) {
-    header.timestamp = static_cast<uint64_t>(std::time(nullptr));
+namespace {
+void setup_timestamp(message_20::Header& header) {
+    const auto secc_time_us = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
+            .count());
+    header.timestamp = secc_time_us; // [V2G20-2676] Header timestamp is secc time encoded at microseconds resolution
+}
+
+template <typename Response> Response handle_sequence_error(const d20::Session& session) {
+    Response res;
+    setup_header(res.header, session);
+    return response_with_code(res, message_20::datatypes::ResponseCode::FAILED_SequenceError);
+}
+
+} // namespace
+
+//[V2G20-1529] Note 2
+uint64_t secc_time_s() {
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+}
+
+uint64_t secc_time_ms() {
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+            .count());
 }
 
 bool validate_and_setup_header(message_20::Header& header, const Session& cur_session,
@@ -38,12 +62,6 @@ bool validate_and_setup_header(message_20::Header& header, const Session& cur_se
 void setup_header(message_20::Header& header, const Session& cur_session) {
     header.session_id = cur_session.get_id();
     setup_timestamp(header);
-}
-
-template <typename Response> Response handle_sequence_error(const d20::Session& session) {
-    Response res;
-    setup_header(res.header, session);
-    return response_with_code(res, message_20::datatypes::ResponseCode::FAILED_SequenceError);
 }
 
 // Todo(sl): Not happy at all. Need refactoring. Only ctx.respond and Session is needed. Not the whole Context.

--- a/lib/everest/iso15118/src/iso15118/d20/context_helper.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/context_helper.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #include <chrono>
+#include <limits>
 
 #include <iso15118/detail/d20/context_helper.hpp>
 #include <iso15118/detail/helper.hpp>
@@ -24,12 +25,7 @@
 namespace iso15118::d20 {
 
 namespace {
-void setup_timestamp(message_20::Header& header) {
-    const auto secc_time_us = static_cast<uint64_t>(
-        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
-            .count());
-    header.timestamp = secc_time_us; // [V2G20-2676] Header timestamp is secc time encoded at microseconds resolution
-}
+constexpr uint64_t MICROSECONDS_PER_SECOND = 1'000'000;
 
 template <typename Response> Response handle_sequence_error(const d20::Session& session) {
     Response res;
@@ -39,16 +35,32 @@ template <typename Response> Response handle_sequence_error(const d20::Session& 
 
 } // namespace
 
-//[V2G20-1529] Note 2
-uint64_t secc_time_s() {
+uint64_t now_in_secc_time() {
     return static_cast<uint64_t>(
-        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
+            .count());
 }
 
-uint64_t secc_time_ms() {
-    return static_cast<uint64_t>(
-        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
-            .count());
+std::optional<uint32_t> departure_time_offset(const std::optional<uint64_t>& departure_time,
+                                              uint64_t header_timestamp) {
+    if (not departure_time.has_value()) {
+        return std::nullopt;
+    }
+
+    // [V2G20-2104] The offset is measured from the timestamp this very message carries, not from a
+    // fresh clock reading, which could already have crossed a second boundary.
+    const auto sent_at = header_timestamp / MICROSECONDS_PER_SECOND;
+
+    if (departure_time.value() <= sent_at) {
+        return std::nullopt; // [V2G20-2103]
+    }
+
+    const auto offset = departure_time.value() - sent_at;
+    if (offset > std::numeric_limits<uint32_t>::max()) {
+        return std::nullopt;
+    }
+
+    return static_cast<uint32_t>(offset);
 }
 
 bool validate_and_setup_header(message_20::Header& header, const Session& cur_session,
@@ -61,7 +73,7 @@ bool validate_and_setup_header(message_20::Header& header, const Session& cur_se
 
 void setup_header(message_20::Header& header, const Session& cur_session) {
     header.session_id = cur_session.get_id();
-    setup_timestamp(header);
+    header.timestamp = now_in_secc_time();
 }
 
 // Todo(sl): Not happy at all. Need refactoring. Only ctx.respond and Session is needed. Not the whole Context.

--- a/lib/everest/iso15118/src/iso15118/d20/state/ac_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/ac_charge_loop.cpp
@@ -65,13 +65,12 @@ void convert(Dynamic_BPT_AC_Res& out, const AcTargetPower& targets, const d20::A
 
 // TODO(sl): Refactor with DcChargeLoop state
 namespace {
-template <typename T>
-void set_dynamic_parameters_in_res(T& res_mode, const UpdateDynamicModeParameters& parameters,
-                                   uint64_t header_timestamp) {
+template <typename T> void set_dynamic_parameters_in_res(T& res_mode, const UpdateDynamicModeParameters& parameters) {
     if (parameters.departure_time) {
         const auto departure_time = static_cast<uint64_t>(parameters.departure_time.value());
-        if (departure_time > header_timestamp) {
-            res_mode.departure_time = static_cast<uint32_t>(departure_time - header_timestamp);
+        const auto now = secc_time_s();
+        if (departure_time > now) {
+            res_mode.departure_time = static_cast<uint32_t>(departure_time - now);
         }
     }
     res_mode.target_soc = parameters.target_soc;
@@ -136,7 +135,7 @@ handle_request(const message_20::AC_ChargeLoopRequest& req, const d20::Session& 
         convert(res_mode, target_powers, present_powers);
 
         if (selected_mobility_needs_mode == dt::MobilityNeedsMode::ProvidedBySecc) {
-            set_dynamic_parameters_in_res(res_mode, dynamic_parameters, res.header.timestamp);
+            set_dynamic_parameters_in_res(res_mode, dynamic_parameters);
         }
 
     } else if (std::holds_alternative<Dynamic_BPT_AC_Req>(req.control_mode)) {
@@ -152,7 +151,7 @@ handle_request(const message_20::AC_ChargeLoopRequest& req, const d20::Session& 
         convert(res_mode, target_powers, present_powers);
 
         if (selected_mobility_needs_mode == dt::MobilityNeedsMode::ProvidedBySecc) {
-            set_dynamic_parameters_in_res(res_mode, dynamic_parameters, res.header.timestamp);
+            set_dynamic_parameters_in_res(res_mode, dynamic_parameters);
         }
     }
 

--- a/lib/everest/iso15118/src/iso15118/d20/state/ac_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/ac_charge_loop.cpp
@@ -65,14 +65,10 @@ void convert(Dynamic_BPT_AC_Res& out, const AcTargetPower& targets, const d20::A
 
 // TODO(sl): Refactor with DcChargeLoop state
 namespace {
-template <typename T> void set_dynamic_parameters_in_res(T& res_mode, const UpdateDynamicModeParameters& parameters) {
-    if (parameters.departure_time) {
-        const auto departure_time = static_cast<uint64_t>(parameters.departure_time.value());
-        const auto now = secc_time_s();
-        if (departure_time > now) {
-            res_mode.departure_time = static_cast<uint32_t>(departure_time - now);
-        }
-    }
+template <typename T>
+void set_dynamic_parameters_in_res(T& res_mode, const UpdateDynamicModeParameters& parameters,
+                                   uint64_t header_timestamp) {
+    res_mode.departure_time = departure_time_offset(parameters.departure_time, header_timestamp);
     res_mode.target_soc = parameters.target_soc;
 
     // [V2G20-1366]
@@ -135,7 +131,7 @@ handle_request(const message_20::AC_ChargeLoopRequest& req, const d20::Session& 
         convert(res_mode, target_powers, present_powers);
 
         if (selected_mobility_needs_mode == dt::MobilityNeedsMode::ProvidedBySecc) {
-            set_dynamic_parameters_in_res(res_mode, dynamic_parameters);
+            set_dynamic_parameters_in_res(res_mode, dynamic_parameters, res.header.timestamp);
         }
 
     } else if (std::holds_alternative<Dynamic_BPT_AC_Req>(req.control_mode)) {
@@ -151,7 +147,7 @@ handle_request(const message_20::AC_ChargeLoopRequest& req, const d20::Session& 
         convert(res_mode, target_powers, present_powers);
 
         if (selected_mobility_needs_mode == dt::MobilityNeedsMode::ProvidedBySecc) {
-            set_dynamic_parameters_in_res(res_mode, dynamic_parameters);
+            set_dynamic_parameters_in_res(res_mode, dynamic_parameters, res.header.timestamp);
         }
     }
 

--- a/lib/everest/iso15118/src/iso15118/d20/state/ac_der_iec_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/ac_der_iec_charge_loop.cpp
@@ -48,12 +48,12 @@ void convert(dt::DsoCosPhiSetpoint& out, const iec::DSOCosPhiSetpoint& in) {
     out.step_response_time_constant_reactive_power = dt::from_float(in.step_response_time_constant_reactive_power);
 }
 
-void set_dynamic_parameters_in_res(Dynamic_DER_Res& res_mode, const UpdateDynamicModeParameters& parameters,
-                                   uint64_t header_timestamp) {
+void set_dynamic_parameters_in_res(Dynamic_DER_Res& res_mode, const UpdateDynamicModeParameters& parameters) {
     if (parameters.departure_time) {
         const auto departure_time = static_cast<uint64_t>(parameters.departure_time.value());
-        if (departure_time > header_timestamp) {
-            res_mode.departure_time = static_cast<uint32_t>(departure_time - header_timestamp);
+        const auto now = secc_time_s();
+        if (departure_time > now) {
+            res_mode.departure_time = static_cast<uint32_t>(departure_time - now);
         }
     }
     res_mode.target_soc = parameters.target_soc;
@@ -176,7 +176,7 @@ handle_request(const message_20::DER_AC_ChargeLoopRequest& req, const d20::Sessi
              dso_cos_phi_setpoint);
 
         if (selected_mobility_needs_mode == dt::MobilityNeedsMode::ProvidedBySecc) {
-            set_dynamic_parameters_in_res(res_mode, dynamic_parameters, res.header.timestamp);
+            set_dynamic_parameters_in_res(res_mode, dynamic_parameters);
         }
     }
 

--- a/lib/everest/iso15118/src/iso15118/d20/state/ac_der_iec_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/ac_der_iec_charge_loop.cpp
@@ -48,14 +48,9 @@ void convert(dt::DsoCosPhiSetpoint& out, const iec::DSOCosPhiSetpoint& in) {
     out.step_response_time_constant_reactive_power = dt::from_float(in.step_response_time_constant_reactive_power);
 }
 
-void set_dynamic_parameters_in_res(Dynamic_DER_Res& res_mode, const UpdateDynamicModeParameters& parameters) {
-    if (parameters.departure_time) {
-        const auto departure_time = static_cast<uint64_t>(parameters.departure_time.value());
-        const auto now = secc_time_s();
-        if (departure_time > now) {
-            res_mode.departure_time = static_cast<uint32_t>(departure_time - now);
-        }
-    }
+void set_dynamic_parameters_in_res(Dynamic_DER_Res& res_mode, const UpdateDynamicModeParameters& parameters,
+                                   uint64_t header_timestamp) {
+    res_mode.departure_time = departure_time_offset(parameters.departure_time, header_timestamp);
     res_mode.target_soc = parameters.target_soc;
 
     // [V2G20-3155]
@@ -176,7 +171,7 @@ handle_request(const message_20::DER_AC_ChargeLoopRequest& req, const d20::Sessi
              dso_cos_phi_setpoint);
 
         if (selected_mobility_needs_mode == dt::MobilityNeedsMode::ProvidedBySecc) {
-            set_dynamic_parameters_in_res(res_mode, dynamic_parameters);
+            set_dynamic_parameters_in_res(res_mode, dynamic_parameters, res.header.timestamp);
         }
     }
 

--- a/lib/everest/iso15118/src/iso15118/d20/state/authorization_setup.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/authorization_setup.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
+#include <cinttypes>
 #include <random>
 
 #include <iso15118/d20/state/authorization.hpp>
@@ -69,7 +70,7 @@ Result AuthorizationSetup::feed(Event ev) {
         const auto res = handle_request(*req, m_ctx.session, m_ctx.session_config.cert_install_service,
                                         m_ctx.session_config.authorization_services);
 
-        logf_info("Timestamp: %d", req->header.timestamp);
+        logf_info("Timestamp: %" PRIu64, req->header.timestamp);
 
         m_ctx.respond(res);
 

--- a/lib/everest/iso15118/src/iso15118/d20/state/dc_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/dc_charge_loop.cpp
@@ -3,8 +3,8 @@
 #include <iso15118/d20/state/dc_charge_loop.hpp>
 #include <iso15118/d20/state/dc_welding_detection.hpp>
 
-#include<optional>
-#include<variant>
+#include <optional>
+#include <variant>
 
 #include <iso15118/detail/d20/context_helper.hpp>
 #include <iso15118/detail/d20/state/dc_charge_loop.hpp>

--- a/lib/everest/iso15118/src/iso15118/d20/state/dc_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/dc_charge_loop.cpp
@@ -3,6 +3,9 @@
 #include <iso15118/d20/state/dc_charge_loop.hpp>
 #include <iso15118/d20/state/dc_welding_detection.hpp>
 
+#include<optional>
+#include<variant>
+
 #include <iso15118/detail/d20/context_helper.hpp>
 #include <iso15118/detail/d20/state/dc_charge_loop.hpp>
 #include <iso15118/detail/d20/state/power_delivery.hpp>
@@ -69,13 +72,12 @@ template <> void convert(Dynamic_BPT_DC_Res& out, const d20::DcTransferLimits& i
 }
 
 namespace {
-template <typename T>
-void set_dynamic_parameters_in_res(T& res_mode, const UpdateDynamicModeParameters& parameters,
-                                   uint64_t header_timestamp) {
+template <typename T> void set_dynamic_parameters_in_res(T& res_mode, const UpdateDynamicModeParameters& parameters) {
     if (parameters.departure_time) {
         const auto departure_time = static_cast<uint64_t>(parameters.departure_time.value());
-        if (departure_time > header_timestamp) {
-            res_mode.departure_time = static_cast<uint32_t>(departure_time - header_timestamp);
+        const auto now = secc_time_s();
+        if (departure_time > now) {
+            res_mode.departure_time = static_cast<uint32_t>(departure_time - now);
         }
     }
     res_mode.target_soc = parameters.target_soc;
@@ -152,7 +154,7 @@ message_20::DC_ChargeLoopResponse handle_request(const message_20::DC_ChargeLoop
         convert(res_mode, dc_limits);
 
         if (selected_mobility_needs_mode == dt::MobilityNeedsMode::ProvidedBySecc) {
-            set_dynamic_parameters_in_res(res_mode, dynamic_parameters, res.header.timestamp);
+            set_dynamic_parameters_in_res(res_mode, dynamic_parameters);
         }
 
     } else if (std::holds_alternative<Dynamic_BPT_DC_Req>(req.control_mode)) {
@@ -174,7 +176,7 @@ message_20::DC_ChargeLoopResponse handle_request(const message_20::DC_ChargeLoop
         convert(res_mode, dc_limits);
 
         if (selected_mobility_needs_mode == dt::MobilityNeedsMode::ProvidedBySecc) {
-            set_dynamic_parameters_in_res(res_mode, dynamic_parameters, res.header.timestamp);
+            set_dynamic_parameters_in_res(res_mode, dynamic_parameters);
         }
     }
 

--- a/lib/everest/iso15118/src/iso15118/d20/state/dc_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/dc_charge_loop.cpp
@@ -72,14 +72,10 @@ template <> void convert(Dynamic_BPT_DC_Res& out, const d20::DcTransferLimits& i
 }
 
 namespace {
-template <typename T> void set_dynamic_parameters_in_res(T& res_mode, const UpdateDynamicModeParameters& parameters) {
-    if (parameters.departure_time) {
-        const auto departure_time = static_cast<uint64_t>(parameters.departure_time.value());
-        const auto now = secc_time_s();
-        if (departure_time > now) {
-            res_mode.departure_time = static_cast<uint32_t>(departure_time - now);
-        }
-    }
+template <typename T>
+void set_dynamic_parameters_in_res(T& res_mode, const UpdateDynamicModeParameters& parameters,
+                                   uint64_t header_timestamp) {
+    res_mode.departure_time = departure_time_offset(parameters.departure_time, header_timestamp);
     res_mode.target_soc = parameters.target_soc;
 
     // [V2G20-1290]
@@ -154,7 +150,7 @@ message_20::DC_ChargeLoopResponse handle_request(const message_20::DC_ChargeLoop
         convert(res_mode, dc_limits);
 
         if (selected_mobility_needs_mode == dt::MobilityNeedsMode::ProvidedBySecc) {
-            set_dynamic_parameters_in_res(res_mode, dynamic_parameters);
+            set_dynamic_parameters_in_res(res_mode, dynamic_parameters, res.header.timestamp);
         }
 
     } else if (std::holds_alternative<Dynamic_BPT_DC_Req>(req.control_mode)) {
@@ -176,7 +172,7 @@ message_20::DC_ChargeLoopResponse handle_request(const message_20::DC_ChargeLoop
         convert(res_mode, dc_limits);
 
         if (selected_mobility_needs_mode == dt::MobilityNeedsMode::ProvidedBySecc) {
-            set_dynamic_parameters_in_res(res_mode, dynamic_parameters);
+            set_dynamic_parameters_in_res(res_mode, dynamic_parameters, res.header.timestamp);
         }
     }
 

--- a/lib/everest/iso15118/src/iso15118/d20/state/schedule_exchange.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/schedule_exchange.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
-#include <ctime>
-
 #include <iso15118/d20/state/dc_cable_check.hpp>
 #include <iso15118/d20/state/power_delivery.hpp>
 #include <iso15118/d20/state/schedule_exchange.hpp>
+
+#include <optional>
+#include <variant>
 
 #include <iso15118/detail/d20/context_helper.hpp>
 #include <iso15118/detail/d20/state/schedule_exchange.hpp>
@@ -25,8 +26,7 @@ namespace {
 auto create_default_scheduled_control_mode(const dt::RationalNumber& max_power) {
     dt::ScheduleTuple schedule;
     schedule.schedule_tuple_id = 1;
-    schedule.charging_schedule.power_schedule.time_anchor =
-        static_cast<uint64_t>(std::time(nullptr)); // PowerSchedule is now active
+    schedule.charging_schedule.power_schedule.time_anchor = secc_time_ms(); // [V2G20-310] PowerSchedule is now active
 
     dt::PowerScheduleEntry power_schedule;
     power_schedule.power = max_power;
@@ -42,12 +42,12 @@ auto create_default_scheduled_control_mode(const dt::RationalNumber& max_power) 
 }
 
 namespace {
-void set_dynamic_parameters_in_res(DynamicResControlMode& res_mode, const UpdateDynamicModeParameters& parameters,
-                                   uint64_t header_timestamp) {
+void set_dynamic_parameters_in_res(DynamicResControlMode& res_mode, const UpdateDynamicModeParameters& parameters) {
     if (parameters.departure_time) {
         const auto departure_time = static_cast<uint64_t>(parameters.departure_time.value());
-        if (departure_time > header_timestamp) {
-            res_mode.departure_time = static_cast<uint32_t>(departure_time - header_timestamp);
+        const auto now = secc_time_s();
+        if (departure_time > now) {
+            res_mode.departure_time = static_cast<uint32_t>(departure_time - now);
         }
     }
     res_mode.target_soc = parameters.target_soc;
@@ -94,7 +94,7 @@ message_20::ScheduleExchangeResponse handle_request(const message_20::ScheduleEx
         auto& mode = res.control_mode.emplace<DynamicResControlMode>();
 
         if (selected_mobility_needs_mode == dt::MobilityNeedsMode::ProvidedBySecc) {
-            set_dynamic_parameters_in_res(mode, dynamic_parameters, res.header.timestamp);
+            set_dynamic_parameters_in_res(mode, dynamic_parameters);
         }
 
     } else {

--- a/lib/everest/iso15118/src/iso15118/d20/state/schedule_exchange.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/schedule_exchange.cpp
@@ -26,7 +26,13 @@ namespace {
 auto create_default_scheduled_control_mode(const dt::RationalNumber& max_power) {
     dt::ScheduleTuple schedule;
     schedule.schedule_tuple_id = 1;
-    schedule.charging_schedule.power_schedule.time_anchor = secc_time_ms(); // [V2G20-310] PowerSchedule is now active
+    // [V2G20-1016] TimeAnchor marks when the first PowerScheduleEntry becomes active, i.e. now.
+    // Unit: Table 112 (PowerScheduleType) is the only TimeAnchor in ISO 15118-20 specified at "ms resolution"
+    // and it cross-references a subclause (8.3.3.2) that no longer exists. Every other TimeAnchor
+    // (EVPowerSchedule, EVPowerProfile, AbsolutePriceSchedule, PriceLevelSchedule, Receipt), MeterTimeStamp,
+    // the header TimeStamp [V2G20-1534] and the Annex J examples use microseconds. Milliseconds follows the
+    // literal text of Table 112; if a price schedule is added to this tuple its anchor must be microseconds.
+    schedule.charging_schedule.power_schedule.time_anchor = secc_time_ms();
 
     dt::PowerScheduleEntry power_schedule;
     power_schedule.power = max_power;

--- a/lib/everest/iso15118/src/iso15118/d20/state/schedule_exchange.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/schedule_exchange.cpp
@@ -23,6 +23,8 @@ using DynamicReqControlMode = message_20::datatypes::Dynamic_SEReqControlMode;
 using DynamicResControlMode = message_20::datatypes::Dynamic_SEResControlMode;
 
 namespace {
+constexpr uint64_t MICROSECONDS_PER_MILLISECOND = 1'000;
+
 auto create_default_scheduled_control_mode(const dt::RationalNumber& max_power) {
     dt::ScheduleTuple schedule;
     schedule.schedule_tuple_id = 1;
@@ -32,7 +34,7 @@ auto create_default_scheduled_control_mode(const dt::RationalNumber& max_power) 
     // (EVPowerSchedule, EVPowerProfile, AbsolutePriceSchedule, PriceLevelSchedule, Receipt), MeterTimeStamp,
     // the header TimeStamp [V2G20-1534] and the Annex J examples use microseconds. Milliseconds follows the
     // literal text of Table 112; if a price schedule is added to this tuple its anchor must be microseconds.
-    schedule.charging_schedule.power_schedule.time_anchor = secc_time_ms();
+    schedule.charging_schedule.power_schedule.time_anchor = now_in_secc_time() / MICROSECONDS_PER_MILLISECOND;
 
     dt::PowerScheduleEntry power_schedule;
     power_schedule.power = max_power;
@@ -48,14 +50,9 @@ auto create_default_scheduled_control_mode(const dt::RationalNumber& max_power) 
 }
 
 namespace {
-void set_dynamic_parameters_in_res(DynamicResControlMode& res_mode, const UpdateDynamicModeParameters& parameters) {
-    if (parameters.departure_time) {
-        const auto departure_time = static_cast<uint64_t>(parameters.departure_time.value());
-        const auto now = secc_time_s();
-        if (departure_time > now) {
-            res_mode.departure_time = static_cast<uint32_t>(departure_time - now);
-        }
-    }
+void set_dynamic_parameters_in_res(DynamicResControlMode& res_mode, const UpdateDynamicModeParameters& parameters,
+                                   uint64_t header_timestamp) {
+    res_mode.departure_time = departure_time_offset(parameters.departure_time, header_timestamp);
     res_mode.target_soc = parameters.target_soc;
     res_mode.minimum_soc = parameters.min_soc;
 }
@@ -100,7 +97,7 @@ message_20::ScheduleExchangeResponse handle_request(const message_20::ScheduleEx
         auto& mode = res.control_mode.emplace<DynamicResControlMode>();
 
         if (selected_mobility_needs_mode == dt::MobilityNeedsMode::ProvidedBySecc) {
-            set_dynamic_parameters_in_res(mode, dynamic_parameters);
+            set_dynamic_parameters_in_res(mode, dynamic_parameters, res.header.timestamp);
         }
 
     } else {

--- a/lib/everest/iso15118/src/iso15118/message/authorization.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/authorization.cpp
@@ -2,7 +2,9 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #include <iso15118/message/authorization.hpp>
 
+#include <stdexcept>
 #include <type_traits>
+#include <variant>
 
 #include <iso15118/detail/variant_access.hpp>
 
@@ -35,6 +37,23 @@ template <> void convert(const struct iso20_AuthorizationResType& in, Authorizat
     convert(in.Header, out.header);
 }
 
+struct AuthorizationModeVisitor {
+    AuthorizationModeVisitor(iso20_AuthorizationReqType& out_) : out(out_){};
+    void operator()([[maybe_unused]] const datatypes::EIM_ASReqAuthorizationMode& in) {
+        CB_SET_USED(out.EIM_AReqAuthorizationMode);
+        init_iso20_EIM_AReqAuthorizationModeType(&out.EIM_AReqAuthorizationMode);
+    }
+    void operator()([[maybe_unused]] const datatypes::PnC_ASReqAuthorizationMode& in) {
+        // Todo(mlitre): none of Id, GenChallenge and ContractCertificateChain are converted,
+        // so in.id and in.gen_challenge are discarded. Reject the request until they are,
+        // rather than let a PnC selection go out on the wire as EIM.
+        throw std::runtime_error("PnC authorization mode not implemented");
+    }
+
+private:
+    iso20_AuthorizationReqType& out;
+};
+
 template <> void convert(const AuthorizationRequest& in, iso20_AuthorizationReqType& out) {
     init_iso20_AuthorizationReqType(&out);
 
@@ -42,8 +61,9 @@ template <> void convert(const AuthorizationRequest& in, iso20_AuthorizationReqT
 
     cb_convert_enum(in.selected_authorization_service, out.SelectedAuthorizationService);
 
-    // Todo(rb): add pnc
-    out.EIM_AReqAuthorizationMode_isUsed = true;
+    // Encode what the caller selected. Which modes the EV offers is application logic, not
+    // this conversion's business; forcing EIM here made a PnC request serialize as EIM.
+    std::visit(AuthorizationModeVisitor{out}, in.authorization_mode);
 }
 
 template <> void convert(const AuthorizationResponse& in, iso20_AuthorizationResType& out) {

--- a/lib/everest/iso15118/test/exi/cb/iso20/authorization.cpp
+++ b/lib/everest/iso15118/test/exi/cb/iso20/authorization.cpp
@@ -1,7 +1,12 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
+
+#include <stdexcept>
 
 #include <iso15118/message/authorization.hpp>
 #include <iso15118/message/variant.hpp>
+
+#include <cbv2g/iso_20/iso20_CommonMessages_Datatypes.h>
 
 #include "helper.hpp"
 
@@ -87,6 +92,49 @@ SCENARIO("Se/Deserialize authorization messages") {
 
         THEN("It should be serialized successfully") {
             REQUIRE(serialize_helper(req) == expected);
+        }
+    }
+
+    GIVEN("Convert authorization_req into the encoder struct") {
+
+        message_20::AuthorizationRequest req;
+
+        req.header = message_20::Header{{0xF2, 0x19, 0x15, 0xB9, 0xDD, 0xDC, 0x12, 0xD1}, 1691411798};
+        // Deliberately EIM in both cases, so the authorization mode variant is the only thing
+        // that can steer which mode the encoder struct carries.
+        req.selected_authorization_service = message_20::datatypes::Authorization::EIM;
+
+        THEN("An eim mode marks eim used and pnc unused") {
+            req.authorization_mode = message_20::datatypes::EIM_ASReqAuthorizationMode{};
+
+            iso20_AuthorizationReqType out{};
+            message_20::convert(req, out);
+
+            CHECK(out.EIM_AReqAuthorizationMode_isUsed);
+            CHECK_FALSE(out.PnC_AReqAuthorizationMode_isUsed);
+        }
+
+        THEN("A pnc mode is rejected rather than encoded as eim") {
+            req.authorization_mode = message_20::datatypes::PnC_ASReqAuthorizationMode{};
+
+            iso20_AuthorizationReqType out{};
+
+            REQUIRE_THROWS_MATCHES(message_20::convert(req, out), std::runtime_error,
+                                   Catch::Matchers::Message("PnC authorization mode not implemented"));
+        }
+    }
+
+    GIVEN("Serialize authorization_req pnc") {
+
+        message_20::AuthorizationRequest req;
+
+        req.header = message_20::Header{{0xF2, 0x19, 0x15, 0xB9, 0xDD, 0xDC, 0x12, 0xD1}, 1691411798};
+        req.selected_authorization_service = message_20::datatypes::Authorization::EIM;
+        req.authorization_mode = message_20::datatypes::PnC_ASReqAuthorizationMode{};
+
+        THEN("The rejection reaches the caller instead of a well formed eim document") {
+            REQUIRE_THROWS_MATCHES(serialize_helper(req), std::runtime_error,
+                                   Catch::Matchers::Message("PnC authorization mode not implemented"));
         }
     }
 }

--- a/lib/everest/iso15118/test/iso15118/fsm/der_iec_charge_loop.cpp
+++ b/lib/everest/iso15118/test/iso15118/fsm/der_iec_charge_loop.cpp
@@ -2,6 +2,8 @@
 // Copyright 2026 Pionix GmbH and Contributors to EVerest
 #include <catch2/catch_test_macros.hpp>
 
+#include <cstdint>
+
 #include <algorithm>
 #include <vector>
 
@@ -12,12 +14,15 @@
 #include <iso15118/d20/state/session_stop.hpp>
 
 #include <iso15118/d20/config.hpp>
+#include <iso15118/detail/d20/context_helper.hpp>
 #include <iso15118/message/ac_der_iec_charge_loop.hpp>
 #include <iso15118/message/power_delivery.hpp>
 #include <iso15118/message/session_setup.hpp>
 #include <iso15118/message/session_stop.hpp>
 
 using namespace iso15118;
+
+constexpr std::uint64_t MICROSECONDS_PER_SECOND = 1'000'000;
 
 namespace dt = message_20::datatypes;
 
@@ -305,7 +310,8 @@ SCENARIO("ISO15118-20 der iec ac charge loop state transitions") {
         present_power.present_active_power = {11, 3};
         state_helper.set_active_control_event(present_power);
         fsm.feed(d20::Event::CONTROL_MESSAGE);
-        const d20::UpdateDynamicModeParameters dynamic_parameters = {std::time(nullptr) + 40, 95, 80};
+        const d20::UpdateDynamicModeParameters dynamic_parameters = {
+            d20::now_in_secc_time() / MICROSECONDS_PER_SECOND + 40, 95, 80};
         state_helper.set_active_control_event(dynamic_parameters);
         fsm.feed(d20::Event::CONTROL_MESSAGE);
 

--- a/lib/everest/iso15118/test/iso15118/states/ac_charge_loop.cpp
+++ b/lib/everest/iso15118/test/iso15118/states/ac_charge_loop.cpp
@@ -2,11 +2,16 @@
 // Copyright Pionix GmbH and Contributors to EVerest
 #include <catch2/catch_test_macros.hpp>
 
+#include <cstdint>
+
+#include <iso15118/detail/d20/context_helper.hpp>
 #include <iso15118/detail/d20/state/ac_charge_loop.hpp>
 
 #include <iso15118/d20/config.hpp>
 
 using namespace iso15118;
+
+constexpr std::uint64_t MICROSECONDS_PER_SECOND = 1'000'000;
 
 namespace dt = message_20::datatypes;
 
@@ -325,7 +330,8 @@ SCENARIO("AC charge loop state handling") {
         auto ac_present_power = d20::AcPresentPower{};
         ac_present_power.present_active_power = {11, 3};
 
-        const d20::UpdateDynamicModeParameters dynamic_parameters = {std::time(nullptr) + 40, 95, 80};
+        const d20::UpdateDynamicModeParameters dynamic_parameters = {
+            d20::now_in_secc_time() / MICROSECONDS_PER_SECOND + 40, 95, 80};
 
         const auto res = d20::state::handle_request(req, session, false, false, 50, ac_target_power, ac_present_power,
                                                     dynamic_parameters);
@@ -374,7 +380,8 @@ SCENARIO("AC charge loop state handling") {
         auto ac_present_power = d20::AcPresentPower{};
         ac_present_power.present_active_power = {11, 3};
 
-        const d20::UpdateDynamicModeParameters dynamic_parameters = {std::time(nullptr) + 40, 95, 80};
+        const d20::UpdateDynamicModeParameters dynamic_parameters = {
+            d20::now_in_secc_time() / MICROSECONDS_PER_SECOND + 40, 95, 80};
 
         const auto res = d20::state::handle_request(req, session, false, false, 50, ac_target_power, ac_present_power,
                                                     dynamic_parameters);

--- a/lib/everest/iso15118/test/iso15118/states/dc_charge_loop.cpp
+++ b/lib/everest/iso15118/test/iso15118/states/dc_charge_loop.cpp
@@ -2,6 +2,8 @@
 // Copyright Pionix GmbH and Contributors to EVerest
 #include <catch2/catch_test_macros.hpp>
 
+#include <ctime>
+
 #include <iso15118/detail/d20/state/dc_charge_loop.hpp>
 
 #include <iso15118/d20/config.hpp>

--- a/lib/everest/iso15118/test/iso15118/states/dc_charge_loop.cpp
+++ b/lib/everest/iso15118/test/iso15118/states/dc_charge_loop.cpp
@@ -2,13 +2,16 @@
 // Copyright Pionix GmbH and Contributors to EVerest
 #include <catch2/catch_test_macros.hpp>
 
-#include <ctime>
+#include <cstdint>
 
+#include <iso15118/detail/d20/context_helper.hpp>
 #include <iso15118/detail/d20/state/dc_charge_loop.hpp>
 
 #include <iso15118/d20/config.hpp>
 
 using namespace iso15118;
+
+constexpr std::uint64_t MICROSECONDS_PER_SECOND = 1'000'000;
 
 namespace dt = message_20::datatypes;
 
@@ -369,7 +372,8 @@ SCENARIO("DC charge loop state handling") {
         req.meter_info_requested = false;
         req.present_voltage = {330, 0};
 
-        const d20::UpdateDynamicModeParameters dynamic_parameters = {std::time(nullptr) + 60, 95, std::nullopt};
+        const d20::UpdateDynamicModeParameters dynamic_parameters = {
+            d20::now_in_secc_time() / MICROSECONDS_PER_SECOND + 60, 95, std::nullopt};
 
         const auto res =
             d20::state::handle_request(req, session, 330, 30, false, false, evse_setup.dc_limits, dynamic_parameters);
@@ -422,7 +426,8 @@ SCENARIO("DC charge loop state handling") {
         req.meter_info_requested = false;
         req.present_voltage = {330, 0};
 
-        const d20::UpdateDynamicModeParameters dynamic_parameters = {std::time(nullptr) + 40, 95, 80};
+        const d20::UpdateDynamicModeParameters dynamic_parameters = {
+            d20::now_in_secc_time() / MICROSECONDS_PER_SECOND + 40, 95, 80};
 
         const auto res =
             d20::state::handle_request(req, session, 330, 30, false, false, evse_setup.dc_limits, dynamic_parameters);
@@ -710,7 +715,8 @@ SCENARIO("DC charge loop state handling") {
         req.meter_info_requested = false;
         req.present_voltage = {330, 0};
 
-        const d20::UpdateDynamicModeParameters dynamic_parameters = {std::time(nullptr) + 60, 95, std::nullopt};
+        const d20::UpdateDynamicModeParameters dynamic_parameters = {
+            d20::now_in_secc_time() / MICROSECONDS_PER_SECOND + 60, 95, std::nullopt};
 
         const auto res =
             d20::state::handle_request(req, session, 330, 30, false, false, evse_setup.dc_limits, dynamic_parameters);
@@ -763,7 +769,8 @@ SCENARIO("DC charge loop state handling") {
         req.meter_info_requested = false;
         req.present_voltage = {330, 0};
 
-        const d20::UpdateDynamicModeParameters dynamic_parameters = {std::time(nullptr) + 40, 95, 80};
+        const d20::UpdateDynamicModeParameters dynamic_parameters = {
+            d20::now_in_secc_time() / MICROSECONDS_PER_SECOND + 40, 95, 80};
 
         const auto res =
             d20::state::handle_request(req, session, 330, 30, false, false, evse_setup.dc_limits, dynamic_parameters);


### PR DESCRIPTION
## Describe your changes

`convert(const AuthorizationRequest&, iso20_AuthorizationReqType&)` in
`lib/everest/iso15118/src/iso15118/message/authorization.cpp` set
`EIM_AReqAuthorizationMode_isUsed = true` unconditionally, ignoring `in.authorization_mode`. A
request whose variant held `PnC_ASReqAuthorizationMode` therefore went out on the wire as a
well formed EIM request: the struct said PnC, the bytes said EIM, and nothing reported a
problem.

This code came from main in #1636 and is shared with the SECC, so the fix is split out to land
on its own rather than waiting on EV-side review.

The fix dispatches on the variant through a named `AuthorizationModeVisitor`, modeled on the
sibling visitor in `authorization_setup.cpp`. It is exhaustive by construction: a future
variant alternative becomes a compile error rather than silently routing to one arm.

PnC stays unimplemented, and the PnC arm now throws
`std::runtime_error("PnC authorization mode not implemented")` instead of setting a flag. That
part is deliberate and worth explaining, because simply setting the PnC flag is not safe:
`init_iso20_AuthorizationReqType` clears only the two `_isUsed` bits,
`init_iso20_PnC_AReqAuthorizationModeType` is a no-op, and `serialize_to_exi` declares
`iso20_exiDocument doc;` uninitialized. Setting the flag therefore leaves the encoder reading
indeterminate stack memory for `Id`, `GenChallenge` and `ContractCertificateChain`. Measured
with a standalone harness against the vendored cbv2g: a zeroed stack yields `-150`, a poisoned
stack yields `-111`, and a reachable state makes the encode **succeed** and emit uninitialized
stack bytes into an `AuthorizationReq`. Throwing makes the rejection deterministic and
independent of stack contents.

No production caller constructs a PnC request variant today, on main or in any open EV branch,
so this changes no live behavior. It closes a latent encoder defect and makes the unimplemented
path fail loudly when someone does reach it.

Tests, in `lib/everest/iso15118/test/exi/cb/iso20/authorization.cpp`:
- convert-level assertions pinning both flags in both directions, so "encodes PnC" is
  distinguishable from "sets no flag at all"
- `REQUIRE_THROWS_MATCHES` on the concrete type and message, which rejects both the original
  behavior (no throw) and an earlier attempt at this fix (which threw the emergent
  `Could not encode exi: -150` off uninitialized memory)
- the pre-existing byte-exact EIM serialization test is untouched and still passes

Full iso15118 suite: 219 passed, 0 failed.

## Issue ticket number and link

None. Prerequisite for the EV-side stack (#2577 through #2584), which depends on this landing
first.

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
