### PR TITLE
Recover active charging sessions after reboot

### DIFF
--- a/modules/EVSE/Auth/include/AuthHandler.hpp
+++ b/modules/EVSE/Auth/include/AuthHandler.hpp
@@ -356,6 +356,18 @@ private:
      * This will check the reservation status of the evse's and send the statusses to the evse manager.
      */
     void check_evse_reserved_and_send_updates();
+
+    /// \brief Persists the given \p identifier of the active transaction at \p evse_id so that it can be restored
+    /// when a session is resumed after a restart. The full (merged) identifier is persisted, not just the token that
+    /// was provided by the charger, because the parent id token is only known after validation and is required to
+    /// stop a transaction with a sibling card of the same group.
+    void persist_active_identifier(int evse_id, const Identifier& identifier);
+    std::optional<Identifier> load_active_identifier(int evse_id);
+    void clear_active_identifier(int evse_id);
+    std::string get_active_identifier_key(int evse_id) const;
+
+    kvsIntf* store;
+    const std::string active_transaction_key_prefix;
 };
 
 } // namespace module

--- a/modules/EVSE/Auth/include/Connector.hpp
+++ b/modules/EVSE/Auth/include/Connector.hpp
@@ -25,6 +25,12 @@ struct Identifier {
     std::optional<types::authorization::IdToken> parent_id_token; ///< Parent id token of the identifier
 };
 
+/// \brief Conversion from a given Identifier \p k to a given json object \p j
+void to_json(json& j, const Identifier& k);
+
+/// \brief Conversion from a given json object \p j to a given Identifier \p k
+void from_json(const json& j, Identifier& k);
+
 struct Connector {
     explicit Connector(
         int id, const types::evse_manager::ConnectorTypeEnum type = types::evse_manager::ConnectorTypeEnum::Unknown) :

--- a/modules/EVSE/Auth/lib/AuthHandler.cpp
+++ b/modules/EVSE/Auth/lib/AuthHandler.cpp
@@ -21,6 +21,21 @@ std::vector<int> intersect(std::vector<int>& a, std::vector<int>& b) {
     return result;
 }
 
+/// \brief Replaces every character that is not allowed in a kvs key by '_'. The kvs interface restricts keys to
+/// ^[A-Za-z0-9_.]*$, so characters that are perfectly valid in a module id (like '-') would make every store and load
+/// fail silently.
+static std::string sanitize_kvs_key(const std::string& key) {
+    std::string sanitized = key;
+    std::replace_if(
+        sanitized.begin(), sanitized.end(),
+        [](const char c) {
+            return not((c >= 'A' and c <= 'Z') or (c >= 'a' and c <= 'z') or (c >= '0' and c <= '9') or c == '_' or
+                       c == '.');
+        },
+        '_');
+    return sanitized;
+}
+
 namespace conversions {
 std::string token_handling_result_to_string(const TokenHandlingResult& result) {
     switch (result) {
@@ -55,7 +70,9 @@ AuthHandler::AuthHandler(const SelectionAlgorithm& selection_algorithm, const in
     prioritize_authorization_over_stopping_transaction(prioritize_authorization_over_stopping_transaction),
     ignore_faults(ignore_faults),
     stop_transaction_on_reswipe(stop_transaction_on_reswipe),
-    reservation_handler(evses, id, store) {
+    reservation_handler(evses, id, store),
+    store(store),
+    active_transaction_key_prefix(sanitize_kvs_key("active_transaction_" + id)) {
 }
 
 AuthHandler::~AuthHandler() {
@@ -856,23 +873,37 @@ void AuthHandler::handle_session_event(const int evse_id, const SessionEvent& ev
         }
     } break;
     case SessionEventEnum::TransactionStarted: {
-        this->evses.at(evse_id)->plugged_in = true;
-        this->evses.at(evse_id)->transaction_active = true;
+        auto& evse = this->evses.at(evse_id);
+        evse->plugged_in = true;
+        evse->transaction_active = true;
+        // notify_evse() already deposited the identifier merged with the validation result (which is the only source
+        // of the parent id token). Only fall back to the token from the event if no identifier is present, e.g. for
+        // token flows that start a transaction without passing through notify_evse().
+        if (not evse->identifier.has_value() and event.transaction_started.has_value()) {
+            const auto& provided_token = event.transaction_started.value().id_tag;
+            evse->identifier = Identifier{provided_token.id_token, provided_token.authorization_type, std::nullopt,
+                                          std::nullopt, provided_token.parent_id_token};
+        }
+        if (evse->identifier.has_value()) {
+            this->persist_active_identifier(evse_id, evse->identifier.value());
+        }
         this->submit_event_for_connector(evse_id, connector_id, ConnectorEvent::TRANSACTION_STARTED);
         // wait for potentially running timeout task to finish execution
-        this->cv.wait(lk, [&evse = this->evses.at(evse_id)]() { return !evse->timeout_in_progress.load(); });
-        this->evses.at(evse_id)->timeout_timer.stop();
+        this->cv.wait(lk, [&evse]() { return !evse->timeout_in_progress.load(); });
+        evse->timeout_timer.stop();
         check_reservations = true;
         break;
     }
     case SessionEventEnum::TransactionFinished:
         this->evses.at(evse_id)->transaction_active = false;
         this->evses.at(evse_id)->identifier.reset();
+        this->clear_active_identifier(evse_id);
         break;
     case SessionEventEnum::SessionFinished: {
         this->evses.at(evse_id)->plugged_in = false;
         this->evses.at(evse_id)->plug_in_timeout = false;
         this->evses.at(evse_id)->identifier.reset();
+        this->clear_active_identifier(evse_id);
         this->submit_event_for_connector(evse_id, connector_id, ConnectorEvent::SESSION_FINISHED);
         // wait for potentially running timeout task to finish execution
         this->cv.wait(lk, [&evse = this->evses.at(evse_id)]() { return !evse->timeout_in_progress.load(); });
@@ -903,6 +934,19 @@ void AuthHandler::handle_session_event(const int evse_id, const SessionEvent& ev
         }
         break;
     }
+    case SessionEventEnum::SessionResumed: {
+        auto& evse = this->evses.at(evse_id);
+        evse->plugged_in = true;
+        evse->transaction_active = true;
+        if (auto identifier = this->load_active_identifier(evse_id); identifier.has_value()) {
+            evse->identifier = std::move(identifier);
+        } else {
+            EVLOG_warning << "Resumed transaction for evse#" << evse_id << " has no persisted authorization identifier";
+        }
+        this->submit_event_for_connector(evse_id, connector_id, ConnectorEvent::TRANSACTION_STARTED);
+        check_reservations = true;
+        break;
+    }
     /// explicitly fall through all the SessionEventEnum values we are not handling
     case SessionEventEnum::Authorized:
         [[fallthrough]];
@@ -923,8 +967,6 @@ void AuthHandler::handle_session_event(const int evse_id, const SessionEvent& ev
     case SessionEventEnum::PluginTimeout:
         [[fallthrough]];
     case SessionEventEnum::SwitchingPhases:
-        [[fallthrough]];
-    case SessionEventEnum::SessionResumed:
         break;
     }
 
@@ -932,6 +974,48 @@ void AuthHandler::handle_session_event(const int evse_id, const SessionEvent& ev
     // send 'reserved' notifications to the evse manager accordingly if needed.
     if (check_reservations) {
         this->check_evse_reserved_and_send_updates();
+    }
+}
+
+std::string AuthHandler::get_active_identifier_key(int evse_id) const {
+    return this->active_transaction_key_prefix + "_" + std::to_string(evse_id);
+}
+
+void AuthHandler::persist_active_identifier(int evse_id, const Identifier& identifier) {
+    if (this->store == nullptr) {
+        return;
+    }
+    try {
+        const json serialized = identifier;
+        this->store->call_store(this->get_active_identifier_key(evse_id), serialized.get<Object>());
+    } catch (const std::exception& e) {
+        EVLOG_warning << "Could not persist active authorization identifier for evse#" << evse_id << ": " << e.what();
+    }
+}
+
+std::optional<Identifier> AuthHandler::load_active_identifier(int evse_id) {
+    if (this->store == nullptr) {
+        return std::nullopt;
+    }
+    try {
+        const auto stored = this->store->call_load(this->get_active_identifier_key(evse_id));
+        if (const auto object = std::get_if<Object>(&stored); object != nullptr) {
+            return json(*object).get<Identifier>();
+        }
+    } catch (const std::exception& e) {
+        EVLOG_warning << "Could not restore active authorization identifier for evse#" << evse_id << ": " << e.what();
+    }
+    return std::nullopt;
+}
+
+void AuthHandler::clear_active_identifier(int evse_id) {
+    if (this->store == nullptr) {
+        return;
+    }
+    try {
+        this->store->call_delete(this->get_active_identifier_key(evse_id));
+    } catch (const std::exception& e) {
+        EVLOG_warning << "Could not clear active authorization identifier for evse#" << evse_id << ": " << e.what();
     }
 }
 

--- a/modules/EVSE/Auth/lib/Connector.cpp
+++ b/modules/EVSE/Auth/lib/Connector.cpp
@@ -5,6 +5,45 @@
 
 namespace module {
 
+void to_json(json& j, const Identifier& k) {
+    // the required parts of the type
+    j = json{
+        {"id_token", k.id_token},
+        {"type", types::authorization::authorization_type_to_string_view(k.type)},
+    };
+    // the optional parts of the type
+    if (k.authorization_status.has_value()) {
+        j["authorization_status"] =
+            types::authorization::authorization_status_to_string_view(k.authorization_status.value());
+    }
+    if (k.expiry_time.has_value()) {
+        j["expiry_time"] = k.expiry_time.value();
+    }
+    if (k.parent_id_token.has_value()) {
+        j["parent_id_token"] = k.parent_id_token.value();
+    }
+}
+
+void from_json(const json& j, Identifier& k) {
+    // the required parts of the type
+    k.id_token = j.at("id_token").get<types::authorization::IdToken>();
+    k.type = types::authorization::string_to_authorization_type(j.at("type"));
+
+    // the optional parts of the type
+    k.authorization_status.reset();
+    k.expiry_time.reset();
+    k.parent_id_token.reset();
+    if (const auto it = j.find("authorization_status"); it != j.end() and not it->is_null()) {
+        k.authorization_status = types::authorization::string_to_authorization_status(*it);
+    }
+    if (const auto it = j.find("expiry_time"); it != j.end() and not it->is_null()) {
+        k.expiry_time = it->get<std::string>();
+    }
+    if (const auto it = j.find("parent_id_token"); it != j.end() and not it->is_null()) {
+        k.parent_id_token = it->get<types::authorization::IdToken>();
+    }
+}
+
 void Connector::submit_event(ConnectorEvent event) {
     state_machine.handle_event(event);
 }

--- a/modules/EVSE/Auth/tests/auth_tests.cpp
+++ b/modules/EVSE/Auth/tests/auth_tests.cpp
@@ -15,6 +15,7 @@
 
 #include <AuthHandler.hpp>
 #include <FakeAuthReceiver.hpp>
+#include <generated/interfaces/kvs/Interface.hpp>
 
 using ::testing::_;
 using ::testing::Field;
@@ -72,6 +73,7 @@ class AuthTest : public ::testing::Test {
 protected:
     std::unique_ptr<AuthHandler> auth_handler;
     std::unique_ptr<FakeAuthReceiver> auth_receiver;
+    std::unique_ptr<kvsIntf> auth_store;
     testing::MockFunction<bool(json message)> send_callback_mock;
     StrictMock<MockFunction<void(const ProvidedIdToken& token, TokenValidationStatus status)>>
         mock_publish_token_validation_status_callback;
@@ -88,10 +90,10 @@ protected:
 
     // Builds the auth handler with the given \p selection_algorithm, registers all test callbacks and inits the
     // evses. SetUp uses PlugEvents; tests that need a different selection algorithm call this again to rebuild.
-    void init_auth_handler(SelectionAlgorithm selection_algorithm) {
+    void init_auth_handler(SelectionAlgorithm selection_algorithm, kvsIntf* store = nullptr) {
         const std::string id = "auth_handler_test_id";
-        this->auth_handler = std::make_unique<AuthHandler>(selection_algorithm, CONNECTION_TIMEOUT, true, false, false,
-                                                           true, id, nullptr);
+        this->auth_handler =
+            std::make_unique<AuthHandler>(selection_algorithm, CONNECTION_TIMEOUT, true, false, false, true, id, store);
 
         this->auth_handler->register_notify_evse_callback([this](const int evse_index,
                                                                  const ProvidedIdToken& provided_token,
@@ -1443,6 +1445,71 @@ TEST_F(AuthTest, test_complete_event_flow) {
     ASSERT_TRUE(result == TokenHandlingResult::USED_TO_START_TRANSACTION);
     ASSERT_TRUE(this->auth_receiver->get_authorization(0));
     ASSERT_FALSE(this->auth_receiver->get_authorization(1));
+}
+
+TEST_F(AuthTest, restored_identifier_can_stop_resumed_transaction) {
+    this->auth_store = std::make_unique<kvsIntf>();
+    this->init_auth_handler(SelectionAlgorithm::PlugEvents, this->auth_store.get());
+
+    std::vector<int32_t> connectors{1};
+    const auto provided_token = get_provided_token(VALID_TOKEN_1, connectors);
+    this->auth_handler->handle_session_event(1, get_transaction_started_event(provided_token));
+
+    // Recreate Auth to model a process restart while retaining KVS data.
+    this->init_auth_handler(SelectionAlgorithm::PlugEvents, this->auth_store.get());
+    SessionEvent resumed_event;
+    resumed_event.event = SessionEventEnum::SessionResumed;
+    this->auth_handler->handle_session_event(1, resumed_event);
+
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Processing));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::UsedToStop));
+    EXPECT_CALL(mock_stop_transaction_callback,
+                Call(0, Field(&StopTransactionRequest::reason, StopTransactionReason::Local)));
+
+    EXPECT_EQ(this->auth_handler->on_token(provided_token), TokenHandlingResult::USED_TO_STOP_TRANSACTION);
+}
+
+/// \brief Test that the parent_id_token that is only known from the validation result survives a restart, so a
+/// different card of the same group can still stop the resumed transaction
+TEST_F(AuthTest, restored_identifier_with_parent_id_can_be_stopped_by_sibling_token) {
+    this->auth_store = std::make_unique<kvsIntf>();
+    this->init_auth_handler(SelectionAlgorithm::PlugEvents, this->auth_store.get());
+
+    std::vector<int32_t> connectors{1};
+    // VALID_TOKEN_1 and VALID_TOKEN_3 share PARENT_ID_TOKEN, but the parent id is only reported by the validate
+    // token callback and is not part of the provided token itself
+    const auto provided_token_1 = get_provided_token(VALID_TOKEN_1, connectors);
+    const auto provided_token_2 = get_provided_token(VALID_TOKEN_3, connectors);
+    ASSERT_FALSE(provided_token_1.parent_id_token.has_value());
+
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token), TokenValidationStatus::Processing));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token), TokenValidationStatus::Accepted));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token), TokenValidationStatus::UsedToStart));
+
+    this->auth_handler->handle_session_event(
+        1, get_session_started_event(types::evse_manager::StartSessionReason::EVConnected));
+    ASSERT_EQ(this->auth_handler->on_token(provided_token_1), TokenHandlingResult::USED_TO_START_TRANSACTION);
+    this->auth_handler->handle_session_event(1, get_transaction_started_event(provided_token_1));
+
+    // Recreate Auth to model a process restart while retaining KVS data.
+    this->init_auth_handler(SelectionAlgorithm::PlugEvents, this->auth_store.get());
+    SessionEvent resumed_event;
+    resumed_event.event = SessionEventEnum::SessionResumed;
+    this->auth_handler->handle_session_event(1, resumed_event);
+
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_2.id_token), TokenValidationStatus::Processing));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_2.id_token), TokenValidationStatus::UsedToStop));
+    EXPECT_CALL(mock_stop_transaction_callback,
+                Call(0, Field(&StopTransactionRequest::reason, StopTransactionReason::Local)));
+
+    EXPECT_EQ(this->auth_handler->on_token(provided_token_2), TokenHandlingResult::USED_TO_STOP_TRANSACTION);
 }
 
 /// \brief Test if a token that is not reserved gets rejected and a parent_id_token that is reserved gets accepted

--- a/modules/EVSE/Auth/tests/stubs/generated/interfaces/kvs/Interface.hpp
+++ b/modules/EVSE/Auth/tests/stubs/generated/interfaces/kvs/Interface.hpp
@@ -1,7 +1,7 @@
 #ifndef KVS_INTERFACE_HPP
 #define KVS_INTERFACE_HPP
 
-#include <iostream>
+#include <map>
 #include <string>
 #include <variant>
 
@@ -14,22 +14,35 @@ using Array = nlohmann::json::array_t;
 using Object = nlohmann::json::object_t;
 
 class kvsIntf {
-private:
-    std::variant<std::nullptr_t, Array, Object, bool, double, int, std::string> value;
-
 public:
+    using Value = std::variant<std::nullptr_t, Array, Object, bool, double, int, std::string>;
+
     kvsIntf() {
     }
-    void call_store(std::string key,
-                    std::variant<std::nullptr_t, Array, Object, bool, double, int, std::string> value) {
-        std::cout << "Store called!" << std::endl;
-        this->value = value;
-    }
-    std::variant<std::nullptr_t, Array, Object, bool, double, int, std::string> call_load(std::string key) {
-        std::cout << "Load called!" << std::endl;
 
-        return this->value;
+    void call_store(std::string key, Value value) {
+        this->values[key] = std::move(value);
     }
+
+    Value call_load(std::string key) {
+        const auto it = this->values.find(key);
+        if (it == this->values.end()) {
+            // the kvs interface returns null for keys that were never stored
+            return nullptr;
+        }
+        return it->second;
+    }
+
+    void call_delete(std::string key) {
+        this->values.erase(key);
+    }
+
+    bool call_exists(std::string key) {
+        return this->values.find(key) != this->values.end();
+    }
+
+private:
+    std::map<std::string, Value> values;
 };
 
 #endif // KVS_INTERFACE_HPP

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -98,16 +98,46 @@ void Charger::main_thread() {
     // Enable CP output
     bsp->enable(true);
 
+    // Start the recovery timeout only after the BSP has been enabled. In
+    // external-ready configurations prepare_transaction_recovery() can run a
+    // long time before the charger thread is started.
+    {
+        Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_mainloop);
+        if (transaction_recovery.pending) {
+            transaction_recovery.started = std::chrono::steady_clock::now();
+        }
+    }
+
     // publish initial values
     signal_max_current(get_max_current_internal());
-    signal_state(shared_context.current_state);
+    bool recovery_pending;
+    {
+        Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_mainloop);
+        recovery_pending = transaction_recovery.pending;
+    }
+    if (not recovery_pending) {
+        signal_state(shared_context.current_state);
+    }
 
     while (!main_thread_handle.shouldExit()) {
 
         const auto events = bsp_event_queue.wait_for(MAINLOOP_UPDATE_RATE);
 
-        for (const auto& event : events) {
-            process_event(event);
+        {
+            Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_mainloop);
+            recovery_pending = transaction_recovery.pending;
+            if (recovery_pending) {
+                transaction_recovery.deferred_events.insert(transaction_recovery.deferred_events.end(), events.begin(),
+                                                            events.end());
+            }
+        }
+
+        if (recovery_pending) {
+            process_transaction_recovery();
+        } else {
+            for (const auto& event : events) {
+                process_event(event);
+            }
         }
 
         {
@@ -158,6 +188,14 @@ void Charger::error_thread() {
 }
 
 void Charger::run_state_machine() {
+
+    if (transaction_recovery.pending) {
+        return;
+    }
+
+    if (transaction_recovery.recovered_in_cp_state_b and shared_context.current_state != EvseState::ChargingPausedEV) {
+        transaction_recovery.recovered_in_cp_state_b = false;
+    }
 
     constexpr int max_mainloop_runs = 10;
     int mainloop_runs = 0;
@@ -927,13 +965,18 @@ void Charger::run_state_machine() {
 
             } else {
                 // This is for BASIC charging only
-                if (not power_available()) {
+                // A recovered CP-B snapshot establishes that the EV is the
+                // side currently pausing. Do not overwrite that fact merely
+                // because EnergyManager/PP data has not arrived after boot.
+                if (not transaction_recovery.recovered_in_cp_state_b and not power_available()) {
                     shared_context.current_state = EvseState::ChargingPausedEVSE;
                     break;
                 }
 
                 // update PWM if it has changed and 5 seconds have passed since last update
-                update_pwm_max_every_5seconds_ampere(get_max_current_internal());
+                if (not transaction_recovery.recovered_in_cp_state_b or transaction_recovery.energy_budget_received) {
+                    update_pwm_max_every_5seconds_ampere(get_max_current_internal());
+                }
             }
             break;
 
@@ -1310,7 +1353,8 @@ float Charger::ampere_to_duty_cycle(float ampere) {
     return duty_cycle;
 }
 
-bool Charger::set_max_current(float c, std::chrono::time_point<std::chrono::steady_clock> validUntil) {
+bool Charger::set_max_current(float c, std::chrono::time_point<std::chrono::steady_clock> validUntil,
+                              bool is_energy_manager_budget) {
     float c_abs{std::fabs(c)};
 
     // is it still valid?
@@ -1319,6 +1363,10 @@ bool Charger::set_max_current(float c, std::chrono::time_point<std::chrono::stea
             Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_set_max_current);
             shared_context.max_current = c_abs;
             shared_context.max_current_valid_until = validUntil;
+            if ((transaction_recovery.pending or transaction_recovery.recovered_in_cp_state_b) and
+                is_energy_manager_budget) {
+                transaction_recovery.energy_budget_received = true;
+            }
         }
         // now after max_current is updated with c_abs we can update c_abs with the internal max current which
         // considers the cable limit as well
@@ -1486,27 +1534,7 @@ void Charger::cleanup_transactions_on_startup() {
     // See if we have an open transaction in persistent storage
     auto session_uuid = store->get_session();
     if (not session_uuid.empty()) {
-        EVLOG_info << "Cleaning up transaction with UUID " << session_uuid << " on start up";
-        store->clear_session();
-
-        // If yes, try to close nicely with the ID we remember and trigger a transaction finished event on success
-        for (const auto& meter : r_powermeter_billing) {
-            const auto response = meter->call_stop_transaction(session_uuid);
-            // If we fail to stop the transaction, it was probably just not active anymore
-            if (response.status == types::powermeter::TransactionRequestStatus::UNEXPECTED_ERROR) {
-                EVLOG_warning << "Failed to stop a transaction on the power meter " << response.error.value_or("");
-                break;
-            } else if (response.status == types::powermeter::TransactionRequestStatus::OK) {
-                // Fill in OCMF from the recovered transaction
-                shared_context.start_signed_meter_value = response.start_signed_meter_value;
-                shared_context.stop_signed_meter_value = response.signed_meter_value;
-                break;
-            }
-        }
-
-        // Send out event to inform OCPP et al
-        std::optional<types::authorization::ProvidedIdToken> id_token;
-        signal_transaction_finished_event(types::evse_manager::StopTransactionReason::PowerLoss, id_token);
+        cleanup_transaction_on_startup(session_uuid);
     }
 
     // Now we did what we could to clean up, so if there are still transactions going on in the power meter close them
@@ -1516,6 +1544,199 @@ void Charger::cleanup_transactions_on_startup() {
     for (const auto& meter : r_powermeter_billing) {
         meter->call_stop_transaction("");
     }
+}
+
+void Charger::cleanup_transaction_on_startup(const std::string& session_uuid) {
+    EVLOG_info << "Cleaning up transaction with UUID " << session_uuid << " on start up";
+    store->clear_session();
+
+    std::optional<types::units_signed::SignedMeterValue> start_signed_meter_value;
+    std::optional<types::units_signed::SignedMeterValue> stop_signed_meter_value;
+
+    // The powermeter calls may block while other modules are still starting up,
+    // so they must not run while holding state_machine_mutex.
+    for (const auto& meter : r_powermeter_billing) {
+        const auto response = meter->call_stop_transaction(session_uuid);
+        if (response.status == types::powermeter::TransactionRequestStatus::UNEXPECTED_ERROR) {
+            EVLOG_warning << "Failed to stop a transaction on the power meter " << response.error.value_or("");
+            break;
+        } else if (response.status == types::powermeter::TransactionRequestStatus::OK) {
+            start_signed_meter_value = response.start_signed_meter_value;
+            stop_signed_meter_value = response.signed_meter_value;
+            break;
+        }
+    }
+
+    {
+        Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_mainloop);
+        shared_context.start_signed_meter_value = start_signed_meter_value;
+        shared_context.stop_signed_meter_value = stop_signed_meter_value;
+        // Consumers read the session id from get_session_id() while the events
+        // below are emitted. It must match the uuid announced by SessionResumed.
+        shared_context.session_uuid = session_uuid;
+    }
+
+    std::optional<types::authorization::ProvidedIdToken> id_token;
+    signal_transaction_finished_event(types::evse_manager::StopTransactionReason::PowerLoss, id_token);
+    // SessionResumed was published for the persisted session before the recovery
+    // outcome was known. Consumers only leave the occupied state again on
+    // SessionFinished, so the stale session has to be closed explicitly here.
+    signal_simple_event(types::evse_manager::SessionEventEnum::SessionFinished);
+
+    {
+        Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_mainloop);
+        shared_context.session_uuid.clear();
+    }
+}
+
+void Charger::prepare_transaction_recovery(const std::string& session_uuid) {
+    Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_disable);
+    transaction_recovery.session_uuid = session_uuid;
+    transaction_recovery.started.reset();
+    transaction_recovery.deferred_events.clear();
+    transaction_recovery.energy_budget_received = false;
+    transaction_recovery.recovered_in_cp_state_b = false;
+    transaction_recovery.cable_limit_read = false;
+    transaction_recovery.pending = not session_uuid.empty();
+}
+
+Charger::TransactionRecoveryResult Charger::reconcile_transaction_on_startup(std::optional<RawCPState> cp_state,
+                                                                             std::optional<bool> relais_on,
+                                                                             bool timed_out) {
+    if (not transaction_recovery.pending) {
+        return TransactionRecoveryResult::Cleanup;
+    }
+
+    // A DC HLC session cannot survive a process restart. Do not infer that it
+    // is active from CP/contactor state alone.
+    const bool resumable_mode = config_context.charge_mode == ChargeMode::AC;
+    const bool cp_state_can_recover =
+        cp_state.has_value() and
+        (cp_state.value() == RawCPState::B or cp_state.value() == RawCPState::C or cp_state.value() == RawCPState::D);
+    const bool waiting_for_cp_state = not cp_state.has_value();
+    const bool cp_requests_power = cp_state_can_recover and cp_state.value() != RawCPState::B;
+    const bool waiting_for_relais_state = cp_requests_power and not relais_on.has_value();
+    const bool cable_limit_known = connector_type != types::evse_board_support::Connector_type::IEC62196Type2Socket or
+                                   shared_context.max_current_cable.has_value();
+    // CP B means the EV is connected but is not requesting power. Recovering
+    // that state does not depend on a power budget or a PP cable limit; those
+    // inputs are only needed to decide whether CP C/D can resume charging.
+    const bool waiting_for_energy_budget =
+        cp_requests_power and (not transaction_recovery.energy_budget_received or not cable_limit_known);
+    if (resumable_mode and not shared_context.flag_disable_requested and not timed_out and
+        (waiting_for_cp_state or waiting_for_relais_state or waiting_for_energy_budget)) {
+        return TransactionRecoveryResult::Pending;
+    }
+
+    // CP B/C/D is sufficient to preserve the persisted transaction. Relay
+    // feedback is used to distinguish Charging from SuspendedEVSE, but lack of
+    // a relay transition after a host-only restart must not destroy the
+    // transaction.
+    const bool ev_connected = resumable_mode and cp_state_can_recover;
+    if (not ev_connected or shared_context.flag_disable_requested) {
+        transaction_recovery.pending = false;
+        return TransactionRecoveryResult::Cleanup;
+    }
+
+    shared_context.session_uuid = transaction_recovery.session_uuid;
+    shared_context.session_active = true;
+    shared_context.flag_transaction_active = true;
+    // The BSP call attached to flag_authorized is made after releasing the
+    // charger state mutex in process_transaction_recovery().
+    shared_context.flag_authorized.set_without_signal(true);
+    shared_context.flag_ev_plugged_in = true;
+    shared_context.contactor_open = not relais_on.value_or(false);
+    shared_context.iec_allow_close_contactor = cp_state.value() == RawCPState::C or cp_state.value() == RawCPState::D;
+
+    const bool budget_is_current = shared_context.max_current_valid_until >= std::chrono::steady_clock::now();
+    const auto cable_limit = static_cast<float>(shared_context.max_current_cable.value_or(shared_context.max_current));
+    const bool power_budget_available = transaction_recovery.energy_budget_received and budget_is_current and
+                                        std::min(shared_context.max_current, cable_limit) > 5.9F;
+
+    if (cp_state.value() == RawCPState::B) {
+        shared_context.current_state = EvseState::ChargingPausedEV;
+        transaction_recovery.recovered_in_cp_state_b = true;
+    } else if (not relais_on.value_or(false) or not power_budget_available) {
+        shared_context.current_state = EvseState::ChargingPausedEVSE;
+    } else {
+        shared_context.current_state = EvseState::Charging;
+    }
+
+    transaction_recovery.pending = false;
+    EVLOG_info << "Recovered transaction with UUID " << shared_context.session_uuid << " in state "
+               << evse_state_to_string(shared_context.current_state);
+    return TransactionRecoveryResult::Recovered;
+}
+
+bool Charger::process_transaction_recovery() {
+    // IEC snapshots take their own mutex and may call into a remote BSP. Read
+    // them before acquiring the charger state mutex.
+    const auto cp_state = bsp->get_cp_state();
+    const auto relais_on = bsp->get_relais_state();
+    // The cable limit cannot change while the recovery window is open, so stop
+    // polling the BSP once it is known.
+    const auto pp_ampacity = (connector_type == types::evse_board_support::Connector_type::IEC62196Type2Socket and
+                              not transaction_recovery.cable_limit_read)
+                                 ? bsp->read_pp_ampacity()
+                                 : std::nullopt;
+
+    TransactionRecoveryResult result = TransactionRecoveryResult::Pending;
+    std::vector<CPEvent> deferred_events;
+    {
+        Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_mainloop);
+        if (not transaction_recovery.pending) {
+            return false;
+        }
+        if (pp_ampacity.has_value()) {
+            shared_context.max_current_cable = pp_ampacity;
+            transaction_recovery.cable_limit_read = true;
+        }
+        const bool timed_out =
+            transaction_recovery.started.has_value() and
+            std::chrono::steady_clock::now() - transaction_recovery.started.value() >= TRANSACTION_RECOVERY_TIMEOUT;
+        result = reconcile_transaction_on_startup(cp_state, relais_on, timed_out);
+        if (result != TransactionRecoveryResult::Pending) {
+            deferred_events.swap(transaction_recovery.deferred_events);
+        }
+        if (result == TransactionRecoveryResult::Recovered) {
+            // Must happen in the same lock scope that cleared the pending flag:
+            // a concurrent enable_disable() would otherwise run the recovered
+            // state's entry actions before the initial Enabled/Disabled event.
+            publish_initial_enable_disable_state();
+        }
+    }
+
+    if (result == TransactionRecoveryResult::Pending) {
+        return true;
+    }
+
+    if (result == TransactionRecoveryResult::Cleanup) {
+        // Powermeter RPCs may block while hardware modules are still starting.
+        // They must not run while holding state_machine_mutex.
+        cleanup_transactions_on_startup();
+        {
+            Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_mainloop);
+            publish_initial_enable_disable_state();
+            signal_state(shared_context.current_state);
+        }
+
+        // CP events are edge triggered. Replay every event observed during the
+        // recovery window so a connected EV cannot remain stranded in Idle.
+        for (const auto event : deferred_events) {
+            process_event(event);
+        }
+        return false;
+    }
+
+    // Restore authorization in the BSP outside the state mutex, then let the
+    // normal state entry execute. This reasserts PWM and power-on commands and
+    // emits exactly the recovered charging state after Enabled/Disabled.
+    bsp->set_authorized(true);
+    {
+        Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_mainloop);
+        run_state_machine();
+    }
+    return false;
 }
 
 std::optional<types::units_signed::SignedMeterValue> Charger::get_stop_signed_meter_value() {
@@ -1691,21 +1912,45 @@ bool Charger::deauthorize_internal() {
 
 void Charger::enable_disable_initial_state_publish() {
     Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_disable);
-    types::evse_manager::EnableDisableSource source{types::evse_manager::Enable_source::Unspecified,
-                                                    types::evse_manager::Enable_state::Unassigned, 10000};
+    if (transaction_recovery.pending) {
+        return;
+    }
+    publish_initial_enable_disable_state();
+}
 
-    // check the startup state and publish it
-    if (shared_context.current_state == EvseState::Disabled) {
-        signal_simple_event(types::evse_manager::SessionEventEnum::Disabled);
-        source.enable_state = types::evse_manager::Enable_state::Disable;
-    } else {
-        signal_simple_event(types::evse_manager::SessionEventEnum::Enabled);
-        source.enable_state = types::evse_manager::Enable_state::Enable;
+void Charger::publish_initial_enable_disable_state() {
+    if (initial_enable_disable_state_published) {
+        return;
     }
 
-    // ensure the state is in the table
-    enable_disable_source_table_update(source);
-    active_enable_disable_source = source;
+    const bool has_explicit_source = not enable_disable_source_table.empty();
+    types::evse_manager::EnableDisableSource source =
+        has_explicit_source
+            ? active_enable_disable_source
+            : types::evse_manager::EnableDisableSource{types::evse_manager::Enable_source::Unspecified,
+                                                       types::evse_manager::Enable_state::Unassigned, 10000};
+
+    // check the startup state and publish it
+    if (shared_context.current_state == EvseState::Disabled or shared_context.flag_disable_requested or
+        not shared_context.connector_enabled) {
+        signal_simple_event(types::evse_manager::SessionEventEnum::Disabled);
+        if (not has_explicit_source) {
+            source.enable_state = types::evse_manager::Enable_state::Disable;
+        }
+    } else {
+        signal_simple_event(types::evse_manager::SessionEventEnum::Enabled);
+        if (not has_explicit_source) {
+            source.enable_state = types::evse_manager::Enable_state::Enable;
+        }
+    }
+
+    // Only synthesize the default source when no real availability request
+    // arrived during recovery. Never overwrite the CSMS/firmware source.
+    if (not has_explicit_source) {
+        enable_disable_source_table_update(source);
+        active_enable_disable_source = source;
+    }
+    initial_enable_disable_state_published = true;
 }
 
 bool Charger::enable_disable(int connector_id, const types::evse_manager::EnableDisableSource& source) {
@@ -1730,10 +1975,17 @@ bool Charger::enable_disable(int connector_id, const types::evse_manager::Enable
         shared_context.connector_enabled = is_enabled;
     }
 
+    // Keep the teardown latch synchronized with the effective availability,
+    // even while transaction recovery prevents the state machine from
+    // running. In particular, a Disable followed by an effective Enable must
+    // cancel the pending teardown before recovery is reconciled.
+    // An enable on connector 0 does not lift a connector specific disable, so
+    // both the global table result and the connector state must agree.
+    shared_context.flag_disable_requested = not(is_enabled and shared_context.connector_enabled);
+
     if (shared_context.current_state == EvseState::Disabled && shared_context.connector_enabled) {
-        // When re-enabling, clear the disable flag and re-enable the BSP before
-        // the state machine sees Idle for the first time.
-        shared_context.flag_disable_requested = false;
+        // When re-enabling, re-enable the BSP before the state machine sees
+        // Idle for the first time.
         bsp->enable(true);
         shared_context.current_state = EvseState::Idle;
     }
@@ -1769,7 +2021,6 @@ bool Charger::enable_disable(int connector_id, const types::evse_manager::Enable
             // or Finished. The Idle state transitions directly to Disabled.
             // cp_state_F() and bsp->enable(false) are called from the Disabled state
             // handler to guarantee correct ordering.
-            shared_context.flag_disable_requested = true;
             shared_context.last_stop_transaction_reason = StopTransactionReason::EVSEDisabled;
         }
         // Drive the state machine synchronously so callers see the resulting

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -95,7 +95,8 @@ public:
     //
 
     // external input to charger: update max_current and new validUntil
-    bool set_max_current(float ampere, std::chrono::time_point<std::chrono::steady_clock> validUntil);
+    bool set_max_current(float ampere, std::chrono::time_point<std::chrono::steady_clock> validUntil,
+                         bool is_energy_manager_budget = true);
     float get_max_current();
 
     sigslot::signal<float> signal_max_current;
@@ -224,6 +225,7 @@ public:
     std::optional<types::evse_manager::StopTransactionReason> get_last_stop_transaction_reason();
 
     void cleanup_transactions_on_startup();
+    void prepare_transaction_recovery(const std::string& session_uuid);
     EventQueue<CPEvent> bsp_event_queue;
 
 private:
@@ -277,6 +279,8 @@ private:
     void process_event(CPEvent event);
 
     void set_state(EvseState s);
+    bool process_transaction_recovery();
+    void publish_initial_enable_disable_state();
 
     // This mutex locks all variables related to the state machine
     Everest::timed_mutex_traceable state_machine_mutex;
@@ -300,6 +304,10 @@ private:
         /// complain if someone misuses.
         template <typename... U> void set_signal(U&&... args) {
             signal.connect(std::forward<U>(args)...);
+        }
+
+        void set_without_signal(bool value) {
+            std::atomic_bool::operator=(value);
         }
 
     private:
@@ -458,6 +466,18 @@ private:
 
     EventQueue<ErrorHandlingEvents> error_handling_event_queue;
 
+    struct TransactionRecovery {
+        std::string session_uuid;
+        std::optional<std::chrono::steady_clock::time_point> started;
+        std::vector<CPEvent> deferred_events;
+        bool energy_budget_received{false};
+        bool recovered_in_cp_state_b{false};
+        bool pending{false};
+        // Read from the mainloop before taking state_machine_mutex
+        std::atomic_bool cable_limit_read{false};
+    } transaction_recovery;
+    bool initial_enable_disable_state_published{false};
+
     // constants
     constexpr static int LEGACY_WAKEUP_TIMEOUT{30000};
     constexpr static int PREPARING_TIMEOUT_PAUSED_BY_EV{10000};
@@ -484,6 +504,7 @@ private:
     static constexpr int WAIT_FOR_ENERGY_IN_AUTHLOOP_TIMEOUT_MS = 5000;
     static constexpr int AC_X1_FALLBACK_TO_NOMINAL_TIMEOUT_MS = 10000;
     static constexpr int STOPPING_CHARGING_TIMEOUT_MS = 20000;
+    static constexpr auto TRANSACTION_RECOVERY_TIMEOUT = std::chrono::seconds(2);
     // Ensures apply_new_target_voltage_current() is called at least every DC_ENFORCE_TARGET_LIMITS_INTERVAL_MS
     // during DC charging. This re-applies EVSE limits to the power supply even when the EV does not send
     // new target values or ignores updated limits from energy management.
@@ -498,8 +519,17 @@ private:
     void enable_disable_source_table_update(const types::evse_manager::EnableDisableSource& source);
 
 protected:
+    enum class TransactionRecoveryResult {
+        Pending,
+        Recovered,
+        Cleanup,
+    };
+
     // provide access for unit tests
     void run_state_machine();
+    void cleanup_transaction_on_startup(const std::string& session_uuid);
+    TransactionRecoveryResult reconcile_transaction_on_startup(std::optional<RawCPState> cp_state,
+                                                               std::optional<bool> relais_on, bool timed_out);
     constexpr auto& get_shared_context() {
         return shared_context;
     }

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -1492,15 +1492,15 @@ void EvseManager::ready() {
     const auto session_id = store->get_session();
     if (!session_id.empty()) {
         charger->signal_session_resumed_event(session_id);
+        charger->prepare_transaction_recovery(session_id);
+    } else {
+        charger->cleanup_transactions_on_startup();
     }
 
-    // By default cleanup left-over transaction from e.g. power loss
-    // TOOD: Add resume handling
-    charger->cleanup_transactions_on_startup();
-
     //  start with a limit of 0 amps. We will get a budget from EnergyManager that is locally limited by hw
-    //  caps.
-    charger->set_max_current(0.0F, steady_clock::now() + std::chrono::seconds(120));
+    //  caps. This is a startup sentinel, not an EnergyManager budget: recovery
+    //  must wait for the first real budget before reasserting active charging.
+    charger->set_max_current(0.0F, steady_clock::now() + std::chrono::seconds(120), false);
     this->p_evse->publish_waiting_for_external_ready(config.external_ready_to_start_charging);
     if (not config.external_ready_to_start_charging) {
         // immediately ready, otherwise delay until we get the external signal
@@ -1519,11 +1519,11 @@ void EvseManager::ready_to_start_charging() {
     p_evse->publish_supported_energy_transfer_modes(*this->supported_energy_transfers.handle());
 
     timepoint_ready_for_charging = std::chrono::steady_clock::now();
-    charger->run();
-
     // this will publish a session event Enabled or Disabled that allows other modules the retrieve this state on
-    // startup
+    // startup. Request it before starting the charger thread so transaction recovery always orders it before the
+    // recovered charging state.
     charger->enable_disable_initial_state_publish();
+    charger->run();
 
     this->p_evse->publish_ready(true);
     EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green), "🌀🌀🌀 Ready to start charging 🌀🌀🌀");

--- a/modules/EVSE/EvseManager/IECStateMachine.cpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.cpp
@@ -84,18 +84,23 @@ IECStateMachine::IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& 
 
     // Subscribe to bsp driver to receive BspEvents from the hardware
     r_bsp->subscribe_event([this](types::board_support_common::BspEvent const& event) {
-        if (enabled) {
-            // feed into state machine
-            process_bsp_event(event);
-        } else {
-            EVLOG_info << "Ignoring BSP Event, BSP is not enabled yet.";
-        }
+        // Always retain the latest physical snapshot. Some BSPs publish their
+        // startup state before EvseManager calls enable(true), and CP/relay
+        // values may not transition again during a host-only restart.
+        process_bsp_event(event);
     });
 }
 
 void IECStateMachine::process_bsp_event(types::board_support_common::BspEvent const& bsp_event) {
     auto event = from_bsp_event(bsp_event.event);
     std::visit(overloaded{[this](const RawCPState& raw_state) {
+                              latest_cp_state = raw_state;
+                              cp_state_received = true;
+                              cp_state_cached_while_disabled = not enabled;
+                              if (cp_state_cached_while_disabled) {
+                                  EVLOG_debug << "Caching BSP CP state until BSP is enabled.";
+                                  return;
+                              }
                               // If it is a raw CP state, run it through the state machine
                               feed_state_machine(raw_state);
                           },
@@ -104,8 +109,16 @@ void IECStateMachine::process_bsp_event(types::board_support_common::BspEvent co
                               // track relais state as confirmed by BSP
                               if (event == CPEvent::PowerOn) {
                                   relais_on = true;
+                                  relais_state_received = true;
+                                  relais_state_cached_while_disabled = not enabled;
                               } else if (event == CPEvent::PowerOff) {
                                   relais_on = false;
+                                  relais_state_received = true;
+                                  relais_state_cached_while_disabled = not enabled;
+                              }
+                              if (not enabled) {
+                                  EVLOG_debug << "Caching BSP relay state until BSP is enabled.";
+                                  return;
                               }
                               check_connector_lock();
 
@@ -474,6 +487,33 @@ void IECStateMachine::setup(bool has_ventilation) {
 void IECStateMachine::enable(bool en) {
     enabled = en;
     r_bsp->call_enable(en);
+    if (en) {
+        // Replay only the snapshots that were swallowed while disabled: the
+        // hardware may never repeat them. A later enable(true) must not re-emit
+        // state the state machine has already processed. A synchronous
+        // republish from call_enable() above clears the flags again.
+        if (cp_state_cached_while_disabled.exchange(false)) {
+            feed_state_machine(latest_cp_state.load());
+        }
+        if (relais_state_cached_while_disabled.exchange(false)) {
+            check_connector_lock();
+            signal_event(relais_on ? CPEvent::PowerOn : CPEvent::PowerOff);
+        }
+    }
+}
+
+std::optional<RawCPState> IECStateMachine::get_cp_state() {
+    if (not cp_state_received) {
+        return std::nullopt;
+    }
+    return latest_cp_state.load();
+}
+
+std::optional<bool> IECStateMachine::get_relais_state() {
+    if (not relais_state_received) {
+        return std::nullopt;
+    }
+    return relais_on.load();
 }
 
 // Forward the over current detection limit to the BSP. Many BSP MCUs monitor the charge current and trigger a fault

--- a/modules/EVSE/EvseManager/IECStateMachine.hpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.hpp
@@ -102,6 +102,9 @@ public:
 
     void set_authorized(bool a);
 
+    std::optional<RawCPState> get_cp_state();
+    std::optional<bool> get_relais_state();
+
     void set_ev_simplified_mode_evse_limit(bool l) {
         ev_simplified_mode_evse_limit = l;
     }
@@ -135,6 +138,11 @@ private:
     bool car_plugged_in{false};
 
     RawCPState last_cp_state{RawCPState::Disabled};
+    std::atomic<RawCPState> latest_cp_state{RawCPState::Disabled};
+    std::atomic_bool cp_state_received{false};
+    // Set while the port is disabled: those events were swallowed and are
+    // replayed once enable(true) is called.
+    std::atomic_bool cp_state_cached_while_disabled{false};
     AsyncTimeout timeout_state_c1;
     AsyncTimeout timeout_unlock_state_F;
 
@@ -155,6 +163,8 @@ private:
 
     std::atomic_bool enabled{false};
     std::atomic_bool relais_on{false};
+    std::atomic_bool relais_state_received{false};
+    std::atomic_bool relais_state_cached_while_disabled{false};
 
     static constexpr std::chrono::seconds power_off_under_load_in_c1_timeout{6};
     static constexpr std::chrono::seconds unlock_in_state_f_timeout{5};

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -18,10 +18,13 @@ using namespace types::evse_manager;
 // class that provides access to internal state from the Charger class
 struct ChargerDerived : public Charger {
     using Charger::Charger;
+    using Charger::cleanup_transaction_on_startup;
     using Charger::get_enable_disable_source_table;
     using Charger::get_hlc_use_5percent_current_session;
     using Charger::get_shared_context;
+    using Charger::reconcile_transaction_on_startup;
     using Charger::run_state_machine;
+    using Charger::TransactionRecoveryResult;
 
     // updated when a non-zero connector is used to enable_disable()
     constexpr const auto& connector_enabled() {
@@ -47,6 +50,7 @@ struct ChargerTest : public testing::Test {
     std::unique_ptr<IECStateMachine> charger_bsp;
     std::unique_ptr<ErrorHandling> charger_error_handling;
     std::vector<std::unique_ptr<powermeterIntf>> charger_powermeter_billing;
+    std::vector<std::unique_ptr<kvsIntf>> charger_store_kvs;
     std::unique_ptr<PersistentStore> charger_store;
 
     // error handling requirements
@@ -72,10 +76,12 @@ struct ChargerTest : public testing::Test {
 
     void SetUp() override {
         reset_last_event();
+        charger_store = std::make_unique<PersistentStore>(charger_store_kvs, "EVSETEST");
         charger = std::make_unique<ChargerDerived>(
             charger_bsp, charger_error_handling, charger_powermeter_billing, charger_store,
             types::evse_board_support::Connector_type::IEC62196Type2Socket, "EVSETEST");
         charger->signal_simple_event.connect(&ChargerTest::session_event, this);
+        charger->signal_charging_paused_evse_event.connect(&ChargerTest::charging_paused_evse_event, this);
     }
 
     void TearDown() override {
@@ -84,12 +90,19 @@ struct ChargerTest : public testing::Test {
 
     void session_event(SessionEventEnum event) {
         last_event = event;
+        session_events.push_back(event);
+    }
+
+    void charging_paused_evse_event(ChargingPausedEVSEReasons reasons) {
+        paused_evse_events.push_back(std::move(reasons));
     }
 
     static constexpr SessionEventEnum default_event{SessionEventEnum::SessionFinished};
     static constexpr EnableDisableSource default_source{Enable_source::Unspecified, Enable_state::Unassigned, 10000};
 
     SessionEventEnum last_event{default_event};
+    std::vector<SessionEventEnum> session_events;
+    std::vector<ChargingPausedEVSEReasons> paused_evse_events;
 
     constexpr void reset_last_event() {
         last_event = default_event;
@@ -762,6 +775,224 @@ TEST_F(ChargerTest, DisableDuringIdle) {
     EXPECT_EQ(last_event, SessionEventEnum::Disabled);
 }
 
+TEST_F(ChargerTest, RecoversPersistedTransactionFromLiveCpStateC) {
+    charger->prepare_transaction_recovery("persisted-session");
+    charger->get_shared_context().max_current_cable = 32.F;
+    charger->set_max_current(16.F, std::chrono::steady_clock::now() + std::chrono::minutes(1));
+
+    // The initial Enabled publication must be ordered before the recovered
+    // charging state so consumers cannot finish startup in Available.
+    charger->enable_disable_initial_state_publish();
+    EXPECT_TRUE(session_events.empty());
+
+    EXPECT_EQ(charger->reconcile_transaction_on_startup(RawCPState::C, true, false),
+              ChargerDerived::TransactionRecoveryResult::Recovered);
+    charger->enable_disable_initial_state_publish();
+    charger->run_state_machine();
+
+    const auto& ctx = charger->get_shared_context();
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::Charging);
+    EXPECT_EQ(ctx.session_uuid, "persisted-session");
+    EXPECT_TRUE(ctx.session_active);
+    EXPECT_TRUE(ctx.flag_transaction_active);
+    EXPECT_TRUE(ctx.flag_authorized);
+    EXPECT_TRUE(ctx.flag_ev_plugged_in);
+    ASSERT_EQ(session_events.size(), 2);
+    EXPECT_EQ(session_events[0], SessionEventEnum::Enabled);
+    EXPECT_EQ(session_events[1], SessionEventEnum::ChargingStarted);
+
+    // The real startup path invokes this once before starting the charger
+    // thread. A repeated request after recovery must not publish Enabled after
+    // ChargingStarted.
+    charger->enable_disable_initial_state_publish();
+    ASSERT_EQ(session_events.size(), 2);
+}
+
+TEST_F(ChargerTest, RecoversPersistedTransactionAsSuspendedWhenEvIsInCpStateB) {
+    charger->prepare_transaction_recovery("persisted-session");
+    charger->get_shared_context().max_current_cable = 32.F;
+    charger->set_max_current(16.F, std::chrono::steady_clock::now() + std::chrono::minutes(1));
+
+    EXPECT_EQ(charger->reconcile_transaction_on_startup(RawCPState::B, std::nullopt, false),
+              ChargerDerived::TransactionRecoveryResult::Recovered);
+    charger->enable_disable_initial_state_publish();
+    charger->run_state_machine();
+
+    const auto& ctx = charger->get_shared_context();
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::ChargingPausedEV);
+    EXPECT_TRUE(ctx.flag_transaction_active);
+    EXPECT_EQ(last_event, SessionEventEnum::ChargingPausedEV);
+}
+
+TEST_F(ChargerTest, RecoversCpStateBWithoutEnergyBudgetOrCableLimit) {
+    charger->prepare_transaction_recovery("persisted-session");
+
+    EXPECT_EQ(charger->reconcile_transaction_on_startup(RawCPState::B, std::nullopt, false),
+              ChargerDerived::TransactionRecoveryResult::Recovered);
+    charger->enable_disable_initial_state_publish();
+    charger->run_state_machine();
+
+    const auto& ctx = charger->get_shared_context();
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::ChargingPausedEV);
+    EXPECT_FALSE(ctx.max_current_cable.has_value());
+    EXPECT_TRUE(ctx.flag_transaction_active);
+    EXPECT_EQ(last_event, SessionEventEnum::ChargingPausedEV);
+}
+
+TEST_F(ChargerTest, EffectiveEnableDuringRecoveryCancelsPendingDisable) {
+    constexpr EnableDisableSource disable_source{Enable_source::CSMS, Enable_state::Disable, 100};
+    constexpr EnableDisableSource enable_source{Enable_source::CSMS, Enable_state::Enable, 100};
+
+    charger->prepare_transaction_recovery("persisted-session");
+
+    EXPECT_FALSE(charger->enable_disable(1, disable_source));
+    EXPECT_TRUE(charger->flag_disable_requested());
+    EXPECT_FALSE(charger->connector_enabled());
+
+    EXPECT_TRUE(charger->enable_disable(1, enable_source));
+    EXPECT_FALSE(charger->flag_disable_requested());
+    EXPECT_TRUE(charger->connector_enabled());
+
+    EXPECT_EQ(charger->reconcile_transaction_on_startup(RawCPState::B, std::nullopt, false),
+              ChargerDerived::TransactionRecoveryResult::Recovered);
+    EXPECT_EQ(charger->get_shared_context().current_state, Charger::EvseState::ChargingPausedEV);
+}
+
+TEST_F(ChargerTest, WaitsForReconcileUntilCpAndRelaisFeedbackHaveArrived) {
+    charger->prepare_transaction_recovery("persisted-session");
+    charger->get_shared_context().max_current_cable = 32.F;
+    charger->set_max_current(0.F, std::chrono::steady_clock::now() + std::chrono::minutes(1));
+
+    // PowerOff commonly arrives before the first CP event. It is not enough
+    // on its own to decide whether the persisted session is stale.
+    EXPECT_EQ(charger->reconcile_transaction_on_startup(std::nullopt, false, false),
+              ChargerDerived::TransactionRecoveryResult::Pending);
+    EXPECT_TRUE(session_events.empty());
+    EXPECT_TRUE(paused_evse_events.empty());
+
+    // Once C arrives, confirmed open relays mean that the EV is requesting
+    // power but the EVSE is not supplying it.
+    EXPECT_EQ(charger->reconcile_transaction_on_startup(RawCPState::C, false, false),
+              ChargerDerived::TransactionRecoveryResult::Recovered);
+    charger->enable_disable_initial_state_publish();
+    charger->run_state_machine();
+    const auto& ctx = charger->get_shared_context();
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::ChargingPausedEVSE);
+    EXPECT_TRUE(ctx.contactor_open);
+    EXPECT_TRUE(ctx.flag_transaction_active);
+    ASSERT_EQ(session_events.size(), 1);
+    EXPECT_EQ(session_events[0], SessionEventEnum::Enabled);
+    ASSERT_EQ(paused_evse_events.size(), 1);
+    ASSERT_EQ(paused_evse_events[0].reasons.size(), 1);
+    EXPECT_EQ(paused_evse_events[0].reasons[0], PauseChargingEVSEReasonEnum::NoEnergy);
+}
+
+TEST_F(ChargerTest, WaitsForReconcileWhenCpRequestsPowerWithoutRelaisFeedback) {
+    charger->prepare_transaction_recovery("persisted-session");
+
+    EXPECT_EQ(charger->reconcile_transaction_on_startup(RawCPState::C, std::nullopt, false),
+              ChargerDerived::TransactionRecoveryResult::Pending);
+
+    const auto& ctx = charger->get_shared_context();
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::Idle);
+    EXPECT_FALSE(ctx.session_active);
+    EXPECT_FALSE(ctx.flag_transaction_active);
+    EXPECT_TRUE(session_events.empty());
+}
+
+TEST_F(ChargerTest, PreservesTransactionAsSuspendedWhenRelaisFeedbackTimesOut) {
+    charger->prepare_transaction_recovery("persisted-session");
+
+    EXPECT_EQ(charger->reconcile_transaction_on_startup(RawCPState::C, std::nullopt, true),
+              ChargerDerived::TransactionRecoveryResult::Recovered);
+    charger->enable_disable_initial_state_publish();
+    charger->run_state_machine();
+
+    const auto& ctx = charger->get_shared_context();
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::ChargingPausedEVSE);
+    EXPECT_TRUE(ctx.session_active);
+    EXPECT_TRUE(ctx.flag_transaction_active);
+    ASSERT_EQ(session_events.size(), 1);
+    EXPECT_EQ(session_events[0], SessionEventEnum::Enabled);
+    ASSERT_EQ(paused_evse_events.size(), 1);
+    ASSERT_EQ(paused_evse_events[0].reasons.size(), 1);
+    EXPECT_EQ(paused_evse_events[0].reasons[0], PauseChargingEVSEReasonEnum::NoEnergy);
+}
+
+TEST_F(ChargerTest, DoesNotRecoverPersistedTransactionWithoutLiveCpState) {
+    charger->prepare_transaction_recovery("persisted-session");
+
+    EXPECT_EQ(charger->reconcile_transaction_on_startup(std::nullopt, std::nullopt, false),
+              ChargerDerived::TransactionRecoveryResult::Pending);
+
+    const auto& ctx = charger->get_shared_context();
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::Idle);
+    EXPECT_FALSE(ctx.session_active);
+    EXPECT_FALSE(ctx.flag_transaction_active);
+    EXPECT_TRUE(session_events.empty());
+}
+
+TEST_F(ChargerTest, CleansUpPersistedTransactionWhenCpStateTimesOut) {
+    charger->prepare_transaction_recovery("persisted-session");
+
+    EXPECT_EQ(charger->reconcile_transaction_on_startup(std::nullopt, std::nullopt, true),
+              ChargerDerived::TransactionRecoveryResult::Cleanup);
+}
+
+TEST_F(ChargerTest, CleanupOfPersistedTransactionFinishesTheResumedSession) {
+    // A SessionResumed event was published for the persisted session before the
+    // recovery outcome was known. Consumers track the connector as occupied
+    // until they see SessionFinished, so the cleanup must emit it.
+    std::optional<std::size_t> simple_events_before_transaction_finished;
+    std::string transaction_finished_uuid;
+    charger->signal_transaction_finished_event.connect(
+        [this, &simple_events_before_transaction_finished, &transaction_finished_uuid](
+            const StopTransactionReason& reason, const std::optional<types::authorization::ProvidedIdToken>&) {
+            simple_events_before_transaction_finished = session_events.size();
+            transaction_finished_uuid = charger->get_session_id();
+            EXPECT_EQ(reason, StopTransactionReason::PowerLoss);
+        });
+
+    std::string session_finished_uuid;
+    charger->signal_simple_event.connect([this, &session_finished_uuid](SessionEventEnum event) {
+        if (event == SessionEventEnum::SessionFinished) {
+            session_finished_uuid = charger->get_session_id();
+        }
+    });
+
+    charger->cleanup_transaction_on_startup("persisted-session");
+
+    ASSERT_EQ(session_events.size(), 1);
+    EXPECT_EQ(session_events[0], SessionEventEnum::SessionFinished);
+    // TransactionFinished must be published before SessionFinished
+    ASSERT_TRUE(simple_events_before_transaction_finished.has_value());
+    EXPECT_EQ(simple_events_before_transaction_finished.value(), 0);
+    // Both events must be attributed to the resumed session
+    EXPECT_EQ(transaction_finished_uuid, "persisted-session");
+    EXPECT_EQ(session_finished_uuid, "persisted-session");
+    // The stale uuid must not leak into subsequent events
+    EXPECT_TRUE(charger->get_session_id().empty());
+}
+
+TEST_F(ChargerTest, WaitsForEnergyBudgetBeforeRecoveringCharging) {
+    charger->prepare_transaction_recovery("persisted-session");
+    charger->get_shared_context().max_current_cable = 32.F;
+
+    EXPECT_EQ(charger->reconcile_transaction_on_startup(RawCPState::C, true, false),
+              ChargerDerived::TransactionRecoveryResult::Pending);
+
+    charger->set_max_current(16.F, std::chrono::steady_clock::now() + std::chrono::minutes(1));
+    EXPECT_EQ(charger->reconcile_transaction_on_startup(RawCPState::C, true, false),
+              ChargerDerived::TransactionRecoveryResult::Recovered);
+    charger->enable_disable_initial_state_publish();
+    charger->run_state_machine();
+
+    EXPECT_EQ(charger->get_shared_context().current_state, Charger::EvseState::Charging);
+    ASSERT_EQ(session_events.size(), 2);
+    EXPECT_EQ(session_events[0], SessionEventEnum::Enabled);
+    EXPECT_EQ(session_events[1], SessionEventEnum::ChargingStarted);
+}
+
 // ----------------------------------------------------------------------------
 // tests for dlink_error()
 // A D-LINK_ERROR normally restarts SLAC matching via T_step_X1/T_step_EF
@@ -931,6 +1162,14 @@ void IECStateMachine::connector_force_unlock() {
 }
 
 void IECStateMachine::set_authorized(bool a) {
+}
+
+std::optional<RawCPState> IECStateMachine::get_cp_state() {
+    return std::nullopt;
+}
+
+std::optional<bool> IECStateMachine::get_relais_state() {
+    return std::nullopt;
 }
 
 const std::string cpevent_to_string(CPEvent e) {

--- a/modules/EVSE/EvseManager/tests/IECStateMachineTest.cpp
+++ b/modules/EVSE/EvseManager/tests/IECStateMachineTest.cpp
@@ -88,6 +88,30 @@ TEST(IECStateMachine, init) {
     module::IECStateMachine state_machine(std::move(bsp_if), true, false);
 }
 
+TEST(IECStateMachine, ReportsOnlyHardwareCpAndRelaisState) {
+    BspStub bsp;
+    std::unique_ptr<evse_board_supportIntf> bsp_if = std::make_unique<module::stub::evse_board_supportIntfStub>(bsp);
+    module::IECStateMachine state_machine(std::move(bsp_if), true, false);
+
+    state_machine.enable(true);
+    EXPECT_FALSE(state_machine.get_cp_state().has_value());
+    EXPECT_FALSE(state_machine.get_relais_state().has_value());
+
+    // This evaluates the IEC state machine without a new hardware CP sample.
+    // It must not make the synthetic default state available to recovery.
+    state_machine.allow_power_on(false, Reason::PowerOff);
+    EXPECT_FALSE(state_machine.get_cp_state().has_value());
+
+    bsp.raise_event(Event::PowerOff);
+    ASSERT_TRUE(state_machine.get_relais_state().has_value());
+    EXPECT_FALSE(state_machine.get_relais_state().value());
+    EXPECT_FALSE(state_machine.get_cp_state().has_value());
+
+    bsp.raise_event(Event::C);
+    ASSERT_TRUE(state_machine.get_cp_state().has_value());
+    EXPECT_EQ(state_machine.get_cp_state().value(), module::RawCPState::C);
+}
+
 #if 0
 // test to demonstrate the output from backtrace
 


### PR DESCRIPTION
## Describe your changes

  After a reboot mid-session (e.g. OTA-triggered), EVerest reported connector 1 as Available via MQTT and OCPP even though charging was still ongoing.

  The charger now defers startup state publication when a session is persisted and reconciles against live BSP feedback (CP state, relay, energy budget) before reporting:

  - CP B/C/D preserves the persisted transaction; relay + energy budget decide between Charging, SuspendedEV, and SuspendedEVSE. Missing feedback times out (2 s) conservatively instead of destroying a live session.
  - CP events arriving during the recovery window are deferred and replayed if the session turns out stale, so a plugged-in EV can't be stranded in Idle.
  - The recovered state runs its normal entry actions (power-on, PWM, correctly ordered Enabled → charging state).
  - Auth persists the merged authorization identifier (incl. validated parent id token) in KVS and restores it on SessionResumed, so RFID stop — including sibling cards — works for resumed sessions.
  - Stale-session cleanup at boot now emits SessionFinished so consumers release the connector.
  - IEC state machine caches BSP state received before enable and replays it once.

  Known limitations: DC/HLC sessions are not resumed (cleaned up as before); the powermeter billing transaction is not re-verified on resume; recovery requires the BSP to report CP state within 2 s of startup.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

