### PR TITLE
fix(ocpp): inject OCPP16LegacyCtrlr for OCPP201/OCPPmulti 2.x device model

### DIFF
--- a/docs/source/how-to-guides/ocpp-storage-migration.rst
+++ b/docs/source/how-to-guides/ocpp-storage-migration.rst
@@ -300,9 +300,13 @@ What to keep in mind
   individual ``MeterPublicKey[N]`` variables, and
   ``ChargingScheduleAllowedChargingRateUnit`` values ``Current``/``Power`` are
   converted to ``A``/``W``.
-* The ``OCPP16LegacyCtrlr`` component configuration is always required for
-  OCPP 1.6 operation. If it is absent from ``DeviceModelConfigPath``, the
-  module injects a built-in default schema for it automatically.
+* The ``OCPP16LegacyCtrlr`` component configuration is always required, for
+  OCPP 1.6 as well as OCPP 2.x operation: the device model is shared between
+  all supported OCPP versions so that a station can switch between them
+  seamlessly, which requires the full set of components for every version to
+  be present. If it is absent from ``DeviceModelConfigPath`` (for example in a
+  directory copied from a release before this component existed), the module
+  injects a built-in default schema for it automatically.
 * Once configuration was migrated or changed by the CSMS the configuration is
   protected from being overwritten by defaults in the component configuration.
   This ensures that values are not accidentally reset to defaults on

--- a/lib/everest/ocpp/include/ocpp/v2/device_model_storage_sqlite.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/device_model_storage_sqlite.hpp
@@ -33,7 +33,9 @@ public:
     /// \param db_path              Path to database
     /// \param migration_files_path Path to the migration files to initialize the database (only needs to be set if
     ///                             `init_db` is true)
-    /// \param config_path          Path to the device model config used to initialize the database
+    /// \param config_path          Path to the device model config used to initialize the database. If the config
+    ///                             does not contain the OCPP16LegacyCtrlr component, the built-in default schema for
+    ///                             it is injected (see InitDeviceModelDb::initialize_database).
     ///
     explicit DeviceModelStorageSqlite(const fs::path& db_path, const std::filesystem::path& migration_files_path,
                                       const std::filesystem::path& config_path);

--- a/lib/everest/ocpp/include/ocpp/v2/init_device_model_db.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/init_device_model_db.hpp
@@ -176,10 +176,10 @@ public:
     /// \param component_configs    A map with all components, variables, characteristics and attributes.
     /// \param delete_db_if_exists  Set to true to delete the database if it already exists.
     /// \param inject_ocpp16_legacy_ctrlr_fallback
-    ///                             If true and OCPP16LegacyCtrlr is absent from both \p component_configs
-    ///                             and the existing database, inject built-in defaults. Required for
-    ///                             backwards compatibility with component config directories that predate
-    ///                             the OCPP1.6 device model implementation.
+    ///                             If true and OCPP16LegacyCtrlr is absent from \p component_configs, add the
+    ///                             built-in defaults so the component is inserted and updated like any other
+    ///                             component. Required for backwards compatibility with component config
+    ///                             directories that predate the OCPP1.6 device model implementation.
     ///
     /// \throws InitDeviceModelDbError  - When database could not be initialized or
     ///                                 - Foreign keys could not be turned on or

--- a/lib/everest/ocpp/lib/ocpp/v2/device_model.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/device_model.cpp
@@ -82,6 +82,20 @@ bool component_variables_match(const std::vector<ComponentVariable>& component_v
                            (component.instance == v.component.instance) and (variable == v.variable)); // B08.FR.23
                }) != component_variables.end();
 }
+
+std::string format_missing_required_variable(const RequiredComponentVariable& required_variable,
+                                             const std::string& reason) {
+    std::stringstream ss;
+    ss << required_variable.component.name << "/"
+       << (required_variable.variable.has_value() ? required_variable.variable.value().name : "<unnamed>") << ": "
+       << reason;
+    if (required_variable.component.name == ControllerComponents::OCPP16LegacyCtrlr.name) {
+        ss << " (the OCPP16LegacyCtrlr component is required for every OCPP version so the device model supports "
+              "switching between OCPP 1.6 and 2.x; add standardized/OCPP16LegacyCtrlr.json to the device model "
+              "config directory or initialize the database with the built-in OCPP16LegacyCtrlr fallback enabled)";
+    }
+    return ss.str();
+}
 } // namespace
 
 void DeviceModel::check_variable_has_value(const ComponentVariable& component_variable, const AttributeEnum attribute) {
@@ -140,11 +154,7 @@ void DeviceModel::check_required_variables() {
         try {
             check_required_variable(required_variable, supported_versions);
         } catch (const std::exception& e) {
-            std::stringstream ss;
-            ss << required_variable.component.name << "/"
-               << (required_variable.variable.has_value() ? required_variable.variable.value().name : "<unnamed>")
-               << ": " << e.what();
-            missing_var_errors.push_back(ss.str());
+            missing_var_errors.push_back(format_missing_required_variable(required_variable, e.what()));
         }
     }
 
@@ -159,11 +169,7 @@ void DeviceModel::check_required_variables() {
             try {
                 check_required_variable(required_variable, supported_versions);
             } catch (const std::exception& e) {
-                std::stringstream ss;
-                ss << required_variable.component.name << "/"
-                   << (required_variable.variable.has_value() ? required_variable.variable.value().name : "<unnamed>")
-                   << ": " << e.what();
-                missing_var_errors.push_back(ss.str());
+                missing_var_errors.push_back(format_missing_required_variable(required_variable, e.what()));
             }
         }
     }

--- a/lib/everest/ocpp/lib/ocpp/v2/device_model_storage_sqlite.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/device_model_storage_sqlite.cpp
@@ -25,7 +25,7 @@ DeviceModelStorageSqlite::DeviceModelStorageSqlite(const fs::path& db_path, cons
     }
     const auto component_configs = get_all_component_configs(config_path);
     InitDeviceModelDb init_device_model_db(db_path, migration_files_path);
-    init_device_model_db.initialize_database(component_configs, false, false);
+    init_device_model_db.initialize_database(component_configs, false);
 
     initialize_connection(db_path);
 }

--- a/lib/everest/ocpp/lib/ocpp/v2/init_device_model_db.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/init_device_model_db.cpp
@@ -120,9 +120,9 @@ void InitDeviceModelDb::initialize_database(
         existing_components = get_all_components_from_db();
     }
 
-    // If OCPP16LegacyCtrlr is not present in the config files nor the database, add the built-in default config for it.
-    // This ensures the OCPP 1.6 device model bridge works even with a custom DeviceModelConfigPath that does not
-    // include the file.
+    // If OCPP16LegacyCtrlr is not present in the config files, add the built-in default config for it so the
+    // component is inserted and kept up to date like any other component. This keeps the OCPP 1.6 device model
+    // bridge working with a custom DeviceModelConfigPath that does not include the file.
     const bool config_files_contain_ocpp16_legacy_ctrlr =
         std::any_of(component_configs.begin(), component_configs.end(),
                     [](const auto& c) { return c.first.name == OCPP16_LEGACY_CTRLR_COMPONENT_CONFIG; });
@@ -130,34 +130,27 @@ void InitDeviceModelDb::initialize_database(
         std::any_of(existing_components.begin(), existing_components.end(),
                     [](const auto& c) { return c.first.name == OCPP16_LEGACY_CTRLR_COMPONENT_CONFIG; });
 
+    // Only allocate an augmented copy when the fallback component is actually missing from the config.
+    std::optional<std::map<ComponentKey, std::vector<DeviceModelVariable>>> augmented;
+    if (inject_ocpp16_legacy_ctrlr_fallback && !config_files_contain_ocpp16_legacy_ctrlr) {
+        if (!db_contains_ocpp16_legacy_ctrlr) {
+            EVLOG_warning
+                << "OCPP16LegacyCtrlr not found in component config directory or database, using built-in defaults";
+        }
+        augmented = component_configs;
+        ensure_ocpp16_legacy_ctrlr(*augmented);
+    }
+
+    const auto& configs = augmented.has_value() ? *augmented : component_configs;
+
     // Components in the database that no longer have a matching entry in the component
     // config (e.g. NetworkConfiguration_<N>.json was removed from the install) are kept
     // in place and reported via a warning. Pruning these rows used to drop migration
     // targets, so the operator could end up with a populated NetworkConnectionProfiles
     // blob and no per-slot components to migrate it into.
     if (this->database_exists) {
-        warn_about_components_missing_from_config(component_configs, existing_components);
+        warn_about_components_missing_from_config(configs, existing_components);
     }
-
-    // Only allocate an augmented copy when the fallback component is actually missing.
-    std::optional<std::map<ComponentKey, std::vector<DeviceModelVariable>>> augmented;
-    if (inject_ocpp16_legacy_ctrlr_fallback && !config_files_contain_ocpp16_legacy_ctrlr &&
-        !db_contains_ocpp16_legacy_ctrlr) {
-        EVLOG_warning
-            << "OCPP16LegacyCtrlr not found in component config directory or database, using built-in defaults";
-        try {
-            const json fallback_json = json::parse(get_default_ocpp16_legacy_ctrlr_schema());
-            const ComponentKey key = fallback_json;
-            const std::vector<DeviceModelVariable> variables =
-                get_all_component_properties(fallback_json.at("properties"));
-            augmented = component_configs;
-            augmented->insert({key, variables});
-        } catch (const json::parse_error& e) {
-            EVLOG_error << "Failed to parse built-in OCPP16LegacyCtrlr fallback: " << e.what();
-        }
-    }
-
-    const auto& configs = augmented.has_value() ? *augmented : component_configs;
 
     // Check if the config is consistent.
     check_integrity(configs);

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_device_model_storage_sqlite.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_device_model_storage_sqlite.cpp
@@ -1,11 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
 
+#include <filesystem>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <device_model_test_helper.hpp>
+#include <everest/database/sqlite/connection.hpp>
+#include <sqlite3.h>
 
+#include <ocpp/common/constants.hpp>
+#include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/device_model.hpp>
 #include <ocpp/v2/device_model_storage_sqlite.hpp>
 #include <ocpp/v2/init_device_model_db.hpp>
@@ -41,6 +47,92 @@ TEST_F(DeviceModelStorageSQLiteTest, test_check_integrity_invalid) {
     DeviceModelStorageSqlite dm(DATABASE_PATH);
 
     EXPECT_NO_THROW(dm.check_integrity());
+}
+
+/// \brief Fixture that mimics a DeviceModelConfigPath copied from a release that predates OCPP16LegacyCtrlr: a copy
+///        of the example component config with OCPP16LegacyCtrlr.json removed, plus an on-disk database.
+class DeviceModelStorageSQLiteLegacyCtrlrTest : public ::testing::Test {
+protected:
+    const std::filesystem::path work_dir =
+        std::filesystem::temp_directory_path() / "libocpp_test_device_model_storage_legacy_ctrlr";
+    const std::filesystem::path db_path = work_dir / "device_model.db";
+    const std::filesystem::path config_without_legacy_ctrlr = work_dir / "component_config";
+    const std::map<std::int32_t, std::int32_t> evse_connector_structure{{1, 1}, {2, 1}};
+
+    void SetUp() override {
+        std::filesystem::remove_all(work_dir);
+        std::filesystem::create_directories(work_dir);
+        std::filesystem::copy(CONFIG_PATH, config_without_legacy_ctrlr, std::filesystem::copy_options::recursive);
+        ASSERT_TRUE(std::filesystem::remove(config_without_legacy_ctrlr / "standardized" / "OCPP16LegacyCtrlr.json"));
+    }
+
+    void TearDown() override {
+        std::filesystem::remove_all(work_dir);
+    }
+
+    /// \brief Open the storage like OCPP201 / OCPPmulti do and build a device model on top of it.
+    std::unique_ptr<DeviceModel> create_device_model(const std::filesystem::path& config_path) {
+        return std::make_unique<DeviceModel>(
+            std::make_unique<DeviceModelStorageSqlite>(db_path, MIGRATION_FILES_PATH, config_path));
+    }
+
+    /// \brief Write NumberOfConnectors the way the ChargePoint constructor does before check_integrity.
+    static void set_number_of_connectors(DeviceModel& dm, const std::size_t number_of_connectors) {
+        const auto& cv = ControllerComponentVariables::NumberOfConnectors;
+        ASSERT_EQ(dm.set_value(cv.component, cv.variable.value(), AttributeEnum::Actual,
+                               std::to_string(number_of_connectors), VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL, true),
+                  SetVariableStatusEnum::Accepted);
+    }
+};
+
+/// \brief A fresh database initialized from a config directory without OCPP16LegacyCtrlr.json still gets the component
+///        (and thus the required NumberOfConnectors) via the built-in fallback.
+TEST_F(DeviceModelStorageSQLiteLegacyCtrlrTest, fresh_db_without_legacy_ctrlr_config_passes_integrity_check) {
+    auto dm = create_device_model(config_without_legacy_ctrlr);
+
+    set_number_of_connectors(*dm, evse_connector_structure.size());
+    EXPECT_NO_THROW(dm->check_integrity(evse_connector_structure));
+    EXPECT_EQ(dm->get_optional_value<int>(ControllerComponentVariables::NumberOfConnectors), 2);
+}
+
+/// \brief A database that already contains OCPP16LegacyCtrlr (e.g. created from the full component config) keeps it
+///        when re-initialized from a config directory without OCPP16LegacyCtrlr.json.
+TEST_F(DeviceModelStorageSQLiteLegacyCtrlrTest, existing_db_keeps_legacy_ctrlr_when_config_lacks_it) {
+    {
+        auto dm = create_device_model(CONFIG_PATH);
+        set_number_of_connectors(*dm, evse_connector_structure.size());
+        ASSERT_NO_THROW(dm->check_integrity(evse_connector_structure));
+    }
+
+    auto dm = create_device_model(config_without_legacy_ctrlr);
+
+    EXPECT_NO_THROW(dm->check_integrity(evse_connector_structure));
+    EXPECT_EQ(dm->get_optional_value<int>(ControllerComponentVariables::NumberOfConnectors), 2);
+}
+
+/// \brief A database created from an older built-in OCPP16LegacyCtrlr schema picks up variables added since, even
+///        though the config directory has no OCPP16LegacyCtrlr.json to merge from.
+TEST_F(DeviceModelStorageSQLiteLegacyCtrlrTest, existing_db_gains_new_legacy_ctrlr_variables) {
+    const auto& cv = ControllerComponentVariables::ReportClearedErrors;
+    {
+        auto dm = create_device_model(config_without_legacy_ctrlr);
+        ASSERT_TRUE(dm->get_variable_meta_data(cv.component, cv.variable.value()).has_value());
+    }
+    {
+        // Mimic the older schema by dropping the variable from the database.
+        everest::db::sqlite::Connection db(db_path);
+        db.open_connection();
+        auto stmt = db.new_statement("DELETE FROM VARIABLE WHERE NAME = ? AND COMPONENT_ID = "
+                                     "(SELECT ID FROM COMPONENT WHERE NAME = ?)");
+        stmt->bind_text(1, cv.variable.value().name.get(), everest::db::sqlite::SQLiteString::Transient);
+        stmt->bind_text(2, cv.component.name.get(), everest::db::sqlite::SQLiteString::Transient);
+        ASSERT_EQ(stmt->step(), SQLITE_DONE);
+        ASSERT_EQ(stmt->changes(), 1);
+    }
+
+    auto dm = create_device_model(config_without_legacy_ctrlr);
+
+    EXPECT_TRUE(dm->get_variable_meta_data(cv.component, cv.variable.value()).has_value());
 }
 
 } // namespace v2

--- a/modules/EVSE/OCPP201/docs/index.rst
+++ b/modules/EVSE/OCPP201/docs/index.rst
@@ -48,6 +48,14 @@ characteristics, attributes, and monitors. Please see `the documentation for the
 
 To add a custom component, you can simply add another JSON configuration file for it, and it will automatically be applied and reported.
 
+The ``OCPP16LegacyCtrlr`` component (``standardized/OCPP16LegacyCtrlr.json``) is always required, also for pure OCPP 2.x
+operation. The device model is shared between all supported OCPP versions so that a station can switch between OCPP 1.6 and
+OCPP 2.x seamlessly, and this requires the full set of components for every version to be present. If the component is absent
+from **DeviceModelConfigPath** (for example in a directory copied from a release before this component existed), the module
+injects a built-in default schema for it automatically.
+``InternalCtrlr/NumberOfConnectors`` and ``InternalCtrlr/ChargePointId`` are no longer part of the device model; leftover entries
+in custom component configs are tolerated but not used.
+
 Configuring the OCPP2 version
 =============================
 

--- a/modules/EVSE/OCPPmulti/docs/index.rst
+++ b/modules/EVSE/OCPPmulti/docs/index.rst
@@ -143,7 +143,11 @@ network profile selectors, or the ``SecurityCtrlr`` connection fallbacks ``Ident
 those are managed via the standardized OCPP 1.6 keys with their reboot/reconnect semantics, and a mapping file
 containing such a target is rejected at startup. OCPP 1.6
 keys without a standardized device model counterpart are kept in a dedicated ``OCPP16LegacyCtrlr`` component, whose
-``NumberOfConnectors`` value is automatically patched to the actual number of connected EVSEs.
+``NumberOfConnectors`` value is automatically patched to the actual number of connected EVSEs. This component is
+required for OCPP 2.x operation as well: the device model is shared between all supported OCPP versions so that the
+station can switch between OCPP 1.6 and OCPP 2.x seamlessly, which requires the full set of components for every
+version to be present. If ``standardized/OCPP16LegacyCtrlr.json`` is absent from ``DeviceModelConfigPath``, a
+built-in default schema for it is injected automatically.
 
 .. _handwritten_ocppmulti_network-profiles-ocpp16:
 


### PR DESCRIPTION

## Describe your changes

The three-argument DeviceModelStorageSqlite constructor used by OCPP201 and OCPPmulti disabled the OCPP16LegacyCtrlr default fallback. A DeviceModelConfigPath copied from 2026.02.0 lacks OCPP16LegacyCtrlr.json, so NumberOfConnectors was missing, the integrity check threw and the module never became ready. An existing database even had the component removed.

Enable the fallback in that constructor. Add the built-in component to the config map whenever the config directory lacks it, independent of the database contents, so it is inserted and updated like every other component and picks up variables added to the built-in schema on upgrade. Run the missing-config-file warning on the augmented map so an existing database no longer warns about the injected component on every boot.

Mention the injected file in the required-variable error, cover the fresh database, the upgraded database and the re-merge of new variables in unit tests, and document that the component is required for every OCPP version because the shared device model enables switching between 1.6 and 2.x.


## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

