### PR TITLE
fix(libiso15118): Adding reset state.new_data to prevent blocking the whole session

### DIFF
--- a/lib/everest/iso15118/src/iso15118/session/iso.cpp
+++ b/lib/everest/iso15118/src/iso15118/session/iso.cpp
@@ -238,7 +238,8 @@ TimePoint const& Session::poll() {
 
         message_exchange.set_request(make_variant_from_packet(packet));
 
-        packet = {}; // reset the packet
+        packet = {};            // reset the packet
+        state.new_data = false; // reset new_data flag
 
         const auto request_msg_type = ctx.peek_request_type();
 


### PR DESCRIPTION
## Describe your changes
Adding a reset for preventing blocking the whole session.

## Issue ticket number and link
In case that the TCP/TLS fd is blocking the whole session is blocked while reading on the fd. libiso15118 is using typically s non-blocking socket but with the new mechanism to pass already connected/open fd it could happen that the fd is blocking.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

