### PR TITLE
fix(Evse15118D20): repair ev-cli auto-generation markers

### DIFF
--- a/modules/EVSE/Evse15118D20/Evse15118D20.cpp
+++ b/modules/EVSE/Evse15118D20/Evse15118D20.cpp
@@ -17,6 +17,12 @@ void Evse15118D20::ready() {
     invoke_ready(*p_charger);
 }
 
+void Evse15118D20::shutdown() {
+    invoke_shutdown(*p_charger);
+    invoke_shutdown(*p_extensions);
+    invoke_shutdown(*p_grid_support);
+}
+
 void Evse15118D20::set_active_der_directives(const types::grid_support::ActiveDirectiveSet& directives) {
     *active_der_directives.handle() = directives;
 }

--- a/modules/EVSE/Evse15118D20/Evse15118D20.hpp
+++ b/modules/EVSE/Evse15118D20/Evse15118D20.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 2
+// template version 3
 //
 
 #include "ld-ev.hpp"
@@ -87,6 +87,7 @@ private:
     friend class LdEverest;
     void init();
     void ready();
+    void shutdown();
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here

--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -323,6 +323,9 @@ void ISO15118_chargerImpl::ready() {
     }
 }
 
+void ISO15118_chargerImpl::shutdown() {
+}
+
 void ISO15118_chargerImpl::update_supported_vas_services() {
     iso15118::d20::SupportedVASs supported_vas_services;
 

--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.hpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/ISO15118_charger/Implementation.hpp>
@@ -88,6 +88,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     iso15118::session::feedback::Callbacks create_callbacks();

--- a/modules/EVSE/Evse15118D20/extensions/iso15118_extensionsImpl.cpp
+++ b/modules/EVSE/Evse15118D20/extensions/iso15118_extensionsImpl.cpp
@@ -12,6 +12,9 @@ void iso15118_extensionsImpl::init() {
 void iso15118_extensionsImpl::ready() {
 }
 
+void iso15118_extensionsImpl::shutdown() {
+}
+
 void iso15118_extensionsImpl::handle_set_get_certificate_response(
     types::iso15118::ResponseExiStreamStatus& certificate_response) {
     // your code for cmd set_get_certificate_response goes here

--- a/modules/EVSE/Evse15118D20/extensions/iso15118_extensionsImpl.hpp
+++ b/modules/EVSE/Evse15118D20/extensions/iso15118_extensionsImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/iso15118_extensions/Implementation.hpp>
@@ -46,6 +46,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/EVSE/Evse15118D20/grid_support/grid_supportImpl.cpp
+++ b/modules/EVSE/Evse15118D20/grid_support/grid_supportImpl.cpp
@@ -12,6 +12,9 @@ void grid_supportImpl::init() {
 void grid_supportImpl::ready() {
 }
 
+void grid_supportImpl::shutdown() {
+}
+
 types::grid_support::SetDirectivesResponse
 grid_supportImpl::handle_set_active_directives(types::grid_support::ActiveDirectiveSet& directives) {
     if (not directives.directives.empty()) {

--- a/modules/EVSE/Evse15118D20/grid_support/grid_supportImpl.hpp
+++ b/modules/EVSE/Evse15118D20/grid_support/grid_supportImpl.hpp
@@ -5,17 +5,17 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/grid_support/Implementation.hpp>
 
 #include "../Evse15118D20.hpp"
 
-// ev@9d65c5b8-78c2-4208-95b5-ed872434a08d:v1
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 // insert your custom include headers here
 #include <mutex>
-// ev@9d65c5b8-78c2-4208-95b5-ed872434a08d:v1
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 
 namespace module {
 namespace grid_support {
@@ -28,18 +28,18 @@ public:
     grid_supportImpl(Everest::ModuleAdapter* ev, const Everest::PtrContainer<Evse15118D20>& mod, Conf& config) :
         grid_supportImplBase(ev, "grid_support"), mod(mod), config(config){};
 
-    // ev@ce703c19-c14d-4f4b-8056-2ad0f5dd0070:v1
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
     // insert your public definitions here
-    // ev@ce703c19-c14d-4f4b-8056-2ad0f5dd0070:v1
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
 
 protected:
     // command handler functions (virtual)
     virtual types::grid_support::SetDirectivesResponse
     handle_set_active_directives(types::grid_support::ActiveDirectiveSet& directives) override;
 
-    // ev@d37d73a2-baca-45a7-9089-521171267dd9:v1
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
     // insert your protected definitions here
-    // ev@d37d73a2-baca-45a7-9089-521171267dd9:v1
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
 
 private:
     const Everest::PtrContainer<Evse15118D20>& mod;
@@ -47,18 +47,19 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
-    // ev@d014281f-feb6-4c48-8134-117ade18f2ba:v1
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here
     // Logged once when the first non-empty directive set arrives: directives are relayed to the EV
     // at the next V2G session (next-session-dynamic), not applied mid-session.
     std::once_flag directive_relay_log_flag;
-    // ev@d014281f-feb6-4c48-8134-117ade18f2ba:v1
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 
-// ev@e05d7d33-4bca-4f9f-bc15-b2d61d72b99f:v1
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
 // insert other definitions here
-// ev@e05d7d33-4bca-4f9f-bc15-b2d61d72b99f:v1
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
 
 } // namespace grid_support
 } // namespace module


### PR DESCRIPTION
## Describe your changes

`ev-cli mod update EVSE/Evse15118D20` failed because `grid_supportImpl.hpp` used invalid block UUIDs in its auto-generation markers.

- Replace them with the canonical ev-cli block IDs
- Apply the pending template updates: `shutdown()` declarations plus empty stubs in the module and impl classes (behavior-neutral)

`ev-cli mod update` now completes with a zero diff, including a forced update of all generated headers. Module builds and links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)