### PR TITLE
feat(io): SocketCAN socket options and vcan transmit shaping for bus emulation

### DIFF
--- a/lib/everest/io/include/everest/io/can/socket_can_handler.hpp
+++ b/lib/everest/io/include/everest/io/can/socket_can_handler.hpp
@@ -5,15 +5,36 @@
 
 #pragma once
 
+#include <cstdint>
 #include <everest/io/can/can_payload.hpp>
 #include <everest/io/can/can_recv_filter.hpp>
 #include <everest/io/event/unique_fd.hpp>
+#include <optional>
 #include <string>
 #include <vector>
 
 namespace everest::lib::io {
 
 namespace can {
+
+/**
+ * @struct socket_can_options
+ * @brief Socket options requested on \ref socket_can_handler::open beyond the defaults (non
+ *        blocking, minimal send buffer). Defaults set nothing.
+ */
+struct socket_can_options {
+    /**
+     * @brief SO_RCVBUF in bytes, 0 keeps the kernel default. Clamped to net.core.rmem_max. One CAN
+     *        frame costs about 0.5 to 1 KB of skb truesize.
+     */
+    std::uint32_t receive_buffer_bytes{0};
+    /**
+     * @brief SO_PRIORITY (skb->priority), unset keeps the default. Values above 6 need CAP_NET_ADMIN.
+     *        \ref netlink::vcan_netlink_manager::unshaped_socket_priority bypasses the shaper of
+     *        \ref netlink::vcan_netlink_manager::set_transmit_rate_limit.
+     */
+    std::optional<int> socket_priority{};
+};
 
 /**
  * socket_can_handler bundles basic <a href="https://docs.kernel.org/networking/can.html">socket_can</a>
@@ -82,9 +103,11 @@ public:
      * Implementation for \p ClientPolicy
      * @param[in] can_dev The device to bind the socket to.
      * @param[in] recv_filters Optional filters applied on open (replaces stored filters).
+     * @param[in] options Socket options to request on top of the defaults, see \ref socket_can_options.
      * @return True on success, false otherwise.
      */
-    bool open(std::string const& can_dev, std::vector<can_recv_filter> const& recv_filters = {});
+    bool open(std::string const& can_dev, std::vector<can_recv_filter> const& recv_filters = {},
+              socket_can_options const& options = {});
 
     /**
      * @brief Set kernel receive filters for this handler.
@@ -141,6 +164,7 @@ private:
     event::unique_fd m_owned_can_fd;
     std::string m_can_dev;
     std::vector<can_recv_filter> m_recv_filters;
+    socket_can_options m_options;
 };
 } // namespace can
 } // namespace everest::lib::io

--- a/lib/everest/io/include/everest/io/netlink/vcan_netlink_manager.hpp
+++ b/lib/everest/io/include/everest/io/netlink/vcan_netlink_manager.hpp
@@ -71,6 +71,42 @@ public:
     bool destroy(std::string const& interface_name);
 
     /**
+     * @brief Shape what producers write into the vcan with a token bucket (tbf), so a writer feels
+     *        the bus rate as on real hardware: a small SO_SNDBUF blocks at bus rate, the default
+     *        buffer gets ENOBUFS when the queue is full.
+     * @details Qdisc tree over rtnetlink (RTM_NEWQDISC): a 2-band prio root; skb->priority 6/7
+     *          (\ref unshaped_socket_priority, the bridge's own bus-to-host writes) -> pfifo,
+     *          everything else -> tbf. Idempotent; the qdiscs disappear with the interface. tbf
+     *          meters skb bytes (16 per classic frame, 72 per CAN FD frame), derive \p rate_bps from
+     *          the wire cost of the traffic. Without IFF_ECHO (vcan default) local readers get a
+     *          clone before the qdisc, so only the writer is paced; a reader that needs bus rate
+     *          paces its reads.
+     * @param interface_name The interface (must exist).
+     * @param rate_bps Token refill rate in bit/s of skb bytes.
+     * @param burst_bytes Bucket in bytes, at least the CAN FD MTU (72); should be >= rate/HZ.
+     * @param limit_bytes Queue capacity in bytes.
+     * @return True on success. False otherwise (reported through the error handler). A shaper
+     *         installed by an earlier call stays in place with its previous parameters; a failed
+     *         first installation leaves the interface unshaped, unless removing the half
+     *         installed tree fails as well (also reported).
+     */
+    bool set_transmit_rate_limit(std::string const& interface_name, std::uint64_t rate_bps, std::uint32_t burst_bytes,
+                                 std::uint32_t limit_bytes);
+
+    /**
+     * @brief Remove the shaper of \ref set_transmit_rate_limit. Idempotent.
+     * @param interface_name The interface (must exist).
+     * @return True on success, false otherwise (reported through the error handler).
+     */
+    bool clear_transmit_rate_limit(std::string const& interface_name);
+
+    /**
+     * @brief SO_PRIORITY that bypasses the shaper of \ref set_transmit_rate_limit, see
+     *        \ref can::socket_can_options::socket_priority.
+     */
+    static std::uint8_t unshaped_socket_priority();
+
+    /**
      * @brief Access the single instance of this object.
      * @details The underlying object is created on the first call to this function.
      * @return Reference to the object instance
@@ -123,6 +159,26 @@ private:
      * @throws std::runtime_error if the operation fails or ACK is not received.
      */
     void send_netlink_request_impl(int msg_type, int flags, cb_type const& callback);
+
+    /**
+     * @brief Wait for the kernel's answer to \p req: returns on ACK, throws on NLMSG_ERROR or when no
+     *        matching reply arrives.
+     */
+    void await_ack(NetlinkMessage const& req, int msg_type);
+
+    /**
+     * @brief Send one qdisc request (RTM_NEWQDISC or RTM_DELQDISC) and wait for its ACK; throws on
+     *        refusal.
+     * @param kind The qdisc kind, nullptr for a delete.
+     * @param fill_options Appends TCA_OPTIONS; may be empty.
+     */
+    void send_qdisc(int msg_type, unsigned int ifindex, std::uint32_t parent, std::uint32_t handle, char const* kind,
+                    std::function<void(NetlinkMessage&)> const& fill_options);
+
+    /**
+     * @brief Delete the root qdisc; ENOENT (kernel default queue) counts as done. Throws otherwise.
+     */
+    void remove_root_qdisc(unsigned int ifindex);
 
     /**
      * @brief Wraps exception handling for \p send_netlink_request_impl

--- a/lib/everest/io/src/can/socket_can_handler.cpp
+++ b/lib/everest/io/src/can/socket_can_handler.cpp
@@ -2,6 +2,7 @@
 // Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 
 #include <algorithm>
+#include <cstdint>
 #include <everest/io/can/can_recv_filter.hpp>
 #include <everest/io/can/socket_can_handler.hpp>
 #include <everest/io/event/fd_event_handler.hpp>
@@ -110,7 +111,8 @@ bool socket_can_handler::rx(can_dataset& data) {
     return status == 0;
 }
 
-bool socket_can_handler::open(std::string const& can_device, std::vector<can_recv_filter> const& recv_filters) {
+bool socket_can_handler::open(std::string const& can_device, std::vector<can_recv_filter> const& recv_filters,
+                              socket_can_options const& options) {
     // IFNAMSIZ is the size of the buffer to write the name to.
     // This situation is special concerning null termination,
     // The name can occupy the fill buffer. If it does not, nulltermination is necessary
@@ -120,6 +122,7 @@ bool socket_can_handler::open(std::string const& can_device, std::vector<can_rec
         return false;
     }
     m_recv_filters = recv_filters;
+    m_options = options;
     m_can_dev = can_device;
     return open_device() == 0;
 }
@@ -185,6 +188,15 @@ int socket_can_handler::open_device() {
 
     socket::set_non_blocking(can_fd);
     socket::set_socket_send_buffer_to_min(can_fd);
+    // Best effort, see socket_can_options.
+    if (m_options.receive_buffer_bytes != 0) {
+        int rcvbuf = static_cast<int>(std::min<std::uint32_t>(m_options.receive_buffer_bytes, INT32_MAX));
+        (void)::setsockopt(can_fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf));
+    }
+    if (m_options.socket_priority.has_value()) {
+        int prio = *m_options.socket_priority;
+        (void)::setsockopt(can_fd, SOL_SOCKET, SO_PRIORITY, &prio, sizeof(prio));
+    }
     m_owned_can_fd = std::move(can_fd);
 
     if (!apply_recv_filters()) {

--- a/lib/everest/io/src/netlink/vcan_netlink_manager.cpp
+++ b/lib/everest/io/src/netlink/vcan_netlink_manager.cpp
@@ -6,12 +6,15 @@
 #include <linux/netlink.h>
 #include <cstring>
 #include <exception>
+#include <functional>
 #include <iostream>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <net/if.h>
+#include <linux/can.h>
 #include <linux/if_arp.h>
+#include <linux/pkt_sched.h>
 #include <linux/rtnetlink.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
@@ -135,7 +138,28 @@ void vcan_netlink_manager::send_netlink_request_impl(int msg_type, int flags, cb
 
     callback(&req.header, ifi, sizeof(req.buffer));
     send_message(req);
+    await_ack(req, msg_type);
+}
 
+namespace {
+// NLMSG_ERROR with the errno kept apart from the text.
+class netlink_error : public std::runtime_error {
+public:
+    explicit netlink_error(int negative_errno) :
+        std::runtime_error(std::string(strerror(-negative_errno)) + " (error code: " + std::to_string(negative_errno) +
+                           ")"),
+        m_errnum(-negative_errno) {
+    }
+    int errnum() const {
+        return m_errnum;
+    }
+
+private:
+    int m_errnum;
+};
+} // namespace
+
+void vcan_netlink_manager::await_ack(NetlinkMessage const& req, int msg_type) {
     NetlinkMessage response;
     bool ack_received = false;
     int max_recv_attempts = 10;
@@ -162,8 +186,7 @@ void vcan_netlink_manager::send_netlink_request_impl(int msg_type, int flags, cb
                     ack_received = true;
                     return;
                 } else {
-                    throw std::runtime_error(std::string(strerror(-err->error)) +
-                                             " (error code: " + std::to_string(err->error) + ")");
+                    throw netlink_error(err->error);
                 }
             } else if (nlh->nlmsg_type == msg_type) {
                 ack_received = true;
@@ -251,6 +274,202 @@ bool vcan_netlink_manager::bring_down(std::string const& interface_name) {
             ifi->ifi_change = IFF_UP;
         },
         interface_name, "bringDown");
+}
+
+namespace {
+// Qdisc tree installed on a shaped vcan (see set_transmit_rate_limit):
+//   1:  prio, 2 bands, priomap: skb->priority 6/7 -> band 0, everything else -> band 1
+//   1:1 pfifo, explicit limit (a vcan has tx_queue_len 0, the default pfifo would drop all)
+//   1:2 tbf, the rate limit
+// SO_PRIORITY 6 (unshaped_priority) bypasses the shaper, the default priority 0 is shaped.
+constexpr std::uint32_t prio_handle = 0x00010000U;    // 1:
+constexpr std::uint32_t band_unshaped = 0x00010001U;  // 1:1
+constexpr std::uint32_t band_shaped = 0x00010002U;    // 1:2
+constexpr std::uint32_t unshaped_pfifo_limit = 4096U; // frames
+constexpr std::uint8_t unshaped_priority = 6;         // skb->priority mapped to band 0
+} // namespace
+
+std::uint8_t vcan_netlink_manager::unshaped_socket_priority() {
+    return unshaped_priority;
+}
+
+void vcan_netlink_manager::send_qdisc(int msg_type, unsigned int ifindex, std::uint32_t parent, std::uint32_t handle,
+                                      char const* kind, std::function<void(NetlinkMessage&)> const& fill_options) {
+    // NLM_F_CREATE | NLM_F_REPLACE with handle 0 is `tc qdisc replace`: create, change parameters of
+    // the same kind, or swap a different kind.
+    NetlinkMessage req;
+    memset(&req, 0, sizeof(req));
+    req.header.nlmsg_len = NLMSG_LENGTH(sizeof(struct tcmsg));
+    req.header.nlmsg_type = msg_type;
+    req.header.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    if (msg_type == RTM_NEWQDISC) {
+        req.header.nlmsg_flags |= NLM_F_CREATE | NLM_F_REPLACE;
+    }
+    req.header.nlmsg_seq = ++s_netlink_seq_counter;
+    req.header.nlmsg_pid = getpid();
+    struct tcmsg* tcm = (struct tcmsg*)NLMSG_DATA(&req.header);
+    tcm->tcm_family = AF_UNSPEC;
+    tcm->tcm_ifindex = static_cast<int>(ifindex);
+    tcm->tcm_handle = handle;
+    tcm->tcm_parent = parent;
+    if (kind != nullptr) {
+        add_attribute(&req.header, sizeof(req.buffer), TCA_KIND, kind, strlen(kind) + 1);
+    }
+    if (fill_options) {
+        fill_options(req);
+    }
+    send_message(req);
+    await_ack(req, msg_type);
+}
+
+void vcan_netlink_manager::remove_root_qdisc(unsigned int ifindex) {
+    try {
+        send_qdisc(RTM_DELQDISC, ifindex, TC_H_ROOT, 0, nullptr, {});
+    } catch (netlink_error const& e) {
+        // The kernel's default queue has handle 0 and is refused with ENOENT: nothing installed.
+        if (e.errnum() != ENOENT) {
+            throw;
+        }
+    }
+}
+
+bool vcan_netlink_manager::set_transmit_rate_limit(std::string const& interface_name, std::uint64_t rate_bps,
+                                                   std::uint32_t burst_bytes, std::uint32_t limit_bytes) {
+    static constexpr char const* caller = "setTransmitRateLimit";
+    if (rate_bps == 0 or burst_bytes == 0 or limit_bytes == 0) {
+        report_error(interface_name, caller, "rate, burst and limit must be non-zero");
+        return false;
+    }
+    if (burst_bytes < CANFD_MTU) {
+        // tbf refuses a bucket below the MTU, or on kernels that only warn, stalls FD frames.
+        report_error(interface_name, caller,
+                     "burst must be at least the CAN FD MTU of " + std::to_string(CANFD_MTU) + " bytes");
+        return false;
+    }
+    unsigned int const ifindex = ::if_nametoindex(interface_name.c_str());
+    if (ifindex == 0) {
+        report_error(interface_name, caller, std::string("if_nametoindex failed: ") + std::strerror(errno));
+        return false;
+    }
+
+    // Only the tbf carries the arguments. With the tree in place this is the whole update; ENOENT
+    // (no parent) installs the tree below.
+    auto const send_tbf = [&]() {
+        send_qdisc(
+            RTM_NEWQDISC, ifindex, band_shaped, 0, "tbf",
+            [this, rate_bps, burst_bytes, limit_bytes](NetlinkMessage& req) {
+                // TCA_OPTIONS is a nest: open it, append the tbf attributes, then fix up its length.
+                struct rtattr* options = (struct rtattr*)(((char*)&req.header) + NLMSG_ALIGN(req.header.nlmsg_len));
+                options->rta_type = TCA_OPTIONS;
+                options->rta_len = RTA_LENGTH(0);
+                req.header.nlmsg_len = NLMSG_ALIGN(req.header.nlmsg_len) + RTA_ALIGN(RTA_LENGTH(0));
+
+                // rate in bytes/s; linklayer ETHERNET = plain byte accounting, no rate table. buffer is the
+                // bucket in psched ticks (64 ns) for kernels without TCA_TBF_BURST (since 3.13, in bytes).
+                struct tc_tbf_qopt qopt;
+                memset(&qopt, 0, sizeof(qopt));
+                std::uint64_t const rate_bytes = rate_bps / 8U;
+                qopt.rate.rate = rate_bytes > 0xFFFFFFFFULL ? 0xFFFFFFFFU : static_cast<std::uint32_t>(rate_bytes);
+                qopt.rate.linklayer = TC_LINKLAYER_ETHERNET;
+                qopt.limit = limit_bytes;
+                // bytes * 8e9 / rate / 64 = bytes * 125e6 / rate; below 2^59 for any argument.
+                std::uint64_t const burst_ticks = (static_cast<std::uint64_t>(burst_bytes) * 125000000ULL) / rate_bps;
+                qopt.buffer = burst_ticks > 0xFFFFFFFFULL ? 0xFFFFFFFFU : static_cast<std::uint32_t>(burst_ticks);
+                add_attribute(&req.header, sizeof(req.buffer), TCA_TBF_PARMS, &qopt, sizeof(qopt));
+                std::uint32_t const burst = burst_bytes;
+                add_attribute(&req.header, sizeof(req.buffer), TCA_TBF_BURST, &burst, sizeof(burst));
+
+                options->rta_len = (char*)&req.header + req.header.nlmsg_len - (char*)options;
+            });
+    };
+    try {
+        send_tbf();
+        return true;
+    } catch (netlink_error const& e) {
+        if (e.errnum() != ENOENT) {
+            report_error(interface_name, caller, e.what());
+            return false;
+        }
+        // No parent 1: to hang the tbf under: install the tree.
+    } catch (std::exception& e) {
+        report_error(interface_name, caller, e.what());
+        return false;
+    } catch (...) {
+        report_error(interface_name, caller, "Unexpected exception");
+        return false;
+    }
+
+    // prio root with an explicit handle so its bands can be parents. TCA_OPTIONS is the bare
+    // tc_prio_qopt.
+    try {
+        send_qdisc(RTM_NEWQDISC, ifindex, TC_H_ROOT, prio_handle, "prio", [this](NetlinkMessage& req) {
+            struct tc_prio_qopt qopt;
+            memset(&qopt, 0, sizeof(qopt));
+            qopt.bands = 2;
+            for (auto& band : qopt.priomap) {
+                band = 1;
+            }
+            qopt.priomap[6] = 0;
+            qopt.priomap[7] = 0;
+            add_attribute(&req.header, sizeof(req.buffer), TCA_OPTIONS, &qopt, sizeof(qopt));
+        });
+    } catch (std::exception& e) {
+        report_error(interface_name, caller, e.what());
+        return false;
+    } catch (...) {
+        report_error(interface_name, caller, "Unexpected exception");
+        return false;
+    }
+
+    // Past the root, a failure would leave the shaped band with the kernel's default child (a
+    // limit 0 pfifo on a vcan, dropping everything). Remove the root so false always means unshaped.
+    auto const fail_unshaped = [&](std::string const& reason) {
+        std::string outcome;
+        try {
+            remove_root_qdisc(ifindex);
+            outcome = "; the interface is left unshaped";
+        } catch (std::exception& e) {
+            outcome = std::string("; removing the half installed tree failed as well: ") + e.what();
+        } catch (...) {
+            outcome = "; removing the half installed tree failed as well";
+        }
+        report_error(interface_name, caller, reason + outcome);
+        return false;
+    };
+    try {
+        // 1:1 unshaped band: pfifo with an explicit packet limit.
+        send_qdisc(RTM_NEWQDISC, ifindex, band_unshaped, 0, "pfifo", [this](NetlinkMessage& req) {
+            struct tc_fifo_qopt qopt;
+            memset(&qopt, 0, sizeof(qopt));
+            qopt.limit = unshaped_pfifo_limit;
+            add_attribute(&req.header, sizeof(req.buffer), TCA_OPTIONS, &qopt, sizeof(qopt));
+        });
+        // 1:2 shaped band: the token bucket.
+        send_tbf();
+        return true;
+    } catch (std::exception& e) {
+        return fail_unshaped(e.what());
+    } catch (...) {
+        return fail_unshaped("Unexpected exception");
+    }
+}
+
+bool vcan_netlink_manager::clear_transmit_rate_limit(std::string const& interface_name) {
+    static constexpr char const* caller = "clearTransmitRateLimit";
+    unsigned int const ifindex = ::if_nametoindex(interface_name.c_str());
+    if (ifindex == 0) {
+        report_error(interface_name, caller, std::string("if_nametoindex failed: ") + std::strerror(errno));
+        return false;
+    }
+    try {
+        remove_root_qdisc(ifindex);
+        return true;
+    } catch (std::exception& e) {
+        report_error(interface_name, caller, e.what());
+    } catch (...) {
+        report_error(interface_name, caller, "Unexpected exception");
+    }
+    return false;
 }
 
 bool vcan_netlink_manager::destroy(std::string const& interface_name) {

--- a/lib/everest/io/test/CMakeLists.txt
+++ b/lib/everest/io/test/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(everest_io_tests
   fd_event_handler_test.cpp
   fd_event_client_backpressure_test.cpp
   pty_handler_test.cpp
+  vcan_netlink_manager_test.cpp
 )
 
 target_link_libraries(everest_io_tests

--- a/lib/everest/io/test/vcan_netlink_manager_test.cpp
+++ b/lib/everest/io/test/vcan_netlink_manager_test.cpp
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+//
+// Argument checks and failure reporting of the vcan shaper; installing needs CAP_NET_ADMIN.
+
+#include <everest/io/netlink/vcan_netlink_manager.hpp>
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using everest::lib::io::netlink::vcan_netlink_manager;
+
+namespace {
+
+// Cannot exist, so a request past the argument checks fails on the name lookup.
+constexpr char const* no_such_interface = "everest-io-no-such-if";
+
+class vcan_netlink_manager_test : public ::testing::Test {
+protected:
+    void SetUp() override {
+        vcan_netlink_manager::Instance().set_error_handler(
+            [this](std::string const& message) { reports.push_back(message); });
+    }
+    void TearDown() override {
+        vcan_netlink_manager::Instance().set_error_handler({});
+    }
+
+    bool last_report_mentions(std::string const& text) const {
+        return not reports.empty() and reports.back().find(text) != std::string::npos;
+    }
+
+    std::vector<std::string> reports;
+};
+
+} // namespace
+
+TEST_F(vcan_netlink_manager_test, a_burst_below_the_can_fd_mtu_is_rejected_before_anything_is_touched) {
+    auto& manager = vcan_netlink_manager::Instance();
+    EXPECT_FALSE(manager.set_transmit_rate_limit(no_such_interface, 1'000'000, 71, 10'000));
+    ASSERT_EQ(reports.size(), 1U);
+    EXPECT_TRUE(last_report_mentions("burst must be at least the CAN FD MTU of 72 bytes")) << reports.back();
+
+    // 72 passes the check and reaches the lookup.
+    EXPECT_FALSE(manager.set_transmit_rate_limit(no_such_interface, 1'000'000, 72, 10'000));
+    ASSERT_EQ(reports.size(), 2U);
+    EXPECT_TRUE(last_report_mentions("if_nametoindex failed")) << reports.back();
+}
+
+TEST_F(vcan_netlink_manager_test, zero_rate_burst_or_limit_is_rejected) {
+    auto& manager = vcan_netlink_manager::Instance();
+    EXPECT_FALSE(manager.set_transmit_rate_limit(no_such_interface, 0, 72, 10'000));
+    EXPECT_FALSE(manager.set_transmit_rate_limit(no_such_interface, 1'000'000, 0, 10'000));
+    EXPECT_FALSE(manager.set_transmit_rate_limit(no_such_interface, 1'000'000, 72, 0));
+    ASSERT_EQ(reports.size(), 3U);
+    for (auto const& report : reports) {
+        EXPECT_NE(report.find("must be non-zero"), std::string::npos) << report;
+    }
+}
+
+TEST_F(vcan_netlink_manager_test, a_burst_near_the_argument_limit_is_accepted_by_the_checks) {
+    // The maximum burst passes the checks; the bucket arithmetic must not overflow for it.
+    auto& manager = vcan_netlink_manager::Instance();
+    EXPECT_FALSE(manager.set_transmit_rate_limit(no_such_interface, 1'000'000, 0xFFFFFFFFU, 10'000));
+    ASSERT_EQ(reports.size(), 1U);
+    EXPECT_TRUE(last_report_mentions("if_nametoindex failed")) << reports.back();
+}
+
+TEST_F(vcan_netlink_manager_test, clearing_an_unknown_interface_reports_the_lookup_failure) {
+    auto& manager = vcan_netlink_manager::Instance();
+    EXPECT_FALSE(manager.clear_transmit_rate_limit(no_such_interface));
+    ASSERT_EQ(reports.size(), 1U);
+    EXPECT_TRUE(last_report_mentions("'clearTransmitRateLimit'")) << reports.back();
+    EXPECT_TRUE(last_report_mentions("if_nametoindex failed")) << reports.back();
+}


### PR DESCRIPTION
## Describe your changes

`lib/everest/io` support for emulating a CAN bus on a vcan (`pionix_chargebridge`, #2718).

- `socket_can_handler::open(dev, filters, socket_can_options)`: `SO_RCVBUF` and `SO_PRIORITY` on request; defaults set nothing, existing drivers unchanged.
- `vcan_netlink_manager::set_transmit_rate_limit()`: tbf over rtnetlink. prio root, pfifo band for priority 6/7 (`unshaped_socket_priority()`, the bridge's own bus-to-host writes), tbf band for the rest. An update sends only the tbf; the tree is installed on ENOENT; a failure past the root removes the root, so `false` always means unshaped. `clear_transmit_rate_limit()` removes it. `burst >= CANFD_MTU` enforced, bucket arithmetic overflow free.

Tests: `vcan_netlink_manager_test` (argument checks; installing needs `CAP_NET_ADMIN`).

## Issue ticket number and link

Stacked on #2709, base of #2718.
