### PR TITLE
perf(LemDCBM400600): reduce HTTP and polling overhead

### DIFF
--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/LemDCBM400600.hpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/LemDCBM400600.hpp
@@ -24,6 +24,7 @@ struct Conf {
     int port;
     std::string interface;
     std::string meter_tls_certificate;
+    bool http_connection_reuse;
     std::string ntp_server_1_ip_addr;
     int ntp_server_1_port;
     std::string ntp_server_2_ip_addr;
@@ -45,6 +46,8 @@ struct Conf {
     double temperature_hysteresis_K;
     int temperature_min_time_as_valid_ms;
     int command_timeout_ms;
+    int poll_interval_ms;
+    int transaction_ocmf_fetch_interval_s;
 };
 
 class LemDCBM400600 : public Everest::ModuleBase {

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/docs/index.rst
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/docs/index.rst
@@ -27,8 +27,16 @@ during the module's "ready" thread loop), cf. also the notes on time synchroniza
 Variable Powermeter
 -------------------
 
-Publication of the ``powermeter`` var is done with approx. frequency 1/second. This fetches the current ``livemeasure``
+Publication of the ``powermeter`` var is done with an approx. frequency of 1/second by default; the interval is
+configurable via the ``poll_interval_ms`` config option. This fetches the current ``livemeasure``
 values from the device's ``/v1/livemeasure`` endpoint and injects the meter id as determined at initialization.
+
+While a transaction is active, the current OCMF record is additionally fetched as a fallback so that a signed meter
+value is available even if the device becomes unreachable at transaction stop. By default this happens on every poll;
+it can be throttled with the ``transaction_ocmf_fetch_interval_s`` config option.
+
+By default, HTTP(S) connections to the device are kept alive and reused across requests. Set ``http_connection_reuse``
+to ``false`` to restore the previous behavior of one fresh connection per request.
 
 Command start_transaction
 -------------------------

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/docs/index.rst
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/docs/index.rst
@@ -31,9 +31,19 @@ Publication of the ``powermeter`` var is done with an approx. frequency of 1/sec
 configurable via the ``poll_interval_ms`` config option. This fetches the current ``livemeasure``
 values from the device's ``/v1/livemeasure`` endpoint and injects the meter id as determined at initialization.
 
+The poll loop runs at a fixed rate: the time spent performing the requests is subtracted from the wait before the
+next poll, so the interval between two publications stays at ``poll_interval_ms`` instead of growing with the
+latency of the device. This matters because consumers watch this stream for gaps - EvseManager, for instance, aborts
+a DC cable check if it sees no power supply measurement for two seconds. If a gap of more than 1.5 times the
+configured interval does occur, a warning is logged with the measured gap and the duration of the live measurement
+request, so a slow device or network can be identified from the logs.
+
 While a transaction is active, the current OCMF record is additionally fetched as a fallback so that a signed meter
-value is available even if the device becomes unreachable at transaction stop. By default this happens on every poll;
-it can be throttled with the ``transaction_ocmf_fetch_interval_s`` config option.
+value is available even if the device becomes unreachable at transaction stop. This fetch is performed *after* the
+live measurements have been published, so that its round trip is not added to the gap between two publications. By
+default it happens on every poll; it can be throttled with the ``transaction_ocmf_fetch_interval_s`` config option.
+Throttling applies to attempts rather than successes, so a failing OCMF endpoint cannot cause a request on every
+single poll.
 
 By default, HTTP(S) connections to the device are kept alive and reused across requests. Set ``http_connection_reuse``
 to ``false`` to restore the previous behavior of one fresh connection per request.

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/http_client.cpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/http_client.cpp
@@ -40,7 +40,7 @@ static HttpClientError client_error(const std::string& host, unsigned int port, 
 }
 
 static void setup_connection(CURL* connection, struct payloadInTransit& request_payload, std::string& response_body,
-                             curl_slist*& headers, const int command_timeout_ms) {
+                             curl_slist*& headers, const int command_timeout_ms, const bool forbid_reuse) {
     // Override the Content-Type header
     headers = curl_slist_append(nullptr, CONTENT_TYPE_HEADER);
     if (curl_easy_setopt(connection, CURLOPT_HTTPHEADER, headers) != CURLE_OK) {
@@ -56,7 +56,9 @@ static void setup_connection(CURL* connection, struct payloadInTransit& request_
     curl_easy_setopt(connection, CURLOPT_TIMEOUT_MS, command_timeout_ms);
 
     // Misc. settings come here
-    curl_easy_setopt(connection, CURLOPT_FORBID_REUSE, 1);
+    if (forbid_reuse) {
+        curl_easy_setopt(connection, CURLOPT_FORBID_REUSE, 1);
+    }
     if (curl_easy_setopt(connection, CURLOPT_FOLLOWLOCATION, 0) != CURLE_OK) {
         throw std::runtime_error(
             "libcurl signals that HTTP is unsupported. Your build or linkage might be misconfigured.");
@@ -103,7 +105,10 @@ HttpResponse HttpClient::perform_request(CURL* connection, const std::string& re
         request_body, 0
     };
     struct curl_slist* headers;
-    setup_connection(connection, request_payload, response_body, headers, command_timeout_ms);
+    // if there is no connection share, connections must not be reused: without the share, each
+    // request uses a fresh handle, and keeping its connection open would just leak it
+    setup_connection(connection, request_payload, response_body, headers, command_timeout_ms,
+                     /*forbid_reuse=*/this->share == nullptr);
 
     // Set up TLS options if TLS is enabled
     // we define dcbm_cert outside the "if" statement to ensure it outlives curl_easy_perform().
@@ -147,6 +152,11 @@ CURL* HttpClient::create_curl_handle_and_setup_url(const std::string& path) cons
     if (!this->network_interface.empty()) {
         if (curl_easy_setopt(connection, CURLOPT_INTERFACE, this->network_interface.c_str()) != CURLE_OK) {
             throw std::runtime_error("Could not bind to the specified network interface: " + this->network_interface);
+        }
+    }
+    if (this->share != nullptr) {
+        if (curl_easy_setopt(connection, CURLOPT_SHARE, this->share) != CURLE_OK) {
+            throw std::runtime_error("Could not attach the connection share to the CURL handle");
         }
     }
 

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/http_client.cpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/http_client.cpp
@@ -164,6 +164,7 @@ CURL* HttpClient::create_curl_handle_and_setup_url(const std::string& path) cons
 }
 
 HttpResponse HttpClient::get(const std::string& path) const {
+    const auto request_execution_handle = this->request_execution_guard.handle();
     CURL* connection = this->create_curl_handle_and_setup_url(path);
 
     if (curl_easy_setopt(connection, CURLOPT_HTTPGET, 1) != CURLE_OK) {
@@ -185,6 +186,7 @@ HttpResponse HttpClient::get(const std::string& path) const {
 }
 
 HttpResponse HttpClient::put(const std::string& path, const std::string& body) const {
+    const auto request_execution_handle = this->request_execution_guard.handle();
     CURL* connection = this->create_curl_handle_and_setup_url(path);
 
     curl_easy_setopt(connection, CURLOPT_UPLOAD, 1);
@@ -202,6 +204,7 @@ HttpResponse HttpClient::put(const std::string& path, const std::string& body) c
 }
 
 HttpResponse HttpClient::post(const std::string& path, const std::string& body) const {
+    const auto request_execution_handle = this->request_execution_guard.handle();
     CURL* connection = this->create_curl_handle_and_setup_url(path);
 
     if (curl_easy_setopt(connection, CURLOPT_POST, 1) != CURLE_OK) {

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/http_client.hpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/http_client.hpp
@@ -6,10 +6,9 @@
 
 #include "fmt/format.h"
 #include "http_client_interface.hpp"
-#include <array>
 #include <curl/curl.h>
 #include <everest/logging.hpp>
-#include <mutex>
+#include <everest/util/async/monitor.hpp>
 #include <regex>
 #include <stdexcept>
 #include <string>
@@ -65,6 +64,8 @@ public:
     [[nodiscard]] HttpResponse post(const std::string& path, const std::string& body) const override;
 
 private:
+    struct RequestExecutionGuard {};
+
     std::string host;
     int port;
     bool tls_enabled;
@@ -74,17 +75,10 @@ private:
 
     // Shared connection/SSL-session/DNS caches, so consecutive requests reuse the TCP (and TLS)
     // connection instead of reconnecting per request. nullptr if connection reuse is disabled.
-    // The mutexes make the share usable from concurrent requests (poll thread + command handlers).
+    // Requests are serialized because libcurl does not support sharing the connection cache between
+    // concurrent transfers.
     CURLSH* share = nullptr;
-    mutable std::array<std::mutex, CURL_LOCK_DATA_LAST> share_mutexes;
-
-    static void share_lock_cb(CURL* /*handle*/, curl_lock_data data, curl_lock_access /*access*/, void* userptr) {
-        static_cast<HttpClient*>(userptr)->share_mutexes[data].lock();
-    }
-
-    static void share_unlock_cb(CURL* /*handle*/, curl_lock_data data, void* userptr) {
-        static_cast<HttpClient*>(userptr)->share_mutexes[data].unlock();
-    }
+    mutable everest::lib::util::monitor<RequestExecutionGuard> request_execution_guard;
 
     void setup_share() {
         share = curl_share_init();
@@ -92,9 +86,6 @@ private:
             EVLOG_warning << "curl_share_init() failed - falling back to one connection per request";
             return;
         }
-        curl_share_setopt(share, CURLSHOPT_LOCKFUNC, share_lock_cb);
-        curl_share_setopt(share, CURLSHOPT_UNLOCKFUNC, share_unlock_cb);
-        curl_share_setopt(share, CURLSHOPT_USERDATA, this);
         curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
         curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
         curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/http_client.hpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/http_client.hpp
@@ -78,6 +78,8 @@ private:
     // Requests are serialized because libcurl does not support sharing the connection cache between
     // concurrent transfers.
     CURLSH* share = nullptr;
+    // Held for the duration of a request. Note that this is not recursive: a request must never be
+    // issued from within another request on the same client.
     mutable everest::lib::util::monitor<RequestExecutionGuard> request_execution_guard;
 
     void setup_share() {
@@ -86,9 +88,21 @@ private:
             EVLOG_warning << "curl_share_init() failed - falling back to one connection per request";
             return;
         }
-        curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
-        curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
-        curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
+        // No CURLSHOPT_LOCKFUNC/UNLOCKFUNC is registered: all transfers using this share are serialized
+        // by request_execution_guard, so the shared caches are never accessed concurrently. Locking
+        // callbacks would not be sufficient on their own anyway, since libcurl does not support using a
+        // shared connection cache from concurrent transfers at all.
+        for (const auto data : {CURL_LOCK_DATA_CONNECT, CURL_LOCK_DATA_SSL_SESSION, CURL_LOCK_DATA_DNS}) {
+            if (curl_share_setopt(share, CURLSHOPT_SHARE, data) != CURLSHE_OK) {
+                // Without the shared caches there is nothing to reuse, and the connection of a handle
+                // would just be discarded when the handle is cleaned up after the request. Drop the share
+                // so that CURLOPT_FORBID_REUSE is set again and the previous behavior is restored.
+                EVLOG_warning << "curl_share_setopt() failed - falling back to one connection per request";
+                curl_share_cleanup(share);
+                share = nullptr;
+                return;
+            }
+        }
     }
 
     [[nodiscard]] CURL* create_curl_handle_and_setup_url(const std::string& path) const;

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/http_client.hpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/http_client.hpp
@@ -6,8 +6,10 @@
 
 #include "fmt/format.h"
 #include "http_client_interface.hpp"
+#include <array>
 #include <curl/curl.h>
 #include <everest/logging.hpp>
+#include <mutex>
 #include <regex>
 #include <stdexcept>
 #include <string>
@@ -30,7 +32,7 @@ public:
     HttpClient() = delete;
 
     HttpClient(const std::string& host_arg, int port_arg, const std::string& tls_certificate,
-               const std::string& network_interface = "") {
+               const std::string& network_interface = "", bool connection_reuse = true) {
         // initialize libcurl - this is safe to do multiple times, if there are multiple HttpClients
         // Note: This is only thread-safe after libcurl 7.84.0, but we use 8.4.0, so it should be fine
         curl_global_init(CURL_GLOBAL_DEFAULT);
@@ -41,9 +43,15 @@ public:
         tls_enabled = !dcbm_tls_certificate.empty();
         fixup_tls_certificate(dcbm_tls_certificate);
         this->network_interface = network_interface;
+        if (connection_reuse) {
+            setup_share();
+        }
     }
 
     ~HttpClient() override {
+        if (share != nullptr) {
+            curl_share_cleanup(share);
+        }
         // release the libcurl resources - this must be done once for every call to curl_global_init().
         // Note: This is only thread-safe after libcurl 7.84.0, but we use 8.4.0, so it should be fine
         curl_global_cleanup();
@@ -63,6 +71,34 @@ private:
     std::string dcbm_tls_certificate;
     int command_timeout_ms = 5000; // default timeout in milliseconds
     std::string network_interface; // network interface
+
+    // Shared connection/SSL-session/DNS caches, so consecutive requests reuse the TCP (and TLS)
+    // connection instead of reconnecting per request. nullptr if connection reuse is disabled.
+    // The mutexes make the share usable from concurrent requests (poll thread + command handlers).
+    CURLSH* share = nullptr;
+    mutable std::array<std::mutex, CURL_LOCK_DATA_LAST> share_mutexes;
+
+    static void share_lock_cb(CURL* /*handle*/, curl_lock_data data, curl_lock_access /*access*/, void* userptr) {
+        static_cast<HttpClient*>(userptr)->share_mutexes[data].lock();
+    }
+
+    static void share_unlock_cb(CURL* /*handle*/, curl_lock_data data, void* userptr) {
+        static_cast<HttpClient*>(userptr)->share_mutexes[data].unlock();
+    }
+
+    void setup_share() {
+        share = curl_share_init();
+        if (share == nullptr) {
+            EVLOG_warning << "curl_share_init() failed - falling back to one connection per request";
+            return;
+        }
+        curl_share_setopt(share, CURLSHOPT_LOCKFUNC, share_lock_cb);
+        curl_share_setopt(share, CURLSHOPT_UNLOCKFUNC, share_unlock_cb);
+        curl_share_setopt(share, CURLSHOPT_USERDATA, this);
+        curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
+        curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
+        curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
+    }
 
     [[nodiscard]] CURL* create_curl_handle_and_setup_url(const std::string& path) const;
     HttpResponse perform_request(CURL* connection, const std::string& request_body, const char* method_name,

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
@@ -140,12 +140,7 @@ LemDCBM400600Controller::start_transaction(const types::powermeter::TransactionR
         this->current_transaction_id = value.transaction_id;
         this->need_to_stop_transaction = true;
         // make sure the fallback OCMF record for this transaction is fetched on the next poll
-        {
-            auto ocmf_fetch_state = this->ocmf_fetch_state.handle();
-            ocmf_fetch_state->last_fetch =
-                std::chrono::steady_clock::now() - std::chrono::seconds(this->config.transaction_ocmf_fetch_interval_s);
-            ++ocmf_fetch_state->transaction_generation;
-        }
+        this->ocmf_fetch_state.handle()->fetch_due = true;
     } catch (DCBMUnexpectedResponseException& error) {
         const std::string error_message =
             fmt::format("Failed to start transaction {}: {}", value.transaction_id, error.what());
@@ -300,40 +295,46 @@ types::powermeter::Powermeter LemDCBM400600Controller::get_powermeter() {
     } catch (json::exception& json_error) {
         throw UnexpectedDCBMResponseBody(endpoint, fmt::format("Json error '{}'", json_error.what()));
     }
-    const auto now = std::chrono::steady_clock::now();
-    bool should_fetch_ocmf = false;
-    std::uint64_t transaction_generation = 0;
-    if (this->need_to_stop_transaction) {
-        auto ocmf_fetch_state = this->ocmf_fetch_state.handle();
-        should_fetch_ocmf =
-            now - ocmf_fetch_state->last_fetch >= std::chrono::seconds(this->config.transaction_ocmf_fetch_interval_s);
-        transaction_generation = ocmf_fetch_state->transaction_generation;
-    }
-    if (should_fetch_ocmf) {
-        // if there is no ongoing transaction, we do need to fetch the signed meter value to have it available
-        // for the upper layers, otherwise we will not have the OCMF value if we lose connection to the device
-        try {
-            current_signed_meter_value =
-                types::units_signed::SignedMeterValue{fetch_ocmf_result(current_transaction_id), "", "OCMF"};
-            current_signed_meter_value.public_key.emplace(public_key_ocmf);
-            current_signed_meter_value.timestamp.emplace(powermeter_result.timestamp);
-            {
-                auto ocmf_fetch_state = this->ocmf_fetch_state.handle();
-                if (ocmf_fetch_state->transaction_generation == transaction_generation) {
-                    ocmf_fetch_state->last_fetch = now;
-                }
-            }
-        } catch (UnexpectedDCBMResponseCode& error) {
-            EVLOG_error << "LEM DCBM 400/600: Could not get the OCMF value: " << error.what();
-        } catch (UnexpectedDCBMResponseBody& error) {
-            EVLOG_error << "LEM DCBM 400/600: Invalid OCMF value: " << error.what();
-        } catch (HttpClientError& error) {
-            std::string error_message = fmt::format("Failed get the OCMF field {} - connection to device failed: {}",
-                                                    current_transaction_id, error.what());
-            EVLOG_error << error_message;
-        }
-    }
     return powermeter_result;
+}
+
+void LemDCBM400600Controller::update_transaction_fallback_ocmf(const std::string& timestamp) {
+    if (not this->need_to_stop_transaction) {
+        return;
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    {
+        auto ocmf_fetch_state = this->ocmf_fetch_state.handle();
+        const bool should_fetch_ocmf =
+            ocmf_fetch_state->fetch_due or
+            now - ocmf_fetch_state->last_fetch >= std::chrono::seconds(this->config.transaction_ocmf_fetch_interval_s);
+        if (not should_fetch_ocmf) {
+            return;
+        }
+        // Record the attempt up front, regardless of its outcome. A failing or slow OCMF endpoint must
+        // not bypass the throttle and be retried on every single poll - that is precisely when the
+        // device can least afford the extra request. A transaction started while this fetch is still in
+        // flight sets fetch_due again, so the new transaction is still served on the next poll.
+        ocmf_fetch_state->last_fetch = now;
+        ocmf_fetch_state->fetch_due = false;
+    }
+
+    // The signed meter value is only consumed if the device is unreachable when the transaction is
+    // stopped, so this is a pure fallback and must never delay the publication of the live measurements.
+    try {
+        current_signed_meter_value =
+            types::units_signed::SignedMeterValue{fetch_ocmf_result(current_transaction_id), "", "OCMF"};
+        current_signed_meter_value.public_key.emplace(public_key_ocmf);
+        current_signed_meter_value.timestamp.emplace(timestamp);
+    } catch (UnexpectedDCBMResponseCode& error) {
+        EVLOG_error << "LEM DCBM 400/600: Could not get the OCMF value: " << error.what();
+    } catch (UnexpectedDCBMResponseBody& error) {
+        EVLOG_error << "LEM DCBM 400/600: Invalid OCMF value: " << error.what();
+    } catch (HttpClientError& error) {
+        EVLOG_error << fmt::format("Failed get the OCMF field {} - connection to device failed: {}",
+                                   current_transaction_id, error.what());
+    }
 }
 
 types::powermeter::Powermeter

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
@@ -140,7 +140,12 @@ LemDCBM400600Controller::start_transaction(const types::powermeter::TransactionR
         this->current_transaction_id = value.transaction_id;
         this->need_to_stop_transaction = true;
         // make sure the fallback OCMF record for this transaction is fetched on the next poll
-        this->last_ocmf_fetch = {};
+        {
+            auto ocmf_fetch_state = this->ocmf_fetch_state.handle();
+            ocmf_fetch_state->last_fetch =
+                std::chrono::steady_clock::now() - std::chrono::seconds(this->config.transaction_ocmf_fetch_interval_s);
+            ++ocmf_fetch_state->transaction_generation;
+        }
     } catch (DCBMUnexpectedResponseException& error) {
         const std::string error_message =
             fmt::format("Failed to start transaction {}: {}", value.transaction_id, error.what());
@@ -296,8 +301,15 @@ types::powermeter::Powermeter LemDCBM400600Controller::get_powermeter() {
         throw UnexpectedDCBMResponseBody(endpoint, fmt::format("Json error '{}'", json_error.what()));
     }
     const auto now = std::chrono::steady_clock::now();
-    if (this->need_to_stop_transaction and
-        now - this->last_ocmf_fetch >= std::chrono::seconds(this->config.transaction_ocmf_fetch_interval_s)) {
+    bool should_fetch_ocmf = false;
+    std::uint64_t transaction_generation = 0;
+    if (this->need_to_stop_transaction) {
+        auto ocmf_fetch_state = this->ocmf_fetch_state.handle();
+        should_fetch_ocmf =
+            now - ocmf_fetch_state->last_fetch >= std::chrono::seconds(this->config.transaction_ocmf_fetch_interval_s);
+        transaction_generation = ocmf_fetch_state->transaction_generation;
+    }
+    if (should_fetch_ocmf) {
         // if there is no ongoing transaction, we do need to fetch the signed meter value to have it available
         // for the upper layers, otherwise we will not have the OCMF value if we lose connection to the device
         try {
@@ -305,7 +317,12 @@ types::powermeter::Powermeter LemDCBM400600Controller::get_powermeter() {
                 types::units_signed::SignedMeterValue{fetch_ocmf_result(current_transaction_id), "", "OCMF"};
             current_signed_meter_value.public_key.emplace(public_key_ocmf);
             current_signed_meter_value.timestamp.emplace(powermeter_result.timestamp);
-            this->last_ocmf_fetch = now;
+            {
+                auto ocmf_fetch_state = this->ocmf_fetch_state.handle();
+                if (ocmf_fetch_state->transaction_generation == transaction_generation) {
+                    ocmf_fetch_state->last_fetch = now;
+                }
+            }
         } catch (UnexpectedDCBMResponseCode& error) {
             EVLOG_error << "LEM DCBM 400/600: Could not get the OCMF value: " << error.what();
         } catch (UnexpectedDCBMResponseBody& error) {

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
@@ -134,11 +134,13 @@ LemDCBM400600Controller::start_transaction(const types::powermeter::TransactionR
                 EVLOG_error << "LEM DCBM 400/600: Could not close the current transaction, got error:" << error.what();
             }
         }
-        call_with_retry([this, value]() { this->request_device_to_start_transaction(value); },
+        call_with_retry([this, &value]() { this->request_device_to_start_transaction(value); },
                         this->config.transaction_number_of_http_retries,
                         this->config.transaction_retry_wait_in_milliseconds);
         this->current_transaction_id = value.transaction_id;
         this->need_to_stop_transaction = true;
+        // make sure the fallback OCMF record for this transaction is fetched on the next poll
+        this->last_ocmf_fetch = {};
     } catch (DCBMUnexpectedResponseException& error) {
         const std::string error_message =
             fmt::format("Failed to start transaction {}: {}", value.transaction_id, error.what());
@@ -293,7 +295,9 @@ types::powermeter::Powermeter LemDCBM400600Controller::get_powermeter() {
     } catch (json::exception& json_error) {
         throw UnexpectedDCBMResponseBody(endpoint, fmt::format("Json error '{}'", json_error.what()));
     }
-    if (this->need_to_stop_transaction) {
+    const auto now = std::chrono::steady_clock::now();
+    if (this->need_to_stop_transaction and
+        now - this->last_ocmf_fetch >= std::chrono::seconds(this->config.transaction_ocmf_fetch_interval_s)) {
         // if there is no ongoing transaction, we do need to fetch the signed meter value to have it available
         // for the upper layers, otherwise we will not have the OCMF value if we lose connection to the device
         try {
@@ -301,6 +305,7 @@ types::powermeter::Powermeter LemDCBM400600Controller::get_powermeter() {
                 types::units_signed::SignedMeterValue{fetch_ocmf_result(current_transaction_id), "", "OCMF"};
             current_signed_meter_value.public_key.emplace(public_key_ocmf);
             current_signed_meter_value.timestamp.emplace(powermeter_result.timestamp);
+            this->last_ocmf_fetch = now;
         } catch (UnexpectedDCBMResponseCode& error) {
             EVLOG_error << "LEM DCBM 400/600: Could not get the OCMF value: " << error.what();
         } catch (UnexpectedDCBMResponseBody& error) {

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/lem_dcbm_400600_controller.hpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/lem_dcbm_400600_controller.hpp
@@ -7,6 +7,8 @@
 #include "http_client_interface.hpp"
 #include "lem_dcbm_time_sync_helper.hpp"
 #include <chrono>
+#include <cstdint>
+#include <everest/util/async/monitor.hpp>
 #include <functional>
 #include <generated/interfaces/powermeter/Implementation.hpp>
 #include <string>
@@ -97,6 +99,11 @@ public:
     void update_lem_status();
 
 private:
+    struct OCMFFetchState {
+        std::chrono::steady_clock::time_point last_fetch{};
+        std::uint64_t transaction_generation = 0;
+    };
+
     const std::unique_ptr<HttpClientInterface> http_client;
     std::string meter_id;
     std::string public_key;
@@ -106,8 +113,7 @@ private:
     bool need_to_stop_transaction = false;
     std::string current_transaction_id;
     types::units_signed::SignedMeterValue current_signed_meter_value;
-    // when the fallback OCMF record was last fetched; epoch value forces a fetch on the next poll
-    std::chrono::steady_clock::time_point last_ocmf_fetch{};
+    everest::lib::util::monitor<OCMFFetchState> ocmf_fetch_state;
     std::unique_ptr<LemDCBMTimeSyncHelper> time_sync_helper;
     Conf config;
 

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/lem_dcbm_400600_controller.hpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/lem_dcbm_400600_controller.hpp
@@ -7,7 +7,6 @@
 #include "http_client_interface.hpp"
 #include "lem_dcbm_time_sync_helper.hpp"
 #include <chrono>
-#include <cstdint>
 #include <everest/util/async/monitor.hpp>
 #include <functional>
 #include <generated/interfaces/powermeter/Implementation.hpp>
@@ -101,7 +100,10 @@ public:
 private:
     struct OCMFFetchState {
         std::chrono::steady_clock::time_point last_fetch{};
-        std::uint64_t transaction_generation = 0;
+        // Explicit "no fetch has happened yet" state, so the first fetch of a transaction does not
+        // depend on the process uptime having exceeded the configured interval. Set on start up and
+        // whenever a transaction is started.
+        bool fetch_due = true;
     };
 
     const std::unique_ptr<HttpClientInterface> http_client;
@@ -169,6 +171,14 @@ public:
     types::powermeter::TransactionStartResponse start_transaction(const types::powermeter::TransactionReq& value);
     types::powermeter::TransactionStopResponse stop_transaction(const std::string& transaction_id);
     types::powermeter::Powermeter get_powermeter();
+    /// \brief Refreshes the fallback OCMF record of the running transaction, subject to the configured
+    /// throttle interval. No-op if no transaction is active.
+    ///
+    /// This is deliberately separate from get_powermeter() so that the caller can publish the live
+    /// measurements first: the fallback record is only ever read if the device is unreachable at
+    /// transaction stop, so its round trip must not be added to the interval between two publications.
+    /// \param timestamp the device timestamp of the live measurements this fallback record accompanies
+    void update_transaction_fallback_ocmf(const std::string& timestamp);
     inline bool is_initialized() {
         return ("" != meter_id);
     }

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/lem_dcbm_400600_controller.hpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/lem_dcbm_400600_controller.hpp
@@ -6,6 +6,7 @@
 
 #include "http_client_interface.hpp"
 #include "lem_dcbm_time_sync_helper.hpp"
+#include <chrono>
 #include <functional>
 #include <generated/interfaces/powermeter/Implementation.hpp>
 #include <string>
@@ -45,6 +46,9 @@ public:
         const int IT;
         // command timeout in milliseconds
         const int command_timeout_ms;
+        // minimum time in seconds between fetches of the fallback OCMF record during an active
+        // transaction (0 = fetch on every poll)
+        const int transaction_ocmf_fetch_interval_s = 0;
     };
 
     class DCBMUnexpectedResponseException : public std::exception {
@@ -102,6 +106,8 @@ private:
     bool need_to_stop_transaction = false;
     std::string current_transaction_id;
     types::units_signed::SignedMeterValue current_signed_meter_value;
+    // when the fallback OCMF record was last fetched; epoch value forces a fetch on the next poll
+    std::chrono::steady_clock::time_point last_ocmf_fetch{};
     std::unique_ptr<LemDCBMTimeSyncHelper> time_sync_helper;
     Conf config;
 

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/poll_scheduler.hpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/poll_scheduler.hpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#ifndef EVEREST_CORE_MODULE_LEMDCBM400600_POLL_SCHEDULER_H
+#define EVEREST_CORE_MODULE_LEMDCBM400600_POLL_SCHEDULER_H
+
+#include <chrono>
+
+namespace module::main {
+
+/// \brief Fixed-rate schedule for the live measurement poll loop.
+///
+/// A plain "sleep(interval), then perform the requests" loop has a period of interval + request
+/// duration rather than interval, so the publication rate silently degrades with the latency of the
+/// device. That matters because consumers watch the measurement stream for gaps - EvseManager aborts a
+/// DC cable check when it sees no power supply measurement for two seconds - so the headroom against
+/// such a timeout must not depend on how fast the device happens to answer.
+///
+/// This scheduler keeps the phase of the schedule instead: each poll is due exactly one interval after
+/// the previous one was due, and the time spent in the requests is absorbed by a correspondingly
+/// shorter wait. If a poll overruns its interval entirely, the schedule is resynchronized to the
+/// current time rather than firing a burst of catch-up polls.
+class PollScheduler {
+public:
+    using clock = std::chrono::steady_clock;
+
+    /// \param now the reference point of the schedule; the first poll is due one interval after it
+    /// \param interval the desired time between the start of two consecutive polls
+    PollScheduler(clock::time_point now, std::chrono::milliseconds interval) : deadline(now), interval(interval) {
+    }
+
+    /// \brief Advances the schedule and returns the time point at which the next poll is due.
+    ///
+    /// The returned time point is never in the future by more than one interval, and is clamped to
+    /// \p now when the schedule has fallen behind, so it is always safe to pass to sleep_until().
+    clock::time_point next(clock::time_point now) {
+        deadline += interval;
+        if (deadline < now) {
+            // The previous poll took longer than a full interval. Resynchronize to now, so that the
+            // lost time does not turn into a series of immediately-firing catch-up polls.
+            deadline = now;
+            overran = true;
+        } else {
+            overran = false;
+        }
+        return deadline;
+    }
+
+    /// \brief Restarts the schedule, so the next poll is due one interval after \p now.
+    void reset(clock::time_point now) {
+        deadline = now;
+        overran = false;
+    }
+
+    /// \brief Whether the most recent next() call had to resynchronize because the poll overran.
+    [[nodiscard]] bool last_poll_overran() const {
+        return overran;
+    }
+
+private:
+    clock::time_point deadline;
+    std::chrono::milliseconds interval;
+    bool overran = false;
+};
+
+} // namespace module::main
+
+#endif // EVEREST_CORE_MODULE_LEMDCBM400600_POLL_SCHEDULER_H

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/powermeterImpl.cpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/powermeterImpl.cpp
@@ -4,6 +4,7 @@
 #include "powermeterImpl.hpp"
 #include "http_client.hpp"
 #include "lem_dcbm_time_sync_helper.hpp"
+#include "poll_scheduler.hpp"
 #include <chrono>
 #include <everest/logging.hpp>
 #include <fmt/core.h>
@@ -11,6 +12,36 @@
 #include <thread>
 
 namespace module::main {
+
+namespace {
+
+/// \brief Reports an unexpectedly long gap between two consecutive publications of the live measurements.
+///
+/// Consumers of the powermeter var watch this stream for gaps - EvseManager aborts a DC cable check
+/// when it sees no power supply measurement for two seconds - so a gap that grows well beyond the
+/// configured poll interval is worth reporting even though nothing here has failed.
+void warn_on_publication_gap(std::chrono::steady_clock::time_point last_publish,
+                             std::chrono::steady_clock::time_point publish,
+                             std::chrono::steady_clock::duration request_duration,
+                             std::chrono::milliseconds poll_interval) {
+    if (last_publish == std::chrono::steady_clock::time_point{}) {
+        return; // first publication, there is no gap to report yet
+    }
+
+    const auto gap = publish - last_publish;
+    if (gap <= poll_interval + poll_interval / 2) {
+        return;
+    }
+
+    EVLOG_warning << fmt::format(
+        "LEM DCBM 400/600: {} ms between two live measurement publications, expected about {} ms "
+        "(the live measurement request itself took {} ms). Consumers watching the measurement stream may "
+        "time out.",
+        std::chrono::duration_cast<std::chrono::milliseconds>(gap).count(), poll_interval.count(),
+        std::chrono::duration_cast<std::chrono::milliseconds>(request_duration).count());
+}
+
+} // namespace
 
 void powermeterImpl::init() {
     // Dependency injection pattern: Create the HTTP client first,
@@ -51,6 +82,10 @@ void powermeterImpl::init() {
 void powermeterImpl::ready() {
     // Start the live_measure_publisher thread, which periodically publishes the live measurements of the device
     this->live_measure_publisher_thread = std::thread([this] {
+        const auto poll_interval = std::chrono::milliseconds(mod->config.poll_interval_ms);
+        PollScheduler scheduler{std::chrono::steady_clock::now(), poll_interval};
+        auto last_publish = std::chrono::steady_clock::time_point{};
+
         while (true) {
             try {
                 if (!this->controller->is_initialized()) {
@@ -58,10 +93,22 @@ void powermeterImpl::ready() {
                     this->publish_public_key_ocmf(this->controller->get_public_key_ocmf());
                     std::this_thread::sleep_for(
                         std::chrono::milliseconds(mod->config.resilience_initial_connection_retry_delay));
+                    scheduler.reset(std::chrono::steady_clock::now());
                 } else {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(mod->config.poll_interval_ms));
+                    std::this_thread::sleep_until(scheduler.next(std::chrono::steady_clock::now()));
+
+                    const auto request_start = std::chrono::steady_clock::now();
                     auto powermeter_data = this->controller->get_powermeter();
+                    const auto publish = std::chrono::steady_clock::now();
                     this->publish_powermeter(powermeter_data);
+                    warn_on_publication_gap(last_publish, publish, publish - request_start, poll_interval);
+                    last_publish = publish;
+
+                    // Refresh the fallback OCMF record only after the measurements have been published:
+                    // it is a fallback for an unreachable device at transaction stop, so its round trip
+                    // must not be added to the gap between two publications.
+                    this->controller->update_transaction_fallback_ocmf(powermeter_data.timestamp);
+
                     // if the communication error is set, clear the error
                     if (this->error_state_monitor->is_error_active("powermeter/CommunicationFault",
                                                                    "Communication timed out")) {

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/powermeterImpl.cpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/main/powermeterImpl.cpp
@@ -15,8 +15,9 @@ namespace module::main {
 void powermeterImpl::init() {
     // Dependency injection pattern: Create the HTTP client first,
     // then move it into the controller as a constructor argument
-    auto http_client = std::make_unique<HttpClient>(mod->config.ip_address, mod->config.port,
-                                                    mod->config.meter_tls_certificate, mod->config.interface);
+    auto http_client =
+        std::make_unique<HttpClient>(mod->config.ip_address, mod->config.port, mod->config.meter_tls_certificate,
+                                     mod->config.interface, mod->config.http_connection_reuse);
 
     auto ntp_server_spec =
         module::main::ntp_server_spec{mod->config.ntp_server_1_ip_addr, mod->config.ntp_server_1_port,
@@ -28,7 +29,8 @@ void powermeterImpl::init() {
             mod->config.resilience_initial_connection_retries, mod->config.resilience_initial_connection_retry_delay,
             mod->config.resilience_transaction_request_retries, mod->config.resilience_transaction_request_retry_delay,
             mod->config.cable_id, mod->config.tariff_id, mod->config.meter_timezone, mod->config.meter_dst,
-            mod->config.SC, mod->config.UV, mod->config.UD, mod->config.IT, mod->config.command_timeout_ms});
+            mod->config.SC, mod->config.UV, mod->config.UD, mod->config.IT, mod->config.command_timeout_ms,
+            mod->config.transaction_ocmf_fetch_interval_s});
 
     // Validate and normalize temperature thresholds for the monitor.
     // If the error level is configured below the warning level, clamp it and log a warning.
@@ -57,7 +59,7 @@ void powermeterImpl::ready() {
                     std::this_thread::sleep_for(
                         std::chrono::milliseconds(mod->config.resilience_initial_connection_retry_delay));
                 } else {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+                    std::this_thread::sleep_for(std::chrono::milliseconds(mod->config.poll_interval_ms));
                     auto powermeter_data = this->controller->get_powermeter();
                     this->publish_powermeter(powermeter_data);
                     // if the communication error is set, clear the error

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/manifest.yaml
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/manifest.yaml
@@ -15,6 +15,14 @@ config:
     description: The DCBM's HTTPS certificate, in PEM format. If provided, HTTPS will be used. If left empty, regular HTTP will be used. Note that this does not affect the default port - specify a port explicitly if you wish to use a port other than 80.
     type: string
     default: ""
+  http_connection_reuse:
+    description: >-
+      Reuse HTTP(S) connections to the power meter across requests. This avoids a TCP connect
+      (and, with TLS, a full TLS handshake) for every poll. Disable to restore the previous
+      behavior of one fresh connection per request, e.g. if the device misbehaves with
+      keep-alive connections.
+    type: boolean
+    default: true
   ntp_server_1_ip_addr:
     description: The IPv4 address (in 4-octet form W.X.Y.Z) of the first NTP server to use for time sync. If this is left empty, NTP will not be configured on the DCBM - its time will be synced with EVerest's system time instead.
     type: string
@@ -130,6 +138,20 @@ config:
     default: 5000
     maximum: 20000
     minimum: 1000
+  poll_interval_ms:
+    description: The interval in milliseconds between polls of the live measurements (publish rate of the powermeter var).
+    type: integer
+    default: 1000
+    minimum: 100
+  transaction_ocmf_fetch_interval_s:
+    description: >-
+      While a transaction is active, the current OCMF record is periodically fetched from the
+      device as a fallback, so a signed meter value is available even if the device becomes
+      unreachable at transaction stop. This option throttles that fetch to at most once every
+      N seconds. The default of 0 fetches on every poll (previous behavior).
+    type: integer
+    default: 0
+    minimum: 0
 
 provides:
   main:

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/tests/CMakeLists.txt
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/tests/CMakeLists.txt
@@ -104,6 +104,39 @@ target_link_libraries(${TEST_TARGET_NAME} PRIVATE
 add_test(${TEST_TARGET_NAME} ${TEST_TARGET_NAME})
 ev_register_test_target(${TEST_TARGET_NAME})
 
+## Poll scheduler test
+set(TEST_TARGET_NAME ${PROJECT_NAME}_lem_poll_scheduler_tests)
+add_executable(${TEST_TARGET_NAME}
+        test_poll_scheduler.cpp
+)
+
+add_dependencies(${TEST_TARGET_NAME} ${MODULE_NAME})
+
+set(INCLUDE_DIR
+        "main"
+        "tests"
+        "${MODULE_DIR}/main"
+        "${MODULE_DIR}/tests")
+
+get_target_property(GENERATED_INCLUDE_DIR generate_cpp_files EVEREST_GENERATED_INCLUDE_DIR)
+
+target_include_directories(${TEST_TARGET_NAME} PRIVATE
+        tests
+        ${INCLUDE_DIR}
+        ${GENERATED_INCLUDE_DIR}
+)
+
+target_link_libraries(${TEST_TARGET_NAME} PRIVATE
+        GTest::gmock_main
+        everest::timer
+        everest::framework
+        nlohmann_json::nlohmann_json
+        CURL::libcurl
+)
+
+add_test(${TEST_TARGET_NAME} ${TEST_TARGET_NAME})
+ev_register_test_target(${TEST_TARGET_NAME})
+
 ## http client integration client
 
 add_executable(integration_test_http_client

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/tests/test_lem_dcbm_400600_controller.cpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/tests/test_lem_dcbm_400600_controller.cpp
@@ -8,6 +8,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <memory>
 
 namespace module::main {
@@ -218,6 +219,40 @@ TEST_F(LemDCBM400600ControllerTest, test_start_transaction) {
         int(delta.count() / 1E9 / 60),
         48 * 60 -
             3); // delta of max and min stopping time should be 48 hours - 2 minutes wait time and 1 minute safety time
+}
+
+/// \brief Test fallback OCMF is fetched immediately after start and then throttled
+TEST_F(LemDCBM400600ControllerTest, test_fallback_ocmf_fetch_is_immediate_then_throttled) {
+    testing::Sequence seq;
+    EXPECT_CALL(*this->time_sync_helper, sync(testing::_)).Times(1).InSequence(seq);
+    EXPECT_CALL(*this->http_client, post("/v1/legal", this->expected_start_transaction_request_body))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(HttpResponse{201, R"({"running": true})"}));
+    EXPECT_CALL(*this->time_sync_helper, sync_if_deadline_expired(testing::_)).Times(1).InSequence(seq);
+    EXPECT_CALL(*this->http_client, get("/v1/livemeasure"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(HttpResponse{200, this->livemeasure_response}));
+    EXPECT_CALL(*this->http_client, get("/v1/ocmf?transactionId=mock_transaction_id"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(HttpResponse{200, "mock_ocmf_string"}));
+    EXPECT_CALL(*this->time_sync_helper, sync_if_deadline_expired(testing::_)).Times(1).InSequence(seq);
+    EXPECT_CALL(*this->http_client, get("/v1/livemeasure"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(HttpResponse{200, this->livemeasure_response}));
+
+    const LemDCBM400600Controller::Conf throttled_controller_config{
+        0, 0, 1, 0, 0, 0, {}, {}, 0, {}, {}, -1, 0, std::numeric_limits<int>::max()};
+    LemDCBM400600Controller controller(std::move(this->http_client), std::move(this->time_sync_helper),
+                                       throttled_controller_config);
+
+    EXPECT_EQ(controller.start_transaction(this->transaction_request).status,
+              types::powermeter::TransactionRequestStatus::OK);
+    controller.get_powermeter();
+    controller.get_powermeter();
 }
 
 // \brief Test a failed start transaction with the DCBM returning an invalid response

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/tests/test_lem_dcbm_400600_controller.cpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/tests/test_lem_dcbm_400600_controller.cpp
@@ -28,6 +28,40 @@ public:
     LemDCBMTimeSyncHelperMock() : LemDCBMTimeSyncHelper({}, {}){};
 };
 
+// The fields of Conf that the tests actually vary. Everything else is fixed by make_controller_conf()
+// below, so that adding a field to Conf does not silently shift the meaning of every test's config.
+struct ControllerConfOverrides {
+    int init_number_of_http_retries = 0;
+    int init_retry_wait_in_milliseconds = 0;
+    // IT = -1 so that init() does not call set_identification_type()
+    int IT = -1;
+    int transaction_ocmf_fetch_interval_s = 0;
+};
+
+static LemDCBM400600Controller::Conf make_controller_conf(const ControllerConfOverrides& overrides = {}) {
+    return LemDCBM400600Controller::Conf{overrides.init_number_of_http_retries,
+                                         overrides.init_retry_wait_in_milliseconds,
+                                         /*transaction_number_of_http_retries=*/1,
+                                         /*transaction_retry_wait_in_milliseconds=*/0,
+                                         /*cable_id=*/0,
+                                         /*tariff_id=*/0,
+                                         /*meter_timezone=*/{},
+                                         /*meter_dst=*/{},
+                                         /*SC=*/0,
+                                         /*UV=*/{},
+                                         /*UD=*/{},
+                                         overrides.IT,
+                                         /*command_timeout_ms=*/0,
+                                         overrides.transaction_ocmf_fetch_interval_s};
+}
+
+// Performs one iteration of the live measurement poll loop, in the same order as powermeterImpl does:
+// fetch and publish the live measurements first, refresh the fallback OCMF record afterwards.
+static void poll_once(LemDCBM400600Controller& controller) {
+    const auto powermeter = controller.get_powermeter();
+    controller.update_transaction_fallback_ocmf(powermeter.timestamp);
+}
+
 // Fixture class providing
 //   - a http client mock
 //   - default responses & request objects
@@ -93,8 +127,7 @@ protected:
                                                 "publicKey": "A80F10D968E1122F8820F288B23C4E1C0DA912F35B48481274ADFEFE66D7E87E130C7CF2B8047C45CF105041C8C3A57DD242782F755C9443F42DABA9404A67BF"
                                                 })";
 
-    // IT = -1 so that init() does not call set_identification_type()
-    const LemDCBM400600Controller::Conf controller_config{0, 0, 1, 0, 0, 0, {}, {}, 0, {}, {}, -1};
+    const LemDCBM400600Controller::Conf controller_config{make_controller_conf()};
 
     void SetUp() override {
         this->http_client = std::make_unique<HTTPClientMock>();
@@ -245,14 +278,95 @@ TEST_F(LemDCBM400600ControllerTest, test_fallback_ocmf_fetch_is_immediate_then_t
         .WillOnce(testing::Return(HttpResponse{200, this->livemeasure_response}));
 
     const LemDCBM400600Controller::Conf throttled_controller_config{
-        0, 0, 1, 0, 0, 0, {}, {}, 0, {}, {}, -1, 0, std::numeric_limits<int>::max()};
+        make_controller_conf({.transaction_ocmf_fetch_interval_s = std::numeric_limits<int>::max()})};
     LemDCBM400600Controller controller(std::move(this->http_client), std::move(this->time_sync_helper),
                                        throttled_controller_config);
 
     EXPECT_EQ(controller.start_transaction(this->transaction_request).status,
               types::powermeter::TransactionRequestStatus::OK);
-    controller.get_powermeter();
-    controller.get_powermeter();
+    poll_once(controller);
+    poll_once(controller);
+}
+
+/// \brief Test get_powermeter does not fetch the fallback OCMF record itself
+///
+/// The fallback record must be fetched only via update_transaction_fallback_ocmf(), so that the caller
+/// can publish the live measurements before paying for that round trip.
+TEST_F(LemDCBM400600ControllerTest, test_get_powermeter_does_not_fetch_fallback_ocmf) {
+    testing::Sequence seq;
+    EXPECT_CALL(*this->time_sync_helper, sync(testing::_)).Times(1).InSequence(seq);
+    EXPECT_CALL(*this->http_client, post("/v1/legal", this->expected_start_transaction_request_body))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(HttpResponse{201, R"({"running": true})"}));
+    EXPECT_CALL(*this->time_sync_helper, sync_if_deadline_expired(testing::_)).Times(1).InSequence(seq);
+    EXPECT_CALL(*this->http_client, get("/v1/livemeasure"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(HttpResponse{200, this->livemeasure_response}));
+    // Only reached once update_transaction_fallback_ocmf() is called explicitly, never by get_powermeter().
+    bool ocmf_fetched = false;
+    EXPECT_CALL(*this->http_client, get("/v1/ocmf?transactionId=mock_transaction_id"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::DoAll(testing::InvokeWithoutArgs([&ocmf_fetched] { ocmf_fetched = true; }),
+                                 testing::Return(HttpResponse{200, "mock_ocmf_string"})));
+
+    LemDCBM400600Controller controller(std::move(this->http_client), std::move(this->time_sync_helper),
+                                       this->controller_config);
+
+    EXPECT_EQ(controller.start_transaction(this->transaction_request).status,
+              types::powermeter::TransactionRequestStatus::OK);
+
+    const auto powermeter = controller.get_powermeter();
+    EXPECT_FALSE(ocmf_fetched) << "get_powermeter() must not fetch the fallback OCMF record";
+
+    controller.update_transaction_fallback_ocmf(powermeter.timestamp);
+    EXPECT_TRUE(ocmf_fetched);
+}
+
+/// \brief Test a failing fallback OCMF fetch does not bypass the throttle
+///
+/// A slow or erroring OCMF endpoint must not be retried on every single poll: that is precisely when the
+/// device can least afford the extra request, and each attempt delays the publication of the live
+/// measurements by up to the command timeout.
+TEST_F(LemDCBM400600ControllerTest, test_failing_fallback_ocmf_fetch_is_still_throttled) {
+    testing::Sequence seq;
+    EXPECT_CALL(*this->time_sync_helper, sync(testing::_)).Times(1).InSequence(seq);
+    EXPECT_CALL(*this->http_client, post("/v1/legal", this->expected_start_transaction_request_body))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(HttpResponse{201, R"({"running": true})"}));
+    EXPECT_CALL(*this->time_sync_helper, sync_if_deadline_expired(testing::_)).Times(1).InSequence(seq);
+    EXPECT_CALL(*this->http_client, get("/v1/livemeasure"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Return(HttpResponse{200, this->livemeasure_response}));
+    // The single OCMF attempt fails - it must not be repeated on the following polls.
+    EXPECT_CALL(*this->http_client, get("/v1/ocmf?transactionId=mock_transaction_id"))
+        .Times(1)
+        .InSequence(seq)
+        .WillOnce(testing::Throw(HttpClientError("mock connection failure")));
+    // Two further polls, each fetching only the live measurements. Any further OCMF request would be
+    // reported by gmock as an unexpected call, since its expectation above is already saturated.
+    for (int poll = 0; poll < 2; poll++) {
+        EXPECT_CALL(*this->time_sync_helper, sync_if_deadline_expired(testing::_)).Times(1).InSequence(seq);
+        EXPECT_CALL(*this->http_client, get("/v1/livemeasure"))
+            .Times(1)
+            .InSequence(seq)
+            .WillOnce(testing::Return(HttpResponse{200, this->livemeasure_response}));
+    }
+
+    const LemDCBM400600Controller::Conf throttled_controller_config{
+        make_controller_conf({.transaction_ocmf_fetch_interval_s = std::numeric_limits<int>::max()})};
+    LemDCBM400600Controller controller(std::move(this->http_client), std::move(this->time_sync_helper),
+                                       throttled_controller_config);
+
+    EXPECT_EQ(controller.start_transaction(this->transaction_request).status,
+              types::powermeter::TransactionRequestStatus::OK);
+    poll_once(controller);
+    poll_once(controller);
+    poll_once(controller);
 }
 
 // \brief Test a failed start transaction with the DCBM returning an invalid response
@@ -486,7 +600,8 @@ TEST_F(LemDCBM400600ControllerTest, test_init_meter_id_retry_success) {
             200,
             this->livemeasure_response,
         }));
-    const LemDCBM400600Controller::Conf controller_config{number_of_retries, 1, 1, 0, 0, 0, {}, {}, 0, {}, {}, -1};
+    const LemDCBM400600Controller::Conf controller_config{
+        make_controller_conf({.init_number_of_http_retries = number_of_retries, .init_retry_wait_in_milliseconds = 1})};
     LemDCBM400600Controller controller(std::move(this->http_client), std::move(this->time_sync_helper),
                                        controller_config);
 
@@ -507,7 +622,8 @@ TEST_F(LemDCBM400600ControllerTest, test_init_meter_id_retry_fail_eventually) {
         .WillRepeatedly(testing::Throw(HttpClientError{"mock error"}));
     EXPECT_CALL(*this->time_sync_helper, restart_unsafe_period()).Times(0);
 
-    const LemDCBM400600Controller::Conf controller_config{number_of_retries, 1, 1, 0, 0, 0, {}, {}, 0, {}, {}, -1};
+    const LemDCBM400600Controller::Conf controller_config{
+        make_controller_conf({.init_number_of_http_retries = number_of_retries, .init_retry_wait_in_milliseconds = 1})};
     LemDCBM400600Controller controller(std::move(this->http_client), std::move(this->time_sync_helper),
                                        controller_config);
 
@@ -567,7 +683,7 @@ TEST_F(LemDCBM400600ControllerTest, test_init_sets_it_when_valid) {
 
     SETUP_SUCCESSFUL_INIT(seq);
 
-    const LemDCBM400600Controller::Conf config_with_it{0, 0, 1, 0, 0, 0, {}, {}, 0, {}, {}, 5};
+    const LemDCBM400600Controller::Conf config_with_it{make_controller_conf({.IT = 5})};
     LemDCBM400600Controller controller(std::move(this->http_client), std::move(this->time_sync_helper), config_with_it);
 
     // Act - should not throw
@@ -589,7 +705,7 @@ TEST_F(LemDCBM400600ControllerTest, test_init_set_it_fails_on_bad_status_code) {
         .InSequence(seq)
         .WillOnce(testing::Return(HttpResponse{500, "Internal Server Error"}));
 
-    const LemDCBM400600Controller::Conf config_with_it{0, 0, 1, 0, 0, 0, {}, {}, 0, {}, {}, 3};
+    const LemDCBM400600Controller::Conf config_with_it{make_controller_conf({.IT = 3})};
     LemDCBM400600Controller controller(std::move(this->http_client), std::move(this->time_sync_helper), config_with_it);
 
     // Act & Verify
@@ -611,7 +727,7 @@ TEST_F(LemDCBM400600ControllerTest, test_init_set_it_fails_on_rejected) {
         .InSequence(seq)
         .WillOnce(testing::Return(HttpResponse{200, R"({"result": 0})"}));
 
-    const LemDCBM400600Controller::Conf config_with_it{0, 0, 1, 0, 0, 0, {}, {}, 0, {}, {}, 3};
+    const LemDCBM400600Controller::Conf config_with_it{make_controller_conf({.IT = 3})};
     LemDCBM400600Controller controller(std::move(this->http_client), std::move(this->time_sync_helper), config_with_it);
 
     // Act & Verify
@@ -633,7 +749,7 @@ TEST_F(LemDCBM400600ControllerTest, test_init_set_it_fails_on_malformed_json) {
         .InSequence(seq)
         .WillOnce(testing::Return(HttpResponse{200, "not json"}));
 
-    const LemDCBM400600Controller::Conf config_with_it{0, 0, 1, 0, 0, 0, {}, {}, 0, {}, {}, 3};
+    const LemDCBM400600Controller::Conf config_with_it{make_controller_conf({.IT = 3})};
     LemDCBM400600Controller controller(std::move(this->http_client), std::move(this->time_sync_helper), config_with_it);
 
     // Act & Verify
@@ -655,7 +771,7 @@ TEST_F(LemDCBM400600ControllerTest, test_init_set_it_fails_on_missing_result_key
         .InSequence(seq)
         .WillOnce(testing::Return(HttpResponse{200, R"({"status": "ok"})"}));
 
-    const LemDCBM400600Controller::Conf config_with_it{0, 0, 1, 0, 0, 0, {}, {}, 0, {}, {}, 3};
+    const LemDCBM400600Controller::Conf config_with_it{make_controller_conf({.IT = 3})};
     LemDCBM400600Controller controller(std::move(this->http_client), std::move(this->time_sync_helper), config_with_it);
 
     // Act & Verify
@@ -676,7 +792,7 @@ TEST_F(LemDCBM400600ControllerTest, test_init_skips_set_it_when_already_configur
 
     SETUP_SUCCESSFUL_INIT(seq);
 
-    const LemDCBM400600Controller::Conf config_with_it{0, 0, 1, 0, 0, 0, {}, {}, 0, {}, {}, 5};
+    const LemDCBM400600Controller::Conf config_with_it{make_controller_conf({.IT = 5})};
     LemDCBM400600Controller controller(std::move(this->http_client), std::move(this->time_sync_helper), config_with_it);
 
     // Act - should not throw

--- a/modules/HardwareDrivers/PowerMeters/LemDCBM400600/tests/test_poll_scheduler.cpp
+++ b/modules/HardwareDrivers/PowerMeters/LemDCBM400600/tests/test_poll_scheduler.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+// Unit tests for the PollScheduler of the live measurement loop
+
+#include "poll_scheduler.hpp"
+#include <gtest/gtest.h>
+
+namespace module::main {
+
+using namespace std::chrono_literals;
+using clock = PollScheduler::clock;
+
+/// \brief The first poll is due one interval after the reference point
+TEST(PollSchedulerTest, first_poll_is_due_after_one_interval) {
+    const auto start = clock::now();
+    PollScheduler scheduler{start, 1000ms};
+
+    EXPECT_EQ(scheduler.next(start), start + 1000ms);
+    EXPECT_FALSE(scheduler.last_poll_overran());
+}
+
+/// \brief The time spent working is absorbed by the wait, keeping the period at exactly one interval
+///
+/// This is the property the whole class exists for: with a plain sleep-then-work loop the period would
+/// grow to interval + work duration, silently degrading the publication rate as the device gets slower.
+TEST(PollSchedulerTest, work_duration_does_not_extend_the_period) {
+    const auto start = clock::now();
+    PollScheduler scheduler{start, 1000ms};
+
+    const auto first = scheduler.next(start);
+    ASSERT_EQ(first, start + 1000ms);
+
+    // The poll took 400 ms, so the next one is still due 1000 ms after the previous deadline.
+    const auto second = scheduler.next(first + 400ms);
+    EXPECT_EQ(second, start + 2000ms);
+    EXPECT_FALSE(scheduler.last_poll_overran());
+
+    // ... and a slower poll of 900 ms does not shift the schedule either.
+    const auto third = scheduler.next(second + 900ms);
+    EXPECT_EQ(third, start + 3000ms);
+    EXPECT_FALSE(scheduler.last_poll_overran());
+}
+
+/// \brief A poll that overruns its interval resynchronizes instead of queueing catch-up polls
+TEST(PollSchedulerTest, overrun_resynchronizes_the_schedule) {
+    const auto start = clock::now();
+    PollScheduler scheduler{start, 1000ms};
+
+    const auto first = scheduler.next(start);
+    ASSERT_EQ(first, start + 1000ms);
+
+    // The poll took 2500 ms, so its deadline (start + 2000 ms) is already in the past.
+    const auto overrun_now = first + 2500ms;
+    const auto second = scheduler.next(overrun_now);
+    EXPECT_EQ(second, overrun_now);
+    EXPECT_TRUE(scheduler.last_poll_overran());
+
+    // The schedule continues from there rather than firing the missed polls back to back.
+    EXPECT_EQ(scheduler.next(second), overrun_now + 1000ms);
+    EXPECT_FALSE(scheduler.last_poll_overran());
+}
+
+/// \brief A returned deadline is never in the past, so it is always safe for sleep_until()
+TEST(PollSchedulerTest, deadline_is_never_in_the_past) {
+    const auto start = clock::now();
+    PollScheduler scheduler{start, 100ms};
+
+    auto now = start;
+    for (int i = 0; i < 10; i++) {
+        const auto deadline = scheduler.next(now);
+        EXPECT_GE(deadline, now);
+        now = deadline + 250ms; // consistently overrunning the interval
+    }
+}
+
+/// \brief reset() restarts the schedule from the given point
+TEST(PollSchedulerTest, reset_restarts_the_schedule) {
+    const auto start = clock::now();
+    PollScheduler scheduler{start, 1000ms};
+
+    ASSERT_EQ(scheduler.next(start), start + 1000ms);
+
+    const auto resume = start + 30s;
+    scheduler.reset(resume);
+    EXPECT_FALSE(scheduler.last_poll_overran());
+    EXPECT_EQ(scheduler.next(resume), resume + 1000ms);
+}
+
+} // namespace module::main


### PR DESCRIPTION
## Describe your changes

Reduces the HTTP and polling overhead of the LemDCBM400600 driver, and makes the publication rate of
the `powermeter` var independent of the latency of the device.

The rate matters beyond throughput: consumers watch this stream for gaps. `EvseManager` aborts a DC
cable check as soon as it sees no power supply measurement for two seconds, so with a 1 s poll
interval the margin was one second minus whatever the device and network happened to take.

- Reuse HTTP(S) connections across requests via a libcurl share (`http_connection_reuse`, default
  true). Previously every request opened a fresh TCP connection, plus a full TLS handshake when TLS
  is enabled. Requests using the share are serialized, since libcurl does not support using a shared
  connection cache from concurrent transfers - locking callbacks do not change that.
- Run the poll loop at a fixed rate: the request duration is absorbed into the wait instead of being
  added to it, so the period stays at `poll_interval_ms` (default 1000, as before) rather than
  growing to interval + request duration.
- Fetch the fallback OCMF record *after* publishing the live measurements, so its round trip is no
  longer inside the gap between two publications. It can additionally be throttled
  (`transaction_ocmf_fetch_interval_s`, default 0 = every poll as before), and the throttle records
  attempts rather than successes, so a failing OCMF endpoint cannot bypass it.
- Log a warning when the gap between two publications exceeds 1.5x the interval, including the
  measured gap and the request duration, so a slow device or network can be identified from the logs
  of a charger in the field.

All defaults preserve the previous behavior except connection reuse, which is enabled by default.

Co-authored-by: Jan Christoph Habig (@djchhp), who wrote the original version of this PR.

## Issue ticket number and link

None.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
