### PR TITLE
perf(EvseManager): make Node-RED debug interface optional

### DIFF
--- a/config/config-sil-ac-d20.yaml
+++ b/config/config-sil-ac-d20.yaml
@@ -21,6 +21,7 @@ active_modules:
   evse_manager:
     module: EvseManager
     config_module:
+      enable_nodered_interface: true
       ac_enforce_hlc: false
       ac_hlc_enabled: true
       ac_hlc_use_5percent: false

--- a/config/config-sil-ac-temp-derating.yaml
+++ b/config/config-sil-ac-temp-derating.yaml
@@ -30,6 +30,7 @@ active_modules:
       module:
         evse: 1
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: DE*PNX*E12345*1
       session_logging: true

--- a/config/config-sil-dc-consumer-api.yaml
+++ b/config/config-sil-dc-consumer-api.yaml
@@ -81,6 +81,7 @@ active_modules:
   evse_manager:
     module: EvseManager
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: DE*PNX*E12345*1
       evse_id_din: 49A80737A45678

--- a/config/config-sil-dc-d20.yaml
+++ b/config/config-sil-dc-d20.yaml
@@ -19,6 +19,7 @@ active_modules:
   evse_manager:
     module: EvseManager
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: DE*PNX*E12345*1
       evse_id_din: 49A80737A45678

--- a/config/config-sil-dc-isomux-tls.yaml
+++ b/config/config-sil-dc-isomux-tls.yaml
@@ -52,6 +52,7 @@ active_modules:
   evse_manager:
     module: EvseManager
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: DE*PNX*E12345*1
       evse_id_din: 49A80737A45678

--- a/config/config-sil-dc-isomux.yaml
+++ b/config/config-sil-dc-isomux.yaml
@@ -50,6 +50,7 @@ active_modules:
   evse_manager:
     module: EvseManager
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: DE*PNX*E12345*1
       evse_id_din: 49A80737A45678

--- a/config/config-sil-dc-rpcapi.yaml
+++ b/config/config-sil-dc-rpcapi.yaml
@@ -20,6 +20,7 @@ active_modules:
       module:
         evse: 1
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: DE*PNX*E12345*1
       evse_id_din: 49A80737A45678

--- a/config/config-sil-dc-sae-v2g.yaml
+++ b/config/config-sil-dc-sae-v2g.yaml
@@ -17,6 +17,7 @@ active_modules:
   evse_manager:
     module: EvseManager
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: DE*PNX*E12345*1
       evse_id_din: 49A80737A45678

--- a/config/config-sil-dc-sae-v2h.yaml
+++ b/config/config-sil-dc-sae-v2h.yaml
@@ -17,6 +17,7 @@ active_modules:
   evse_manager:
     module: EvseManager
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: DE*PNX*E12345*1
       evse_id_din: 49A80737A45678

--- a/config/config-sil-dc-tls.yaml
+++ b/config/config-sil-dc-tls.yaml
@@ -20,6 +20,7 @@ active_modules:
   evse_manager:
     module: EvseManager
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: DE*PNX*E12345*1
       evse_id_din: 49A80737A45678

--- a/config/config-sil-dc.yaml
+++ b/config/config-sil-dc.yaml
@@ -17,6 +17,7 @@ active_modules:
   evse_manager:
     module: EvseManager
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: DE*PNX*E12345*1
       evse_id_din: 49A80737A45678

--- a/config/config-sil-energy-management.yaml
+++ b/config/config-sil-energy-management.yaml
@@ -19,6 +19,7 @@ active_modules:
       module:
         evse: 1
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: DE*PNX*E12345*1
       session_logging: true
@@ -50,6 +51,7 @@ active_modules:
       module:
         evse: 2
     config_module:
+      enable_nodered_interface: true
       connector_id: 2
       evse_id: DE*PNX*E12345*2
       session_logging: true

--- a/config/config-sil-mcs.yaml
+++ b/config/config-sil-mcs.yaml
@@ -20,6 +20,7 @@ active_modules:
   evse_manager:
     module: EvseManager
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: DE*PNX*E12345*1
       evse_id_din: 49A80737A45678

--- a/config/config-sil-ocpp-API.yaml
+++ b/config/config-sil-ocpp-API.yaml
@@ -21,6 +21,7 @@ active_modules:
         evse: 1
     module: EvseManager
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: "1"
       connector_type: "cType2"
@@ -57,6 +58,7 @@ active_modules:
       module:
         evse: 2
     config_module:
+      enable_nodered_interface: true
       connector_id: 2
       evse_id: "2"
       connector_type: "cType2"

--- a/config/config-sil-ocpp-custom-extension.yaml
+++ b/config/config-sil-ocpp-custom-extension.yaml
@@ -19,6 +19,7 @@ active_modules:
       module:
         evse: 1
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: "1"
       session_logging: true
@@ -47,6 +48,7 @@ active_modules:
       module:
         evse: 2
     config_module:
+      enable_nodered_interface: true
       connector_id: 2
       evse_id: "2"
       session_logging: true

--- a/config/config-sil-ocpp-multi.yaml
+++ b/config/config-sil-ocpp-multi.yaml
@@ -32,6 +32,7 @@ active_modules:
         evse: 1
     module: EvseManager
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: "1"
       connector_type: "cType2"
@@ -68,6 +69,7 @@ active_modules:
       module:
         evse: 2
     config_module:
+      enable_nodered_interface: true
       connector_id: 2
       evse_id: "2"
       connector_type: "cType2"

--- a/config/config-sil-ocpp-pnc.yaml
+++ b/config/config-sil-ocpp-pnc.yaml
@@ -25,6 +25,7 @@ active_modules:
       module:
         evse: 1
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: "DE*PNX*00001"
       session_logging: true
@@ -54,6 +55,7 @@ active_modules:
       module:
         evse: 2
     config_module:
+      enable_nodered_interface: true
       connector_id: 2
       evse_id: "2"
       session_logging: true

--- a/config/config-sil-ocpp.yaml
+++ b/config/config-sil-ocpp.yaml
@@ -21,6 +21,7 @@ active_modules:
         evse: 1
     module: EvseManager
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: "1"
       connector_type: "cType2"
@@ -57,6 +58,7 @@ active_modules:
       module:
         evse: 2
     config_module:
+      enable_nodered_interface: true
       connector_id: 2
       evse_id: "2"
       connector_type: "cType2"

--- a/config/config-sil-ocpp201-pnc.yaml
+++ b/config/config-sil-ocpp201-pnc.yaml
@@ -25,6 +25,7 @@ active_modules:
       module:
         evse: 1
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: "DE*PNX*00001"
       session_logging: true
@@ -52,6 +53,7 @@ active_modules:
       module:
         evse: 2
     config_module:
+      enable_nodered_interface: true
       connector_id: 2
       evse_id: "2"
       session_logging: true

--- a/config/config-sil-ocpp201.yaml
+++ b/config/config-sil-ocpp201.yaml
@@ -19,6 +19,7 @@ active_modules:
       module:
         evse: 1
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: "1"
       connector_type: "cType2"
@@ -49,6 +50,7 @@ active_modules:
       module:
         evse: 2
     config_module:
+      enable_nodered_interface: true
       connector_id: 2
       evse_id: "2"
       connector_type: "cType2"

--- a/config/config-sil-rpcapi.yaml
+++ b/config/config-sil-rpcapi.yaml
@@ -79,6 +79,7 @@ active_modules:
       module:
         evse: 1
     config_module:
+      enable_nodered_interface: true
       ac_enforce_hlc: false
       ac_hlc_enabled: true
       ac_hlc_use_5percent: false

--- a/config/config-sil-two-evse-dc.yaml
+++ b/config/config-sil-two-evse-dc.yaml
@@ -17,6 +17,7 @@ active_modules:
   evse_manager_1:
     module: EvseManager
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: DE*PNX*E12345*1
       evse_id_din: 49A80737A45678
@@ -46,6 +47,7 @@ active_modules:
   evse_manager_2:
     module: EvseManager
     config_module:
+      enable_nodered_interface: true
       connector_id: 2
       evse_id: DE*PNX*E12345*2
       session_logging: true

--- a/config/config-sil-two-evse-rpcapi.yaml
+++ b/config/config-sil-two-evse-rpcapi.yaml
@@ -34,6 +34,7 @@ active_modules:
       module:
         evse: 1
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: DE*PNX*E12345*1
       session_logging: true
@@ -61,6 +62,7 @@ active_modules:
       module:
         evse: 2
     config_module:
+      enable_nodered_interface: true
       connector_id: 2
       evse_id: DE*PNX*E12345*2
       session_logging: true

--- a/config/config-sil-two-evse.yaml
+++ b/config/config-sil-two-evse.yaml
@@ -16,6 +16,7 @@ active_modules:
   evse_manager_1:
     module: EvseManager
     config_module:
+      enable_nodered_interface: true
       connector_id: 1
       evse_id: DE*PNX*E12345*1
       session_logging: true
@@ -40,6 +41,7 @@ active_modules:
   evse_manager_2:
     module: EvseManager
     config_module:
+      enable_nodered_interface: true
       connector_id: 2
       evse_id: DE*PNX*E12345*2
       session_logging: true

--- a/config/config-sil.yaml
+++ b/config/config-sil.yaml
@@ -72,6 +72,7 @@ active_modules:
     module: EnergyManager
   connector_1:
     config_module:
+      enable_nodered_interface: true
       ac_enforce_hlc: false
       ac_hlc_enabled: true
       ac_hlc_use_5percent: false

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -1182,31 +1182,34 @@ void EvseManager::ready() {
             powermeter_cv.notify_one();
 
             // External Nodered interface
-            if (p.phase_seq_error) {
-                mqtt.publish(fmt::format("everest_external/nodered/{}/powermeter/phaseSeqError", config.connector_id),
-                             p.phase_seq_error.value());
+            if (config.enable_nodered_interface) {
+                if (p.phase_seq_error) {
+                    mqtt.publish(
+                        fmt::format("everest_external/nodered/{}/powermeter/phaseSeqError", config.connector_id),
+                        p.phase_seq_error.value());
+                }
+
+                mqtt.publish(fmt::format("everest_external/nodered/{}/powermeter/time_stamp", config.connector_id),
+                             p.timestamp);
+
+                if (p.power_W) {
+                    mqtt.publish(fmt::format("everest_external/nodered/{}/powermeter/totalKw", config.connector_id),
+                                 p.power_W.value().total / 1000., 1);
+                }
+
+                mqtt.publish(fmt::format("everest_external/nodered/{}/powermeter/totalKWattHr", config.connector_id),
+                             p.energy_Wh_import.total / 1000.);
+
+                if (p.energy_Wh_export.has_value()) {
+                    mqtt.publish(
+                        fmt::format("everest_external/nodered/{}/powermeter/totalExportKWattHr", config.connector_id),
+                        p.energy_Wh_export.value().total / 1000.);
+                }
+
+                json j;
+                to_json(j, p);
+                mqtt.publish(fmt::format("everest_external/nodered/{}/powermeter_json", config.connector_id), j.dump());
             }
-
-            mqtt.publish(fmt::format("everest_external/nodered/{}/powermeter/time_stamp", config.connector_id),
-                         p.timestamp);
-
-            if (p.power_W) {
-                mqtt.publish(fmt::format("everest_external/nodered/{}/powermeter/totalKw", config.connector_id),
-                             p.power_W.value().total / 1000., 1);
-            }
-
-            mqtt.publish(fmt::format("everest_external/nodered/{}/powermeter/totalKWattHr", config.connector_id),
-                         p.energy_Wh_import.total / 1000.);
-
-            if (p.energy_Wh_export.has_value()) {
-                mqtt.publish(
-                    fmt::format("everest_external/nodered/{}/powermeter/totalExportKWattHr", config.connector_id),
-                    p.energy_Wh_export.value().total / 1000.);
-            }
-
-            json j;
-            to_json(j, p);
-            mqtt.publish(fmt::format("everest_external/nodered/{}/powermeter_json", config.connector_id), j.dump());
             // /External Nodered interface
         });
     }

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -126,6 +126,7 @@ struct Conf {
     std::string bpt_grid_code_island_method;
     int hlc_charge_loop_without_energy_timeout_s;
     int dc_ramp_ampere_per_second;
+    bool enable_nodered_interface;
 };
 
 class EvseManager : public Everest::ModuleBase {

--- a/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
+++ b/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
@@ -432,8 +432,10 @@ void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
 
         // apply watt limit
         if (value.limits_root_side.total_power_W.has_value()) {
-            mod->mqtt.publish(fmt::format("everest_external/nodered/{}/state/max_watt", mod->config.connector_id),
-                              value.limits_root_side.total_power_W.value().value);
+            if (mod->config.enable_nodered_interface) {
+                mod->mqtt.publish(fmt::format("everest_external/nodered/{}/state/max_watt", mod->config.connector_id),
+                                  value.limits_root_side.total_power_W.value().value);
+            }
             // watt limit converted to current limit
             const float current_limit_power = value.limits_root_side.total_power_W.value().value /
                                               mod->config.ac_nominal_voltage / mod->ac_nr_phases_active;

--- a/modules/EVSE/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EVSE/EvseManager/evse/evse_managerImpl.cpp
@@ -58,31 +58,31 @@ void evse_managerImpl::init() {
     });
 
     // Interface to Node-RED debug UI
+    if (mod->config.enable_nodered_interface) {
+        mod->mqtt.subscribe(fmt::format("everest_external/nodered/{}/cmd/enable", mod->config.connector_id),
+                            [&charger = mod->charger](const std::string& data) {
+                                charger->enable_disable(0, {types::evse_manager::Enable_source::LocalAPI,
+                                                            types::evse_manager::Enable_state::Enable, 100});
+                            });
 
-    mod->mqtt.subscribe(fmt::format("everest_external/nodered/{}/cmd/enable", mod->config.connector_id),
-                        [&charger = mod->charger](const std::string& data) {
-                            charger->enable_disable(0, {types::evse_manager::Enable_source::LocalAPI,
-                                                        types::evse_manager::Enable_state::Enable, 100});
-                        });
+        mod->mqtt.subscribe(fmt::format("everest_external/nodered/{}/cmd/disable", mod->config.connector_id),
+                            [&charger = mod->charger](const std::string& data) {
+                                charger->enable_disable(0, {types::evse_manager::Enable_source::LocalAPI,
+                                                            types::evse_manager::Enable_state::Disable, 100});
+                            });
 
-    mod->mqtt.subscribe(fmt::format("everest_external/nodered/{}/cmd/disable", mod->config.connector_id),
-                        [&charger = mod->charger](const std::string& data) {
-                            charger->enable_disable(0, {types::evse_manager::Enable_source::LocalAPI,
-                                                        types::evse_manager::Enable_state::Disable, 100});
-                        });
+        mod->mqtt.subscribe(
+            fmt::format("everest_external/nodered/{}/cmd/switch_three_phases_while_charging", mod->config.connector_id),
+            [&charger = mod->charger](const std::string& data) {
+                charger->switch_three_phases_while_charging(str_to_bool(data));
+            });
 
-    mod->mqtt.subscribe(
-        fmt::format("everest_external/nodered/{}/cmd/switch_three_phases_while_charging", mod->config.connector_id),
-        [&charger = mod->charger](const std::string& data) {
-            charger->switch_three_phases_while_charging(str_to_bool(data));
-        });
+        mod->mqtt.subscribe(fmt::format("everest_external/nodered/{}/cmd/pause_charging", mod->config.connector_id),
+                            [&charger = mod->charger](const std::string& data) { charger->pause_charging(); });
 
-    mod->mqtt.subscribe(fmt::format("everest_external/nodered/{}/cmd/pause_charging", mod->config.connector_id),
-                        [&charger = mod->charger](const std::string& data) { charger->pause_charging(); });
-
-    mod->mqtt.subscribe(fmt::format("everest_external/nodered/{}/cmd/resume_charging", mod->config.connector_id),
-                        [&charger = mod->charger](const std::string& data) { charger->resume_charging(); });
-
+        mod->mqtt.subscribe(fmt::format("everest_external/nodered/{}/cmd/resume_charging", mod->config.connector_id),
+                            [&charger = mod->charger](const std::string& data) { charger->resume_charging(); });
+    }
     // /Interface to Node-RED debug UI
 
     if (mod->r_powermeter_billing().size() > 0) {
@@ -115,8 +115,10 @@ void evse_managerImpl::ready() {
 
     mod->r_bsp->subscribe_telemetry([this](types::evse_board_support::Telemetry telemetry) {
         // external Nodered interface
-        mod->mqtt.publish(fmt::format("everest_external/nodered/{}/state/temperature", mod->config.connector_id),
-                          telemetry.evse_temperature_C);
+        if (mod->config.enable_nodered_interface) {
+            mod->mqtt.publish(fmt::format("everest_external/nodered/{}/state/temperature", mod->config.connector_id),
+                              telemetry.evse_temperature_C);
+        }
         // external Nodered interface
         publish_telemetry(telemetry);
     });
@@ -386,19 +388,24 @@ void evse_managerImpl::ready() {
     // Note: Deprecated. Only kept for Node red compatibility, will be removed in the future
     // Legacy external mqtt pubs
     mod->charger->signal_max_current.connect([this](float c) {
-        mod->mqtt.publish(fmt::format("everest_external/nodered/{}/state/max_current", mod->config.connector_id), c);
+        if (mod->config.enable_nodered_interface) {
+            mod->mqtt.publish(fmt::format("everest_external/nodered/{}/state/max_current", mod->config.connector_id),
+                              c);
+        }
 
         limits.uuid = mod->info.id;
         limits.max_current = c;
         publish_limits(limits);
     });
 
-    mod->charger->signal_state.connect([this](Charger::EvseState s) {
-        mod->mqtt.publish(fmt::format("everest_external/nodered/{}/state/state_string", mod->config.connector_id),
-                          mod->charger->evse_state_to_string(s));
-        mod->mqtt.publish(fmt::format("everest_external/nodered/{}/state/state", mod->config.connector_id),
-                          static_cast<int>(s));
-    });
+    if (mod->config.enable_nodered_interface) {
+        mod->charger->signal_state.connect([this](Charger::EvseState s) {
+            mod->mqtt.publish(fmt::format("everest_external/nodered/{}/state/state_string", mod->config.connector_id),
+                              mod->charger->evse_state_to_string(s));
+            mod->mqtt.publish(fmt::format("everest_external/nodered/{}/state/state", mod->config.connector_id),
+                              static_cast<int>(s));
+        });
+    }
 }
 
 types::evse_manager::Evse evse_managerImpl::handle_get_evse() {

--- a/modules/EVSE/EvseManager/manifest.yaml
+++ b/modules/EVSE/EvseManager/manifest.yaml
@@ -446,6 +446,14 @@ config:
       Maximum ampere per second limit for up/down ramping of current in charging loop.
     type: integer
     default: 25
+  enable_nodered_interface:
+    description: >-
+      Enable the external MQTT interface to the Node-RED debug UI (topics below
+      everest_external/nodered/<connector_id>/). This publishes powermeter and state
+      updates and subscribes to UI commands (enable/disable/pause/resume/phase switch).
+      Only needed when the Node-RED simulation/debug UI is used.
+    type: boolean
+    default: false
 provides:
   evse:
     interface: evse_manager


### PR DESCRIPTION
## Describe your changes

Gates all external MQTT topics for the Node-RED debug UI (`everest_external/nodered/<connector_id>/...`) behind the new config option `enable_nodered_interface`, default off. This covers the per-powermeter-sample publishes (including a full JSON serialization of every sample), the state/limit publishes and the five UI command subscriptions.

The SIL configs enable the option explicitly since they are meant to be used with the Node-RED UI, so their behavior is unchanged.

## Issue ticket number and link

None.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
