### PR TITLE
fix(OCPPmulti): gate configure_network delegation behind DelegateNetworkConfigurationToSystem

### DIFF
--- a/docs/source/how-to-guides/ocpp-storage-migration.rst
+++ b/docs/source/how-to-guides/ocpp-storage-migration.rst
@@ -327,6 +327,18 @@ so existing connections carry over:
   ``evse_energy_sink``, ``evse_manager``, ``extensions_15118``, ``security``,
   ``system``) are identical to both old modules.
 
+.. note::
+
+   OCPPmulti can delegate network preparation before every CSMS connection
+   attempt to the ``system`` provider's ``configure_network`` command. This is
+   off by default (``DelegateNetworkConfigurationToSystem: false``) and then behaves like
+   the old modules. Before enabling it, make sure the ``system`` provider
+   implements ``configure_network`` (``NotSupported`` is a valid answer), and
+   with the ``system_API`` module that every external client replies to
+   ``e2m/configure_network`` (again, ``NotSupported`` suffices). A client that
+   stays silent blocks each connection attempt until the request times out;
+   consider lowering ``system_API``'s ``cfg_request_reply_to_s`` accordingly.
+
 On the ``provides`` side, OCPPmulti offers the same interfaces as
 ``OCPP201`` (``auth_validator``, ``auth_provider``, ``data_transfer``,
 ``ocpp_generic``, ``session_cost``); the 1.6-specific ``main``

--- a/docs/source/reference/EVerest_API/system_API.yaml
+++ b/docs/source/reference/EVerest_API/system_API.yaml
@@ -231,7 +231,11 @@ operations:
     action: receive
     channel:
       $ref: '#/channels/receive_request_configure_network'
-    description: 'Direction: EVerest to Module'
+    description: >-
+      Direction: EVerest to Module.
+      A client without network-configuration support must still reply, with status NotSupported,
+      instead of staying silent: EVerest blocks the requesting module (e.g. the OCPP connection attempt)
+      until a reply arrives or the request times out.
     reply:
       address:
         location: "$message.header#/replyTo"
@@ -424,7 +428,9 @@ components:
     receive_request_configure_network:
       name: receive_request_configure_network
       title: 'Request configure network'
-      summary: 'Request to prepare a network interface for use.'
+      summary: >-
+        Request to prepare a network interface for use. Reply with status NotSupported if network
+        configuration is not supported; do not leave the request unanswered.
       contentType: application/json
       payload:
         type: object

--- a/modules/EVSE/OCPPmulti/OCPPmulti.cpp
+++ b/modules/EVSE/OCPPmulti/OCPPmulti.cpp
@@ -26,6 +26,9 @@ std::string ConfigAccess::getDatabasePath() const {
 int ConfigAccess::getDelayOcppStart() const {
     return m_config.DelayOcppStart;
 }
+bool ConfigAccess::getDelegateNetworkConfigurationToSystem() const {
+    return m_config.DelegateNetworkConfigurationToSystem;
+}
 std::string ConfigAccess::getDeviceModelConfigMappings() const {
     return m_config.DeviceModelConfigMappings;
 }

--- a/modules/EVSE/OCPPmulti/OCPPmulti.hpp
+++ b/modules/EVSE/OCPPmulti/OCPPmulti.hpp
@@ -52,6 +52,7 @@ public:
     [[nodiscard]] std::string getCustomMrecErrorMapPath() const override;
     [[nodiscard]] std::string getDatabasePath() const override;
     [[nodiscard]] int getDelayOcppStart() const override;
+    [[nodiscard]] bool getDelegateNetworkConfigurationToSystem() const override;
     [[nodiscard]] std::string getDeviceModelConfigMappings() const override;
     [[nodiscard]] std::string getDeviceModelConfigPath() const override;
     [[nodiscard]] std::string getDeviceModelDatabasePath() const override;
@@ -81,6 +82,7 @@ struct Conf {
     std::string CustomMrecErrorMapPath;
     std::string DatabasePath;
     int DelayOcppStart;
+    bool DelegateNetworkConfigurationToSystem;
     std::string DeviceModelConfigPath;
     std::string DeviceModelDatabasePath;
     std::string DeviceModelDatabaseMigrationPath;

--- a/modules/EVSE/OCPPmulti/docs/index.rst
+++ b/modules/EVSE/OCPPmulti/docs/index.rst
@@ -76,6 +76,19 @@ these MQTT topics (the message payload is ignored):
 
 This is intended for debug and testing purposes.
 
+Network preparation via the system provider
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If ``DelegateNetworkConfigurationToSystem`` is set to ``true``, the module asks the ``system`` provider to prepare the network
+(**configure_network**) before every CSMS connection attempt and binds the websocket to the interface address the
+provider returns; see :ref:`Network connection configuration <handwritten_ocppmulti_network-connection-configuration>`.
+The provider must answer promptly (``NotSupported`` is acceptable). With the :ref:`system_API <everest_modules_system_API>`
+module the external client must reply to ``e2m/configure_network``; a client that stays silent blocks every
+connection attempt until the request times out, so the charge point never reaches the CSMS.
+
+With the default ``false`` no request is sent and the connection is established as with the
+:ref:`OCPP201 <everest_modules_OCPP201>` module (``IFace`` handling included).
+
 Device model configuration via component configs
 =================================================
 
@@ -184,10 +197,11 @@ previously used with OCPP 2.x, which writes back the negotiated version; OCPP 1.
 leaving the charge point unable to connect. The same fallback applies when the active slot's profile is
 incomplete; in OCPP 2.x an incomplete slot is simply skipped.
 
-The ``interface_address`` returned by the ``system`` provider's **configure_network** *replaces* the static
-``Internal``/``IFace`` configuration key when binding the websocket - including clearing it when the provider
-answers ``Ready`` or ``NotSupported`` without an address. Since this module always performs the configure_network
-round-trip, ``IFace`` is effectively not used on successful attempts.
+With ``DelegateNetworkConfigurationToSystem`` set to ``true``, the ``interface_address`` returned by the ``system`` provider's
+**configure_network** *replaces* the static ``Internal``/``IFace`` configuration key when binding the websocket -
+including clearing it when the provider answers ``Ready`` or ``NotSupported`` without an address, so ``IFace`` is
+effectively not used on successful attempts. With the default ``false`` no configure_network round-trip is performed
+and ``IFace`` is handled as in the OCPP201 module.
 
 The legacy JSON configuration backend (OCPP 1.6 without a device model, as used by the ``OCPP`` module) is
 unaffected by this and keeps the previous single-profile behavior.
@@ -491,12 +505,13 @@ for production use without modification). Used to execute and control system-wid
 * **set_system_time** to apply the time communicated by the CSMS
 * **get_boot_reason** for the boot notification at startup
 * **configure_network** to prepare the network for a connection attempt on a network profile slot (see
-  :ref:`Network connection configuration <handwritten_ocppmulti_network-connection-configuration>`); a provider
-  without special network handling answers ``NotSupported``
+  :ref:`Network connection configuration <handwritten_ocppmulti_network-connection-configuration>`); only called
+  when ``DelegateNetworkConfigurationToSystem`` is ``true``; a provider without special network handling answers
+  ``NotSupported``
 
 The **log_status** and **firmware_update_status** variables are received to report the corresponding status
-notifications to the CSMS, and **configure_network_status** reports the asynchronous outcome of
-**configure_network** requests.
+notifications to the CSMS, and **configure_network_status** (subscribed only when ``DelegateNetworkConfigurationToSystem``
+is ``true``) reports the asynchronous outcome of **configure_network** requests.
 
 Error reporting
 ===============
@@ -765,16 +780,25 @@ Failover between slots
 """"""""""""""""""""""
 
 Slots are tried in priority order, and the list wraps around. A slot is skipped
-when the ``system`` provider's **configure_network** answers
-``Failed``/``Rejected`` (or does not respond within
-``InternalCtrlr``/``NetworkConfigTimeout`` seconds, default 60), when the
+when ``DelegateNetworkConfigurationToSystem`` is ``true`` and the ``system`` provider's
+**configure_network** answers ``Failed``/``Rejected`` or answers ``Processing``
+without publishing **configure_network_status** within
+``InternalCtrlr``/``NetworkConfigTimeout`` seconds (default 60), when the
 resulting profile is invalid, or when the websocket connection fails
 ``OCPPCommCtrlr``/``NetworkProfileConnectionAttempts`` times in a row. Setting
 ``NetworkProfileConnectionAttempts`` to ``-1`` means retry-forever and thereby
 disables the websocket-failure-driven part of the failover; only do that
 deliberately. There is no automatic fall-back to a higher-priority slot while a
-lower-priority one is connected. The address the ``system`` provider returns
-from **configure_network** is what the websocket is bound to for that attempt.
+lower-priority one is connected. With ``DelegateNetworkConfigurationToSystem`` the
+address the ``system`` provider returns from **configure_network** is what the
+websocket is bound to for that attempt; without it no provider request is made.
+
+The **configure_network** command itself is called synchronously on libocpp's
+connectivity thread, so a provider that does not answer the command at all is
+bounded by the EVerest framework command timeout (300 seconds), not by
+``NetworkConfigTimeout``. Each connection attempt then blocks for that long
+before the slot is retried, which is why the flag must only be enabled with a
+provider (and, for ``system_API``, an external client) that answers promptly.
 
 Profiles with a ``SecurityProfile`` below the *confirmed* security profile -
 the ``SecurityCtrlr``/``SecurityProfile`` value, which is raised only after a

--- a/modules/EVSE/OCPPmulti/generic_ocpp.cpp
+++ b/modules/EVSE/OCPPmulti/generic_ocpp.cpp
@@ -585,17 +585,20 @@ void GenericOcpp::init_subscribe() {
     mv_requires.system.subscribe_firmware_update_status([this](auto arg) { cb_firmware_update_status(arg); });
     mv_requires.system.subscribe_log_status([this](auto arg) { cb_log_status(arg); });
 
-    mv_requires.system.subscribe_configure_network_status([this](const types::network::ConfigureNetworkStatus status) {
-        if (status.status != types::network::ConfigureNetworkFinalStatusEnum::Ready) {
-            EVLOG_warning << "configure_network_status for request_id " << status.request_id << " reported "
-                          << types::network::configure_network_final_status_enum_to_string(status.status)
-                          << "; treating as failure";
-        }
-        ocpp::ConfigNetworkResult result{};
-        result.success = (status.status == types::network::ConfigureNetworkFinalStatusEnum::Ready);
-        result.interface_address = status.interface_address;
-        fulfill_network_request(status.request_id, result);
-    });
+    if (mv_config.getDelegateNetworkConfigurationToSystem()) {
+        mv_requires.system.subscribe_configure_network_status(
+            [this](const types::network::ConfigureNetworkStatus status) {
+                if (status.status != types::network::ConfigureNetworkFinalStatusEnum::Ready) {
+                    EVLOG_warning << "configure_network_status for request_id " << status.request_id << " reported "
+                                  << types::network::configure_network_final_status_enum_to_string(status.status)
+                                  << "; treating as failure";
+                }
+                ocpp::ConfigNetworkResult result{};
+                result.success = (status.status == types::network::ConfigureNetworkFinalStatusEnum::Ready);
+                result.interface_address = status.interface_address;
+                fulfill_network_request(status.request_id, result);
+            });
+    }
 
     if (!mv_requires.reservation.empty() && mv_requires.reservation.at(0) != nullptr) {
         mv_requires.reservation.at(0)->subscribe_reservation_update([this](auto arg) { cb_reservation_update(arg); });
@@ -922,6 +925,14 @@ std::future<ocpp::ConfigNetworkResult> GenericOcpp::cb_configure_network_connect
     if (mv_shutting_down.load()) {
         ocpp::ConfigNetworkResult result{};
         result.success = false;
+        promise.set_value(result);
+        return future;
+    }
+
+    if (!mv_config.getDelegateNetworkConfigurationToSystem()) {
+        // no provider round-trip: connect as the OCPP201 module does, without an interface address
+        ocpp::ConfigNetworkResult result{};
+        result.success = true;
         promise.set_value(result);
         return future;
     }

--- a/modules/EVSE/OCPPmulti/generic_ocpp.hpp
+++ b/modules/EVSE/OCPPmulti/generic_ocpp.hpp
@@ -119,6 +119,7 @@ struct ConfigInterface {
     [[nodiscard]] virtual std::string getCustomMrecErrorMapPath() const = 0;
     [[nodiscard]] virtual std::string getDatabasePath() const = 0;
     [[nodiscard]] virtual int getDelayOcppStart() const = 0;
+    [[nodiscard]] virtual bool getDelegateNetworkConfigurationToSystem() const = 0;
     [[nodiscard]] virtual std::string getDeviceModelConfigMappings() const = 0;
     [[nodiscard]] virtual std::string getDeviceModelConfigPath() const = 0;
     [[nodiscard]] virtual std::string getDeviceModelDatabasePath() const = 0;

--- a/modules/EVSE/OCPPmulti/manifest.yaml
+++ b/modules/EVSE/OCPPmulti/manifest.yaml
@@ -44,6 +44,18 @@ config:
       This is only used to prevent issues from passing by availlable before preparing on a restart.
     type: integer
     default: 0
+  DelegateNetworkConfigurationToSystem:
+    description: >-
+      OCPP 1.6
+      OCPP 2.0.1
+      If true, the system provider is asked to prepare the network (configure_network) before every CSMS
+      connection attempt and the websocket is bound to the interface address it returns. The provider must
+      answer promptly (NotSupported is acceptable); with system_API the external client must reply to
+      e2m/configure_network, otherwise every connection attempt blocks until the framework command timeout.
+      If false (default), no configure_network request is sent and the connection is established like
+      with the OCPP201 module (success, no interface address).
+    type: boolean
+    default: false
   DeviceModelConfigPath:
     description: >-
       OCPP 2.0.1

--- a/modules/EVSE/OCPPmulti/tests/stubs/config_stub.hpp
+++ b/modules/EVSE/OCPPmulti/tests/stubs/config_stub.hpp
@@ -14,6 +14,7 @@ struct ConfigStub : public ocpp_multi::ConfigInterface {
     std::string CustomMrecErrorMapPath{};
     std::string DatabasePath{};
     int DelayOcppStart{1};
+    bool DelegateNetworkConfigurationToSystem{false};
     std::string DeviceModelConfigMappings{};
     std::string DeviceModelConfigPath{"dm_config"};
     std::string DeviceModelDatabasePath{"dm.db"};
@@ -47,6 +48,9 @@ struct ConfigStub : public ocpp_multi::ConfigInterface {
     }
     [[nodiscard]] std::string getDatabasePath() const override {
         return DeviceModelConfigPath;
+    }
+    [[nodiscard]] bool getDelegateNetworkConfigurationToSystem() const override {
+        return DelegateNetworkConfigurationToSystem;
     }
     [[nodiscard]] std::string getDeviceModelConfigMappings() const override {
         return DeviceModelConfigMappings;

--- a/modules/EVSE/OCPPmulti/tests/systemIntf_tests.cpp
+++ b/modules/EVSE/OCPPmulti/tests/systemIntf_tests.cpp
@@ -268,13 +268,14 @@ TEST_F(GenericOcppRequiresTester, subscribeLogStatus) {
 }
 
 // ----------------------------------------------------------------------------
-// configure_network: cb_configure_network_connection_profile() delegates to call_configure_network()
-// synchronously; a Processing answer defers the outcome to the configure_network_status var subscription.
-// Discipline: queue cmd results BEFORE invoking the cb.
+// configure_network: with DelegateNetworkConfigurationToSystem set, cb_configure_network_connection_profile() delegates
+// to call_configure_network() synchronously; a Processing answer defers the outcome to the configure_network_status var
+// subscription. Discipline: queue cmd results BEFORE invoking the cb.
 
 class ConfigureNetworkTester : public GenericOcppRequiresTester {
 protected:
     void SetUp() override {
+        config.DelegateNetworkConfigurationToSystem = true;
         GenericOcppRequiresTester::SetUp();
         interfaces->subscribe_var("system", "call_configure_network",
                                   [this](const auto&, const auto&, const auto& data) {
@@ -413,6 +414,61 @@ TEST_F(ConfigureNetworkTester, callConfigureNetworkInvalidStatusYieldsFailure) {
     const auto result = future.get();
     EXPECT_FALSE(result.success);
     EXPECT_FALSE(result.interface_address.has_value());
+}
+
+// ----------------------------------------------------------------------------
+// configure_network with DelegateNetworkConfigurationToSystem left at its default (false): no provider round-trip,
+// the future resolves immediately like the OCPP201 stub does
+
+class ConfigureNetworkDisabledTester : public GenericOcppRequiresTester {
+protected:
+    void SetUp() override {
+        ASSERT_FALSE(config.DelegateNetworkConfigurationToSystem);
+        GenericOcppRequiresTester::SetUp();
+        interfaces->subscribe_var("system", "call_configure_network",
+                                  [this](const auto&, const auto&, const auto& data) {
+                                      std::lock_guard<std::mutex> lock(m_mutex);
+                                      m_received.push_back(data);
+                                  });
+    }
+
+    std::size_t received_count() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_received.size();
+    }
+
+    std::mutex m_mutex;
+    std::vector<json> m_received;
+};
+
+TEST_F(ConfigureNetworkDisabledTester, disabledResolvesImmediatelyWithoutCallingProvider) {
+    // a queued Ready answer must never be consumed: the provider is not asked at all
+
+    interfaces->add_cmd_result(R"({"status":"Ready","interface_address":"192.168.5.1"})"_json);
+
+    auto future = ocpp->cb_configure_network_connection_profile(1, network_profile(ocpp::v2::OCPPInterfaceEnum::Any));
+
+    ASSERT_EQ(future.wait_for(std::chrono::seconds(0)), std::future_status::ready);
+    const auto result = future.get();
+    EXPECT_TRUE(result.success);
+    EXPECT_FALSE(result.interface_address.has_value());
+
+    EXPECT_FALSE(wait_for_condition([this] { return received_count() >= 1; }, std::chrono::milliseconds(200)));
+}
+
+TEST_F(ConfigureNetworkDisabledTester, disabledIgnoresStatusVar) {
+    // without a pending request a configure_network_status publish is a no-op; nothing is fulfilled twice
+
+    auto future =
+        ocpp->cb_configure_network_connection_profile(1, network_profile(ocpp::v2::OCPPInterfaceEnum::Wired0));
+    ASSERT_EQ(future.wait_for(std::chrono::seconds(0)), std::future_status::ready);
+    EXPECT_TRUE(future.get().success);
+
+    interfaces->publish(0, "configure_network_status",
+                        json{{"request_id", 1}, {"status", "Ready"}, {"interface_address", "10.1.2.3"}});
+    interfaces->publish(0, "configure_network_status", json{{"request_id", 1}, {"status", "Failed"}});
+
+    EXPECT_FALSE(wait_for_condition([this] { return received_count() >= 1; }, std::chrono::milliseconds(200)));
 }
 
 } // namespace

--- a/tests/ocpp_tests/test_sets/everest_test_utils.py
+++ b/tests/ocpp_tests/test_sets/everest_test_utils.py
@@ -125,6 +125,25 @@ class OCPPMultiConfigurationStrategy(EverestConfigAdjustmentStrategy):
         return adjusted
 
 
+class OCPPMultiModuleConfigStrategy(EverestConfigAdjustmentStrategy):
+    """Sets additional `config_module` keys on the OCPP module, for OCPPmulti-only options such as
+    `DelegateNetworkConfigurationToSystem`. Use together with `ocpp_multi_only`: the keys are applied before the
+    rename to `OCPPmulti` and survive it because the framework strategies merge `config_module`."""
+
+    def __init__(self, config_module: dict, ocpp_module_id: str = "ocpp"):
+        self._config_module = config_module
+        self._ocpp_module_id = ocpp_module_id
+
+    def adjust_everest_configuration(self, everest_config: dict) -> dict:
+        adjusted = deepcopy(everest_config)
+        assert "active_modules" in adjusted and self._ocpp_module_id in adjusted["active_modules"], \
+            f"OCPP module id '{self._ocpp_module_id}' missing from EVerest config"
+        module_config = adjusted["active_modules"][self._ocpp_module_id]
+        module_config.setdefault("config_module", {})
+        module_config["config_module"].update(self._config_module)
+        return adjusted
+
+
 class EXIGenerator:
 
     def __init__(self, certs_path):

--- a/tests/ocpp_tests/test_sets/ocpp16/configure_network_ocpp16.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/configure_network_ocpp16.py
@@ -7,6 +7,8 @@ Covers the NotSupported / Ready direct answers and the deferred Processing varia
 (completed via the configure_network_status var). Only the combined OCPPmulti module
 implements the delegation, so the tests are pinned via ocpp_multi_only; the config
 rewrite swaps the legacy OCPP module in the probe config for OCPPmulti (Mode Only1.6).
+The delegation is opt-in (DelegateNetworkConfigurationToSystem, default false), so the config
+adaption below switches it on.
 
 In OCPP1.6 libocpp synthesizes a single network connection profile from
 CentralSystemURI/SecurityProfile with configuration slot 1 and ocppInterface "Any"
@@ -27,6 +29,7 @@ from everest.testing.core_utils._configuration.libocpp_configuration_helper impo
 )
 from everest.testing.ocpp_utils.central_system import CentralSystem
 
+from everest_test_utils import OCPPMultiModuleConfigStrategy
 from everest_test_utils_probe_modules import implement_ocpp16_probe_commands
 
 log = logging.getLogger("OCPPmultiConfigureNetwork16")
@@ -57,6 +60,7 @@ async def _connect(probe_module):
 @pytest.mark.ocpp_version("ocpp1.6")
 @pytest.mark.ocpp_multi_only
 @pytest.mark.everest_core_config("everest-config-ocpp16-probe-module.yaml")
+@pytest.mark.everest_config_adaptions(OCPPMultiModuleConfigStrategy({"DelegateNetworkConfigurationToSystem": True}))
 @pytest.mark.probe_module
 class TestConfigureNetwork16:
 

--- a/tests/ocpp_tests/test_sets/ocpp201/configure_network.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/configure_network.py
@@ -9,7 +9,9 @@ default (ocppInterface Wired0); request_id is a module-generated opaque id.
 
 Only the combined OCPPmulti module implements the delegation (legacy OCPP201 keeps
 the unconditional-success stub), so the tests are pinned via ocpp_multi_only; the
-config rewrite swaps the OCPP201 module in the probe config for OCPPmulti.
+config rewrite swaps the OCPP201 module in the probe config for OCPPmulti. The
+delegation is opt-in (DelegateNetworkConfigurationToSystem, default false), so the config
+adaption below switches it on.
 """
 
 import asyncio
@@ -19,6 +21,8 @@ import threading
 import pytest
 
 from everest.testing.ocpp_utils.central_system import CentralSystem
+
+from everest_test_utils import OCPPMultiModuleConfigStrategy
 
 log = logging.getLogger("OCPPmultiConfigureNetwork")
 
@@ -46,6 +50,7 @@ async def _connect(probe_module):
 @pytest.mark.ocpp_version("ocpp2.0.1")
 @pytest.mark.ocpp_multi_only
 @pytest.mark.everest_core_config("everest-config-ocpp201-probe-module.yaml")
+@pytest.mark.everest_config_adaptions(OCPPMultiModuleConfigStrategy({"DelegateNetworkConfigurationToSystem": True}))
 @pytest.mark.probe_module
 class TestConfigureNetwork:
 


### PR DESCRIPTION

## Describe your changes

OCPPmulti asked the system provider to configure the network before every CSMS connection attempt. With system_API and an external client that does not answer e2m/configure_network, each attempt blocked until the framework command timeout (300 s) and the charge point never connected.

Add the boolean config key DelegateNetworkConfigurationToSystem (default false). When false, no configure_network request is sent, the configure_network_status subscription is skipped and the connection is established as with the OCPP201 module (success, no interface address). When true, the behaviour is unchanged.

- unit tests: existing delegation tests enable the flag; new tests cover the disabled path (immediate success, provider never called, status publishes ignored)
- integration tests opt in via OCPPMultiModuleConfigStrategy
- docs: describe the flag, the integrator obligations before enabling it (provider must answer, NotSupported suffices, system_API clients must reply) and which timeout bounds a non-responding provider

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

