### PR TITLE
fix(EvseManager): remove race in ~Charger()

### DIFF
--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -87,6 +87,9 @@ Charger::~Charger() {
     cp_state_F();
     // need to send an event to wake up processing
     error_handling_event_queue.push(ErrorHandlingEvents::ForceEmergencyShutdown);
+    // The event above may already be consumed when stop() sets the exit signal below, leaving
+    // the error thread blocked in wait() forever with stop() never joining it.
+    error_handling_event_queue.stop();
     error_thread_handle.stop();
 }
 
@@ -120,9 +123,7 @@ void Charger::main_thread() {
 
 void Charger::error_thread() {
     for (;;) {
-        if (error_thread_handle.shouldExit()) {
-            break;
-        }
+        // blocks until an event is pushed or the queue is stopped
         auto events = error_handling_event_queue.wait();
         if (!events.empty()) {
             Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_signal_loop);
@@ -146,6 +147,12 @@ void Charger::error_thread() {
                     break;
                 }
             }
+        }
+
+        // checked after processing so events queued before the shutdown are still handled, and
+        // via is_stopped() too because shouldExit() may still be false when wait() is re-entered
+        if (error_thread_handle.shouldExit() or error_handling_event_queue.is_stopped()) {
+            break;
         }
     }
 }

--- a/modules/EVSE/EvseManager/EventQueue.hpp
+++ b/modules/EVSE/EvseManager/EventQueue.hpp
@@ -17,10 +17,28 @@ public:
 
 private:
     events_t pending;
-    std::mutex mux;
+    mutable std::mutex mux;
     std::condition_variable cv;
+    bool stopped{false};
 
 public:
+    /// @brief Unblock all waiters and let further waits return immediately, one way operation.
+    /// @details Already pending events are still delivered. Consumers using wait_for() must check
+    ///          is_stopped() to leave their loop, otherwise they spin.
+    void stop() {
+        {
+            std::lock_guard<std::mutex> lock(mux);
+            stopped = true;
+        }
+        cv.notify_all();
+    }
+
+    /// @brief true once stop() has been called
+    bool is_stopped() const {
+        std::lock_guard<std::mutex> lock(mux);
+        return stopped;
+    }
+
     void push(const E& event) {
         {
             std::lock_guard<std::mutex> lock(mux);
@@ -38,7 +56,7 @@ public:
 
     events_t wait() {
         std::unique_lock<std::mutex> ul(mux);
-        cv.wait(ul, [this]() { return !pending.empty(); });
+        cv.wait(ul, [this]() { return !pending.empty() or stopped; });
         events_t active;
         pending.swap(active);
         ul.unlock();
@@ -47,7 +65,7 @@ public:
 
     template <class Rep, class Period> events_t wait_for(const std::chrono::duration<Rep, Period>& rel_time) {
         std::unique_lock<std::mutex> ul(mux);
-        if (!cv.wait_for(ul, rel_time, [this]() { return !pending.empty(); })) {
+        if (!cv.wait_for(ul, rel_time, [this]() { return !pending.empty() or stopped; })) {
             return {};
         }
         events_t active;

--- a/modules/EVSE/EvseManager/tests/EventQueueTest.cpp
+++ b/modules/EVSE/EvseManager/tests/EventQueueTest.cpp
@@ -3,6 +3,7 @@
 #include <EventQueue.hpp>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <condition_variable>
 #include <mutex>
 #include <thread>
@@ -89,6 +90,84 @@ TEST(EventQueue, wait) {
     EXPECT_EQ(events.size(), 0);
 
     wait_thread.join();
+}
+
+TEST(EventQueue, stop_unblocks_wait) {
+    module::EventQueue<ErrorHandlingEvents> queue;
+
+    std::condition_variable cv;
+    std::mutex mux;
+    bool waiting{false};
+    bool returned{false};
+    std::size_t count = 0;
+
+    std::thread wait_thread([&cv, &mux, &queue, &waiting, &returned, &count]() {
+        {
+            std::lock_guard<std::mutex> lock(mux);
+            waiting = true;
+        }
+        cv.notify_one();
+        const auto events = queue.wait();
+        {
+            std::lock_guard<std::mutex> lock(mux);
+            count = events.size();
+            returned = true;
+        }
+        cv.notify_one();
+    });
+
+    std::unique_lock<std::mutex> ul(mux);
+    cv.wait(ul, [&waiting] { return waiting; });
+    EXPECT_FALSE(returned);
+
+    // stop() must interrupt a blocking wait(), otherwise ~Charger() cannot join the error thread
+    queue.stop();
+
+    const auto unblocked = cv.wait_for(ul, std::chrono::seconds(1), [&returned] { return returned; });
+    EXPECT_TRUE(unblocked) << "wait() was not interrupted by stop()";
+    if (unblocked) {
+        EXPECT_EQ(count, 0U);
+    } else {
+        // release the thread so that the test reports a failure instead of hanging in join()
+        ul.unlock();
+        queue.push(ErrorHandlingEvents::PreventCharging);
+        ul.lock();
+        cv.wait(ul, [&returned] { return returned; });
+    }
+    ul.unlock();
+
+    wait_thread.join();
+}
+
+TEST(EventQueue, stop_keeps_pending_events) {
+    module::EventQueue<ErrorHandlingEvents> queue;
+
+    // an event queued before the stop must still be delivered, otherwise ~Charger() would drop
+    // its ForceEmergencyShutdown
+    queue.push(ErrorHandlingEvents::PreventCharging);
+    queue.stop();
+    EXPECT_TRUE(queue.is_stopped());
+
+    // safe to block on, the event queued above satisfies the predicate either way
+    auto events = queue.wait();
+    ASSERT_EQ(events.size(), 1);
+    EXPECT_EQ(events[0], ErrorHandlingEvents::PreventCharging);
+
+    // the queue is drained now, stop_unblocks_wait_for covers that a further wait returns at once
+    events = queue.get_events();
+    EXPECT_EQ(events.size(), 0);
+}
+
+TEST(EventQueue, stop_unblocks_wait_for) {
+    module::EventQueue<ErrorHandlingEvents> queue;
+    queue.stop();
+
+    const auto start = std::chrono::steady_clock::now();
+    const auto events = queue.wait_for(std::chrono::seconds(5));
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_EQ(events.size(), 0);
+    EXPECT_LT(elapsed, std::chrono::seconds(1)) << "wait_for() ignored the stop and waited for the timeout";
 }
 
 } // namespace


### PR DESCRIPTION
## Describe your changes
Fixing one aspect of the EvseManager shutdow that likely caused a flaky test.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

