### PR TITLE
fix(EvManager): ISO15118 Pause/Resume on EV side

### DIFF
--- a/applications/utils/everest-testing/src/everest/testing/core_utils/controller/everest_test_controller.py
+++ b/applications/utils/everest-testing/src/everest/testing/core_utils/controller/everest_test_controller.py
@@ -53,7 +53,7 @@ class EverestTestController(TestController):
     def plug_in_ac_iso(self, connector_id=1, payment_type=""):
         self._mqtt_client.publish(
             f"{self._mqtt_external_prefix}everest_external/nodered/{connector_id}/carsim/cmd/execute_charging_session",
-            f"sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC {payment_type} 86400 0;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 60;iso_stop_charging;iso_wait_v2g_session_stopped;unplug")
+            f"sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC {payment_type} 86400 0;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 60;iso_wait_v2g_session_stopped;unplug")
 
     def plug_in_dc_iso(self, connector_id=1, payment_type=""):
         self._mqtt_client.publish(

--- a/modules/EV/EvManager/main/car_simulation.cpp
+++ b/modules/EV/EvManager/main/car_simulation.cpp
@@ -5,6 +5,7 @@
 #include "constants.hpp"
 
 #include <everest/logging.hpp>
+#include <fmt/core.h>
 
 constexpr double MS_FACTOR = (1.0 / 60.0 / 60.0 / 1000.0);
 
@@ -278,30 +279,11 @@ bool CarSimulation::iso_dc_power_on(const CmdArguments& arguments) {
         return true;
     }
 
-    if (sim_data.iso_charger_paused) {
-
-        const auto cmds =
-            std::array<std::string, 2>{"pause;iso_wait_v2g_session_stopped;sleep 2;iso_wait_pwm_is_running;",
-                                       "iso_wait_pwr_ready;iso_wait_for_stop 36000"};
-
-        EVLOG_info << "Charger wants to pause the session";
-        r_ev_board_support->call_allow_power_on(false);
-
-        // NOTE(sl): Change when the Energymode has more then 2 values
-        const std::string energy_mode = (sim_data.energy_mode == EnergyMode::AC) ? "AC" : "DC";
-        const std::string iso_start_v2g_session = "iso_start_v2g_session " + energy_mode + ";";
-
-        auto& modify_session_cmds = sim_data.modify_charging_session_cmds.emplace();
-
-        modify_session_cmds = cmds[0];
-        modify_session_cmds += iso_start_v2g_session;
-        modify_session_cmds += cmds[1];
-
-        sim_data.iso_pwr_ready = false;
-        sim_data.sleep_ticks_left.reset();
-        sim_data.iso_charger_paused = false;
-
-        // NOTE(sl): return false, otherwise the simulation will end too early before the session cmds can be adjusted
+    // Return false in both cases, otherwise the simulation ends before the session cmds can be adjusted
+    if (sim_data.iso_stopped) {
+        arm_restart_after_charger_stop();
+    } else if (sim_data.iso_charger_paused) {
+        arm_resume_after_charger_pause();
     }
 
     return false;
@@ -352,6 +334,7 @@ bool CarSimulation::iso_start_v2g_session(const CmdArguments& arguments, bool th
     } else {
         return false;
     }
+    sim_data.v2g_session_active = true;
     return true;
 }
 
@@ -395,47 +378,74 @@ bool CarSimulation::iso_wait_for_stop(const CmdArguments& arguments, size_t loop
     }
     if (sim_data.iso_stopped) {
         EVLOG_info << "POWER OFF iso stopped";
-        r_ev_board_support->call_allow_power_on(false);
-        sim_data.state = SimState::PLUGGED_IN;
-        sim_data.sleep_ticks_left.reset();
-        return true;
+        // Return false afterwards, otherwise the simulation ends before the session cmds can be adjusted
+        arm_restart_after_charger_stop();
+        return false;
     }
 
     if (sim_data.iso_charger_paused) {
-
-        const auto cmds =
-            std::array<std::string, 2>{"pause;iso_wait_v2g_session_stopped;sleep 2;iso_wait_pwm_is_running;",
-                                       "iso_wait_pwr_ready;iso_wait_for_stop 36000"};
-
-        EVLOG_info << "Charger wants to pause the session";
-        r_ev_board_support->call_allow_power_on(false);
-
-        // NOTE(sl): Change when the Energymode has more then 2 values
-        const std::string energy_mode = (sim_data.energy_mode == EnergyMode::AC) ? "AC" : "DC";
-        const std::string iso_start_v2g_session = "iso_start_v2g_session " + energy_mode + ";";
-
-        auto& modify_session_cmds = sim_data.modify_charging_session_cmds.emplace();
-
-        modify_session_cmds = cmds[0];
-        modify_session_cmds += iso_start_v2g_session;
-        modify_session_cmds += cmds[1];
-
-        sim_data.iso_pwr_ready = false;
-        sim_data.sleep_ticks_left.reset();
-        sim_data.iso_charger_paused = false;
-
-        // NOTE(sl): return false, otherwise the simulation will end too early before the session cmds can be adjusted
+        arm_resume_after_charger_pause();
         return false;
     }
     return false;
 }
 
-bool CarSimulation::iso_wait_v2g_session_stopped(const CmdArguments& arguments) {
-    if (sim_data.v2g_finished) {
-        sim_data.v2g_finished = false;
-        return true;
+// ISO 15118-20 charger pause: the link stays matched, so wait for PWM and resume the session.
+void CarSimulation::arm_resume_after_charger_pause() {
+    EVLOG_info << "Charger wants to pause the session";
+    r_ev_board_support->call_allow_power_on(false);
+
+    // NOTE(sl): Change when the Energymode has more then 2 values
+    const std::string energy_mode = (sim_data.energy_mode == EnergyMode::AC) ? "AC" : "DC";
+
+    auto& modify_session_cmds = sim_data.modify_charging_session_cmds.emplace();
+
+    modify_session_cmds = "pause;iso_wait_v2g_session_stopped;sleep 2;iso_wait_pwm_is_running;";
+    modify_session_cmds += "iso_start_v2g_session " + energy_mode + ";";
+    modify_session_cmds += "iso_wait_pwr_ready;iso_wait_for_stop 36000";
+
+    sim_data.iso_pwr_ready = false;
+    sim_data.sleep_ticks_left.reset();
+    sim_data.iso_charger_paused = false;
+}
+
+// DIN SPEC and ISO 15118-2 have no charger-side pause: the charger terminates the V2G session
+// and wakes the EV up again via PWM. The wake-up requires a full new SLAC matching and V2G
+// session, so stay plugged in and re-arm the whole session start instead of ending the simulation.
+void CarSimulation::arm_restart_after_charger_stop() {
+    EVLOG_info << "Charger stopped the session, waiting for a PWM wake-up to start a new one";
+    r_ev_board_support->call_allow_power_on(false);
+    sim_data.state = SimState::PLUGGED_IN;
+
+    const bool dc = sim_data.energy_mode == EnergyMode::DC;
+
+    auto& modify_session_cmds = sim_data.modify_charging_session_cmds.emplace();
+
+    modify_session_cmds = "pause;iso_wait_v2g_session_stopped;sleep 2;iso_wait_pwm_is_running;";
+    if (not r_slac.empty()) {
+        modify_session_cmds += "iso_wait_slac_matched;";
     }
-    return false;
+    modify_session_cmds += std::string{"iso_start_v2g_session "} + (dc ? "DC" : "AC") + ";";
+    modify_session_cmds += "iso_wait_pwr_ready;";
+    if (dc) {
+        modify_session_cmds += "iso_dc_power_on;";
+    } else {
+        const std::string phases = (charge_mode == ChargeMode::ACThreePhase) ? "3" : "1";
+        modify_session_cmds += "iso_draw_power_regulated " + fmt::format("{:g}", charge_current_a) + "," + phases + ";";
+    }
+    modify_session_cmds += "iso_wait_for_stop 36000";
+
+    // Force iso_wait_slac_matched to trigger a new matching: the EV slac sim still reports MATCHED,
+    // but the charger restarts its matching on resume and only pairs with a peer in MATCHING state
+    sim_data.slac_state = types::slac::State::UNMATCHED;
+    sim_data.iso_stopped = false;
+    sim_data.iso_pwr_ready = false;
+    sim_data.dc_power_on = false;
+    sim_data.sleep_ticks_left.reset();
+}
+
+bool CarSimulation::iso_wait_v2g_session_stopped(const CmdArguments& arguments) {
+    return not sim_data.v2g_session_active;
 }
 
 bool CarSimulation::iso_pause_charging(const CmdArguments& arguments) {
@@ -450,7 +460,6 @@ bool CarSimulation::iso_wait_for_resume(const CmdArguments& arguments) {
 }
 
 bool CarSimulation::iso_start_bcb_toggle(const CmdArguments& arguments) {
-    sim_data.v2g_finished = false;
     sim_data.state = SimState::BCB_TOGGLE;
     if (sim_data.bcb_toggles >= std::stoul(arguments[0]) || sim_data.bcb_toggles == 3) {
         sim_data.bcb_toggles = 0;

--- a/modules/EV/EvManager/main/car_simulation.hpp
+++ b/modules/EV/EvManager/main/car_simulation.hpp
@@ -94,8 +94,8 @@ public:
         sim_data.iso_charger_paused = iso_charger_paused;
     }
 
-    void set_v2g_finished(bool v2g_finished) {
-        sim_data.v2g_finished = v2g_finished;
+    void set_v2g_session_active(bool v2g_session_active) {
+        sim_data.v2g_session_active = v2g_session_active;
     }
 
     void set_dc_power_on(bool dc_power_on) {
@@ -147,4 +147,6 @@ private:
     const std::unique_ptr<ev_managerImplBase>& p_ev_manager;
 
     void simulate_soc();
+    void arm_resume_after_charger_pause();
+    void arm_restart_after_charger_stop();
 };

--- a/modules/EV/EvManager/main/car_simulatorImpl.cpp
+++ b/modules/EV/EvManager/main/car_simulatorImpl.cpp
@@ -369,7 +369,7 @@ void car_simulatorImpl::subscribe_to_variables_on_init() {
             // TODO(SL): Adding missing reactive power
         });
         _ev->subscribe_stop_from_charger([this]() { car_simulation->set_iso_stopped(true); });
-        _ev->subscribe_v2g_session_finished([this]() { car_simulation->set_v2g_finished(true); });
+        _ev->subscribe_v2g_session_finished([this]() { car_simulation->set_v2g_session_active(false); });
         _ev->subscribe_dc_power_on([this]() { car_simulation->set_dc_power_on(true); });
         _ev->subscribe_pause_from_charger([this]() { car_simulation->set_iso_charger_paused(true); });
     }

--- a/modules/EV/EvManager/main/simulation_data.hpp
+++ b/modules/EV/EvManager/main/simulation_data.hpp
@@ -40,7 +40,7 @@ struct SimulationData {
     types::slac::State slac_state{types::slac::State::UNMATCHED};
     std::optional<size_t> sleep_ticks_left{};
 
-    bool v2g_finished{false};
+    bool v2g_session_active{false};
     bool iso_stopped{false};
     bool iso_charger_paused{false};
     size_t evse_maxcurrent{0};

--- a/tests/core_tests/smoke_tests.py
+++ b/tests/core_tests/smoke_tests.py
@@ -210,6 +210,20 @@ async def assert_no_events(mock, excluded_events, wait_time=2, reset_after_check
         mock.reset_mock()
 
 
+async def wait_for_variable_value(mock, expected_value, timeout=30):
+    """Wait until the mock received a variable publication with the expected value."""
+    start_time = asyncio.get_event_loop().time()
+
+    while asyncio.get_event_loop().time() - start_time < timeout:
+        for call in mock.call_args_list:
+            if call[0][0] == expected_value:
+                mock.reset_mock()
+                return
+        await asyncio.sleep(0.1)
+
+    raise TimeoutError(f"Timeout waiting for variable value {expected_value}")
+
+
 async def wait_for_ready(mock, timeout=5):
     """Wait until the ready mock has been called."""
     start_time = asyncio.get_event_loop().time()
@@ -1201,12 +1215,12 @@ async def test_pwm_ac_session_paused_by_evse(
     connections={
         "evse_manager": [Requirement("connector_1", "evse")],
         "gcp": [Requirement("grid_connection_point", "external_limits")],
+        "slac": [Requirement("slac", "evse")],
     }
 )
 @pytest.mark.xdist_group(name="ISO15118")
 @pytest.mark.everest_config_adaptions(AcConfigAdjustmentStrategy())
 @pytest.mark.everest_core_config("config-sil.yaml")
-@pytest.mark.skip(reason="Currently fails because EV Simulator does not start a new session once it is a user pause")
 async def test_iso15118_ac_session_paused_by_evse(
     test_controller: TestController, everest_core: EverestCore
 ):
@@ -1216,8 +1230,11 @@ async def test_iso15118_ac_session_paused_by_evse(
     probe_module, session_event_mock, powermeter_mock, _ = await setup_session_mocks(
         test_controller, everest_core
     )
+    slac_state_mock = Mock()
+    probe_module.subscribe_variable("slac", "state", slac_state_mock)
     await start_session(test_controller, session_event_mock, test_controller.plug_in_ac_iso)
     await assert_energy_exceeds(powermeter_mock, energy_threshold_wh=10, timeout=15)
+    slac_state_mock.reset_mock()
     await probe_module.call_command(
         "evse_manager",
         "pause_charging",
@@ -1225,7 +1242,10 @@ async def test_iso15118_ac_session_paused_by_evse(
     )
     await wait_for_session_events(session_event_mock, ["ChargingPausedEVSE"])
     await assert_power_below(powermeter_mock, power_threshold_w=10, timeout=5)
-    await assert_no_events(session_event_mock, ["ChargingStarted"], wait_time=5)
+    # Resume only once the EVSE has processed the V2G session teardown: the D-LINK handler
+    # resets SLAC last, so UNMATCHED means the pause has settled.
+    await wait_for_variable_value(slac_state_mock, "UNMATCHED", timeout=15)
+    await assert_no_events(session_event_mock, ["ChargingStarted"])
     await probe_module.call_command(
         "evse_manager",
         "resume_charging",
@@ -1240,12 +1260,12 @@ async def test_iso15118_ac_session_paused_by_evse(
     connections={
         "evse_manager": [Requirement("evse_manager", "evse")],
         "gcp": [Requirement("grid_connection_point", "external_limits")],
+        "slac": [Requirement("slac", "evse")],
     }
 )
 @pytest.mark.xdist_group(name="ISO15118")
 @pytest.mark.everest_core_config("config-sil-dc.yaml")
 @pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy())
-@pytest.mark.skip(reason="Currently fails because EV Simulator does not start a new session once it is a user pause")
 async def test_iso15118_dc_session_paused_by_evse(
     test_controller: TestController, everest_core: EverestCore
 ):
@@ -1256,9 +1276,12 @@ async def test_iso15118_dc_session_paused_by_evse(
     probe_module, session_event_mock, powermeter_mock, _ = await setup_session_mocks(
         test_controller, everest_core
     )
+    slac_state_mock = Mock()
+    probe_module.subscribe_variable("slac", "state", slac_state_mock)
 
     await start_session(test_controller, session_event_mock, test_controller.plug_in_dc_iso)
     await assert_energy_exceeds(powermeter_mock, energy_threshold_wh=10, timeout=15)
+    slac_state_mock.reset_mock()
     await probe_module.call_command(
         "evse_manager",
         "pause_charging",
@@ -1266,6 +1289,10 @@ async def test_iso15118_dc_session_paused_by_evse(
     )
     await wait_for_session_events(session_event_mock, ["ChargingPausedEVSE"])
     await assert_power_below(powermeter_mock, power_threshold_w=10, timeout=5)
+    # Resume only once the EVSE has processed the V2G session teardown: the D-LINK handler
+    # resets SLAC last, so UNMATCHED means the pause has settled.
+    await wait_for_variable_value(slac_state_mock, "UNMATCHED", timeout=15)
+    await assert_no_events(session_event_mock, ["ChargingStarted"])
     await probe_module.call_command(
         "evse_manager",
         "resume_charging",


### PR DESCRIPTION

## Describe your changes

DIN SPEC 70121 and ISO 15118-2 have no defined EVSE side pause: the EVSE terminates the V2G session and wakes the EV up again via PWM. The car simulator treated stop_from_charger as the end of the simulation, so resuming from ChargingPausedEVSE only worked for ISO 15118-20. The simulation now stays plugged in and re-arms a full session start instead: wait for the PWM wake-up, redo SLAC matching and start a new V2G session (AC power draw / DC power on).

Replace the v2g_finished event latch with a v2g_session_active flag so iso_wait_v2g_session_stopped no longer hangs when no session is running.

Park plug_in_ac_iso in iso_wait_for_stop like the DC variant so it reacts to charger-initiated stops, and unskip the paused-by-EVSE smoke tests. The tests resume once the EVSE SLAC state reports UNMATCHED, i.e. after the session teardown has settled.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

