### PR TITLE
docs(deperecation-index): add missing deprecation index entries for 2026.10

### DIFF
--- a/docs/source/project/releases/deprecation-index.rst
+++ b/docs/source/project/releases/deprecation-index.rst
@@ -41,3 +41,50 @@ to the corresponding migration guide.
      - 2027.04.0
      - Use the `get_evse` command, which provides both the eMI3-format EVSE ID
        (ISO 15118-2 Annex H) and the DIN 70121 EVSE ID (DIN SPEC 91286)
+   * - ``manager --conf``, alias of ``--config``
+       (see :ref:`reference-manager-cli`)
+     - 2026.10.0
+     - 2027.04.0
+     - Replace ``--conf <path>`` with ``--config <path>`` in start scripts and
+       service units. Passing both is rejected; using ``--conf`` logs a warning
+       at startup.
+   * - ``manager --db-init``, now a no-op
+       (see :ref:`reference-manager-cli`)
+     - 2026.10.0
+     - 2027.04.0
+     - Drop the flag. Seeding the database from the YAML config when it holds no
+       valid configuration is the default with ``--config --db``. Use the
+       experimental ``--reset-from-yaml`` to force re-seeding.
+   * - ``ocpp_consumer_API``: ``is_connected`` variable and its
+       ``get_is_connected`` request/reply (operations ``receive_is_connected``,
+       ``send_request_get_is_connected``, ``receive_reply_get_is_connected``,
+       schema ``ConnectedStatus``), superseded by ``connection_status``
+     - 2026.10.0
+     - 2027.04.0
+     - Subscribe to ``receive_connection_status`` (or request it via
+       ``send_request_get_connection_status``) and read its ``connected``
+       property; the message also carries the details of the connection the
+       status refers to.
+   * - ``ocpp_consumer_API`` and ``ocpp`` interface: OCPP 1.6 key-only variable
+       addressing (empty ``component.name``, ``variable.name`` = configuration
+       key) in ``get_variables``, ``set_variables`` and ``monitor_variables``,
+       superseded by canonical component/variable addressing
+     - 2026.10.0
+     - 2027.04.0
+     - :ref:`Migration from OCPP 1.6 key addressing
+       <handwritten_ocppmulti_migration-from-ocpp16-key-addressing>`. OCPPmulti
+       logs a warning naming the canonical address on the first use of each
+       legacy key.
+   * - :ref:`EvseManager <everest_modules_EvseManager>` configuration option
+       ``lock_connector_in_state_b: false``
+     - 2026.10.0
+     - 2027.04.0
+     - Remove the option and set ``unlock_when_deauthorized: true`` instead.
+       The connector then stays unlocked in CP state B until the session is
+       authorized, which covers the original use case (no lock on plug-in
+       before authorization). Unlike the deprecated option it keeps the
+       connector locked while an authorized session is paused in state B and
+       does not lock in state C/D without authorization or closed relays.
+       Both options violate IEC 61851-1:2019 D.6.5 Table D.9 line 4 and must
+       not be used in public environments; the module logs a warning at
+       startup for either.

--- a/modules/EVSE/OCPPmulti/docs/index.rst
+++ b/modules/EVSE/OCPPmulti/docs/index.rst
@@ -937,6 +937,8 @@ Monitoring configuration changes
 Legacy-form registrations (empty component name) receive legacy-shaped events.
 Registrations are additive across calls.
 
+.. _handwritten_ocppmulti_migration-from-ocpp16-key-addressing:
+
 Migration from OCPP 1.6 key addressing
 ======================================
 


### PR DESCRIPTION

## Describe your changes

- manager --conf (alias of --config)
- manager --db-init (no-op)
- ocpp_consumer_API is_connected variable and get_is_connected request/reply, superseded by connection_status
- OCPP 1.6 key-only variable addressing in get_variables, set_variables and monitor_variables, superseded by canonical component/variable addressing
- EvseManager lock_connector_in_state_b: false, replaced by unlock_when_deauthorized: true

All are deprecated in 2026.10.0 with earliest removal in 2027.04.0.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

