### PR TITLE
feat(io): rx pause/resume, tx drain hooks and coalescing for fd_event_client

### DIFF
--- a/lib/everest/io/README.md
+++ b/lib/everest/io/README.md
@@ -46,6 +46,36 @@ time: `on_error()` reports `true` from the call until the reopen.
 
 `tx()` and `reset()` are loop-thread only: call them from the thread that drives `sync()`, or from
 a callback that thread dispatches.
+
+## Flow control between clients
+
+A consumer forwarding from one client into another (pty into TCP) can throttle the source instead
+of dropping when the sink's buffer is full:
+
+- `pause_rx()` / `resume_rx()` / `rx_paused()`: stop and restart monitoring the source for
+  readability; the kernel buffer fills and the writer blocks. A paused stream socket still reports
+  the peer closing through the error handler. Rejected without a monitored connection (before the
+  first `sync()`, during a reopen or a handshake), idempotent, and a reconnect starts unpaused:
+  re-apply from `set_on_ready_action`.
+- `tx_queue_depth()` / `set_tx_drained_action()`: pause the source past a watermark, resume it from
+  the drained action. `reset()` and a failed connection clear the buffer without draining; resume
+  the source from the sink's `set_on_ready_action`, not from the error handler: without pre-connect
+  buffering `tx()` rejects until the reopen completes.
+- `tx_coalescing(payload, max_payload_size)`: append to the newest waiting payload instead of
+  queueing another. Exists only for a policy declaring `supports_tx_coalescing{true}`: a byte stream
+  whose `tx()` leaves exactly the unsent bytes in the payload (`tcp_socket`, `pty_handler`). Frame
+  transports and TLS do not compile with it.
+
+All share the loop-thread contract of `tx()`.
+
+## PTY
+
+`pty_handler` opens the master non blocking. A write the slave has not drained returns early,
+`tx()` keeps the unsent bytes and the client retries; a blocking master would stall the whole loop.
+Undrained data queues up to `max_buffered_tx_payloads`, then `tx()` rejects. A feeder that must not
+lose data throttles its source with the flow control above, otherwise it checks the return value of
+`tx()`.
+
 ## TLS
 
 Drives the libtls (`everest::tls`) `Server` and `Client` through the same

--- a/lib/everest/io/include/everest/io/event/fd_event_client.hpp
+++ b/lib/everest/io/include/everest/io/event/fd_event_client.hpp
@@ -640,7 +640,8 @@ public:
      * @tparam P SFINAE hook, always \p ClientPolicy. Do not pass.
      * @param[in] payload The data to be transmitted
      * @param[in] max_payload_size Upper bound for a merged payload; a larger \p payload is queued on
-     * its own
+     * its own. Peer dependent: use the peer's receive window or the MSS, not larger than the socket
+     * send buffer
      * @return True if merged or buffered. A merge is accepted even with the buffer at
      * \ref max_buffered_tx_payloads; a new entry is rejected as in \ref tx
      */
@@ -653,10 +654,6 @@ public:
         if (not m_tx_buffer.empty()) {
             auto& newest = m_tx_buffer.back();
             if (newest.size() + payload.size() <= max_payload_size) {
-                // Size for the bound once instead of growing per merge.
-                if (newest.capacity() < max_payload_size) {
-                    newest.reserve(max_payload_size);
-                }
                 newest.insert(newest.end(), payload.begin(), payload.end());
                 // A waiting payload already holds the write registration or a wakeup is in flight.
                 return true;

--- a/lib/everest/io/include/everest/io/event/fd_event_client.hpp
+++ b/lib/everest/io/include/everest/io/event/fd_event_client.hpp
@@ -194,6 +194,34 @@ public:
      */
     void set_on_ready_action(std::function<void()>&& item);
 
+    /**
+     * @brief Stop monitoring the connection for readability.
+     * @details Backpressure towards the writer behind the descriptor: the kernel buffer fills and
+     *          the writer blocks. Error, hangup and write monitoring are unaffected. A stream socket
+     *          is watched for the peer closing its writing side instead (EPOLLRDHUP), reported
+     *          through the error handler; unread data is lost with the connection. Rejected while
+     *          no connection is monitored (before the first \ref sync, during a reopen or a
+     *          handshake). A new connection starts unpaused, re-apply from \ref set_on_ready_action.
+     *          Idempotent. Loop thread only, like \ref sync.
+     * @return True if reads are paused
+     */
+    bool pause_rx();
+
+    /**
+     * @brief Resume monitoring the connection for readability after \ref pause_rx.
+     * @details Level triggered: data queued while paused is dispatched on the next poll. Idempotent,
+     *          same constraints as \ref pause_rx.
+     * @return True if reads are resumed
+     */
+    bool resume_rx();
+
+    /**
+     * @brief Whether reads are paused on the current connection.
+     * @details False without a monitored connection and for every new connection until paused.
+     * @return True if paused by \ref pause_rx
+     */
+    bool rx_paused() const;
+
 protected:
     /**
      * @brief Constructor.
@@ -303,14 +331,31 @@ protected:
     /**
      * @brief Consume the error code of an error or hangup notification on \p fd.
      * @details Prefers the error of the client policy, then SO_ERROR, then the notification kind
-     *          itself (ENOTCONN for a hangup, EIO otherwise) for a descriptor that is not a
-     *          socket. Never resolves to 0, which would read as a cleared error. Reading SO_ERROR
-     *          clears it, so call this exactly once per connection.
+     *          itself (ENOTCONN for a hangup, ECONNRESET for the peer shutting its writing side,
+     *          EIO otherwise) for a descriptor that is not a socket. Never resolves to 0, which
+     *          would read as a cleared error. Reading SO_ERROR clears it, so call this exactly
+     *          once per connection.
      * @param[in] fd The file descriptor the notification arrived on
-     * @param[in] kind poll_events::hungup for a hangup, poll_events::error otherwise
+     * @param[in] kind poll_events::hungup for a hangup, poll_events::read_hungup for a peer that
+     *            shut its writing side while reads were paused, poll_events::error otherwise
      * @return A nonzero error code
      */
     int consume_poll_error(int fd, poll_events kind);
+
+    /**
+     * @brief The descriptor of the current connection.
+     * @return The descriptor, -1 without a connection
+     */
+    int connected_fd();
+
+    /**
+     * @brief Switch monitoring the connection for readability off or on.
+     * @details Implements \ref pause_rx and \ref resume_rx: swaps readability against the peer close
+     *          watch in one event handler modification, so on failure nothing changed.
+     * @param[in] paused True to stop reads, false to resume them
+     * @return True if the requested state is in force
+     */
+    bool set_rx_paused(bool paused);
 
     static poll_events default_desired_events();
 
@@ -410,6 +455,8 @@ protected:
     ready_action m_on_ready_action;
     std::atomic_uint64_t m_connected_generation{0};
     bool m_connection_failed{false};
+    // Reads paused on the current connection; cleared on retire and on registration.
+    bool m_rx_paused{false};
     // Every connection attempt pre-increments the generation, so 0 cannot match a connection.
     std::uint64_t m_ready_fired_generation{0};
     std::uint64_t m_handshake_deadline_generation{0};
@@ -467,7 +514,8 @@ public:
      * payloads, not bytes, so the memory ceiling is this many times the size of a payload the
      * caller writes.
      * For the socket policies, whose \p PayloadT is a `std::vector<std::uint8_t>`, that size is
-     * whatever the caller passes.
+     * whatever the caller passes. With \ref tx_coalescing the ceiling is this many times the larger
+     * of the bound and the largest single payload.
      */
     static constexpr std::size_t max_buffered_tx_payloads{1024};
 
@@ -536,12 +584,7 @@ public:
         if (not connection_accepts_tx()) {
             return false;
         }
-        if (m_tx_buffer.size() >= max_buffered_tx_payloads) {
-            return false;
-        }
-        m_tx_buffer.emplace(payload);
-        m_io_event_fd.notify();
-        return true;
+        return enqueue_tx(payload);
     }
 
     /**
@@ -584,6 +627,67 @@ public:
         reset_connection_state();
         schedule_reset();
         return true;
+    }
+
+    /**
+     * @brief Send data, appending it to the newest buffered payload when possible.
+     * @details Like \ref tx, but if payloads are waiting and the merged size stays within
+     * \p max_payload_size, \p payload is appended to the newest one. Nothing is held back: a payload
+     * queued on an empty buffer goes out on the next writable event. The newest payload may be mid
+     * write, so the policy must leave exactly the unsent bytes in it and tolerate it growing; only a
+     * \p ClientPolicy declaring `static constexpr bool supports_tx_coalescing{true}` has this function,
+     * see \ref utilities::policy_supports_tx_coalescing. Loop thread only.
+     * @tparam P SFINAE hook, always \p ClientPolicy. Do not pass.
+     * @param[in] payload The data to be transmitted
+     * @param[in] max_payload_size Upper bound for a merged payload; a larger \p payload is queued on
+     * its own
+     * @return True if merged or buffered. A merge is accepted even with the buffer at
+     * \ref max_buffered_tx_payloads; a new entry is rejected as in \ref tx
+     */
+    template <class P = ClientPolicy, std::enable_if_t<utilities::policy_supports_tx_coalescing_v<P>, int> = 0>
+    bool tx_coalescing(ClientPayloadT const& payload, std::size_t max_payload_size) {
+        static_assert(std::is_same_v<P, ClientPolicy>, "P selects the overload on ClientPolicy only, do not pass it");
+        if (not connection_accepts_tx()) {
+            return false;
+        }
+        if (not m_tx_buffer.empty()) {
+            auto& newest = m_tx_buffer.back();
+            if (newest.size() + payload.size() <= max_payload_size) {
+                // Size for the bound once instead of growing per merge.
+                if (newest.capacity() < max_payload_size) {
+                    newest.reserve(max_payload_size);
+                }
+                newest.insert(newest.end(), payload.begin(), payload.end());
+                // A waiting payload already holds the write registration or a wakeup is in flight.
+                return true;
+            }
+        }
+        // Same rejection conditions as tx.
+        return enqueue_tx(payload);
+    }
+
+    /**
+     * @brief Number of payloads waiting in the tx buffer.
+     * @details Loop thread only. With \ref set_tx_drained_action and \ref pause_rx: pause the source
+     * past a watermark, resume when drained.
+     * @return 0 to \ref max_buffered_tx_payloads
+     */
+    std::size_t tx_queue_depth() const {
+        return m_tx_buffer.size();
+    }
+
+    /**
+     * @brief Register a callback fired when the tx buffer runs empty.
+     * @details Called on the loop thread right after the last buffered payload was written, inside
+     * this client's dispatch: \ref tx, \ref reset and pausing or resuming another client are fine
+     * there, destroying this client is not. Not called by \ref reset or on a failed connection, which
+     * clear the buffer without sending. Resume a paused source from \ref set_on_ready_action, not from
+     * the error handler: without pre-connect buffering \ref tx rejects until the reopen completes.
+     * Pass an empty function to unregister.
+     * @param[in] item The callback
+     */
+    void set_tx_drained_action(std::function<void()> item) {
+        add_action([this, item = std::move(item)]() mutable { m_tx_drained_action = std::move(item); });
     }
 
     /**
@@ -696,6 +800,16 @@ private:
     // peer even while it is still open and still registered. The connection state cannot answer
     // this: without the guards below a successful read would report code 0 and put a retired
     // connection back to connected.
+    // Shared by tx and tx_coalescing.
+    bool enqueue_tx(ClientPayloadT const& payload) {
+        if (m_tx_buffer.size() >= max_buffered_tx_payloads) {
+            return false;
+        }
+        m_tx_buffer.emplace(payload);
+        m_io_event_fd.notify();
+        return true;
+    }
+
     bool handle_is_current() const {
         return m_handle != nullptr and m_handle_generation == m_connect_generation.load();
     }
@@ -713,6 +827,13 @@ private:
         auto success = m_handle->tx(elem);
         if (success) {
             m_tx_buffer.pop();
+            if (m_tx_buffer.empty() and m_tx_drained_action) {
+                m_tx_drained_action();
+                // The action may have reset this client; do not report the retired connection, see receive_one.
+                if (not handle_is_current()) {
+                    return action_status::empty;
+                }
+            }
             return action_status::success;
         }
         return action_status::fail;
@@ -816,6 +937,8 @@ private:
             client_status->ok = false;
             client_status->fd = -1;
         }
+        // The pause belonged to the connection just retired.
+        m_rx_paused = false;
         m_handle.reset();
         return action_status::success;
     }
@@ -867,6 +990,7 @@ private:
     std::shared_ptr<async_connect_state> m_async_connect_state;
     cb_rx m_rx;
     std::function<void()> m_open_device;
+    std::function<void()> m_tx_drained_action;
     std::queue<ClientPayloadT> m_tx_buffer;
     ClientPayloadT m_data;
     bool m_buffer_tx_before_connect{false};
@@ -894,6 +1018,9 @@ private:
  *                                    // connection is up instead of rejecting them. Absent means it does not.
  *                                    // Read only for a policy that offers setup/connect. Overridable per
  *                                    // instance, see utilities::tx_buffering
+ *   static constexpr bool supports_tx_coalescing; // [optional] tx_coalescing() exists for this policy. Only for a
+ *                                    // byte stream whose tx() leaves exactly the unsent bytes in the payload and
+ *                                    // tolerates it growing between retries. Absent means false.
  *   bool open(ArgsT... args);        // Opens the device. Parameters given by fd_event_client's constructor.
  *                                    // Return true on success, false otherwise
  *   bool setup(ArgsT... args);       // [optional] Setup the device. Parameters given by fd_event_client's constructor.

--- a/lib/everest/io/include/everest/io/event/fd_event_handler.hpp
+++ b/lib/everest/io/include/everest/io/event/fd_event_handler.hpp
@@ -30,6 +30,8 @@ enum class poll_events {
     write = 2,
     error = 3,
     hungup = 4,
+    /// Peer closed its writing side (EPOLLRDHUP). Only when monitored for, stream sockets only.
+    read_hungup = 5,
 };
 
 // event/fd_event_client.hpp and socket/socket.hpp declare poll_events opaquely to break the
@@ -252,6 +254,16 @@ public:
      * @return Description
      */
     bool modify_event_handler(int fd, poll_events event, event_modification change);
+
+    /**
+     * @brief Enable one set of events and disable another in a single EPOLL_CTL_MOD.
+     * @details Both changes take effect or neither. An event in both lists ends up enabled.
+     * @param[in] fd The file descriptor
+     * @param[in] enable Events to monitor
+     * @param[in] disable Events to stop monitoring
+     * @return True on success, false otherwise (unregistered fd, or epoll failure with events unchanged)
+     */
+    bool modify_event_handler(int fd, event_list const& enable, event_list const& disable);
 
     /**
      * @brief Stop monitoring of events on the file descriptor.

--- a/lib/everest/io/include/everest/io/serial/event_pty.hpp
+++ b/lib/everest/io/include/everest/io/serial/event_pty.hpp
@@ -18,7 +18,10 @@ using event_pty_base = event::fd_event_client<pty_handler>::type;
 
 /**
  * event_pty extends \ref event_pty_base for the special handling needed
- * for data and status, which are both received via RX
+ * for data and status, which are both received via RX.
+ *
+ * Writes to a slave that stopped reading queue in the tx buffer and are rejected once it is full
+ * instead of stalling the loop, see \ref pty_handler.
  */
 class event_pty : public event_pty_base {
     /**

--- a/lib/everest/io/include/everest/io/serial/pty_handler.hpp
+++ b/lib/everest/io/include/everest/io/serial/pty_handler.hpp
@@ -40,6 +40,13 @@ struct pty_status {
  * error checking. <br>
  * Although this class can be used on its own, the main purpose is to implement the
  * \p ClientPolicy of \ref event::fd_event_client
+ *
+ * The master is non blocking: a write the slave has not made room for returns false from \ref tx
+ * with the unsent bytes left in the payload, and the client retries on the next writable event.
+ * Undrained data queues in the client's tx buffer up to
+ * \ref event::generic_fd_event_client::max_buffered_tx_payloads, then tx() rejects. A consumer
+ * that must not lose data throttles its source (tx_queue_depth(), set_tx_drained_action(),
+ * pause_rx()); a blocking master would stall the whole event loop instead.
  */
 class pty_handler {
 public:
@@ -50,6 +57,12 @@ public:
     using PayloadT = std::vector<uint8_t>;
 
     /**
+     * @var supports_tx_coalescing
+     * @brief Byte stream, \ref tx leaves exactly the unsent bytes in the payload.
+     */
+    static constexpr bool supports_tx_coalescing{true};
+
+    /**
      * @brief The class is default constructed
      */
     pty_handler() = default;
@@ -57,14 +70,16 @@ public:
 
     /**
      * @brief Write a dataset to the PTY
-     * @details Implementation for \p ClientPolicy
+     * @details Implementation for \p ClientPolicy. A partial write removes the written bytes from
+     * \p data, a would-block leaves it unchanged; both return false with \ref get_error zero.
      * @param[in] data Payload
-     * @return True on success, False on failure and partial writes.
+     * @return True on success, false on failure, partial write or would-block.
      */
     bool tx(PayloadT& data);
     /**
      * @brief Read a dataset from the PTY
-     * @details Implementation for \p ClientPolicy
+     * @details Implementation for \p ClientPolicy. Nothing pending returns false with \ref get_error
+     * zero.
      * @param[in] data Payload
      * @return True on success, False otherwise.
      */
@@ -74,7 +89,7 @@ public:
      * @brief Open the PTY
      * @details Activates <a href="https://lists.gnu.org/archive/html/bug-readline/2011-01/msg00004.html">EXTPROC</a>
      * an <a href="https://man7.org/linux/man-pages/man2/TIOCPKT.2const.html">TIOCPKT</a>
-     * via \ref make_pty_mode_aware. <br>
+     * via \ref make_pty_mode_aware; the master is made non blocking. <br>
      * Implementation for \p ClientPolicy
      * @return True on success, false otherwise.
      */
@@ -89,7 +104,8 @@ public:
 
     /**
      * @brief Get the current error
-     * @details Implementation for \p ClientPolicy
+     * @details Implementation for \p ClientPolicy. Set by \ref open, \ref tx and \ref rx only; a
+     * would-block or partial write leaves it zero, \ref get_status never sets it.
      * @return The last errno. Zero if there is no error.
      */
     int get_error() const;

--- a/lib/everest/io/include/everest/io/tcp/tcp_socket.hpp
+++ b/lib/everest/io/include/everest/io/tcp/tcp_socket.hpp
@@ -29,6 +29,12 @@ public:
     using PayloadT = std::vector<uint8_t>;
 
     /**
+     * @var supports_tx_coalescing
+     * @brief Byte stream, \ref tx leaves exactly the unsent bytes in the payload.
+     */
+    static constexpr bool supports_tx_coalescing{true};
+
+    /**
      * @brief The class is default constructed
      */
     tcp_socket() = default;

--- a/lib/everest/io/include/everest/io/utilities/event_client_async_policy.hpp
+++ b/lib/everest/io/include/everest/io/utilities/event_client_async_policy.hpp
@@ -98,6 +98,38 @@ template <typename T>
 inline constexpr bool policy_buffers_tx_before_connect_v = policy_buffers_tx_before_connect<T>::value;
 
 /**
+ * @brief Trait: T declares a member 'supports_tx_coalescing'.
+ */
+template <typename T, typename V = void> struct has_member_supports_tx_coalescing : std::false_type {};
+
+/**
+ * @brief Specialization for a T that has it.
+ */
+template <typename T>
+struct has_member_supports_tx_coalescing<T, std::void_t<decltype(T::supports_tx_coalescing)>> : std::true_type {};
+
+/**
+ * @brief Trait: whether generic_fd_event_client::tx_coalescing exists for a policy. False unless
+ * the policy declares 'supports_tx_coalescing'.
+ * @details Coalescing appends to a payload the policy may be mid way through sending. Only a byte
+ * stream whose tx() leaves exactly the unsent bytes in the payload and tolerates it growing may
+ * opt in; frame transports and TLS (identical buffer on retry) may not.
+ */
+template <typename T, typename V = void> struct policy_supports_tx_coalescing : std::false_type {};
+
+/**
+ * @brief Specialization carrying the declared value.
+ */
+template <typename T>
+struct policy_supports_tx_coalescing<T, std::enable_if_t<has_member_supports_tx_coalescing<T>::value>>
+    : std::integral_constant<bool, T::supports_tx_coalescing> {};
+
+/**
+ * @brief Variable template for policy_supports_tx_coalescing.
+ */
+template <typename T> inline constexpr bool policy_supports_tx_coalescing_v = policy_supports_tx_coalescing<T>::value;
+
+/**
  * @enum tx_buffering
  * @brief Whether a client holds payloads written before its connection is up.
  * @details Selected per instance at construction, defaulting to what the policy declares through

--- a/lib/everest/io/src/event/fd_event_client.cpp
+++ b/lib/everest/io/src/event/fd_event_client.cpp
@@ -102,19 +102,24 @@ bool generic_fd_event_client_impl::setup_error_event_handler() {
 void generic_fd_event_client_impl::setup_io_event_handler(int fd) {
     using namespace everest::lib::io::event;
     m_connection_failed = false;
+    // Registered for reading below.
+    m_rx_paused = false;
     // Belongs to the previous connection, so it may not describe a failure of this one.
     m_local_error_text.clear();
     m_event_handler->register_event_handler(
         fd,
         [this, fd](auto events) {
             // A terminal notification wins over a pending handshake: the connection it would be
-            // negotiated on is gone.
-            if (events.count(poll_events::error) or events.count(poll_events::hungup)) {
+            // negotiated on is gone. read_hungup is monitored only while paused, see pause_rx.
+            if (events.count(poll_events::error) or events.count(poll_events::hungup) or
+                events.count(poll_events::read_hungup)) {
                 // Level triggered, so the fd keeps notifying until the queued teardown removes it,
                 // and reading SO_ERROR clears it.
                 if (not m_connection_failed) {
                     m_connection_failed = true;
-                    auto const kind = events.count(poll_events::error) != 0 ? poll_events::error : poll_events::hungup;
+                    auto const kind = events.count(poll_events::error) != 0    ? poll_events::error
+                                      : events.count(poll_events::hungup) != 0 ? poll_events::hungup
+                                                                               : poll_events::read_hungup;
                     set_error_status_and_notify(consume_poll_error(fd, kind));
                 }
                 return;
@@ -305,8 +310,52 @@ int generic_fd_event_client_impl::consume_poll_error(int fd, poll_events kind) {
     }
     // With no code to read back, the fallback describes the notification rather than naming a
     // cause: this client also drives serial lines and tun/tap devices, where ECONNRESET would
-    // invent a peer that reset nothing.
-    return socket::consume_poll_error(fd, kind, kind == poll_events::hungup ? ENOTCONN : EIO);
+    // invent a peer that reset nothing. read_hungup is a stream peer closing: ECONNRESET, as the
+    // read path reports it.
+    auto const fallback = kind == poll_events::hungup ? ENOTCONN : kind == poll_events::read_hungup ? ECONNRESET : EIO;
+    return socket::consume_poll_error(fd, kind, fallback);
+}
+
+bool generic_fd_event_client_impl::pause_rx() {
+    return set_rx_paused(true);
+}
+
+bool generic_fd_event_client_impl::resume_rx() {
+    return set_rx_paused(false);
+}
+
+int generic_fd_event_client_impl::connected_fd() {
+    auto client_status = m_client_status.handle();
+    return client_status->ok ? client_status->fd : -1;
+}
+
+bool generic_fd_event_client_impl::rx_paused() const {
+    return m_rx_paused;
+}
+
+bool generic_fd_event_client_impl::set_rx_paused(bool paused) {
+    // The handshake owns the monitored events.
+    if (m_handshake_pending()) {
+        return false;
+    }
+    // Between a reopen and the registration of its descriptor there is nothing to pause.
+    auto const fd = connected_fd();
+    if (fd < 0 or not m_event_handler->is_registered(fd)) {
+        return false;
+    }
+    if (m_rx_paused == paused) {
+        return true;
+    }
+    // Paused, EPOLLRDHUP stands in for readability to notice the peer closing (non-socket
+    // descriptors ignore it). One modification, so a failure changes nothing.
+    auto const off = paused ? poll_events::read : poll_events::read_hungup;
+    auto const on = paused ? poll_events::read_hungup : poll_events::read;
+    if (not m_event_handler->modify_event_handler(fd, fd_event_handler::event_list{on},
+                                                  fd_event_handler::event_list{off})) {
+        return false;
+    }
+    m_rx_paused = paused;
+    return true;
 }
 
 bool generic_fd_event_client_impl::monitor_for(int fd, poll_events desired) {
@@ -314,11 +363,10 @@ bool generic_fd_event_client_impl::monitor_for(int fd, poll_events desired) {
     if (not is_monitorable(desired)) {
         return false;
     }
-    auto read_ok = m_event_handler->modify_event_handler(
-        fd, poll_events::read, desired == poll_events::read ? event_modification::add : event_modification::remove);
-    auto write_ok = m_event_handler->modify_event_handler(
-        fd, poll_events::write, desired == poll_events::write ? event_modification::add : event_modification::remove);
-    return read_ok and write_ok;
+    // One modification: never both or neither in between.
+    auto const other = desired == poll_events::read ? poll_events::write : poll_events::read;
+    return m_event_handler->modify_event_handler(fd, fd_event_handler::event_list{desired},
+                                                 fd_event_handler::event_list{other});
 }
 
 poll_events generic_fd_event_client_impl::default_desired_events() {
@@ -384,14 +432,9 @@ void generic_fd_event_client_impl::set_on_ready_action(ready_action&& item) {
     // Assign on the loop thread, where it is read when a connection becomes ready.
     add_action([this, item = std::move(item)]() mutable {
         m_on_ready_action = std::move(item);
-        auto connected = false;
-        {
-            auto client_status = m_client_status.handle();
-            connected = client_status->ok;
-        }
         // A connected transport is not a ready client while its handshake is outstanding, and
         // the connected status outlives a failure until the queued teardown runs.
-        if (connected and not m_connection_failed and not m_handshake_pending()) {
+        if (connected_fd() >= 0 and not m_connection_failed and not m_handshake_pending()) {
             // Explicit registration on a ready connection asks to be called now.
             m_ready_fired_generation = 0;
             maybe_fire_ready();

--- a/lib/everest/io/src/event/fd_event_client.cpp
+++ b/lib/everest/io/src/event/fd_event_client.cpp
@@ -4,6 +4,7 @@
 #include <everest/io/event/fd_event_client.hpp>
 #include <everest/io/event/fd_event_handler.hpp>
 #include <everest/io/socket/socket.hpp>
+#include <everest/util/misc/container.hpp>
 
 #include <cerrno>
 #include <utility>
@@ -101,6 +102,7 @@ bool generic_fd_event_client_impl::setup_error_event_handler() {
 
 void generic_fd_event_client_impl::setup_io_event_handler(int fd) {
     using namespace everest::lib::io::event;
+    namespace util = everest::lib::util;
     m_connection_failed = false;
     // Registered for reading below.
     m_rx_paused = false;
@@ -111,15 +113,13 @@ void generic_fd_event_client_impl::setup_io_event_handler(int fd) {
         [this, fd](auto events) {
             // A terminal notification wins over a pending handshake: the connection it would be
             // negotiated on is gone. read_hungup is monitored only while paused, see pause_rx.
-            if (events.count(poll_events::error) or events.count(poll_events::hungup) or
-                events.count(poll_events::read_hungup)) {
+            if (util::exists_any(events, poll_events::error, poll_events::hungup, poll_events::read_hungup)) {
                 // Level triggered, so the fd keeps notifying until the queued teardown removes it,
                 // and reading SO_ERROR clears it.
                 if (not m_connection_failed) {
                     m_connection_failed = true;
-                    auto const kind = events.count(poll_events::error) != 0    ? poll_events::error
-                                      : events.count(poll_events::hungup) != 0 ? poll_events::hungup
-                                                                               : poll_events::read_hungup;
+                    auto const kind = util::first_present(events, poll_events::error, poll_events::hungup)
+                                          .value_or(poll_events::read_hungup);
                     set_error_status_and_notify(consume_poll_error(fd, kind));
                 }
                 return;

--- a/lib/everest/io/src/event/fd_event_handler.cpp
+++ b/lib/everest/io/src/event/fd_event_handler.cpp
@@ -32,6 +32,8 @@ uint32_t poll_event_to_bitmask(poll_events e) {
         return EPOLLERR;
     case poll_events::hungup:
         return EPOLLHUP;
+    case poll_events::read_hungup:
+        return EPOLLRDHUP;
     }
     return 0;
 }
@@ -52,6 +54,9 @@ std::set<poll_events> bitmask_to_poll_events(uint32_t bitmask) {
     }
     if (bitmask & EPOLLHUP) {
         result.insert(poll_events::hungup);
+    }
+    if (bitmask & EPOLLRDHUP) {
+        result.insert(poll_events::read_hungup);
     }
     return result;
 }
@@ -126,6 +131,16 @@ public:
             return result;
         };
         return modify(fd, events, action);
+    }
+
+    bool modify_swap(int fd, fd_event_handler::event_list const& enable, fd_event_handler::event_list const& disable) {
+        auto const raw_disable = sum_events(disable);
+        auto action = [raw_disable](uint32_t current, fd_event_handler::event_list const& change) {
+            auto raw_change = sum_events(change);
+            auto result = (current & (~raw_disable)) | raw_change;
+            return result;
+        };
+        return modify(fd, enable, action);
     }
 
     bool modify_replace(int fd, fd_event_handler::event_list const& events) {
@@ -331,6 +346,12 @@ bool fd_event_handler::modify_event_handler(int fd, event_list const& events, ev
 
 bool fd_event_handler::modify_event_handler(int fd, poll_events event, event_modification change) {
     return modify_event_handler(fd, event_list{event}, change);
+}
+bool fd_event_handler::modify_event_handler(int fd, event_list const& enable, event_list const& disable) {
+    if (fd == -1) {
+        return false;
+    }
+    return m_handlers->modify_swap(fd, enable, disable);
 }
 
 bool fd_event_handler::remove_event_handler(int fd) {

--- a/lib/everest/io/src/raw/raw_socket.cpp
+++ b/lib/everest/io/src/raw/raw_socket.cpp
@@ -30,9 +30,8 @@ bool raw_socket::tx(PayloadT& payload) {
         return false;
     }
     if (status < static_cast<ssize_t>(payload.size())) {
-        // We have a reference to the current data. Replace it with what is left to be written
-        // and return false. This signals the current block cannot be removed from the buffer.
-        payload = {payload.begin() + status, payload.end()};
+        // Keep the unsent bytes in place and return false: the block stays in the buffer.
+        payload.erase(payload.begin(), payload.begin() + status);
         return false;
     }
     return true;

--- a/lib/everest/io/src/serial/pty_handler.cpp
+++ b/lib/everest/io/src/serial/pty_handler.cpp
@@ -4,6 +4,8 @@
 #include <cstring>
 #include <errno.h>
 #include <everest/io/serial/pty_handler.hpp>
+#include <everest/io/socket/socket.hpp>
+#include <exception>
 #include <iostream>
 #include <sys/types.h>
 #include <termios.h>
@@ -14,14 +16,19 @@ namespace everest::lib::io::serial {
 bool pty_handler::tx(PayloadT& data) {
     auto status = ::write(m_dev.master_fd, data.data(), data.size());
     if (status == -1) {
+        if (errno == EAGAIN or errno == EWOULDBLOCK) {
+            // Slave has not read enough; retried on the next writable event. Not an error.
+            error_id = 0;
+            return false;
+        }
         error_id = errno;
         std::cout << "ERROR: Failed to write to pty master." << std::endl;
         return false;
     }
     if (status < static_cast<ssize_t>(data.size())) {
-        // We have a reference to the current data. Replace it with what is left to be written
-        // and return false. This signals the current block cannot be removed from the buffer.
-        data = {data.begin() + status, data.end()};
+        // Keep the unsent bytes in place and return false: the block stays in the buffer. Not an error.
+        data.erase(data.begin(), data.begin() + status);
+        error_id = 0;
         return false;
     }
     error_id = 0;
@@ -34,6 +41,11 @@ bool pty_handler::rx(PayloadT& data) {
     data.resize(buffer_size_limit);
     auto n_bytes = ::read(m_dev.master_fd, data.data(), data.size());
     if (n_bytes == -1) {
+        if (errno == EAGAIN or errno == EWOULDBLOCK) {
+            // Wakeup without data. Not an error.
+            error_id = 0;
+            return false;
+        }
         error_id = errno;
         return false;
     }
@@ -46,6 +58,14 @@ bool pty_handler::open() {
     auto mypty = serial::openpty();
     if (not mypty.has_value()) {
         error_id = errno;
+        return false;
+    }
+    // Driven from an event loop: a full slave buffer must yield EAGAIN, not block.
+    try {
+        socket::set_non_blocking(mypty->master_fd);
+    } catch (std::exception const&) {
+        error_id = errno;
+        std::cout << "ERROR: Preparing pty master for non blocking operation" << std::endl;
         return false;
     }
 
@@ -75,7 +95,7 @@ pty_status pty_handler::get_status() {
     struct termios status;
     auto attr_res = tcgetattr(m_dev.master_fd, &status);
     if (attr_res == -1) {
-        error_id = errno;
+        // Not part of the connection: error_id describes open, tx and rx only.
         std::cout << "Failed to get attributes" << std::endl;
         return result;
     }
@@ -84,8 +104,6 @@ pty_status pty_handler::get_status() {
     result.ixoff = status.c_iflag & IXOFF;   // enable xon/xoff flow control on input
     result.cstopb = status.c_cflag & CSTOPB; // two stop bits instead of one
     result.cbaud = cfgetospeed(&status);
-
-    error_id = 0;
     return result;
 }
 

--- a/lib/everest/io/src/tcp/tcp_socket.cpp
+++ b/lib/everest/io/src/tcp/tcp_socket.cpp
@@ -84,9 +84,8 @@ bool tcp_socket::tx(PayloadT& payload) {
         return false;
     }
     if (status < static_cast<ssize_t>(payload.size())) {
-        // We have a reference to the current data. Replace it with what is left to be written
-        // and return false. This signals the current block cannot be removed from the buffer.
-        payload = {payload.begin() + status, payload.end()};
+        // Keep the unsent bytes in place and return false: the block stays in the buffer.
+        payload.erase(payload.begin(), payload.begin() + status);
         return false;
     }
     return true;

--- a/lib/everest/io/test/CMakeLists.txt
+++ b/lib/everest/io/test/CMakeLists.txt
@@ -9,6 +9,8 @@ add_executable(everest_io_tests
   fd_event_client_async_test.cpp
   client_connect_error_test.cpp
   fd_event_handler_test.cpp
+  fd_event_client_backpressure_test.cpp
+  pty_handler_test.cpp
 )
 
 target_link_libraries(everest_io_tests

--- a/lib/everest/io/test/fd_event_client_alias_test.cpp
+++ b/lib/everest/io/test/fd_event_client_alias_test.cpp
@@ -108,6 +108,42 @@ static_assert(
 static_assert(not everest::lib::io::utilities::event_client_handshake_policy_v<everest::lib::io::tcp::tcp_socket>,
               "the handshake policy trait must not match a hookless policy");
 
+// tx_coalescing() appends to a payload possibly mid write: only byte stream policies that trim
+// the sent prefix may have it, frame transports and TLS must not.
+template <class Client, class = void> struct client_has_tx_coalescing : std::false_type {};
+template <class Client>
+struct client_has_tx_coalescing<Client, std::void_t<decltype(std::declval<Client&>().tx_coalescing(
+                                            std::declval<typename Client::ClientPayloadT const&>(), std::size_t{}))>>
+    : std::true_type {};
+
+static_assert(everest::lib::io::utilities::policy_supports_tx_coalescing_v<everest::lib::io::tcp::tcp_socket>,
+              "tcp_socket must admit tx_coalescing");
+static_assert(client_has_tx_coalescing<everest::lib::io::tcp::tcp_client>::value,
+              "tcp_client must expose tx_coalescing()");
+static_assert(everest::lib::io::utilities::policy_supports_tx_coalescing_v<everest::lib::io::serial::pty_handler>,
+              "pty_handler must admit tx_coalescing");
+static_assert(client_has_tx_coalescing<everest::lib::io::serial::event_pty_base>::value,
+              "event_pty_base must expose tx_coalescing()");
+
+static_assert(not everest::lib::io::utilities::policy_supports_tx_coalescing_v<everest::lib::io::raw::raw_socket>,
+              "raw_socket is a frame transport and must not admit tx_coalescing");
+static_assert(not client_has_tx_coalescing<everest::lib::io::raw::raw_client>::value,
+              "raw_client must not expose tx_coalescing()");
+static_assert(not everest::lib::io::utilities::policy_supports_tx_coalescing_v<everest::lib::io::tun_tap::tap_handler>,
+              "tap_handler is a frame transport and must not admit tx_coalescing");
+static_assert(not client_has_tx_coalescing<everest::lib::io::tun_tap::tap_client>::value,
+              "tap_client must not expose tx_coalescing()");
+static_assert(
+    not everest::lib::io::utilities::policy_supports_tx_coalescing_v<everest::lib::io::udp::udp_client_socket>,
+    "udp_client_socket is a datagram transport and must not admit tx_coalescing");
+static_assert(not client_has_tx_coalescing<everest::lib::io::udp::udp_client>::value,
+              "udp_client must not expose tx_coalescing()");
+static_assert(
+    not everest::lib::io::utilities::policy_supports_tx_coalescing_v<everest::lib::io::can::socket_can_handler>,
+    "socket_can_handler is a frame transport and must not admit tx_coalescing");
+static_assert(not client_has_tx_coalescing<everest::lib::io::can::socket_can>::value,
+              "socket_can must not expose tx_coalescing()");
+
 #ifdef EVEREST_IO_ENABLE_TLS
 static_assert(std::is_class_v<everest::lib::io::tls::tls_client>, "tls_client alias must resolve");
 static_assert(std::is_abstract_v<everest::lib::io::tls::tls_client_interface>,
@@ -122,6 +158,11 @@ static_assert(everest::lib::io::utilities::event_client_handshake_policy_v<evere
               "tls_client_socket must satisfy the handshake client policy");
 static_assert(everest::lib::io::utilities::has_member_get_error_string_v<everest::lib::io::tls::tls_client_socket>,
               "tls_client_socket must expose get_error_string()");
+static_assert(
+    not everest::lib::io::utilities::policy_supports_tx_coalescing_v<everest::lib::io::tls::tls_client_socket>,
+    "tls_client_socket retries a would-block with the identical buffer and must not admit tx_coalescing");
+static_assert(not client_has_tx_coalescing<everest::lib::io::tls::tls_client>::value,
+              "tls_client must not expose tx_coalescing()");
 #endif
 
 TEST(fd_event_client_alias, tcp_client_constructs_hookless_path_unchanged) {

--- a/lib/everest/io/test/fd_event_client_backpressure_test.cpp
+++ b/lib/everest/io/test/fd_event_client_backpressure_test.cpp
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+//
+// pause_rx()/resume_rx(), tx_coalescing() and the tx drained action on a fake byte stream policy;
+// the peer close case uses tcp_client on loopback.
+
+// GCC -O3 false positive (-Wstringop-overflow) on std::vector<uint8_t> copies of the one-byte
+// payloads below; the library itself builds with -Werror.
+#if defined(__GNUC__) and not defined(__clang__)
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+
+#include <everest/io/event/event_fd.hpp>
+#include <everest/io/event/fd_event_client.hpp>
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tcp/tcp_client.hpp>
+#include <everest/io/utilities/event_client_async_policy.hpp>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+using namespace everest::lib::io;
+
+using everest::lib::io::event::fd_event_client;
+using everest::lib::io::event::semaphore_fd;
+
+namespace {
+
+template <class Client, class Predicate>
+bool pump_until(Client& client, std::chrono::milliseconds timeout, Predicate&& predicate) {
+    auto const deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        client.sync(1ms);
+        if (predicate()) {
+            return true;
+        }
+    }
+    return predicate();
+}
+
+template <class Client> void pump_for(Client& client, std::chrono::milliseconds timeout) {
+    auto const deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        client.sync(1ms);
+    }
+}
+
+// What the policy handed to the wire, and how often it was asked to.
+struct wire {
+    std::vector<std::uint8_t> bytes;
+    std::size_t tx_calls{0};
+    // Bytes one tx call writes. Anything short of the payload is a partial write.
+    std::size_t bytes_per_tx{std::numeric_limits<std::size_t>::max()};
+};
+
+// Readable on demand: a semaphore fd stays readable for as many reads as pushes.
+struct rx_source {
+    semaphore_fd ready;
+    std::atomic<int> pending{0};
+
+    void push() {
+        ++pending;
+        ready.notify();
+    }
+
+    bool take() {
+        if (pending.load() <= 0) {
+            return false;
+        }
+        --pending;
+        ready.read();
+        return true;
+    }
+};
+
+// A synchronous byte stream policy: opens at once, reads one byte per push, writes bytes_per_tx
+// bytes per call and leaves the rest in the payload, the way tcp_socket and pty_handler do.
+class byte_stream_policy {
+public:
+    using PayloadT = std::vector<std::uint8_t>;
+    static constexpr bool supports_tx_coalescing{true};
+
+    bool open(std::shared_ptr<wire> w, std::shared_ptr<rx_source> s) {
+        m_wire = std::move(w);
+        m_source = std::move(s);
+        return static_cast<bool>(m_wire) and static_cast<bool>(m_source);
+    }
+
+    bool tx(PayloadT& payload) {
+        ++m_wire->tx_calls;
+        auto const n = std::min(m_wire->bytes_per_tx, payload.size());
+        m_wire->bytes.insert(m_wire->bytes.end(), payload.begin(), payload.begin() + static_cast<std::ptrdiff_t>(n));
+        payload.erase(payload.begin(), payload.begin() + static_cast<std::ptrdiff_t>(n));
+        return payload.empty();
+    }
+
+    bool rx(PayloadT& data) {
+        if (not m_source->take()) {
+            return false;
+        }
+        data.assign(1, 0x2a);
+        return true;
+    }
+
+    int get_fd() const {
+        return m_source->ready.get_raw_fd();
+    }
+
+    int get_error() const {
+        return 0;
+    }
+
+private:
+    std::shared_ptr<wire> m_wire;
+    std::shared_ptr<rx_source> m_source;
+};
+
+static_assert(not utilities::event_client_async_policy_v<byte_stream_policy>);
+static_assert(utilities::policy_supports_tx_coalescing_v<byte_stream_policy>);
+
+using byte_stream_client = fd_event_client<byte_stream_policy>::type;
+using payload = byte_stream_policy::PayloadT;
+
+struct bridge_end {
+    std::shared_ptr<wire> w{std::make_shared<wire>()};
+    std::shared_ptr<rx_source> source{std::make_shared<rx_source>()};
+    byte_stream_client client{w, source};
+    std::atomic<int> rx_count{0};
+
+    bridge_end() {
+        client.set_rx_handler([this](auto const&, auto&) { ++rx_count; });
+        // The first sync registers the descriptor.
+        client.sync(1ms);
+    }
+};
+
+payload bytes(std::initializer_list<std::uint8_t> values) {
+    return payload(values);
+}
+
+} // namespace
+
+TEST(fd_event_client_coalescing_test, payloads_queued_back_to_back_are_written_as_one) {
+    bridge_end end;
+    EXPECT_TRUE(end.client.tx_coalescing(bytes({1, 2}), 8));
+    EXPECT_TRUE(end.client.tx_coalescing(bytes({3, 4}), 8));
+    EXPECT_EQ(end.client.tx_queue_depth(), 1U);
+
+    ASSERT_TRUE(pump_until(end.client, 2s, [&] { return end.w->bytes.size() == 4; }));
+    EXPECT_EQ(end.w->bytes, bytes({1, 2, 3, 4}));
+    EXPECT_EQ(end.w->tx_calls, 1U);
+    EXPECT_EQ(end.client.tx_queue_depth(), 0U);
+}
+
+TEST(fd_event_client_coalescing_test, the_size_bound_starts_a_new_payload) {
+    bridge_end end;
+    EXPECT_TRUE(end.client.tx_coalescing(bytes({1, 2}), 3));
+    EXPECT_TRUE(end.client.tx_coalescing(bytes({3, 4}), 3));
+    EXPECT_EQ(end.client.tx_queue_depth(), 2U);
+
+    ASSERT_TRUE(pump_until(end.client, 2s, [&] { return end.w->bytes.size() == 4; }));
+    EXPECT_EQ(end.w->bytes, bytes({1, 2, 3, 4}));
+    EXPECT_EQ(end.w->tx_calls, 2U);
+}
+
+TEST(fd_event_client_coalescing_test, a_payload_beyond_the_bound_is_accepted_on_its_own) {
+    bridge_end end;
+    EXPECT_TRUE(end.client.tx_coalescing(bytes({1}), 2));
+    EXPECT_TRUE(end.client.tx_coalescing(bytes({2, 3, 4, 5}), 2));
+    EXPECT_EQ(end.client.tx_queue_depth(), 2U);
+
+    ASSERT_TRUE(pump_until(end.client, 2s, [&] { return end.w->bytes.size() == 5; }));
+    EXPECT_EQ(end.w->bytes, bytes({1, 2, 3, 4, 5}));
+}
+
+TEST(fd_event_client_coalescing_test, appending_to_a_payload_mid_partial_write_keeps_the_byte_order) {
+    bridge_end end;
+    end.w->bytes_per_tx = 2;
+    EXPECT_TRUE(end.client.tx(bytes({1, 2, 3, 4})));
+    // One tx call went out and left {3, 4} at the front of the buffer.
+    ASSERT_TRUE(pump_until(end.client, 2s, [&] { return end.w->bytes.size() == 2; }));
+    ASSERT_EQ(end.client.tx_queue_depth(), 1U);
+
+    EXPECT_TRUE(end.client.tx_coalescing(bytes({5, 6}), 16));
+    EXPECT_EQ(end.client.tx_queue_depth(), 1U);
+
+    ASSERT_TRUE(pump_until(end.client, 2s, [&] { return end.w->bytes.size() == 6; }));
+    EXPECT_EQ(end.w->bytes, bytes({1, 2, 3, 4, 5, 6}));
+    EXPECT_EQ(end.client.tx_queue_depth(), 0U);
+}
+
+TEST(fd_event_client_coalescing_test, a_merge_is_accepted_once_the_payload_bound_is_reached) {
+    bridge_end end;
+    for (std::size_t i = 0; i < byte_stream_client::max_buffered_tx_payloads; ++i) {
+        ASSERT_TRUE(end.client.tx(bytes({0})));
+    }
+    EXPECT_FALSE(end.client.tx(bytes({0})));
+    EXPECT_TRUE(end.client.tx_coalescing(bytes({1}), 4));
+    EXPECT_EQ(end.client.tx_queue_depth(), byte_stream_client::max_buffered_tx_payloads);
+    EXPECT_FALSE(end.client.tx_coalescing(bytes({2, 3, 4, 5}), 4));
+}
+
+TEST(fd_event_client_tx_drain_test, the_drained_action_fires_once_when_the_last_payload_left) {
+    bridge_end end;
+    std::atomic<int> drained{0};
+    end.client.set_tx_drained_action([&] { ++drained; });
+    EXPECT_TRUE(end.client.tx(bytes({1})));
+    EXPECT_TRUE(end.client.tx(bytes({2})));
+
+    ASSERT_TRUE(pump_until(end.client, 2s, [&] { return drained.load() == 1; }));
+    EXPECT_EQ(end.w->bytes, bytes({1, 2}));
+    pump_for(end.client, 30ms);
+    EXPECT_EQ(drained.load(), 1);
+}
+
+TEST(fd_event_client_tx_drain_test, a_reset_drops_the_buffer_without_draining) {
+    bridge_end end;
+    std::atomic<int> drained{0};
+    end.client.set_tx_drained_action([&] { ++drained; });
+    end.client.sync(1ms);
+
+    EXPECT_TRUE(end.client.tx(bytes({1})));
+    end.client.reset();
+    pump_for(end.client, 50ms);
+    EXPECT_EQ(drained.load(), 0);
+    EXPECT_TRUE(end.w->bytes.empty());
+    EXPECT_EQ(end.client.tx_queue_depth(), 0U);
+
+    // The reopened connection drains as before.
+    EXPECT_TRUE(end.client.tx(bytes({2})));
+    ASSERT_TRUE(pump_until(end.client, 2s, [&] { return drained.load() == 1; }));
+    EXPECT_EQ(end.w->bytes, bytes({2}));
+}
+
+TEST(fd_event_client_tx_drain_test, a_reset_from_the_drained_action_does_not_report_the_retired_connection) {
+    bridge_end end;
+    std::atomic<int> up_edges{0};
+    std::atomic<int> drained{0};
+    end.client.set_error_handler([&](int code, auto const&) {
+        if (code == 0) {
+            ++up_edges;
+        }
+    });
+    // The first drain resets, the second only counts.
+    end.client.set_tx_drained_action([&] {
+        if (drained++ == 0) {
+            end.client.reset();
+        }
+    });
+    // Let the first connection's code 0 pass.
+    pump_for(end.client, 50ms);
+    up_edges = 0;
+
+    EXPECT_TRUE(end.client.tx(bytes({1})));
+    ASSERT_TRUE(pump_until(end.client, 2s, [&] { return drained.load() == 1; }));
+    pump_for(end.client, 50ms);
+    // Exactly one up edge: the reopened connection. The write that drained the retired one must not
+    // report it.
+    EXPECT_EQ(up_edges.load(), 1);
+
+    // Already up: no further edge.
+    EXPECT_TRUE(end.client.tx(bytes({2})));
+    ASSERT_TRUE(pump_until(end.client, 2s, [&] { return drained.load() == 2; }));
+    EXPECT_EQ(end.w->bytes, bytes({1, 2}));
+    EXPECT_EQ(up_edges.load(), 1);
+}
+
+TEST(fd_event_client_rx_pause_test, pause_is_rejected_before_the_connection_is_monitored) {
+    std::shared_ptr<wire> w = std::make_shared<wire>();
+    std::shared_ptr<rx_source> source = std::make_shared<rx_source>();
+    byte_stream_client client{w, source};
+    // No monitored connection yet.
+    EXPECT_FALSE(client.pause_rx());
+    EXPECT_FALSE(client.resume_rx());
+    EXPECT_FALSE(client.rx_paused());
+    client.sync(1ms);
+    EXPECT_TRUE(client.pause_rx());
+    EXPECT_TRUE(client.rx_paused());
+    EXPECT_TRUE(client.resume_rx());
+    EXPECT_FALSE(client.rx_paused());
+}
+
+TEST(fd_event_client_rx_pause_test, paused_reads_hold_the_data_until_resume) {
+    bridge_end end;
+    ASSERT_TRUE(end.client.pause_rx());
+    end.source->push();
+    pump_for(end.client, 50ms);
+    EXPECT_EQ(end.rx_count.load(), 0);
+
+    ASSERT_TRUE(end.client.resume_rx());
+    EXPECT_TRUE(pump_until(end.client, 2s, [&] { return end.rx_count.load() == 1; }));
+}
+
+TEST(fd_event_client_rx_pause_test, pause_and_resume_are_idempotent) {
+    bridge_end end;
+    EXPECT_TRUE(end.client.pause_rx());
+    EXPECT_TRUE(end.client.pause_rx());
+    end.source->push();
+    pump_for(end.client, 30ms);
+    EXPECT_EQ(end.rx_count.load(), 0);
+
+    EXPECT_TRUE(end.client.resume_rx());
+    EXPECT_TRUE(end.client.resume_rx());
+    EXPECT_TRUE(pump_until(end.client, 2s, [&] { return end.rx_count.load() == 1; }));
+}
+
+TEST(fd_event_client_rx_pause_test, a_reset_while_paused_comes_back_unpaused) {
+    bridge_end end;
+    ASSERT_TRUE(end.client.pause_rx());
+    end.client.reset();
+    pump_for(end.client, 30ms);
+
+    EXPECT_FALSE(end.client.rx_paused());
+    end.source->push();
+    EXPECT_TRUE(pump_until(end.client, 2s, [&] { return end.rx_count.load() == 1; }));
+}
+
+TEST(fd_event_client_rx_pause_test, the_pause_state_does_not_outlive_the_connection) {
+    bridge_end end;
+    ASSERT_TRUE(end.client.pause_rx());
+    ASSERT_TRUE(end.client.rx_paused());
+
+    // reset() runs on the next pass, the reopened descriptor is registered one pass later: in
+    // between there is no monitored connection and the old pause is gone.
+    end.client.reset();
+    end.client.sync(1ms);
+    EXPECT_FALSE(end.client.rx_paused());
+    EXPECT_FALSE(end.client.pause_rx());
+    EXPECT_FALSE(end.client.resume_rx());
+
+    // Registered again.
+    pump_for(end.client, 30ms);
+    EXPECT_FALSE(end.client.rx_paused());
+    ASSERT_TRUE(end.client.pause_rx());
+    EXPECT_TRUE(end.client.rx_paused());
+    end.source->push();
+    pump_for(end.client, 30ms);
+    EXPECT_EQ(end.rx_count.load(), 0);
+    ASSERT_TRUE(end.client.resume_rx());
+    EXPECT_TRUE(pump_until(end.client, 2s, [&] { return end.rx_count.load() == 1; }));
+}
+
+TEST(fd_event_client_rx_pause_test, writes_go_out_while_reads_are_paused) {
+    bridge_end end;
+    ASSERT_TRUE(end.client.pause_rx());
+    EXPECT_TRUE(end.client.tx(bytes({7})));
+    ASSERT_TRUE(pump_until(end.client, 2s, [&] { return end.w->bytes.size() == 1; }));
+    EXPECT_EQ(end.w->bytes, bytes({7}));
+}
+
+TEST(fd_event_client_rx_pause_test, a_peer_close_while_paused_is_reported) {
+    int srv = ::socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(srv, 0);
+    sockaddr_in sa{};
+    sa.sin_family = AF_INET;
+    sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    sa.sin_port = 0;
+    ASSERT_EQ(::bind(srv, reinterpret_cast<sockaddr*>(&sa), sizeof(sa)), 0);
+    ASSERT_EQ(::listen(srv, 1), 0);
+    socklen_t len = sizeof(sa);
+    ASSERT_EQ(::getsockname(srv, reinterpret_cast<sockaddr*>(&sa), &len), 0);
+    auto const port = ntohs(sa.sin_port);
+
+    tcp::tcp_client client("127.0.0.1", port, 1000);
+    std::atomic<bool> ready{false};
+    std::atomic<int> failure{0};
+    client.set_on_ready_action([&]() { ready = true; });
+    client.set_error_handler([&](int code, auto const&) {
+        if (code != 0 and failure.load() == 0) {
+            failure = code;
+        }
+    });
+    ASSERT_TRUE(pump_until(client, 5s, [&] { return ready.load(); }));
+    // Handshake completed into the backlog; does not block.
+    int const peer = ::accept(srv, nullptr, nullptr);
+    ASSERT_GE(peer, 0);
+
+    // Paused: the FIN below must still be reported.
+    ASSERT_TRUE(client.pause_rx());
+    ::close(peer);
+
+    EXPECT_TRUE(pump_until(client, 2s, [&] { return failure.load() != 0; }))
+        << "a peer close while paused was not reported";
+
+    ::close(srv);
+}

--- a/lib/everest/io/test/fd_event_handler_test.cpp
+++ b/lib/everest/io/test/fd_event_handler_test.cpp
@@ -147,6 +147,46 @@ TEST(fd_event_handler_test, register_reports_false_when_epoll_add_fails) {
     ::close(raw);
 }
 
+TEST(fd_event_handler_test, swapping_events_takes_effect_in_one_modification) {
+    fd_event_handler handler;
+    int pipe_fds[2];
+    ASSERT_EQ(::pipe(pipe_fds), 0);
+    // The write end of an empty pipe is writable at once and never readable.
+    int writes = 0;
+    ASSERT_TRUE(handler.register_event_handler(
+        pipe_fds[1],
+        [&](fd_event_handler::event_list const& events) {
+            writes += static_cast<int>(events.count(poll_events::write));
+        },
+        poll_events::read));
+    EXPECT_FALSE(handler.poll(20ms));
+    EXPECT_EQ(writes, 0);
+
+    EXPECT_TRUE(handler.modify_event_handler(pipe_fds[1], fd_event_handler::event_list{poll_events::write},
+                                             fd_event_handler::event_list{poll_events::read}));
+    EXPECT_TRUE(handler.poll(100ms));
+    EXPECT_EQ(writes, 1);
+
+    EXPECT_TRUE(handler.modify_event_handler(pipe_fds[1], fd_event_handler::event_list{poll_events::read},
+                                             fd_event_handler::event_list{poll_events::write}));
+    EXPECT_FALSE(handler.poll(20ms));
+    EXPECT_EQ(writes, 1);
+
+    // An event named on both sides ends up enabled.
+    EXPECT_TRUE(handler.modify_event_handler(pipe_fds[1], fd_event_handler::event_list{poll_events::write},
+                                             fd_event_handler::event_list{poll_events::write}));
+    EXPECT_TRUE(handler.poll(100ms));
+    EXPECT_EQ(writes, 2);
+
+    ASSERT_TRUE(handler.unregister_event_handler(pipe_fds[1]));
+    EXPECT_FALSE(handler.modify_event_handler(pipe_fds[1], fd_event_handler::event_list{poll_events::write},
+                                              fd_event_handler::event_list{poll_events::read}));
+    EXPECT_FALSE(handler.modify_event_handler(-1, fd_event_handler::event_list{poll_events::write},
+                                              fd_event_handler::event_list{poll_events::read}));
+    ::close(pipe_fds[0]);
+    ::close(pipe_fds[1]);
+}
+
 TEST(fd_event_handler_test, poll_keeps_the_batch_across_a_registration_exchange) {
     fd_event_handler handler;
 

--- a/lib/everest/io/test/pty_handler_test.cpp
+++ b/lib/everest/io/test/pty_handler_test.cpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+//
+// pty_handler as fd_event_client policy: a false from tx()/rx() that means retry must leave
+// get_error() at zero.
+
+#include <everest/io/serial/pty_handler.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using everest::lib::io::serial::pty_handler;
+
+namespace {
+
+// Nobody reads the slave, so writes stall: partial write or EAGAIN, both return false.
+bool write_until_would_block(pty_handler& handler, std::size_t& attempts) {
+    for (attempts = 0; attempts < 1000; ++attempts) {
+        pty_handler::PayloadT payload(1400, 0x55);
+        if (not handler.tx(payload)) {
+            return not payload.empty();
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+TEST(pty_handler_test, a_write_the_slave_has_not_drained_is_a_retry_not_an_error) {
+    pty_handler handler;
+    ASSERT_TRUE(handler.open());
+    ASSERT_EQ(handler.get_error(), 0);
+
+    std::size_t attempts = 0;
+    ASSERT_TRUE(write_until_would_block(handler, attempts)) << "the master never reported a would-block";
+    EXPECT_GT(attempts, 0U);
+    EXPECT_EQ(handler.get_error(), 0);
+
+    // Retry stalls again, still no error.
+    pty_handler::PayloadT payload(1400, 0x55);
+    EXPECT_FALSE(handler.tx(payload));
+    EXPECT_FALSE(payload.empty());
+    EXPECT_EQ(handler.get_error(), 0);
+}
+
+TEST(pty_handler_test, a_read_with_nothing_pending_is_a_retry_not_an_error) {
+    pty_handler handler;
+    ASSERT_TRUE(handler.open());
+
+    // Drain the status packets queued by open() until the master would block.
+    pty_handler::PayloadT data;
+    int reads = 0;
+    while (handler.rx(data) and reads < 16) {
+        ++reads;
+    }
+    ASSERT_LT(reads, 16);
+    EXPECT_EQ(handler.get_error(), 0);
+}
+
+TEST(pty_handler_test, a_status_query_leaves_the_error_alone) {
+    pty_handler handler;
+    ASSERT_TRUE(handler.open());
+    (void)handler.get_status();
+    EXPECT_EQ(handler.get_error(), 0);
+}

--- a/lib/everest/util/include/everest/util/misc/container.hpp
+++ b/lib/everest/util/include/everest/util/misc/container.hpp
@@ -62,6 +62,31 @@ template <typename Container, typename T> bool exists(const Container& c, const 
 }
 
 /**
+ * @brief True if any of \p vals exists in \p c.
+ * @details Each value is looked up with \ref exists.
+ */
+template <typename Container, typename... T> bool exists_any(const Container& c, const T&... vals) {
+    return (exists(c, vals) || ...);
+}
+
+/**
+ * @brief The first of \p first, \p rest... that exists in \p c, in argument order.
+ * @details Each value is looked up with \ref exists.
+ * @return The first value found, std::nullopt if none exists.
+ */
+template <typename Container, typename T, typename... Ts>
+std::optional<T> first_present(const Container& c, const T& first, const Ts&... rest) {
+    if (exists(c, first)) {
+        return first;
+    }
+    if constexpr (sizeof...(rest) == 0) {
+        return std::nullopt;
+    } else {
+        return first_present(c, rest...);
+    }
+}
+
+/**
  * @brief Implementation for sequence containers (vector, list, etc.).
  * @return Pointer to the found element or nullptr.
  */

--- a/lib/everest/util/tests/CMakeLists.txt
+++ b/lib/everest/util/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(everest_util_tests
   async/thread_pool_scaling_tests.cpp
   async/wrapper_tests.cpp
   misc/change_tracker_tests.cpp
+  misc/container_tests.cpp
   enum/EnumFlagsTest.cpp
   enum/EnumFlagsTest_B.cpp
   math/comparison_tests.cpp

--- a/lib/everest/util/tests/misc/container_tests.cpp
+++ b/lib/everest/util/tests/misc/container_tests.cpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <everest/util/misc/container.hpp>
+
+#include <gtest/gtest.h>
+
+#include <set>
+#include <vector>
+
+namespace {
+
+using namespace everest::lib::util;
+
+TEST(container, exists_any_matches_any_argument) {
+    std::set<int> const s{1, 2, 3};
+    std::vector<int> const v{1, 2, 3};
+    EXPECT_TRUE(exists_any(s, 3));
+    EXPECT_TRUE(exists_any(s, 7, 8, 2));
+    EXPECT_FALSE(exists_any(s, 7, 8));
+    EXPECT_TRUE(exists_any(v, 7, 1));
+    EXPECT_FALSE(exists_any(v, 7));
+}
+
+TEST(container, first_present_follows_argument_order) {
+    std::set<int> const s{2, 3};
+    std::vector<int> const v{2, 3};
+    EXPECT_EQ(first_present(s, 1, 3, 2), std::optional<int>{3});
+    EXPECT_EQ(first_present(s, 2, 3), std::optional<int>{2});
+    EXPECT_EQ(first_present(s, 1), std::nullopt);
+    EXPECT_EQ(first_present(s, 1, 4), std::nullopt);
+    EXPECT_EQ(first_present(v, 1, 3, 2), std::optional<int>{3});
+    EXPECT_EQ(first_present(v, 1), std::nullopt);
+}
+
+} // namespace


### PR DESCRIPTION
## Describe your changes

Flow control for `fd_event_client`, needed to bridge a pty into TCP in `pionix_chargebridge`: since #2562 bounded the tx buffer, overflow dropped silently.

- `pause_rx()` / `resume_rx()` / `rx_paused()`: stop reading, the kernel buffer fills and the writer blocks. A paused stream socket reports the peer closing (EPOLLRDHUP, `poll_events::read_hungup`). Rejected without a monitored connection; a reconnect starts unpaused.
- `tx_queue_depth()` / `set_tx_drained_action()`: pause the source at a watermark, resume on drain. `reset()` and a failed connection do not drain; resume from `set_on_ready_action`.
- `tx_coalescing()`: append to the newest waiting payload within a bound. Only for policies declaring `supports_tx_coalescing` (`tcp_socket`, `pty_handler`); others do not compile.
- `fd_event_handler::modify_event_handler(fd, enable, disable)`: one `EPOLL_CTL_MOD`.
- `pty_handler`: non blocking master; would-block and partial writes return false with `get_error() == 0`. A slave that stops reading no longer stalls the loop; undrained data is rejected once the tx buffer is full (README).

No behaviour change for existing users unless they call the new functions; all in-tree consumers compile unchanged.

Tests: `fd_event_client_backpressure_test`, `pty_handler_test`, event swap in `fd_event_handler_test`, alias gate for `tx_coalescing`.

## Issue ticket number and link

Follow-up to #2562. Base of #2723 and #2718.
