### PR TITLE
chore: add mlitre as EnergyManager codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,7 +33,7 @@
 /modules/API/ @hikinggrass @pietfried @corneliusclaussen @djchhp @SebaLukas @james-ctc @cburandt @florinmihut
 /modules/API/RpcApi/ @FaHaGit @barsnick @corneliusclaussen @hikinggrass @pietfried @SebaLukas @mlitre
 /modules/EnergyManagement/EEBUS/ @mlitre @andistorm @hikinggrass @pietfried
-/modules/EnergyManagement/EnergyManager/ @corneliusclaussen @hikinggrass @pietfried
+/modules/EnergyManagement/EnergyManager/ @corneliusclaussen @hikinggrass @pietfried @mlitre
 /modules/EnergyManagement/EnergyNode/ @corneliusclaussen @hikinggrass @pietfried
 /modules/EV/EvManager/ @SebaLukas @pietfried @james-ctc @mlitre
 /modules/EV/PyEvJosev/ @SebaLukas @corneliusclaussen @pietfried @james-ctc @mlitre

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,7 +34,7 @@
 /modules/API/RpcApi/ @FaHaGit @barsnick @corneliusclaussen @hikinggrass @pietfried @SebaLukas @mlitre
 /modules/EnergyManagement/EEBUS/ @mlitre @andistorm @hikinggrass @pietfried
 /modules/EnergyManagement/EnergyManager/ @corneliusclaussen @hikinggrass @pietfried @mlitre
-/modules/EnergyManagement/EnergyNode/ @corneliusclaussen @hikinggrass @pietfried
+/modules/EnergyManagement/EnergyNode/ @corneliusclaussen @hikinggrass @pietfried @mlitre
 /modules/EV/EvManager/ @SebaLukas @pietfried @james-ctc @mlitre
 /modules/EV/PyEvJosev/ @SebaLukas @corneliusclaussen @pietfried @james-ctc @mlitre
 /modules/EVSE/Auth/ @pietfried @corneliusclaussen @hikinggrass @mlitre


### PR DESCRIPTION
Adds @mlitre as a codeowner for `/modules/EnergyManagement/EnergyManager/`.