### PR TITLE
perf(framework): remove per-message json copies in the pub/sub path

### DIFF
--- a/lib/everest/framework/include/utils/message_handler.hpp
+++ b/lib/everest/framework/include/utils/message_handler.hpp
@@ -45,7 +45,7 @@ public:
     ~MessageHandler();
 
     /// \brief Adds given \p message to the message queue for processing
-    void add(const ParsedMessage& message);
+    void add(ParsedMessage message);
 
     /// \brief Stops all threads started by this handler
     void stop();

--- a/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
+++ b/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
@@ -112,7 +112,7 @@ private:
 
     void on_mqtt_message();
     void on_mqtt_connect();
-    void handle_mqtt_message(const Message& message);
+    void handle_mqtt_message(Message&& message);
 
     void on_mqtt_disconnect();
     nlohmann::json get_internal(const MQTTRequest& request);

--- a/lib/everest/framework/include/utils/types.hpp
+++ b/lib/everest/framework/include/utils/types.hpp
@@ -25,14 +25,13 @@ using Command = std::function<Result(const Parameters&)>;
 using ArgumentType = std::vector<std::string>;
 using Arguments = std::map<std::string, ArgumentType>;
 using ReturnType = std::vector<std::string>;
-using JsonCallback = std::function<void(json)>;
-using ValueCallback = std::function<void(Value)>;
+using JsonCallback = std::function<void(const json&)>;
+using ValueCallback = std::function<void(const Value&)>;
 using ConfigMap = std::map<std::string, everest::config::ConfigEntry>;
 using ModuleConfigs = std::map<std::string, ConfigMap>;
 using Array = json::array_t;
 using Object = json::object_t;
-// TODO (aw): can we pass the handler arguments by const ref?
-using Handler = std::function<void(const std::string&, json)>;
+using Handler = std::function<void(const std::string&, const json&)>;
 using StringHandler = std::function<void(std::string)>;
 using StringPairHandler = std::function<void(const std::string& topic, const std::string& data)>;
 

--- a/lib/everest/framework/lib/everest.cpp
+++ b/lib/everest/framework/lib/everest.cpp
@@ -544,7 +544,11 @@ void Everest::publish_var(const std::string& impl_id, const std::string& var_nam
 
     const auto var_topic = fmt::format("{}/var/{}", this->config.mqtt_prefix(this->module_id, impl_id), var_name);
 
-    MqttMessagePayload payload{MqttMessageType::Var, json{{"data", value}}};
+    // Serialize the message directly instead of deep-copying `value` through two json envelopes
+    // (json{{"data", value}} + adl_serializer<MqttMessagePayload>). The produced bytes must stay
+    // identical to dumping MqttMessagePayload{MqttMessageType::Var, json{{"data", value}}}.
+    const std::string payload = fmt::format(R"({{"data":{{"data":{}}},"msg_type":"{}"}})", value.dump(),
+                                            mqtt_message_type_to_string(MqttMessageType::Var));
 
     // FIXME(kai): implement an efficient way of choosing qos for each variable
     this->mqtt_abstraction->publish(var_topic, payload, QOS::QOS2);

--- a/lib/everest/framework/lib/message_handler.cpp
+++ b/lib/everest/framework/lib/message_handler.cpp
@@ -115,7 +115,7 @@ MessageHandler::~MessageHandler() {
     stop();
 }
 
-void MessageHandler::add(const ParsedMessage& message) {
+void MessageHandler::add(ParsedMessage message) {
     // Once stopped (during teardown) no further messages must be dispatched: doing so could
     // enqueue work or spawn the ready thread after the worker threads have been joined and
     // while the objects the handlers reference are being destroyed.
@@ -136,7 +136,7 @@ void MessageHandler::add(const ParsedMessage& message) {
 
     if (msg_type == MqttMessageType::CmdResult || msg_type == MqttMessageType::ConfigurationResponse) {
         EVLOG_verbose << "Pushing cmd_result message to queue: " << message.data;
-        result_message_queue.push(message);
+        result_message_queue.push(std::move(message));
     } else if (msg_type == MqttMessageType::GlobalReady) {
         const auto topic_copy = message.topic;
         const auto data_copy = message.data.at("data");
@@ -163,9 +163,9 @@ void MessageHandler::add(const ParsedMessage& message) {
             old_ready.join();
         }
     } else if (msg_type == MqttMessageType::ExternalMQTT) {
-        external_mqtt_message_queue.push(message);
+        external_mqtt_message_queue.push(std::move(message));
     } else {
-        operation_message_queue.push(message);
+        operation_message_queue.push(std::move(message));
     }
 }
 

--- a/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
+++ b/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
@@ -413,17 +413,17 @@ void MQTTAbstractionImpl::on_mqtt_message() {
         if (not msg.has_value()) {
             break;
         }
-        handle_mqtt_message(msg.value());
+        handle_mqtt_message(std::move(msg.value()));
     }
 }
 
-void MQTTAbstractionImpl::handle_mqtt_message(const Message& message) {
+void MQTTAbstractionImpl::handle_mqtt_message(Message&& message) {
     BOOST_LOG_FUNCTION();
 
     EVLOG_verbose << "Incoming MQTT message. topic: " << message.topic << " payload: " << message.payload;
 
-    const auto& topic = message.topic;
-    const auto& payload = message.payload;
+    auto& topic = message.topic;
+    auto& payload = message.payload;
 
     try {
         std::string_view topic_view = topic;
@@ -432,7 +432,9 @@ void MQTTAbstractionImpl::handle_mqtt_message(const Message& message) {
             topic_view.compare(0, mqtt_everest_prefix_view.size(), mqtt_everest_prefix_view) == 0) {
             EVLOG_verbose << fmt::format("topic {} starts with {}", topic, mqtt_everest_prefix);
             try {
-                this->message_handler.add(ParsedMessage{std::move(topic), json::parse(payload.begin(), payload.end())});
+                // parse before moving the topic, so the error path below can still log it
+                auto data = json::parse(payload.begin(), payload.end());
+                this->message_handler.add(ParsedMessage{std::move(topic), std::move(data)});
             } catch (nlohmann::detail::parse_error& e) {
                 EVLOG_warning << fmt::format("Could not decode json for incoming topic '{}': {}", topic, payload);
                 return;


### PR DESCRIPTION
## Describe your changes

Removes redundant JSON DOM copies in the framework's pub/sub message path:

- Pass callback arguments by const reference: `JsonCallback`, `ValueCallback` and `Handler` took their json argument by value, which deep-copied the JSON DOM twice per registered handler for every incoming message (resolves the TODO in `utils/types.hpp`). All wrapped lambdas and the generated module code already declare `const&` parameters, so this is source-compatible.
- Move incoming messages instead of copying: `MessageHandler::add` now takes its `ParsedMessage` by value and moves it into the worker queues, and `handle_mqtt_message` takes the `Message` as rvalue so the previously no-op `std::move(topic)`/`std::move(payload)` (bound as `const auto&`) actually move. The json payload is parsed before the topic is moved so the parse-error path can still log the topic.
- Serialize var publishes once: `publish_var` built the wire message by copying the value through two json envelopes (`json{{"data", value}}` plus the implicit `adl_serializer<MqttMessagePayload>` conversion). It now serializes directly into the payload string. The wire format (`{"data":{"data":<value>},"msg_type":"Var"}`) is unchanged, verified byte-identical in a SIL run.

For a topic with N in-process subscribers this removes 2N+3 JSON DOM deep copies and 2 payload string copies per message.

## Issue ticket number and link

None.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (no documentation changes needed - internal implementation only, wire format unchanged)
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
