### PR TITLE
ci: authenticate Bazel's GitHub downloads

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,14 @@ build:ci --copt=-g0
 build:ci --repository_cache=~/.cache/bazel-repo-cache
 build:ci --disk_cache=~/.cache/bazel-disk-cache
 
+# Authenticate external downloads from GitHub. Anonymous archive fetches share a
+# per-IP rate limit that answers 429 and fails the job before anything is built.
+# The helper serves the credentials CI writes to ~/.netrc, on the redirect
+# target as well as on the URL a repository rule names; see the helper for why
+# netrc alone does not cover both.
+build:ci --credential_helper=github.com=%workspace%/.ci/bazel/netrc_credential_helper.py
+build:ci --credential_helper=codeload.github.com=%workspace%/.ci/bazel/netrc_credential_helper.py
+
 # workaround for goption.c:169:14: error: two or more data types in declaration specifiers on armv7
 build:armv7-linux-gnueabihf --repo_env=BAZEL_CONLYOPTS="-std=gnu17"
 build:aarch64-linux-gnu --repo_env=BAZEL_CONLYOPTS=""

--- a/.ci/bazel/netrc_credential_helper.py
+++ b/.ci/bazel/netrc_credential_helper.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Pionix GmbH and Contributors to EVerest
+"""Bazel credential helper serving HTTP Basic auth from a netrc file.
+
+Bazel applies netrc itself only to the URL a repository rule names. GitHub
+answers those URLs with a redirect to another host, for example
+github.com/<owner>/<repo>/archive/<ref>.tar.gz to codeload.github.com, and
+Bazel drops the Authorization header across a cross-host redirect without
+re-reading netrc for the new host. The request that transfers the archive is
+therefore anonymous and shares the per-IP rate limit that answers 429.
+
+Bazel does consult a credential helper again for the redirect target, so
+serving netrc through this helper keeps every hop authenticated. It is wired up
+per host in .bazelrc; see the --credential_helper lines there.
+
+Protocol: https://github.com/EngFlow/credential-helper-spec
+"""
+
+import base64
+import json
+import os
+import sys
+from netrc import netrc
+from urllib.parse import urlparse
+
+NO_CREDENTIALS = {"headers": {}}
+
+
+def lookup(uri):
+    host = urlparse(uri).hostname
+    path = os.environ.get("NETRC") or os.path.join(os.path.expanduser("~"), ".netrc")
+    if not host or not os.path.exists(path):
+        return NO_CREDENTIALS
+    entry = netrc(path).authenticators(host)
+    if entry is None:
+        return NO_CREDENTIALS
+    login, _, password = entry
+    basic = base64.b64encode(f"{login}:{password}".encode()).decode()
+    return {"headers": {"Authorization": [f"Basic {basic}"]}}
+
+
+def main(argv):
+    if len(argv) != 2 or argv[1] != "get":
+        print(f"usage: {os.path.basename(argv[0])} get", file=sys.stderr)
+        return 2
+    request = json.load(sys.stdin)
+    json.dump(lookup(request.get("uri", "")), sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/workflows/job_bazel-build-test.yaml
+++ b/.github/workflows/job_bazel-build-test.yaml
@@ -15,6 +15,14 @@ jobs:
       - run: echo branch name is ${{ github.ref }}
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Authenticate GitHub downloads
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          umask 077
+          for host in github.com codeload.github.com; do
+            printf 'machine %s\nlogin x-access-token\npassword %s\n' "$host" "$GITHUB_TOKEN"
+          done > "$HOME/.netrc"
       - name: Mount bazel repo cache
         uses: actions/cache@v5
         with:

--- a/.github/workflows/job_bazel-cross-build.yaml
+++ b/.github/workflows/job_bazel-cross-build.yaml
@@ -19,6 +19,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Authenticate GitHub downloads
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          umask 077
+          for host in github.com codeload.github.com; do
+            printf 'machine %s\nlogin x-access-token\npassword %s\n' "$host" "$GITHUB_TOKEN"
+          done > "$HOME/.netrc"
       - name: Mount bazel repo cache
         uses: actions/cache@v5
         with:

--- a/.github/workflows/job_build-cmake-gcc.yml
+++ b/.github/workflows/job_build-cmake-gcc.yml
@@ -166,7 +166,7 @@ jobs:
           build-kit run-script run_unit_tests
       - name: Archive test results
         if: ${{ always() && (steps.run_unit_tests.outcome == 'success' || steps.run_unit_tests.outcome == 'failure') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           if-no-files-found: error
           name: ${{ env.CTEST_REPORT_ARTIFACT_NAME }}

--- a/.github/workflows/job_integrations-tests.yml
+++ b/.github/workflows/job_integrations-tests.yml
@@ -86,7 +86,7 @@ jobs:
           mkdir scripts
           rsync -a source/${{ inputs.build_kit_scripts_directory }}/ scripts
       - name: Download build-kit image
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v5.0.0
         with:
           name: ${{ inputs.build_kit_artifact_name }}
       - name: Load build-kit image

--- a/.github/workflows/job_ocpp-tests.yml
+++ b/.github/workflows/job_ocpp-tests.yml
@@ -65,7 +65,7 @@ jobs:
           mkdir scripts
           rsync -a source/${{ inputs.build_kit_scripts_directory }}/ scripts
       - name: Download build-kit image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.8
         with:
           name: ${{ inputs.build_kit_artifact_name }}
       - name: Load build-kit image


### PR DESCRIPTION
## Describe your changes

CI job setup fetched from endpoints that answer 429 under a shared per-IP rate limit,
failing jobs before anything was built. This is the first of two PRs removing those
fetches; the second bakes test dependencies into the build-kit image.

Bazel's external downloads from GitHub were anonymous. This authenticates them with
the token the workflow already has, via a credential helper reading `~/.netrc`.

The helper serves credentials for the redirect target as well as for the URL a
repository rule names, which `--credential_helper` needs and a bare netrc does not
cover on its own. Both Bazel workflows write the netrc before the build.

Also pins three floating action versions (`upload-artifact@v4`, `download-artifact@v5`)
so a job cannot pick up a new major on an unrelated day.

Independent of the build-kit PR: both branch from `main`, touch disjoint files, and
either can merge first.

## Issue ticket number and link

None.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the contribution documentation and made sure that my changes meet its requirements
