### PR TITLE
chore(codeowners): add pietfried to EEBUS module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,7 +32,7 @@
 # modules
 /modules/API/ @hikinggrass @pietfried @corneliusclaussen @djchhp @SebaLukas @james-ctc @cburandt @florinmihut
 /modules/API/RpcApi/ @FaHaGit @barsnick @corneliusclaussen @hikinggrass @pietfried @SebaLukas @mlitre
-/modules/EnergyManagement/EEBUS/ @mlitre @andistorm @hikinggrass
+/modules/EnergyManagement/EEBUS/ @mlitre @andistorm @hikinggrass @pietfried
 /modules/EnergyManagement/EnergyManager/ @corneliusclaussen @hikinggrass @pietfried
 /modules/EnergyManagement/EnergyNode/ @corneliusclaussen @hikinggrass @pietfried
 /modules/EV/EvManager/ @SebaLukas @pietfried @james-ctc @mlitre


### PR DESCRIPTION
Adds `@pietfried` as a code owner for `/modules/EnergyManagement/EEBUS/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjKcjbY7y74kniS1syHEZ2