### PR TITLE
feat(YetiSimulator): make line impedance and measurement noise configurable

### DIFF
--- a/modules/Simulation/YetiSimulator/YetiSimulator.cpp
+++ b/modules/Simulation/YetiSimulator/YetiSimulator.cpp
@@ -535,9 +535,13 @@ void YetiSimulator::add_noise() {
     const auto random_number_between_0_and_1 = [] {
         return static_cast<double>(rand()) / static_cast<double>(RAND_MAX);
     };
-    const auto noise = 1 + (random_number_between_0_and_1() - 0.5) * 0.02;
-    const auto lonoise = 1 + (random_number_between_0_and_1() - 0.5) * 0.005;
-    const auto impedance = module_state->simdata_setting.impedance / 1000.0;
+    // multiplicative noise, uniformly distributed within +-peak_percent
+    const auto random_noise_factor = [&](const double peak_percent) {
+        return 1 + (random_number_between_0_and_1() - 0.5) * 2.0 * peak_percent / 100.0;
+    };
+    const auto noise = random_noise_factor(config.measurement_noise_percent);
+    const auto lonoise = random_noise_factor(config.frequency_noise_percent);
+    const auto impedance = module_state->simdata_setting.impedance_ohm;
 
     module_state->simulation_data.currents.L1 = module_state->simdata_setting.currents.L1 * noise;
     module_state->simulation_data.currents.L2 = module_state->simdata_setting.currents.L2 * noise;

--- a/modules/Simulation/YetiSimulator/YetiSimulator.hpp
+++ b/modules/Simulation/YetiSimulator/YetiSimulator.hpp
@@ -33,6 +33,9 @@ struct Conf {
     std::string dummy_meter_value_blob_stop;
     double ac_nominal_voltage;
     double ac_nominal_frequency;
+    double ac_line_impedance_ohm;
+    double measurement_noise_percent;
+    double frequency_noise_percent;
     double max_current_A_import;
     double min_current_A_import;
 };
@@ -86,6 +89,7 @@ public:
         new_state->simdata_setting.frequencies.L1 = nominal_frequency;
         new_state->simdata_setting.frequencies.L2 = nominal_frequency;
         new_state->simdata_setting.frequencies.L3 = nominal_frequency;
+        new_state->simdata_setting.impedance_ohm = config.ac_line_impedance_ohm;
         new_state->simulation_data.frequencies.L1 = nominal_frequency;
         new_state->simulation_data.frequencies.L2 = nominal_frequency;
         new_state->simulation_data.frequencies.L3 = nominal_frequency;

--- a/modules/Simulation/YetiSimulator/manifest.yaml
+++ b/modules/Simulation/YetiSimulator/manifest.yaml
@@ -30,6 +30,29 @@ config:
     default: 50.0
     minimum: 50.0
     maximum: 60.0
+  ac_line_impedance_ohm:
+    description: >-
+      Line impedance in Ohm per phase between the grid and the simulated power meter. The reported phase voltage
+      drops by ac_line_impedance_ohm * current, so the reported power is below ac_nominal_voltage * current while
+      charging. Set to 0 to always report the nominal voltage.
+    type: number
+    minimum: 0
+    default: 0.5
+  measurement_noise_percent:
+    description: >-
+      Peak amplitude in percent of the uniformly distributed random noise applied to the simulated voltages,
+      currents, CP voltage, PP resistor and RCD current. Set to 0 for deterministic readings. The CP voltage is
+      decoded with a +-1.1 V window, so values above a few percent break the CP state detection.
+    type: number
+    minimum: 0
+    default: 1.0
+  frequency_noise_percent:
+    description: >-
+      Peak amplitude in percent of the uniformly distributed random noise applied to the simulated grid frequency.
+      Set to 0 for a deterministic frequency reading.
+    type: number
+    minimum: 0
+    default: 0.25
   max_current_A_import:
     description: >-
       Maximum import current in amps reported as a hardware capability. The default matches a 32 A AC wallbox. DC

--- a/modules/Simulation/YetiSimulator/util/state.hpp
+++ b/modules/Simulation/YetiSimulator/util/state.hpp
@@ -84,7 +84,7 @@ struct SimulationData {
 struct SimdataSetting {
     double cp_voltage = 12.0;
     double pp_resistor = 220.1;
-    double impedance = 500.0;
+    double impedance_ohm = 0.5;
     double rcd_current = 0.1;
     bool diode_fail = false;
     bool error_e = false;


### PR DESCRIPTION
## Describe your changes

### Motivation

The `YetiSimulator` power meter reports the phase voltage as `ac_nominal_voltage - 0.5 Ohm * current` and applies a fixed, uniformly distributed noise of ±1 % to the simulated voltages, currents, CP voltage, PP resistor and RCD current (±0.25 % to the grid frequency). Both the line impedance (`SimdataSetting::impedance = 500.0` mOhm in `util/state.hpp`) and the noise amplitudes (the `0.02` / `0.005` factors in `add_noise()`) were hard-coded.

In a SIL setup the meter can therefore never report the nominal power: with `ac_nominal_voltage: 200` (#2523) and a 30 A limit it reads ~185 V and ~5.55 kW instead of 6 kW, which is confusing when the OCPP `MeterValues` are compared with the limit set by the CSMS or the energy manager. It also rules out deterministic meter readings for automated tests.

### What changed

New config options in `manifest.yaml`, all defaulting to the previous behaviour:

| option | default | effect |
|---|---|---|
| `ac_line_impedance_ohm` | `0.5` | per-phase voltage drop `impedance * current`; `0` always reports the nominal voltage |
| `measurement_noise_percent` | `1.0` | peak amplitude of the uniform noise on voltages, currents, CP voltage, PP resistor and RCD current; `0` gives deterministic readings |
| `frequency_noise_percent` | `0.25` | peak amplitude of the uniform noise on the grid frequency |

- `YetiSimulator.hpp`: `Conf` extended with the three options; `reset_module_state()` applies `ac_line_impedance_ohm` next to the nominal voltage/frequency, so the value also survives the runtime reset triggered by `ev_board_supportImpl::handle_enable()`.
- `util/state.hpp`: `SimdataSetting::impedance` (mOhm, `500.0`) becomes `impedance_ohm` (`0.5`) so the unit is explicit.
- `YetiSimulator.cpp`: `add_noise()` derives both noise factors from the config through a small helper; `2 * peak_percent / 100` reproduces the previous `0.02` / `0.005` exactly.

### Backward compatibility

All options are optional with the previous values as defaults, so existing configurations behave exactly as before.

### How to test

1. Set on a YetiSimulator instance in a SIL config (e.g. `config/config-sil-ocpp.yaml`):

   ```yaml
   yeti_driver_1:
     module: YetiSimulator
     config_module:
       connector_id: 1
       ac_nominal_voltage: 200
       ac_line_impedance_ohm: 0
       measurement_noise_percent: 0
   ```

2. Start a charging session: the published `powermeter` values (and the OCPP `MeterValues`) report `voltage_V.L1` at exactly the nominal 200 V and `power_W = 200 V * current` without jitter, instead of ~185 V / ~5.55 kW ± 1 % at 30 A.
3. Without the new options the readings are unchanged.

Build verified with `ninja YetiSimulator` in the devcontainer; `ev-cli` regenerates the config loader from the manifest, so the new `Conf` members are exercised by the build.

## Issue ticket number and link

Closes #2737

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (config option descriptions in `manifest.yaml`)
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLYYsKQCV3PebXbmFqKxLQ
