### PR TITLE
fix(slac_API): align AsyncAPI spec with implementation

### DIFF
--- a/docs/source/reference/EVerest_API/slac_API.yaml
+++ b/docs/source/reference/EVerest_API/slac_API.yaml
@@ -232,8 +232,7 @@ components:
         $ref: '#/components/schemas/SLACState'
       examples:
         - summary: "Example state MATCHED"
-          payload:
-            "state": "MATCHED"
+          payload: "MATCHED"
     send_dlink_ready:
       name: send_dlink_ready
       title: 'Dlink ready'
@@ -245,8 +244,7 @@ components:
         $ref: '#/components/schemas/DLinkStatus'
       examples:
         - summary: "Example dlink_ready true"
-          payload:
-            "dlink_ready": true
+          payload: true
     send_request_error_routine:
       name: send_request_error_routine
       title: 'Request error routine'
@@ -266,8 +264,7 @@ components:
         $ref: '#/components/schemas/MACAddress'
       examples:
         - summary: "Example MAC address"
-          payload:
-            "ev_mac_address": "AA:BB:CC:DD:EE:FF"
+          payload: "AA:BB:CC:DD:EE:FF"
 
     send_raise_error:
       name: send_raise_error
@@ -326,33 +323,29 @@ components:
       type: boolean
       description: 'true: start SLAC after reset, false: stop SLAC'
     SLACState:
-      type: object
-      properties:
-        state:
-          type: string
-          description: Provides the state enum.
-          enum:
-            - UNMATCHED
-            - MATCHING
-            - MATCHED
+      description: Provides the state enum.
+      type: string
+      enum:
+        - UNMATCHED
+        - MATCHING
+        - MATCHED
     DLinkStatus:
-      type: object
-      properties:
-        dlink_ready:
-          type: boolean
-          description: >-
-            Inform higher layers about a change in data link status. Emits true
-            if link was set up and false when the link is shut down.
+      description: >-
+        Inform higher layers about a change in data link status. Emits true
+        if link was set up and false when the link is shut down.
+      type: boolean
     MACAddress:
-      type: object
-      properties:
-        ev_mac_address:
-          type: string
-          description: >-
-            Inform higher layers about the MAC address of the vehicle (upper case)
-          pattern: ^[A-F0-9]{2}(:[A-F0-9]{2}){5}$
+      description: >-
+        Inform higher layers about the MAC address of the vehicle (upper case)
+      type: string
+      pattern: ^[A-F0-9]{2}(:[A-F0-9]{2}){5}$
     Error:
+      description: >-
+        Error object with type, subtype and message.
       type: object
+      additionalProperties: true
+      required:
+        - type
       properties:
         type:
           $ref: '#/components/schemas/ErrorEnum'
@@ -363,12 +356,16 @@ components:
           type: string
           description: Addition information about the error
     ErrorEnum:
-      type: string
       description: |
         Type of Error
         - CommunicationFault: 'The communication to the hardware or underlying driver is lost or has errors.'
         - VendorError: 'Vendor specific error code. Will stop charging session.'
         - VendorWarning: 'Vendor specific error code. Charging may continue.'
+      type: string
+      enum:
+        - CommunicationFault
+        - VendorError
+        - VendorWarning
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"


### PR DESCRIPTION
## Describe your changes

SLACState, DLinkStatus and MACAddress were documented as wrapper objects, but the module sends and expects bare JSON values (string enum, boolean, string). Also add the missing enum list to ErrorEnum and align the Error schema with the other API definitions.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

