### PR TITLE
fix(everest_api_types): accept HardwareCapabilities without supports_cp_state_E

### DIFF
--- a/docs/source/reference/EVerest_API/evse_board_support_API.yaml
+++ b/docs/source/reference/EVerest_API/evse_board_support_API.yaml
@@ -629,7 +629,6 @@ components:
         - max_phase_count_export
         - min_phase_count_export
         - supports_changing_phases_during_charging
-        - supports_cp_state_E
         - connector_type
       properties:
         max_current_A_import:
@@ -678,7 +677,9 @@ components:
         supports_cp_state_E:
           description: >-
             Indicates whether setting Control Pilot to state E is supported (true) or not
+            (false). Treated as false when omitted.
           type: boolean
+          default: false
         connector_type:
           description: Type of charging connector available at this EVSE
           type: string

--- a/lib/everest/everest_api_types/src/everest_api_types/evse_board_support/json_codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/evse_board_support/json_codec.cpp
@@ -450,7 +450,7 @@ void from_json(json const& j, HardwareCapabilities& k) {
     k.max_phase_count_export = j.at("max_phase_count_export");
     k.min_phase_count_export = j.at("min_phase_count_export");
     k.supports_changing_phases_during_charging = j.at("supports_changing_phases_during_charging");
-    k.supports_cp_state_E = j.at("supports_cp_state_E");
+    k.supports_cp_state_E = j.value("supports_cp_state_E", false);
     k.connector_type = j.at("connector_type");
 
     if (j.contains("max_plug_temperature_C")) {

--- a/lib/everest/everest_api_types/tests/CMakeLists.txt
+++ b/lib/everest/everest_api_types/tests/CMakeLists.txt
@@ -84,6 +84,7 @@ target_include_directories(${TEST_TARGET_NAME} PUBLIC
 target_sources(${TEST_TARGET_NAME} PRIVATE
   manual_tests/serialization/generic.hpp
   manual_tests/serialization/generic.cpp
+  manual_tests/serialization/evse_board_support.cpp
   manual_tests/serialization/telemetry.cpp
   manual_tests/source_file_hash_check/source_file_hash_check.cpp
 )

--- a/lib/everest/everest_api_types/tests/manual_tests/serialization/evse_board_support.cpp
+++ b/lib/everest/everest_api_types/tests/manual_tests/serialization/evse_board_support.cpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "everest_api_types/evse_board_support/codec.hpp"
+#include "everest_api_types/utilities/codec.hpp"
+#include "nlohmann/json.hpp"
+#include <gtest/gtest.h>
+
+using namespace everest::lib::API::V1_0::types::evse_board_support;
+
+namespace {
+
+constexpr std::string_view capabilities_without_cp_state_E = R"({
+    "max_current_A_import": 724.638,
+    "min_current_A_import": 0,
+    "max_phase_count_import": 3,
+    "min_phase_count_import": 3,
+    "max_current_A_export": 0,
+    "min_current_A_export": 0,
+    "max_phase_count_export": 0,
+    "min_phase_count_export": 0,
+    "supports_changing_phases_during_charging": false,
+    "connector_type": "IEC62196Type2Cable"
+})";
+
+} // namespace
+
+TEST(evse_board_support, hardware_capabilities_without_cp_state_E_defaults_to_false) {
+    HardwareCapabilities result;
+    ASSERT_TRUE(everest::lib::API::deserialize(std::string(capabilities_without_cp_state_E), result));
+
+    EXPECT_FALSE(result.supports_cp_state_E);
+    EXPECT_FLOAT_EQ(result.max_current_A_import, 724.638f);
+    EXPECT_EQ(result.max_phase_count_import, 3);
+    EXPECT_FALSE(result.supports_changing_phases_during_charging);
+    EXPECT_EQ(result.connector_type, Connector_type::IEC62196Type2Cable);
+    EXPECT_FALSE(result.max_plug_temperature_C.has_value());
+}
+
+TEST(evse_board_support, hardware_capabilities_with_cp_state_E_is_read) {
+    auto payload = nlohmann::json::parse(capabilities_without_cp_state_E);
+    payload["supports_cp_state_E"] = true;
+
+    HardwareCapabilities result;
+    ASSERT_TRUE(everest::lib::API::deserialize(payload.dump(), result));
+
+    EXPECT_TRUE(result.supports_cp_state_E);
+}
+
+TEST(evse_board_support, hardware_capabilities_serialization_emits_cp_state_E) {
+    HardwareCapabilities capabilities{};
+    capabilities.supports_cp_state_E = true;
+    capabilities.connector_type = Connector_type::IEC62196Type2Socket;
+
+    auto serialized = nlohmann::json::parse(serialize(capabilities));
+    EXPECT_EQ(serialized.at("supports_cp_state_E"), true);
+    EXPECT_EQ(serialized.at("connector_type"), "IEC62196Type2Socket");
+}


### PR DESCRIPTION

## Describe your changes

Since #2597 the evse_board_support_API decoder requires supports_cp_state_E and drops the whole capabilities payload if it is missing. External BSP implementations written against the published AsyncAPI do not send the field, so the EvseManager never receives hardware capabilities.

Read the field with a default of false, drop it from the required list in the AsyncAPI spec and add serialization tests for the missing, set and serialized cases.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

