### PR TITLE
fix(EvseManager): request energy again after a pause by the EVSE

### DIFF
--- a/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
+++ b/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
@@ -4,6 +4,7 @@
 #include "energyImpl.hpp"
 
 #include <everest/helpers/phase_rotation.hpp>
+#include <everest/util/misc/container.hpp>
 
 #include <chrono>
 #include <cstdint>
@@ -142,6 +143,31 @@ void energyImpl::ready() {
             request_energy_thread.detach();
         }
     });
+
+    mod->charger->signal_charging_paused_evse_event.connect(
+        [this](const types::evse_manager::ChargingPausedEVSEReasons& paused) {
+            using types::evse_manager::PauseChargingEVSEReasonEnum;
+            paused_by_user_or_error = everest::lib::util::exists_any(
+                paused.reasons, PauseChargingEVSEReasonEnum::UserPause, PauseChargingEVSEReasonEnum::Error);
+        });
+}
+
+bool energyImpl::should_request_energy() const {
+    if (not mod->config.request_zero_power_in_idle) {
+        return true;
+    }
+    switch (charger_state) {
+    case Charger::EvseState::Charging:
+    case Charger::EvseState::PrepareCharging:
+    case Charger::EvseState::WaitingForAuthentication:
+    case Charger::EvseState::ChargingPausedEV:
+        return true;
+    case Charger::EvseState::ChargingPausedEVSE:
+        // a pause for missing energy alone keeps requesting so that charging can resume
+        return not paused_by_user_or_error;
+    default:
+        return false;
+    }
 }
 
 types::energy::EvseState to_energy_evse_state(const Charger::EvseState charger_state) {
@@ -195,9 +221,7 @@ void energyImpl::request_energy_from_energy_manager(bool priority_request) {
     clear_export_request_schedule();
 
     // If we need energy, copy local limit schedules to energy_flow_request.
-    if (charger_state == Charger::EvseState::Charging || charger_state == Charger::EvseState::PrepareCharging ||
-        charger_state == Charger::EvseState::WaitingForAuthentication ||
-        charger_state == Charger::EvseState::ChargingPausedEV || !mod->config.request_zero_power_in_idle) {
+    if (should_request_energy()) {
 
         // copy complete external limit schedules for import
         if (not mod->get_local_energy_limits().schedule_import.empty()) {

--- a/modules/EVSE/EvseManager/energy_grid/energyImpl.hpp
+++ b/modules/EVSE/EvseManager/energy_grid/energyImpl.hpp
@@ -61,10 +61,12 @@ private:
     void clear_export_request_schedule();
     void clear_request_schedules();
     void request_energy_from_energy_manager(bool priority_request);
+    bool should_request_energy() const;
     types::evse_board_support::HardwareCapabilities hw_caps;
     float last_enforced_limit{0.};
     float limit_when_random_delay_started{0.};
     std::atomic<Charger::EvseState> charger_state;
+    std::atomic<bool> paused_by_user_or_error{false};
     static constexpr std::chrono::seconds detect_startup_with_ev_attached_duration{5};
 
     std::string source_base;

--- a/modules/EVSE/EvseManager/manifest.yaml
+++ b/modules/EVSE/EvseManager/manifest.yaml
@@ -272,8 +272,9 @@ config:
     default: V2G
   request_zero_power_in_idle:
     description: >-
-      "true: In Idle mode (no car connected), request 0A from energy management. In installations with many charging stations this should be set"
-      "to allow the power to be distributed to the chargers that are connected to a car."
+      "true: In Idle mode (no car connected) and while charging is paused by the EVSE for a user pause or an error, request 0A from"
+      "energy management. In installations with many charging stations this should be set to allow the power to be distributed to the"
+      "chargers that are connected to a car. A pause because of missing energy keeps requesting energy so that charging can resume."
       "false: Request the normal current even if no car is connected. This speeds up the start of charging on AC BASIC charging as"
       "EvseManager does not need to wait for energy from the energy manager after plug in."
     type: boolean

--- a/tests/core_tests/smoke_tests.py
+++ b/tests/core_tests/smoke_tests.py
@@ -47,6 +47,19 @@ class AcConfigAdjustmentStrategy(EverestConfigAdjustmentStrategy):
         adjusted_config["active_modules"]["connector_1"]["config_module"]["hlc_charge_loop_without_energy_timeout_s"] = self.hlc_charge_loop_without_energy_timeout_s
         return adjusted_config
 
+class RequestZeroPowerInIdleAdjustmentStrategy(EverestConfigAdjustmentStrategy):
+    """
+    Adjustment strategy to set request_zero_power_in_idle of connector_1
+    """
+
+    def __init__(self, request_zero_power_in_idle: bool):
+        self.request_zero_power_in_idle = request_zero_power_in_idle
+
+    def adjust_everest_configuration(self, everest_config: Dict):
+        adjusted_config = deepcopy(everest_config)
+        adjusted_config["active_modules"]["connector_1"]["config_module"]["request_zero_power_in_idle"] = self.request_zero_power_in_idle
+        return adjusted_config
+
 class DcConfigAdjustmentStrategy(EverestConfigAdjustmentStrategy):
     """
     Adjustment strategy to disable DIN SPEC 70121 module
@@ -1159,11 +1172,28 @@ async def test_iso15118_dc_session_paused_by_ev(
 )
 @pytest.mark.xdist_group(name="ISO15118")
 @pytest.mark.everest_core_config("config-sil.yaml")
+@pytest.mark.parametrize(
+    "request_zero_power_in_idle",
+    [
+        pytest.param(
+            False,
+            marks=pytest.mark.everest_config_adaptions(RequestZeroPowerInIdleAdjustmentStrategy(False)),
+            id="request_zero_power_in_idle_false",
+        ),
+        pytest.param(
+            True,
+            marks=pytest.mark.everest_config_adaptions(RequestZeroPowerInIdleAdjustmentStrategy(True)),
+            id="request_zero_power_in_idle_true",
+        ),
+    ],
+)
 async def test_pwm_ac_session_paused_by_evse(
-    test_controller: TestController, everest_core: EverestCore
+    request_zero_power_in_idle, test_controller: TestController, everest_core: EverestCore
 ):
     """
     Test session events of a basic PWM AC charging session with session paused by EVSE.
+    With request_zero_power_in_idle the EVSE requests no energy while paused by the user and has to request
+    energy again once the pause is lifted, otherwise it could never resume.
     """
 
     probe_module, session_event_mock, powermeter_mock, _ = await setup_session_mocks(


### PR DESCRIPTION

## Describe your changes

With request_zero_power_in_idle enabled, EvseManager requested 0A in ChargingPausedEVSE. The energy manager enforced 0A, so power_available() stayed false and the NoEnergy pause reason kept the state machine paused even after resume_charging() had cleared the user pause. Charging could only continue after an unplug. A pause for missing energy could not recover at all.

Only request 0A while a pause reason without energy demand is active (UserPause or Error). Once only NoEnergy is left, request the local limits again immediately so the energy manager can hand the budget back and charging resumes.

Track the active pause reasons in energyImpl via the Charger's ChargingPausedEVSE event and document the behaviour in the manifest. Parametrize test_pwm_ac_session_paused_by_evse over both values of request_zero_power_in_idle; the true variant fails without this fix.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

