### PR TITLE
fix(iso15118): give TU-local message helpers internal linkage

### DIFF
--- a/lib/everest/iso15118/src/iso15118/d20/state/supported_app_protocol.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/supported_app_protocol.cpp
@@ -25,14 +25,13 @@ constexpr std::array AcNamespaces = {ISO20_AC_NAMESPACE, ISO20_DER_IEC_NAMESPACE
 
 using ResponseCode = message_20::SupportedAppProtocolResponse::ResponseCode;
 
+namespace {
 struct SupportedEnergyModes {
     bool ac{false};
     bool dc{false};
     bool acdp{false};
     bool wpt{false};
 };
-
-namespace {
 
 message_20::SupportedAppProtocolResponse handle_request(const message_20::SupportedAppProtocolRequest& req,
                                                         const SupportedEnergyModes& modes,

--- a/lib/everest/iso15118/src/iso15118/message/ac_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/ac_charge_loop.cpp
@@ -337,6 +337,7 @@ void convert(const datatypes::BPT_Dynamic_AC_CLResControlMode& in,
     convert(static_cast<const datatypes::Dynamic_AC_CLResControlMode&>(in), out);
 }
 
+namespace {
 struct ControlModeVisitor {
     using ScheduledCM = datatypes::Scheduled_AC_CLResControlMode;
     using BPT_ScheduledCM = datatypes::BPT_Scheduled_AC_CLResControlMode;
@@ -376,6 +377,7 @@ struct ControlModeVisitor {
 private:
     iso20_ac_AC_ChargeLoopResType& res;
 };
+} // namespace
 
 template <> void convert(const AC_ChargeLoopResponse& in, struct iso20_ac_AC_ChargeLoopResType& out) {
     init_iso20_ac_AC_ChargeLoopResType(&out);
@@ -426,6 +428,7 @@ template <> void convert(const datatypes::DisplayParameters& in, struct iso20_ac
     CPP2CB_ASSIGN_IF_USED(in.inlet_hot, out.InletHot);
 }
 
+namespace {
 struct ModeRequestVisitor {
     using ScheduledCM = datatypes::Scheduled_AC_CLReqControlMode;
     using BPT_ScheduledCM = datatypes::BPT_Scheduled_AC_CLReqControlMode;
@@ -515,6 +518,7 @@ public:
 private:
     iso20_ac_AC_ChargeLoopReqType& req;
 };
+} // namespace
 
 template <> void convert(const AC_ChargeLoopRequest& in, struct iso20_ac_AC_ChargeLoopReqType& out) {
     init_iso20_ac_AC_ChargeLoopReqType(&out);

--- a/lib/everest/iso15118/src/iso15118/message/ac_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/ac_charge_parameter_discovery.cpp
@@ -100,6 +100,7 @@ template <> void insert_type(VariantAccess& va, const struct iso20_ac_AC_ChargeP
     va.insert_type<AC_ChargeParameterDiscoveryResponse>(in);
 }
 
+namespace {
 struct ModeResponseVisitor {
 public:
     ModeResponseVisitor(iso20_ac_AC_ChargeParameterDiscoveryResType& res_) : res(res_){};
@@ -146,6 +147,7 @@ public:
 private:
     iso20_ac_AC_ChargeParameterDiscoveryResType& res;
 };
+} // namespace
 
 template <>
 void convert(const AC_ChargeParameterDiscoveryResponse& in, struct iso20_ac_AC_ChargeParameterDiscoveryResType& out) {
@@ -178,6 +180,7 @@ template <> void insert_type(VariantAccess& va, const struct iso20_ac_AC_ChargeP
     va.insert_type<AC_ChargeParameterDiscoveryRequest>(in);
 }
 
+namespace {
 struct ModeRequestVisitor {
 public:
     ModeRequestVisitor(iso20_ac_AC_ChargeParameterDiscoveryReqType& req_) : req(req_){};
@@ -213,6 +216,7 @@ public:
 private:
     iso20_ac_AC_ChargeParameterDiscoveryReqType& req;
 };
+} // namespace
 
 template <>
 void convert(const AC_ChargeParameterDiscoveryRequest& in, struct iso20_ac_AC_ChargeParameterDiscoveryReqType& out) {

--- a/lib/everest/iso15118/src/iso15118/message/ac_der_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/ac_der_charge_loop.cpp
@@ -204,6 +204,7 @@ void convert(const struct iso20_ac_der_iec_DER_Scheduled_AC_CLReqControlModeType
     out.grid_event_condition = in.GridEventCondition;
 }
 
+namespace {
 struct ReqControlModeVisitor {
     using DER_ScheduledCM = datatypes::DER_Scheduled_AC_CLReqControlMode;
     using DER_DynamicCM = datatypes::DER_Dynamic_AC_CLReqControlMode;
@@ -227,6 +228,7 @@ struct ReqControlModeVisitor {
 private:
     iso20_ac_der_iec_AC_ChargeLoopReqType& req;
 };
+} // namespace
 
 template <> void convert(const DER_AC_ChargeLoopRequest& in, struct iso20_ac_der_iec_AC_ChargeLoopReqType& out) {
     init_iso20_ac_der_iec_AC_ChargeLoopReqType(&out);
@@ -499,6 +501,7 @@ void convert(const struct iso20_ac_der_iec_DER_Dynamic_AC_CLResControlModeType& 
     CB2CPP_CONVERT_IF_USED(in.DSOCosPhiSetpoint, out.dso_cos_phi_setpoint);
 }
 
+namespace {
 struct ControlModeVisitor {
     using DER_ScheduledCM = datatypes::DER_Scheduled_AC_CLResControlMode;
     using DER_DynamicCM = datatypes::DER_Dynamic_AC_CLResControlMode;
@@ -522,6 +525,7 @@ struct ControlModeVisitor {
 private:
     iso20_ac_der_iec_AC_ChargeLoopResType& res;
 };
+} // namespace
 
 template <> void convert(const DER_AC_ChargeLoopResponse& in, struct iso20_ac_der_iec_AC_ChargeLoopResType& out) {
     init_iso20_ac_der_iec_AC_ChargeLoopResType(&out);

--- a/lib/everest/iso15118/src/iso15118/message/authorization.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/authorization.cpp
@@ -37,6 +37,7 @@ template <> void convert(const struct iso20_AuthorizationResType& in, Authorizat
     convert(in.Header, out.header);
 }
 
+namespace {
 struct AuthorizationModeVisitor {
     AuthorizationModeVisitor(iso20_AuthorizationReqType& out_) : out(out_){};
     void operator()([[maybe_unused]] const datatypes::EIM_ASReqAuthorizationMode& in) {
@@ -53,6 +54,7 @@ struct AuthorizationModeVisitor {
 private:
     iso20_AuthorizationReqType& out;
 };
+} // namespace
 
 template <> void convert(const AuthorizationRequest& in, iso20_AuthorizationReqType& out) {
     init_iso20_AuthorizationReqType(&out);

--- a/lib/everest/iso15118/src/iso15118/message/authorization_setup.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/authorization_setup.cpp
@@ -45,6 +45,7 @@ template <> void convert(const AuthorizationSetupRequest& in, iso20_Authorizatio
     convert(in.header, out.Header);
 }
 
+namespace {
 struct AuthorizationModeVisitor {
     AuthorizationModeVisitor(iso20_AuthorizationSetupResType& out_) : out(out_){};
     void operator()([[maybe_unused]] const datatypes::EIM_ASResAuthorizationMode& in) {
@@ -61,6 +62,7 @@ struct AuthorizationModeVisitor {
 private:
     iso20_AuthorizationSetupResType& out;
 };
+} // namespace
 
 template <> void convert(const AuthorizationSetupResponse& in, iso20_AuthorizationSetupResType& out) {
     init_iso20_AuthorizationSetupResType(&out);

--- a/lib/everest/iso15118/src/iso15118/message/dc_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/dc_charge_loop.cpp
@@ -302,6 +302,7 @@ void convert(const datatypes::BPT_Dynamic_DC_CLResControlMode& in,
     convert(in.min_voltage, out.EVSEMinimumVoltage);
 }
 
+namespace {
 struct ControlModeVisitor {
     using ScheduledCM = datatypes::Scheduled_DC_CLResControlMode;
     using BPT_ScheduledCM = datatypes::BPT_Scheduled_DC_CLResControlMode;
@@ -337,6 +338,7 @@ struct ControlModeVisitor {
 private:
     iso20_dc_DC_ChargeLoopResType& res;
 };
+} // namespace
 
 template <> void convert(const DC_ChargeLoopResponse& in, struct iso20_dc_DC_ChargeLoopResType& out) {
     init_iso20_dc_DC_ChargeLoopResType(&out);
@@ -449,6 +451,7 @@ void convert(const datatypes::BPT_Dynamic_DC_CLReqControlMode& in,
     CPP2CB_CONVERT_IF_USED(in.min_v2x_energy_request, out.EVMinimumV2XEnergyRequest);
 }
 
+namespace {
 struct RequestControlModeVisitor {
     using ScheduledCM = datatypes::Scheduled_DC_CLReqControlMode;
     using BPT_ScheduledCM = datatypes::BPT_Scheduled_DC_CLReqControlMode;
@@ -484,6 +487,7 @@ struct RequestControlModeVisitor {
 private:
     iso20_dc_DC_ChargeLoopReqType& req;
 };
+} // namespace
 
 template <> void convert(const DC_ChargeLoopRequest& in, iso20_dc_DC_ChargeLoopReqType& out) {
     init_iso20_dc_DC_ChargeLoopReqType(&out);

--- a/lib/everest/iso15118/src/iso15118/message/dc_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/dc_charge_parameter_discovery.cpp
@@ -91,6 +91,7 @@ void convert(const struct iso20_dc_DC_ChargeParameterDiscoveryResType& in, DC_Ch
 // End conversion for deserializing a DCChargeParameterResponse (EVside)
 
 // Begin conversion for serializing a DCChargeParameterResponse (EVSEside)
+namespace {
 struct ModeResponseVisitor {
     ModeResponseVisitor(iso20_dc_DC_ChargeParameterDiscoveryResType& res_) : res(res_){};
     void operator()(const DC_ModeRes& in) {
@@ -128,6 +129,7 @@ struct ModeResponseVisitor {
 private:
     iso20_dc_DC_ChargeParameterDiscoveryResType& res;
 };
+} // namespace
 
 template <>
 void convert(const DC_ChargeParameterDiscoveryResponse& in, struct iso20_dc_DC_ChargeParameterDiscoveryResType& out) {
@@ -159,6 +161,7 @@ template <> size_t serialize(const DC_ChargeParameterDiscoveryResponse& in, cons
 
 // Begin conversion for serializing a DCChargeParameterRequest (EVside)
 
+namespace {
 struct ModeRequestVisitor {
     ModeRequestVisitor(iso20_dc_DC_ChargeParameterDiscoveryReqType& req_) : req(req_){};
     void operator()(const DC_ModeReq& in) {
@@ -192,6 +195,7 @@ struct ModeRequestVisitor {
 private:
     iso20_dc_DC_ChargeParameterDiscoveryReqType& req;
 };
+} // namespace
 
 template <>
 void convert(const DC_ChargeParameterDiscoveryRequest& in, iso20_dc_DC_ChargeParameterDiscoveryReqType& out) {

--- a/lib/everest/iso15118/src/iso15118/message/schedule_exchange.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/schedule_exchange.cpp
@@ -499,6 +499,7 @@ template <> void convert(const datatypes::ScheduleTuple& in, struct iso20_Schedu
     CPP2CB_CONVERT_IF_USED(in.discharging_schedule, out.DischargingSchedule);
 }
 
+namespace {
 struct ModeResponseVisitor {
     ModeResponseVisitor(iso20_ScheduleExchangeResType& res_) : res(res_){};
     void operator()(const datatypes::Dynamic_SEResControlMode& in) {
@@ -533,6 +534,7 @@ struct ModeResponseVisitor {
 private:
     iso20_ScheduleExchangeResType& res;
 };
+} // namespace
 
 template <> void convert(const ScheduleExchangeResponse& in, struct iso20_ScheduleExchangeResType& out) {
     init_iso20_ScheduleExchangeResType(&out);
@@ -622,6 +624,7 @@ template <> void convert(const datatypes::EVEnergyOffer& in, struct iso20_EVEner
     convert(in.absolute_price_schedule, out.EVAbsolutePriceSchedule);
 }
 
+namespace {
 struct ModeRequestVisitor {
     ModeRequestVisitor(iso20_ScheduleExchangeReqType& req_) : req(req_){};
     void operator()(const datatypes::Dynamic_SEReqControlMode& in) {
@@ -657,6 +660,7 @@ struct ModeRequestVisitor {
 private:
     iso20_ScheduleExchangeReqType& req;
 };
+} // namespace
 
 template <> void convert(const ScheduleExchangeRequest& in, iso20_ScheduleExchangeReqType& out) {
     init_iso20_ScheduleExchangeReqType(&out);

--- a/lib/everest/iso15118/src/iso15118/message/service_detail.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/service_detail.cpp
@@ -245,6 +245,7 @@ template <> void convert(const ServiceDetailRequest& in, iso20_ServiceDetailReqT
     convert(in.header, out.Header);
 }
 
+namespace {
 struct ParameterValueVisitor {
     ParameterValueVisitor(iso20_ParameterType& parameter_) : parameter(parameter_){};
     void operator()(const bool& in) {
@@ -276,6 +277,7 @@ struct ParameterValueVisitor {
 private:
     iso20_ParameterType& parameter;
 };
+} // namespace
 
 template <> void convert(const ServiceDetailResponse& in, iso20_ServiceDetailResType& out) {
     init_iso20_ServiceDetailResType(&out);


### PR DESCRIPTION
## What

Five helper visitor type names in `iso15118::message_20` are each defined in more than one translation unit, with different contents:

| Name | Defined in |
|---|---|
| `AuthorizationModeVisitor` | `authorization.cpp`, `authorization_setup.cpp` |
| `ControlModeVisitor` | `ac_charge_loop.cpp`, `ac_der_charge_loop.cpp`, `dc_charge_loop.cpp` |
| `ModeRequestVisitor` | `ac_charge_loop.cpp`, `ac_charge_parameter_discovery.cpp`, `dc_charge_parameter_discovery.cpp`, `schedule_exchange.cpp` |
| `ModeResponseVisitor` | `ac_charge_parameter_discovery.cpp`, `dc_charge_parameter_discovery.cpp`, `schedule_exchange.cpp` |
| `ReqControlModeVisitor` | `ac_der_charge_loop.cpp` |

Two definitions of one class type in a single program is an ODR violation — ill-formed, no diagnostic required. Compiling the two `AuthorizationModeVisitor` TUs with `-flto` shows it:

```
authorization.cpp:40:8: warning: type 'AuthorizationModeVisitor' violates the C++ One Definition Rule [-Wodr]
note: a different type is defined in another translation unit
note: the first difference of corresponding definitions is field 'out'
```

This PR wraps them in anonymous namespaces, matching what `tbd_controller.cpp`, `socket_helper.cpp` and `ac_der_sae_charge_loop.cpp` already do. Internal linkage gives each file a distinct type, so there is nothing left to collide.

## Why it matters, given nothing is broken today

Nothing miscompiles right now, but only by accident. The only functions these classes emit are the constructor and `operator()`, whose mangled names carry their differing parameter types, so no two symbols collide:

```
_ZN...24AuthorizationModeVisitorC1ER26iso20_AuthorizationReqType        # authorization.cpp
_ZN...24AuthorizationModeVisitorC1ER31iso20_AuthorizationSetupResType   # authorization_setup.cpp
```

Destructors, copy/move members, and any no-argument member mangle from the class name alone, so they collide outright. All these symbols are weak/COMDAT, which the linker folds *silently* — keeping one definition for the whole program. Give any of these classes a member that owns a resource and you get a clean build plus one destructor running against two different layouts.

`-Wodr` is the only thing that detects this, and it only exists under `-flto`, which this project does not enable — so the compiler never had a chance to tell us.

## Scope

`io::SSLContext` is deliberately **not** changed: `connection_ssl.hpp:17` forward-declares it for a `unique_ptr` pimpl, so it needs external linkage. Three TU-local helpers that do not collide today (`SupportedEnergyModes`, `RequestControlModeVisitor`, `ParameterValueVisitor`) are wrapped too, so the rule is uniform.

No functional change.

## Verification

- All **61** libiso15118 translation units recompiled with the project's real flags plus `-Werror` — all clean.
- Full library links with **zero** undefined `iso15118::` symbols, confirming no cross-TU reference relied on the old external linkage.
- Symbols confirmed changed from `W` (weak global) to `t` (local) in the emitted objects.
- The `-Wodr` diagnostic above: **1 before, 0 after**.
- `clang-format` 15.0.6 from `ghcr.io/everest/everest-clang-format:v1.3.3` — no changes.