### PR TITLE
fix(EvseManager): do not reset CP state F on BSP state events

### DIFF
--- a/modules/EVSE/EvseManager/IECStateMachine.cpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.cpp
@@ -155,7 +155,9 @@ std::queue<CPEvent> IECStateMachine::state_machine(std::optional<RawCPState> con
         case RawCPState::Disabled:
             if (last_cp_state != RawCPState::Disabled) {
                 pwm_running = false;
-                r_bsp->call_cp_state_X1();
+                if (not cp_state_f_requested) {
+                    r_bsp->call_cp_state_X1();
+                }
                 ev_simplified_mode = false;
                 timer_state_C1 = TimerControl::stop;
                 call_allow_power_on_bsp(false);
@@ -166,7 +168,9 @@ std::queue<CPEvent> IECStateMachine::state_machine(std::optional<RawCPState> con
         case RawCPState::A:
             if (last_cp_state != RawCPState::A) {
                 pwm_running = false;
-                r_bsp->call_cp_state_X1();
+                if (not cp_state_f_requested) {
+                    r_bsp->call_cp_state_X1();
+                }
                 ev_simplified_mode = false;
                 car_plugged_in = false;
                 call_allow_power_on_bsp(false);
@@ -291,7 +295,9 @@ std::queue<CPEvent> IECStateMachine::state_machine(std::optional<RawCPState> con
                 timer_state_C1 = TimerControl::stop;
                 call_allow_power_on_bsp(false);
                 pwm_running = false;
-                r_bsp->call_cp_state_X1();
+                if (not cp_state_f_requested) {
+                    r_bsp->call_cp_state_X1();
+                }
                 if (last_cp_state == RawCPState::B || last_cp_state == RawCPState::C ||
                     last_cp_state == RawCPState::D) {
                     events.push(CPEvent::BCDtoEF);
@@ -363,6 +369,7 @@ void IECStateMachine::set_pwm(double value) {
         } else {
             pwm_running = false;
         }
+        cp_state_f_requested = false;
     }
 
     if (ev_simplified_mode_evse_limit and ev_simplified_mode and value > ev_simplified_mode_evse_limit_pwm) {
@@ -381,6 +388,7 @@ void IECStateMachine::set_cp_state_X1() {
     {
         Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::IEC_set_cp_state_X1);
         pwm_running = false;
+        cp_state_f_requested = false;
     }
     r_bsp->call_cp_state_X1();
     // Don't run the state machine in the callers context
@@ -392,6 +400,7 @@ void IECStateMachine::set_cp_state_F() {
     {
         Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::IEC_set_cp_state_F);
         pwm_running = false;
+        cp_state_f_requested = true;
     }
     r_bsp->call_cp_state_F();
     // Don't run the state machine in the callers context

--- a/modules/EVSE/EvseManager/IECStateMachine.hpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.hpp
@@ -135,6 +135,9 @@ private:
     bool car_plugged_in{false};
 
     RawCPState last_cp_state{RawCPState::Disabled};
+    // True while the high level state machine wants CP state F. Guards the automatic X1 reset on
+    // Disabled/A/E events, which could otherwise undo a concurrently commanded F on the BSP.
+    bool cp_state_f_requested{false};
     AsyncTimeout timeout_state_c1;
     AsyncTimeout timeout_unlock_state_F;
 

--- a/modules/EVSE/EvseManager/tests/IECStateMachineTest.cpp
+++ b/modules/EVSE/EvseManager/tests/IECStateMachineTest.cpp
@@ -27,6 +27,7 @@ struct BspStub : public module::stub::ModuleAdapterStub {
         _bsp["allow_power_on"] = &BspStub::call_allow_power_on;
         _bsp["enable"] = &BspStub::call_enable;
         _bsp["cp_state_X1"] = &BspStub::call_cp_state_X1;
+        _bsp["cp_state_F"] = &BspStub::call_cp_state_F;
         _bsp["pwm_on"] = &BspStub::call_pwm_on;
     }
 
@@ -56,6 +57,11 @@ struct BspStub : public module::stub::ModuleAdapterStub {
 
     virtual Result call_cp_state_X1(Parameters p) {
         std::cout << "call_cp_state_X1(" << p << ")" << std::endl;
+        return std::nullopt;
+    }
+
+    virtual Result call_cp_state_F(Parameters p) {
+        std::cout << "call_cp_state_F(" << p << ")" << std::endl;
         return std::nullopt;
     }
 
@@ -502,6 +508,80 @@ TEST_F(ConnectorLockTest, force_unlock_overrides_authorized) {
     sm->connector_force_unlock();
 
     EXPECT_GT(unlock_count, 0) << "connector_force_unlock should unlock even when authorized";
+}
+
+// ---------------------------------------------------------------------------
+// Tests for CP state F persistence
+//
+// The high level state machine commands state F on fatal errors. A BSP state
+// event (e.g. the initial A published around startup) arriving after that
+// command must not trigger the automatic X1 reset, which would undo the F
+// and unmask the fault.
+
+struct CpStateFTest : public testing::Test {
+    struct CpCommandRecorder : public BspStub {
+        std::vector<std::string> cp_commands;
+
+        Result call_cp_state_X1(Parameters p) override {
+            cp_commands.push_back("X1");
+            return BspStub::call_cp_state_X1(p);
+        }
+
+        Result call_cp_state_F(Parameters p) override {
+            cp_commands.push_back("F");
+            return BspStub::call_cp_state_F(p);
+        }
+    };
+
+    CpCommandRecorder bsp;
+    std::unique_ptr<evse_board_supportIntf> bsp_if;
+
+    std::unique_ptr<module::IECStateMachine> create_state_machine() {
+        bsp_if = std::make_unique<module::stub::evse_board_supportIntfStub>(bsp);
+        auto sm = std::make_unique<module::IECStateMachine>(bsp_if, true, false);
+        sm->enable(true);
+        return sm;
+    }
+};
+
+TEST_F(CpStateFTest, state_events_do_not_undo_requested_state_f) {
+    auto sm = create_state_machine();
+
+    sm->set_cp_state_F();
+    ASSERT_EQ(bsp.cp_commands, std::vector<std::string>{"F"});
+
+    // BSP still reports A, the F command has not taken effect there yet
+    bsp.raise_event(Event::A);
+    EXPECT_EQ(bsp.cp_commands, std::vector<std::string>{"F"}) << "A event must not reset the requested state F to X1";
+
+    bsp.raise_event(Event::E);
+    EXPECT_EQ(bsp.cp_commands, std::vector<std::string>{"F"}) << "E event must not reset the requested state F to X1";
+}
+
+TEST_F(CpStateFTest, x1_request_reenables_automatic_reset) {
+    auto sm = create_state_machine();
+
+    sm->set_cp_state_F();
+    bsp.raise_event(Event::F);
+    sm->set_cp_state_X1();
+    bsp.cp_commands.clear();
+
+    bsp.raise_event(Event::A);
+    EXPECT_EQ(bsp.cp_commands, std::vector<std::string>{"X1"})
+        << "after an X1 request the A event should reset the CP state again";
+}
+
+TEST_F(CpStateFTest, pwm_request_reenables_automatic_reset) {
+    auto sm = create_state_machine();
+
+    sm->set_cp_state_F();
+    bsp.raise_event(Event::F);
+    sm->set_pwm(0.05);
+    bsp.cp_commands.clear();
+
+    bsp.raise_event(Event::A);
+    EXPECT_EQ(bsp.cp_commands, std::vector<std::string>{"X1"})
+        << "after a PWM request the A event should reset the CP state again";
 }
 
 } // namespace


### PR DESCRIPTION

## Describe your changes

The IEC state machine responded to Disabled/A/E events with an unconditional cp_state_X1, which could undo a concurrently commanded state F (fatal error) and unmask the fault, allowing a plug-in to start a session on an inoperative EVSE. Track the requested F until the high level state machine commands X1 or PWM, and skip the automatic reset while it is active.

Fixes flaky test_iso15118_dc_session_error_before_session, observed by https://github.com/EVerest/EVerest/actions/runs/33366396406/job/99434929443

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

