### PR TITLE
EvseManager: Skip DC cable check / precharge during renegotiation

### DIFF
--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -580,18 +580,39 @@ void EvseManager::ready() {
 
             // Cable check for DC charging
             r_hlc[0]->subscribe_start_cable_check([this] {
+                if (config.allow_dc_charging_during_renegotiation and
+                    charger->get_current_state() == Charger::EvseState::Charging) {
+                    renegotiation_while_charging = true;
+                    EVLOG_debug << "Skipping CableCheck during DC renegotiation and reporting success immediately";
+                    if (r_imd.empty()) {
+                        r_hlc[0]->call_update_isolation_status(types::iso15118::IsolationStatus::No_IMD);
+                    } else {
+                        r_hlc[0]->call_update_isolation_status(types::iso15118::IsolationStatus::Valid);
+                    }
+                    r_hlc[0]->call_cable_check_finished(true);
+                    return;
+                } else {
+                    renegotiation_while_charging = false;
+                }
+
                 power_supply_DC_charging_phase = types::power_supply_DC::ChargingPhase::CableCheck;
                 cable_check();
             });
 
             // Cable check for DC charging
-            r_hlc[0]->subscribe_start_pre_charge(
-                [this] { power_supply_DC_charging_phase = types::power_supply_DC::ChargingPhase::PreCharge; });
+            r_hlc[0]->subscribe_start_pre_charge([this] {
+                if (renegotiation_while_charging) {
+                    EVLOG_debug << "Skipping PreCharge phase switch during DC renegotiation";
+                    return;
+                }
+                power_supply_DC_charging_phase = types::power_supply_DC::ChargingPhase::PreCharge;
+            });
 
             // Notification that current demand has started
             r_hlc[0]->subscribe_current_demand_started([this] {
                 power_supply_DC_charging_phase = types::power_supply_DC::ChargingPhase::Charging;
                 current_demand_active = true;
+                renegotiation_while_charging = false;
                 apply_new_target_voltage_current();
                 charger->notify_currentdemand_started();
                 if (not r_over_voltage_monitor.empty()) {

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -86,6 +86,7 @@ struct Conf {
     int cable_check_relays_open_voltage_V;
     int cable_check_relays_closed_timeout_s;
     bool cable_check_wait_below_60V_before_finish;
+    bool allow_dc_charging_during_renegotiation;
     bool hack_skoda_enyaq;
     int hack_present_current_offset;
     bool hack_pause_imd_during_precharge;
@@ -419,6 +420,7 @@ private:
     static constexpr int CABLECHECK_SELFTEST_TIMEOUT{30};
 
     std::atomic_bool current_demand_active{false};
+    std::atomic_bool renegotiation_while_charging{false};
     std::atomic_bool slac_unmatched{false};
     std::mutex powermeter_mutex;
     std::condition_variable powermeter_cv;

--- a/modules/EVSE/EvseManager/manifest.yaml
+++ b/modules/EVSE/EvseManager/manifest.yaml
@@ -192,6 +192,16 @@ config:
           This may save a few seconds as it avoids unnecessary voltage down and up ramping.
     type: boolean
     default: true
+  allow_dc_charging_during_renegotiation:
+    description: >-
+      Allow ISO 15118 DC service renegotiation without interrupting active DC charging.
+      If enabled and the EV requests a new CableCheck while CurrentDemand is already active,
+      EvseManager treats this as a renegotiation with the cable still plugged in, reports CableCheck
+      success immediately and keeps the power supply in the charging phase instead of re-running the
+      normal CableCheck and PreCharge sequence.
+      Enable this only if the EVSE and power supply safely support this simplified renegotiation flow.
+    type: boolean
+    default: false
   hack_skoda_enyaq:
     description: >-
       Skoda Enyaq requests DC charging voltages below its battery level or even below 0 initially.


### PR DESCRIPTION
Add EVSE config to skip DC cable check / precharge during renegotiation

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

