### PR TITLE
fix(chargebridge): expand the ## placeholder in the tap IP, count from 1

### DIFF
--- a/applications/pionix_chargebridge/config/config-multi-bridge.yaml
+++ b/applications/pionix_chargebridge/config/config-multi-bridge.yaml
@@ -1,6 +1,8 @@
 # Device addresses: IPv4 or IPv6 literals (IPv6 also accepted bracketed "[fd00::5]";
 # link-local needs a scope: "fe80::5%eth0") or hostnames.
 charge_bridge_ip_list : [ "10.0.0.5", "10.0.0.6"]
+# "##" in any name, device path, tap name or tap IP below is replaced with the
+# 1-based position of the device in charge_bridge_ip_list (cb_1, cb_2, ...).
 
 charge_bridge:
   name: cb_##

--- a/applications/pionix_chargebridge/src/utilities/parse_config.cpp
+++ b/applications/pionix_chargebridge/src/utilities/parse_config.cpp
@@ -376,6 +376,8 @@ charge_bridge_config set_config_placeholders(charge_bridge_config const& src, ch
         result.plc->cb_remote = ip;
         result.plc->cb = result.cb_name;
         replace(result.plc->plc_tap);
+        replace(result.plc->plc_ip);
+        replace(result.plc->plc_netmaks);
     }
     if (result.bsp.has_value()) {
         result.bsp->cb_remote = ip;
@@ -420,8 +422,10 @@ std::vector<charge_bridge_config> parse_config_multi(std::string const& config_f
         ip_list_node >> ip_list;
         std::vector<charge_bridge_config> cb_config_list(ip_list.size());
 
+        // The "##" placeholder counts from 1, not 0: it is also used as the last octet of the
+        // tap's IPv4 address (e.g. "172.25.5.##"), where 0 is the network address.
         for (std::size_t i = 0; i < ip_list.size(); ++i) {
-            set_config_placeholders(base_config, cb_config_list[i], strip_brackets(ip_list[i]), i);
+            set_config_placeholders(base_config, cb_config_list[i], strip_brackets(ip_list[i]), i + 1);
         }
 
         return cb_config_list;


### PR DESCRIPTION
Stacked on #2718 (base: `feat/cb-session-ownership`).

## Problem

`set_config_placeholders()` replaced `##` in the CB name, the CAN/serial device names, the tap name and the BSP module ids, but not in the PLC block's `ip`/`netmask`. A multi-bridge config with `ip: 172.25.5.##` therefore tried to configure the literal string on every tap.

## Fix

- Substitute the placeholder in `plc.ip` and `plc.netmask` as well.
- Number the instances from 1 instead of 0: the same placeholder now forms the last octet of an IPv4 address, where 0 is the network address. Devices are `cb_1`, `cb_2`, ... in the order of `charge_bridge_ip_list`.
- Documented in `config-multi-bridge.yaml`.

Note: anything hard-wired to `cb_0_*` names or `bsp_0` (udev rules, module configs) needs to move to `cb_1_*`.

## Test

Built the tool and ran it against a two-device multi config with `ip: 172.25.5.##`; both taps come up with `172.25.5.1` / `172.25.5.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)