### PR TITLE
feat(Evse15118D20): add change detection for DC EV values

### DIFF
--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -23,6 +23,30 @@ std::mutex GEL; // Global EVerest Lock
 namespace dt = iso15118::message_20::datatypes;
 
 namespace {
+bool almost_eq(double a, double b) {
+    constexpr auto eps = 1e-6;
+    return std::fabs(a - b) <= eps;
+}
+
+bool dc_ev_target_values_equal(const types::iso15118::DcEvTargetValues& lhs,
+                               const types::iso15118::DcEvTargetValues& rhs) {
+    return almost_eq(lhs.dc_ev_target_voltage, rhs.dc_ev_target_voltage) &&
+           almost_eq(lhs.dc_ev_target_current, rhs.dc_ev_target_current);
+}
+
+bool optional_limit_equal(const std::optional<float>& lhs, const std::optional<float>& rhs) {
+    if (lhs.has_value() != rhs.has_value()) {
+        return false;
+    }
+    return not lhs.has_value() or almost_eq(lhs.value(), rhs.value());
+}
+
+bool dc_ev_maximum_limits_equal(const types::iso15118::DcEvMaximumLimits& lhs,
+                                const types::iso15118::DcEvMaximumLimits& rhs) {
+    return optional_limit_equal(lhs.dc_ev_maximum_current_limit, rhs.dc_ev_maximum_current_limit) &&
+           optional_limit_equal(lhs.dc_ev_maximum_power_limit, rhs.dc_ev_maximum_power_limit) &&
+           optional_limit_equal(lhs.dc_ev_maximum_voltage_limit, rhs.dc_ev_maximum_voltage_limit);
+}
 
 iso15118::config::TlsNegotiationStrategy convert_tls_negotiation_strategy(const std::string& strategy) {
     using Strategy = iso15118::config::TlsNegotiationStrategy;
@@ -122,6 +146,39 @@ types::iso15118::EnergyTransferMode get_energy_transfer_mode(const dt::ServiceCa
 }
 
 } // namespace
+
+void ISO15118_chargerImpl::publish_dc_ev_target_voltage_current_if_changed(
+    const types::iso15118::DcEvTargetValues& values) {
+    {
+        std::scoped_lock lock(published_dc_values_mutex);
+        if (last_published_dc_ev_target_values.has_value() &&
+            dc_ev_target_values_equal(last_published_dc_ev_target_values.value(), values)) {
+            return;
+        }
+        last_published_dc_ev_target_values = values;
+    }
+
+    publish_dc_ev_target_voltage_current(values);
+}
+
+void ISO15118_chargerImpl::reset_published_value_cache() {
+    std::scoped_lock lock(published_dc_values_mutex);
+    last_published_dc_ev_target_values.reset();
+    last_published_dc_ev_maximum_limits.reset();
+}
+
+void ISO15118_chargerImpl::publish_dc_ev_maximum_limits_if_changed(const types::iso15118::DcEvMaximumLimits& limits) {
+    {
+        std::scoped_lock lock(published_dc_values_mutex);
+        if (last_published_dc_ev_maximum_limits.has_value() &&
+            dc_ev_maximum_limits_equal(last_published_dc_ev_maximum_limits.value(), limits)) {
+            return;
+        }
+        last_published_dc_ev_maximum_limits = limits;
+    }
+
+    publish_dc_ev_maximum_limits(limits);
+}
 
 void ISO15118_chargerImpl::init() {
 
@@ -412,7 +469,7 @@ iso15118::session::feedback::Callbacks ISO15118_chargerImpl::create_callbacks() 
     feedback::Callbacks callbacks;
 
     callbacks.dc_pre_charge_target_voltage = [this](float target_voltage) {
-        publish_dc_ev_target_voltage_current({target_voltage, 0});
+        publish_dc_ev_target_voltage_current_if_changed({target_voltage, 0});
     };
 
     callbacks.notify_ev_charging_needs = [this](const dt::ServiceCategory& service_category,
@@ -499,27 +556,27 @@ iso15118::session::feedback::Callbacks ISO15118_chargerImpl::create_callbacks() 
                 const auto target_voltage = dt::from_RationalNumber(scheduled_mode->target_voltage);
                 const auto target_current = dt::from_RationalNumber(scheduled_mode->target_current);
 
-                publish_dc_ev_target_voltage_current({target_voltage, target_current});
+                publish_dc_ev_target_voltage_current_if_changed({target_voltage, target_current});
 
                 if (scheduled_mode->max_charge_current and scheduled_mode->max_voltage and
                     scheduled_mode->max_charge_power) {
                     const auto max_current = dt::from_RationalNumber(scheduled_mode->max_charge_current.value());
                     const auto max_voltage = dt::from_RationalNumber(scheduled_mode->max_voltage.value());
                     const auto max_power = dt::from_RationalNumber(scheduled_mode->max_charge_power.value());
-                    publish_dc_ev_maximum_limits({max_current, max_power, max_voltage});
+                    publish_dc_ev_maximum_limits_if_changed({max_current, max_power, max_voltage});
                 }
 
             } else if (const auto* bpt_scheduled_mode = std::get_if<BPT_ScheduleReqControlModeDC>(dc_control_mode)) {
                 const auto target_voltage = dt::from_RationalNumber(bpt_scheduled_mode->target_voltage);
                 const auto target_current = dt::from_RationalNumber(bpt_scheduled_mode->target_current);
-                publish_dc_ev_target_voltage_current({target_voltage, target_current});
+                publish_dc_ev_target_voltage_current_if_changed({target_voltage, target_current});
 
                 if (bpt_scheduled_mode->max_charge_current and bpt_scheduled_mode->max_voltage and
                     bpt_scheduled_mode->max_charge_power) {
                     const auto max_current = dt::from_RationalNumber(bpt_scheduled_mode->max_charge_current.value());
                     const auto max_voltage = dt::from_RationalNumber(bpt_scheduled_mode->max_voltage.value());
                     const auto max_power = dt::from_RationalNumber(bpt_scheduled_mode->max_charge_power.value());
-                    publish_dc_ev_maximum_limits({max_current, max_power, max_voltage});
+                    publish_dc_ev_maximum_limits_if_changed({max_current, max_power, max_voltage});
                 }
 
                 // publish_dc_ev_maximum_limits({max_limits.current, max_limits.power, max_limits.voltage});
@@ -541,7 +598,7 @@ iso15118::session::feedback::Callbacks ISO15118_chargerImpl::create_callbacks() 
     };
 
     callbacks.dc_max_limits = [this](const feedback::DcMaximumLimits& max_limits) {
-        publish_dc_ev_maximum_limits({max_limits.current, max_limits.power, max_limits.voltage});
+        publish_dc_ev_maximum_limits_if_changed({max_limits.current, max_limits.power, max_limits.voltage});
     };
 
     callbacks.ac_limits = [this](const feedback::AcLimits& limits) {
@@ -655,12 +712,15 @@ iso15118::session::feedback::Callbacks ISO15118_chargerImpl::create_callbacks() 
             break;
         case Signal::DLINK_TERMINATE:
             publish_dlink_terminate(nullptr);
+            reset_published_value_cache();
             break;
         case Signal::DLINK_PAUSE:
             publish_dlink_pause(nullptr);
+            reset_published_value_cache();
             break;
         case Signal::DLINK_ERROR:
             publish_dlink_error(nullptr);
+            reset_published_value_cache();
             break;
         }
     };

--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.hpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.hpp
@@ -15,6 +15,7 @@
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 #include <bitset>
 #include <mutex>
+#include <optional>
 
 #include "der_relay.hpp"
 #include "grid_event.hpp"
@@ -101,6 +102,9 @@ private:
 
     std::vector<iso15118::d20::SupportedVASs> supported_vas_services_per_provider;
     std::mutex vas_mutex;
+    std::mutex published_dc_values_mutex;
+    std::optional<types::iso15118::DcEvTargetValues> last_published_dc_ev_target_values;
+    std::optional<types::iso15118::DcEvMaximumLimits> last_published_dc_ev_maximum_limits;
 
     void update_supported_vas_services();
     std::optional<size_t> get_vas_provider_index(uint16_t service_id);
@@ -117,6 +121,9 @@ private:
     // concurrent applies and leave a mixed DER-function map. Outermost lock; acquired before GEL.
     std::mutex der_apply_mutex;
     void apply_active_der_directives();
+    void reset_published_value_cache();
+    void publish_dc_ev_target_voltage_current_if_changed(const types::iso15118::DcEvTargetValues& values);
+    void publish_dc_ev_maximum_limits_if_changed(const types::iso15118::DcEvMaximumLimits& limits);
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 


### PR DESCRIPTION
## Describe your changes
Introduce functions to publish DC EV target voltage/current and maximum limits only if changed.
Implement comparison logic to detect changes in DC EV target values and limits.
Use std::optional to store last published values for efficient change tracking.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

