### PR TITLE
fix(modules): make the modules that lose code regenerate cleanly

### DIFF
--- a/modules/EVSE/EvseSlac/EvseSlac.cpp
+++ b/modules/EVSE/EvseSlac/EvseSlac.cpp
@@ -12,4 +12,8 @@ void EvseSlac::ready() {
     invoke_ready(*p_main);
 }
 
+void EvseSlac::shutdown() {
+    invoke_shutdown(*p_main);
+}
+
 } // namespace module

--- a/modules/EVSE/EvseSlac/EvseSlac.hpp
+++ b/modules/EVSE/EvseSlac/EvseSlac.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 2
+// template version 3
 //
 
 #include "ld-ev.hpp"
@@ -43,6 +43,7 @@ private:
     friend class LdEverest;
     void init();
     void ready();
+    void shutdown();
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here

--- a/modules/EVSE/EvseSlac/main/fsm_controller.cpp
+++ b/modules/EVSE/EvseSlac/main/fsm_controller.cpp
@@ -42,6 +42,16 @@ bool FSMController::signal_simple_event(slac::fsm::evse::Event ev) {
     return event_result == fsm::HandleEventResult::SUCCESS;
 }
 
+void FSMController::quit() {
+    {
+        const std::lock_guard<std::mutex> feed_lck(feed_mtx);
+        quit_requested = true;
+        new_event = true;
+    }
+
+    new_event_cv.notify_all();
+}
+
 void FSMController::run() {
     ctx.log_info("Starting the SLAC state machine");
 
@@ -51,7 +61,7 @@ void FSMController::run() {
 
     running = true;
 
-    while (true) {
+    while (not quit_requested) {
         auto feed_result = fsm.feed();
 
         if (feed_result.transition()) {
@@ -65,10 +75,11 @@ void FSMController::run() {
                 // call feed directly again
                 continue;
             }
-            new_event_cv.wait_for(feed_lck, std::chrono::milliseconds(timeout), [this] { return new_event; });
+            new_event_cv.wait_for(feed_lck, std::chrono::milliseconds(timeout),
+                                  [this] { return new_event or quit_requested; });
         } else {
             // nothing happened, no return value -> wait for new event
-            new_event_cv.wait(feed_lck, [this] { return new_event; });
+            new_event_cv.wait(feed_lck, [this] { return new_event or quit_requested; });
         }
 
         if (new_event) {
@@ -76,4 +87,8 @@ void FSMController::run() {
             new_event = false;
         }
     }
+
+    running = false;
+
+    ctx.log_info("Stopped the SLAC state machine");
 }

--- a/modules/EVSE/EvseSlac/main/fsm_controller.hpp
+++ b/modules/EVSE/EvseSlac/main/fsm_controller.hpp
@@ -18,12 +18,16 @@ public:
     bool signal_leave_bcd();
     void run();
 
+    /// \brief Makes run() return; safe to call from another thread.
+    void quit();
+
 private:
     bool signal_simple_event(slac::fsm::evse::Event ev);
     slac::fsm::evse::Context& ctx;
     slac::fsm::evse::FSM fsm;
 
     bool running{false};
+    bool quit_requested{false};
 
     std::mutex feed_mtx;
     std::condition_variable new_event_cv;

--- a/modules/EVSE/EvseSlac/main/slacImpl.cpp
+++ b/modules/EVSE/EvseSlac/main/slacImpl.cpp
@@ -120,6 +120,15 @@ void slacImpl::ready() {
     }
 }
 
+void slacImpl::shutdown() {
+    // The SLAC I/O loop feeds the state machine, so it has to be stopped first.
+    slac_io.quit();
+
+    if (fsm_ctrl) {
+        fsm_ctrl->quit();
+    }
+}
+
 void slacImpl::handle_reset(bool& enable) {
     if (not fsm_ctrl) {
         return;

--- a/modules/EVSE/EvseSlac/main/slacImpl.hpp
+++ b/modules/EVSE/EvseSlac/main/slacImpl.hpp
@@ -5,18 +5,17 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
-#include "fsm_controller.hpp"
-#include <everest/slac/io.hpp>
 #include <generated/interfaces/slac/Implementation.hpp>
-#include <slac/slac.hpp>
 
 #include "../EvseSlac.hpp"
 
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
-// insert your custom include headers here
+#include "fsm_controller.hpp"
+#include <everest/slac/io.hpp>
+#include <slac/slac.hpp>
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 
 namespace module {
@@ -72,6 +71,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     slac::fsm::evse::Context fsm_ctx;

--- a/modules/EVSE/OCPP/OCPP.cpp
+++ b/modules/EVSE/OCPP/OCPP.cpp
@@ -1133,6 +1133,15 @@ void OCPP::ready() {
     this->started = true;
 }
 
+void OCPP::shutdown() {
+    invoke_shutdown(*p_main);
+    invoke_shutdown(*p_auth_validator);
+    invoke_shutdown(*p_auth_provider);
+    invoke_shutdown(*p_data_transfer);
+    invoke_shutdown(*p_ocpp_generic);
+    invoke_shutdown(*p_session_cost);
+}
+
 int32_t OCPP::get_ocpp_connector_id(int32_t evse_id, int32_t connector_id) {
     return this->evse_connector_map.at(evse_id).at(connector_id);
 }

--- a/modules/EVSE/OCPP/OCPP.hpp
+++ b/modules/EVSE/OCPP/OCPP.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 2
+// template version 3
 //
 
 #include "ld-ev.hpp"
@@ -69,13 +69,15 @@ struct Event {
 };
 
 using EvseConnectorMap = std::map<int32_t, std::map<int32_t, int32_t>>;
-// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
-
 namespace module {
 
 // Shared OCPP module support code lives in lib/everest/ocpp_module_common;
 // pull the names into the module namespace to keep call sites unchanged.
 namespace conversions = ocpp_module_common::v16::conversions;
+} // namespace module
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+
+namespace module {
 
 struct Conf {
     std::string ChargePointConfigPath;
@@ -175,6 +177,7 @@ private:
     friend class LdEverest;
     void init();
     void ready();
+    void shutdown();
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPP/auth_provider/auth_token_providerImpl.cpp
+++ b/modules/EVSE/OCPP/auth_provider/auth_token_providerImpl.cpp
@@ -12,5 +12,9 @@ void auth_token_providerImpl::init() {
 void auth_token_providerImpl::ready() {
 }
 
+void auth_token_providerImpl::shutdown() {
+    // no resources of its own to release, all OCPP state is owned by the module
+}
+
 } // namespace auth_provider
 } // namespace module

--- a/modules/EVSE/OCPP/auth_provider/auth_token_providerImpl.hpp
+++ b/modules/EVSE/OCPP/auth_provider/auth_token_providerImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/auth_token_provider/Implementation.hpp>
@@ -44,6 +44,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPP/auth_validator/auth_token_validatorImpl.cpp
+++ b/modules/EVSE/OCPP/auth_validator/auth_token_validatorImpl.cpp
@@ -15,6 +15,10 @@ void auth_token_validatorImpl::init() {
 void auth_token_validatorImpl::ready() {
 }
 
+void auth_token_validatorImpl::shutdown() {
+    // no resources of its own to release, all OCPP state is owned by the module
+}
+
 types::authorization::ValidationResult
 auth_token_validatorImpl::handle_validate_token(types::authorization::ProvidedIdToken& provided_token) {
 

--- a/modules/EVSE/OCPP/auth_validator/auth_token_validatorImpl.hpp
+++ b/modules/EVSE/OCPP/auth_validator/auth_token_validatorImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/auth_token_validator/Implementation.hpp>
@@ -46,6 +46,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPP/data_transfer/ocpp_data_transferImpl.cpp
+++ b/modules/EVSE/OCPP/data_transfer/ocpp_data_transferImpl.cpp
@@ -12,6 +12,10 @@ void ocpp_data_transferImpl::init() {
 void ocpp_data_transferImpl::ready() {
 }
 
+void ocpp_data_transferImpl::shutdown() {
+    // no resources of its own to release, all OCPP state is owned by the module
+}
+
 types::ocpp::DataTransferStatus to_everest(ocpp::v16::DataTransferStatus status) {
     switch (status) {
     case ocpp::v16::DataTransferStatus::Accepted:

--- a/modules/EVSE/OCPP/data_transfer/ocpp_data_transferImpl.hpp
+++ b/modules/EVSE/OCPP/data_transfer/ocpp_data_transferImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/ocpp_data_transfer/Implementation.hpp>
@@ -45,6 +45,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPP/main/ocpp_1_6_charge_pointImpl.cpp
+++ b/modules/EVSE/OCPP/main/ocpp_1_6_charge_pointImpl.cpp
@@ -11,6 +11,10 @@ void ocpp_1_6_charge_pointImpl::init() {
 void ocpp_1_6_charge_pointImpl::ready() {
 }
 
+void ocpp_1_6_charge_pointImpl::shutdown() {
+    // no resources of its own to release, all OCPP state is owned by the module
+}
+
 bool ocpp_1_6_charge_pointImpl::handle_stop() {
     if (this->mod->charge_point == nullptr) {
         EVLOG_warning << "ChargePoint not initialized, cannot handle stop command";

--- a/modules/EVSE/OCPP/main/ocpp_1_6_charge_pointImpl.hpp
+++ b/modules/EVSE/OCPP/main/ocpp_1_6_charge_pointImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/ocpp_1_6_charge_point/Implementation.hpp>
@@ -51,6 +51,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPP/ocpp_generic/ocppImpl.cpp
+++ b/modules/EVSE/OCPP/ocpp_generic/ocppImpl.cpp
@@ -103,6 +103,10 @@ void ocppImpl::init() {
 void ocppImpl::ready() {
 }
 
+void ocppImpl::shutdown() {
+    // no resources of its own to release, all OCPP state is owned by the module
+}
+
 bool ocppImpl::handle_stop() {
     if (this->mod->charge_point == nullptr) {
         EVLOG_warning << "ChargePoint not initialized, cannot handle stop command";

--- a/modules/EVSE/OCPP/ocpp_generic/ocppImpl.hpp
+++ b/modules/EVSE/OCPP/ocpp_generic/ocppImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/ocpp/Implementation.hpp>
@@ -54,6 +54,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPP/session_cost/session_costImpl.cpp
+++ b/modules/EVSE/OCPP/session_cost/session_costImpl.cpp
@@ -12,5 +12,9 @@ void session_costImpl::init() {
 void session_costImpl::ready() {
 }
 
+void session_costImpl::shutdown() {
+    // no resources of its own to release, all OCPP state is owned by the module
+}
+
 } // namespace session_cost
 } // namespace module

--- a/modules/EVSE/OCPP/session_cost/session_costImpl.hpp
+++ b/modules/EVSE/OCPP/session_cost/session_costImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/session_cost/Implementation.hpp>
@@ -44,6 +44,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPP201/OCPP201.cpp
+++ b/modules/EVSE/OCPP201/OCPP201.cpp
@@ -1151,6 +1151,14 @@ void OCPP201::ready() {
     }
 }
 
+void OCPP201::shutdown() {
+    invoke_shutdown(*p_auth_validator);
+    invoke_shutdown(*p_auth_provider);
+    invoke_shutdown(*p_data_transfer);
+    invoke_shutdown(*p_ocpp_generic);
+    invoke_shutdown(*p_session_cost);
+}
+
 void OCPP201::charging_schedules_timer_callback() {
     // Single-flight + coalesce: the recompute body publishes schedules within EVerest and applies the
     // external limits. It now fires concurrently from the interval timer, the libocpp message thread,

--- a/modules/EVSE/OCPP201/OCPP201.hpp
+++ b/modules/EVSE/OCPP201/OCPP201.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 2
+// template version 3
 //
 
 #include "ld-ev.hpp"
@@ -46,8 +46,6 @@ using EventQueue =
     std::map<int32_t,
              std::queue<std::variant<types::evse_manager::SessionEvent, Everest::error::Error, ocpp::v2::MeterValue,
                                      types::system::FirmwareUpdateStatus, types::system::LogStatus>>>;
-// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
-
 namespace module {
 
 // Shared OCPP module support code lives in lib/everest/ocpp_module_common;
@@ -69,6 +67,10 @@ using ocpp_module_common::TransactionHandler;
 using ocpp_module_common::TxEvent;
 using ocpp_module_common::TxEventEffect;
 using ocpp_module_common::TxStartStopPoint;
+} // namespace module
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+
+namespace module {
 
 struct Conf {
     std::string MessageLogPath;
@@ -154,6 +156,7 @@ private:
     friend class LdEverest;
     void init();
     void ready();
+    void shutdown();
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPP201/auth_provider/auth_token_providerImpl.cpp
+++ b/modules/EVSE/OCPP201/auth_provider/auth_token_providerImpl.cpp
@@ -12,5 +12,9 @@ void auth_token_providerImpl::init() {
 void auth_token_providerImpl::ready() {
 }
 
+void auth_token_providerImpl::shutdown() {
+    // no resources of its own to release, all OCPP state is owned by the module
+}
+
 } // namespace auth_provider
 } // namespace module

--- a/modules/EVSE/OCPP201/auth_provider/auth_token_providerImpl.hpp
+++ b/modules/EVSE/OCPP201/auth_provider/auth_token_providerImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/auth_token_provider/Implementation.hpp>
@@ -44,6 +44,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPP201/auth_validator/auth_token_validatorImpl.cpp
+++ b/modules/EVSE/OCPP201/auth_validator/auth_token_validatorImpl.cpp
@@ -17,6 +17,10 @@ void auth_token_validatorImpl::init() {
 void auth_token_validatorImpl::ready() {
 }
 
+void auth_token_validatorImpl::shutdown() {
+    // no resources of its own to release, all OCPP state is owned by the module
+}
+
 types::authorization::ValidationResult
 auth_token_validatorImpl::handle_validate_token(types::authorization::ProvidedIdToken& provided_token) {
 

--- a/modules/EVSE/OCPP201/auth_validator/auth_token_validatorImpl.hpp
+++ b/modules/EVSE/OCPP201/auth_validator/auth_token_validatorImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/auth_token_validator/Implementation.hpp>
@@ -46,6 +46,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPP201/data_transfer/ocpp_data_transferImpl.cpp
+++ b/modules/EVSE/OCPP201/data_transfer/ocpp_data_transferImpl.cpp
@@ -14,6 +14,10 @@ void ocpp_data_transferImpl::init() {
 void ocpp_data_transferImpl::ready() {
 }
 
+void ocpp_data_transferImpl::shutdown() {
+    // no resources of its own to release, all OCPP state is owned by the module
+}
+
 types::ocpp::DataTransferResponse
 ocpp_data_transferImpl::handle_data_transfer(types::ocpp::DataTransferRequest& request) {
 

--- a/modules/EVSE/OCPP201/data_transfer/ocpp_data_transferImpl.hpp
+++ b/modules/EVSE/OCPP201/data_transfer/ocpp_data_transferImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/ocpp_data_transfer/Implementation.hpp>
@@ -45,6 +45,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPP201/ocpp_generic/ocppImpl.cpp
+++ b/modules/EVSE/OCPP201/ocpp_generic/ocppImpl.cpp
@@ -24,6 +24,10 @@ void ocppImpl::init() {
 void ocppImpl::ready() {
 }
 
+void ocppImpl::shutdown() {
+    // no resources of its own to release, all OCPP state is owned by the module
+}
+
 bool ocppImpl::handle_stop() {
     // Disconnects the websocket connection and stops the OCPP communication.
     // No OCPP messages will be stored and sent after a restart.

--- a/modules/EVSE/OCPP201/ocpp_generic/ocppImpl.hpp
+++ b/modules/EVSE/OCPP201/ocpp_generic/ocppImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/ocpp/Implementation.hpp>
@@ -62,6 +62,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPP201/session_cost/session_costImpl.cpp
+++ b/modules/EVSE/OCPP201/session_cost/session_costImpl.cpp
@@ -12,5 +12,9 @@ void session_costImpl::init() {
 void session_costImpl::ready() {
 }
 
+void session_costImpl::shutdown() {
+    // no resources of its own to release, all OCPP state is owned by the module
+}
+
 } // namespace session_cost
 } // namespace module

--- a/modules/EVSE/OCPP201/session_cost/session_costImpl.hpp
+++ b/modules/EVSE/OCPP201/session_cost/session_costImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/session_cost/Implementation.hpp>
@@ -44,6 +44,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPPmulti/OCPPmulti.cpp
+++ b/modules/EVSE/OCPPmulti/OCPPmulti.cpp
@@ -129,4 +129,12 @@ void OCPPmulti::ready() {
     m_ocpp.ready(module::get_config_service_client());
 }
 
+void OCPPmulti::shutdown() {
+    invoke_shutdown(*p_auth_validator);
+    invoke_shutdown(*p_auth_provider);
+    invoke_shutdown(*p_data_transfer);
+    invoke_shutdown(*p_ocpp_generic);
+    invoke_shutdown(*p_session_cost);
+}
+
 } // namespace module

--- a/modules/EVSE/OCPPmulti/OCPPmulti.hpp
+++ b/modules/EVSE/OCPPmulti/OCPPmulti.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 2
+// template version 3
 //
 
 #include "ld-ev.hpp"
@@ -86,17 +86,17 @@ struct Conf {
     std::string DeviceModelDatabaseMigrationPath;
     bool EnableLegacyConfigMigration;
     std::string DeviceModelConfigMappings;
-    int Ocpp16NetworkConfigSlot;
     bool EnableExternalWebsocketControl;
     std::string EverestDeviceModelDatabasePath;
+    int GridSupportHeartbeatS;
     std::string MessageLogPath;
     int MessageQueueResumeDelay;
+    std::string Mode;
+    int Ocpp16NetworkConfigSlot;
     int RequestCompositeScheduleDurationS;
     std::string RequestCompositeScheduleUnit;
     int ResetStopDelay;
     std::string UserConfigPath;
-    std::string Mode;
-    int GridSupportHeartbeatS;
 };
 
 class OCPPmulti : public Everest::ModuleBase {
@@ -182,6 +182,7 @@ private:
     friend class LdEverest;
     void init();
     void ready();
+    void shutdown();
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPPmulti/auth_provider/auth_token_providerImpl.cpp
+++ b/modules/EVSE/OCPPmulti/auth_provider/auth_token_providerImpl.cpp
@@ -12,5 +12,9 @@ void auth_token_providerImpl::init() {
 void auth_token_providerImpl::ready() {
 }
 
+void auth_token_providerImpl::shutdown() {
+    // no resources of its own to release, all OCPP state is owned by the module
+}
+
 } // namespace auth_provider
 } // namespace module

--- a/modules/EVSE/OCPPmulti/auth_provider/auth_token_providerImpl.hpp
+++ b/modules/EVSE/OCPPmulti/auth_provider/auth_token_providerImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/auth_token_provider/Implementation.hpp>
@@ -44,6 +44,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPPmulti/auth_validator/auth_token_validatorImpl.cpp
+++ b/modules/EVSE/OCPPmulti/auth_validator/auth_token_validatorImpl.cpp
@@ -12,6 +12,10 @@ void auth_token_validatorImpl::init() {
 void auth_token_validatorImpl::ready() {
 }
 
+void auth_token_validatorImpl::shutdown() {
+    // no resources of its own to release, all OCPP state is owned by the module
+}
+
 types::authorization::ValidationResult
 auth_token_validatorImpl::handle_validate_token(types::authorization::ProvidedIdToken& provided_token) {
     return mod->m_ocpp.handle_validate_token(provided_token);

--- a/modules/EVSE/OCPPmulti/auth_validator/auth_token_validatorImpl.hpp
+++ b/modules/EVSE/OCPPmulti/auth_validator/auth_token_validatorImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/auth_token_validator/Implementation.hpp>
@@ -46,6 +46,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPPmulti/data_transfer/ocpp_data_transferImpl.cpp
+++ b/modules/EVSE/OCPPmulti/data_transfer/ocpp_data_transferImpl.cpp
@@ -12,6 +12,10 @@ void ocpp_data_transferImpl::init() {
 void ocpp_data_transferImpl::ready() {
 }
 
+void ocpp_data_transferImpl::shutdown() {
+    // no resources of its own to release, all OCPP state is owned by the module
+}
+
 types::ocpp::DataTransferResponse
 ocpp_data_transferImpl::handle_data_transfer(types::ocpp::DataTransferRequest& request) {
     return mod->m_ocpp.handle_data_transfer(request);

--- a/modules/EVSE/OCPPmulti/data_transfer/ocpp_data_transferImpl.hpp
+++ b/modules/EVSE/OCPPmulti/data_transfer/ocpp_data_transferImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/ocpp_data_transfer/Implementation.hpp>
@@ -45,6 +45,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPPmulti/ocpp_generic/ocppImpl.cpp
+++ b/modules/EVSE/OCPPmulti/ocpp_generic/ocppImpl.cpp
@@ -12,6 +12,10 @@ void ocppImpl::init() {
 void ocppImpl::ready() {
 }
 
+void ocppImpl::shutdown() {
+    // no resources of its own to release, all OCPP state is owned by the module
+}
+
 bool ocppImpl::handle_stop() {
     return mod->m_ocpp.handle_stop();
 }

--- a/modules/EVSE/OCPPmulti/ocpp_generic/ocppImpl.hpp
+++ b/modules/EVSE/OCPPmulti/ocpp_generic/ocppImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/ocpp/Implementation.hpp>
@@ -54,6 +54,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/EVSE/OCPPmulti/session_cost/session_costImpl.cpp
+++ b/modules/EVSE/OCPPmulti/session_cost/session_costImpl.cpp
@@ -12,5 +12,9 @@ void session_costImpl::init() {
 void session_costImpl::ready() {
 }
 
+void session_costImpl::shutdown() {
+    // no resources of its own to release, all OCPP state is owned by the module
+}
+
 } // namespace session_cost
 } // namespace module

--- a/modules/EVSE/OCPPmulti/session_cost/session_costImpl.hpp
+++ b/modules/EVSE/OCPPmulti/session_cost/session_costImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/session_cost/Implementation.hpp>
@@ -44,6 +44,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/HardwareDrivers/PowerMeters/CarloGavazzi_EM580/CarloGavazzi_EM580.cpp
+++ b/modules/HardwareDrivers/PowerMeters/CarloGavazzi_EM580/CarloGavazzi_EM580.cpp
@@ -15,4 +15,9 @@ void CarloGavazzi_EM580::ready() {
     invoke_ready(*p_temperature_sensor);
 }
 
+void CarloGavazzi_EM580::shutdown() {
+    invoke_shutdown(*p_main);
+    invoke_shutdown(*p_temperature_sensor);
+}
+
 } // namespace module

--- a/modules/HardwareDrivers/PowerMeters/CarloGavazzi_EM580/CarloGavazzi_EM580.hpp
+++ b/modules/HardwareDrivers/PowerMeters/CarloGavazzi_EM580/CarloGavazzi_EM580.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 2
+// template version 3
 //
 
 #include "ld-ev.hpp"
@@ -55,6 +55,7 @@ private:
     friend class LdEverest;
     void init();
     void ready();
+    void shutdown();
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here

--- a/modules/HardwareDrivers/PowerMeters/CarloGavazzi_EM580/main/powermeterImpl.cpp
+++ b/modules/HardwareDrivers/PowerMeters/CarloGavazzi_EM580/main/powermeterImpl.cpp
@@ -212,6 +212,11 @@ void warn_if_comm_retry_delay_exceeds_reboot_budget(int retry_count, int retry_d
 } // namespace
 
 powermeterImpl::~powermeterImpl() {
+    shutdown();
+}
+
+void powermeterImpl::shutdown() {
+    // idempotent, so it does not matter whether the framework got here first or the destructor did
     stop_requested_.store(true);
     stop_cv_.notify_all();
     if (live_measure_thread_.joinable()) {

--- a/modules/HardwareDrivers/PowerMeters/CarloGavazzi_EM580/main/powermeterImpl.hpp
+++ b/modules/HardwareDrivers/PowerMeters/CarloGavazzi_EM580/main/powermeterImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/powermeter/Implementation.hpp>
@@ -44,12 +44,11 @@ public:
     powermeterImpl(Everest::ModuleAdapter* ev, const Everest::PtrContainer<CarloGavazzi_EM580>& mod, Conf& config) :
         powermeterImplBase(ev, "main"), mod(mod), config(config){};
 
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
     // Marker used to append the transaction id to the tariff text (TT field).
     // Format: "<tariff_text><=><transaction_id>"
     static constexpr std::string_view TARIFF_TEXT_TRANSACTION_ID_MARKER = "<=>";
 
-    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
-    // insert your public definitions here
     ~powermeterImpl() override;
     // Test-only access helpers (used by unit tests to avoid spinning up the full
     // EVerest runtime). These are intentionally narrow: inject transport + tweak
@@ -116,6 +115,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     std::unique_ptr<transport::AbstractModbusTransport> p_modbus_transport;

--- a/modules/HardwareDrivers/PowerMeters/CarloGavazzi_EM580/temperature_sensor/temperature_sensorImpl.cpp
+++ b/modules/HardwareDrivers/PowerMeters/CarloGavazzi_EM580/temperature_sensor/temperature_sensorImpl.cpp
@@ -12,5 +12,9 @@ void temperature_sensorImpl::init() {
 void temperature_sensorImpl::ready() {
 }
 
+void temperature_sensorImpl::shutdown() {
+    // the powermeter implementation owns the modbus transport and its threads
+}
+
 } // namespace temperature_sensor
 } // namespace module

--- a/modules/HardwareDrivers/PowerMeters/CarloGavazzi_EM580/temperature_sensor/temperature_sensorImpl.hpp
+++ b/modules/HardwareDrivers/PowerMeters/CarloGavazzi_EM580/temperature_sensor/temperature_sensorImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/temperature_sensor/Implementation.hpp>
@@ -45,6 +45,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/Misc/Store/main/kvsImpl.hpp
+++ b/modules/Misc/Store/main/kvsImpl.hpp
@@ -51,7 +51,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
-    void shutdown();
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     std::map<std::string, std::variant<std::nullptr_t, Array, Object, bool, double, int, std::string>> kvs{};

--- a/modules/Simulation/ManagerLifecycleSimulator/ManagerLifecycleSimulator.hpp
+++ b/modules/Simulation/ManagerLifecycleSimulator/ManagerLifecycleSimulator.hpp
@@ -22,8 +22,7 @@ class ManagerLifecycleSimulator : public Everest::ModuleBase {
 public:
     ManagerLifecycleSimulator() = delete;
     ManagerLifecycleSimulator(const ModuleInfo& info, Everest::MqttProvider& mqtt_provider, Conf& config) :
-        ModuleBase(info), mqtt(mqtt_provider), config(config) {
-    }
+        ModuleBase(info), mqtt(mqtt_provider), config(config){};
 
     Everest::MqttProvider& mqtt;
     const Conf& config;

--- a/modules/Simulation/TemperatureSensorSimulator/TemperatureSensorSimulator.cpp
+++ b/modules/Simulation/TemperatureSensorSimulator/TemperatureSensorSimulator.cpp
@@ -12,4 +12,8 @@ void TemperatureSensorSimulator::ready() {
     invoke_ready(*p_temperature_sensor);
 }
 
+void TemperatureSensorSimulator::shutdown() {
+    invoke_shutdown(*p_temperature_sensor);
+}
+
 } // namespace module

--- a/modules/Simulation/TemperatureSensorSimulator/TemperatureSensorSimulator.hpp
+++ b/modules/Simulation/TemperatureSensorSimulator/TemperatureSensorSimulator.hpp
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
-#ifndef TEMPERATURESENSORSIMULATOR_HPP
-#define TEMPERATURESENSORSIMULATOR_HPP
+#ifndef TEMPERATURE_SENSOR_SIMULATOR_HPP
+#define TEMPERATURE_SENSOR_SIMULATOR_HPP
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 2
+// template version 3
 //
 
 #include "ld-ev.hpp"
 
+// headers for provided interface implementations
 #include <generated/interfaces/temperature_sensor/Implementation.hpp>
 
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
@@ -44,6 +45,7 @@ private:
     friend class LdEverest;
     void init();
     void ready();
+    void shutdown();
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
@@ -56,4 +58,4 @@ private:
 
 } // namespace module
 
-#endif // TEMPERATURESENSORSIMULATOR_HPP
+#endif // TEMPERATURE_SENSOR_SIMULATOR_HPP

--- a/modules/Simulation/TemperatureSensorSimulator/temperature_sensor/temperature_sensorImpl.cpp
+++ b/modules/Simulation/TemperatureSensorSimulator/temperature_sensor/temperature_sensorImpl.cpp
@@ -112,6 +112,11 @@ void temperature_sensorImpl::init() {
 void temperature_sensorImpl::ready() {
 }
 
+void temperature_sensorImpl::shutdown() {
+    // Thread::stop() signals and joins, and is a no-op once the worker is gone
+    publish_thread_handle.stop();
+}
+
 void temperature_sensorImpl::publish_worker() {
     while (true) {
         if (publish_thread_handle.shouldExit()) {

--- a/modules/Simulation/TemperatureSensorSimulator/temperature_sensor/temperature_sensorImpl.hpp
+++ b/modules/Simulation/TemperatureSensorSimulator/temperature_sensor/temperature_sensorImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/temperature_sensor/Implementation.hpp>
@@ -54,6 +54,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here


### PR DESCRIPTION
Stacked on #2659, which adds the `ev-cli mod update` check this PR makes pass.

## What

One commit per module, each making `ev-cli mod update --force <module>` a no-op:

| Module | What was wrong |
| --- | --- |
| `EVSE/EvseSlac` | three hand-written includes above the generated `../EvseSlac.hpp` include |
| `EVSE/OCPP` | `conversions` namespace alias inside the generated `namespace module` block |
| `EVSE/OCPP201` | block of `ocpp_module_common` aliases and using-declarations, same spot |
| `EVSE/OCPPmulti` | generated `Conf` members appended by hand instead of in generated order |
| `HardwareDrivers/PowerMeters/CarloGavazzi_EM580` | `TARIFF_TEXT_TRANSACTION_ID_MARKER` above the marked public region |
| `Misc/Store` | `shutdown()` declared by hand without `override` |
| `Simulation/ManagerLifecycleSimulator` | generated constructor body reformatted by hand |
| `Simulation/TemperatureSensorSimulator` | hand-written include guard name |

That is every module the check flagged as losing hand-written code.

## Result

`tests/ev-cli/check_mod_update.py` over all 111 C++ modules:

```
before:  clean: 3,  content loss: 8, template refresh: 99, failed: 1  -> exit 2 (fail)
after:   clean: 11, content loss: 0, template refresh: 99, failed: 1  -> exit 2 (fail)
```

The single remaining failure is `EVSE/Evse15118D20`, where ev-cli refuses to
update the module at all because `grid_supportImpl.hpp` carries invented
`ev@<uuid>` markers. That one is handled in its own PR; once it lands the check
drops to exit 1, i.e. pass with a warning about the 99 modules that only need
the template v2->v3 / v3->v4 bump.

## Regenerating pulls in `shutdown()`

The current templates declare `shutdown()`, so every regenerated module needed
matching definitions. Module-level handlers forward to their implementations.
Implementation handlers do real teardown where the implementation owns
something:

- `EvseSlac`: stops the SLAC I/O loop, then the state machine - `FSMController`
  grew a `quit()`, its `run()` loop previously had no exit path at all.
- `CarloGavazzi_EM580`: the powermeter already stopped and joined its live
  measurement and time sync threads in its destructor; that teardown moved into
  `shutdown()` and the destructor calls it.
- `TemperatureSensorSimulator`: stops and joins the publish worker.

Everywhere else the handler is an explicit no-op, so behaviour is unchanged. In
particular the OCPP modules deliberately do not stop the charge point on
shutdown - that is a behaviour change and wants its own PR.

## Testing

Each module builds. Unit tests pass: `CarloGavazzi_EM580` 28/28, `OCPPmulti`
169/172 (3 pre-existing skips).
Every commit is clang-format clean (15.0.6, from the CI build-env image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
