### PR TITLE
fix(EvseV2G): reset DC status codes per connection

### DIFF
--- a/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -667,15 +667,7 @@ void ISO15118_chargerImpl::handle_send_error(types::iso15118::EvseError& error) 
 void ISO15118_chargerImpl::handle_reset_error() {
     v2g_ctx->evse_v2g_data.rcd = 0;
 
-    v2g_ctx->evse_v2g_data.evse_status_code[PHASE_INIT] = iso2_DC_EVSEStatusCodeType_EVSE_NotReady;
-    v2g_ctx->evse_v2g_data.evse_status_code[PHASE_AUTH] = iso2_DC_EVSEStatusCodeType_EVSE_NotReady;
-    v2g_ctx->evse_v2g_data.evse_status_code[PHASE_PARAMETER] = iso2_DC_EVSEStatusCodeType_EVSE_Ready; // [V2G-DC-453]
-    v2g_ctx->evse_v2g_data.evse_status_code[PHASE_ISOLATION] =
-        iso2_DC_EVSEStatusCodeType_EVSE_IsolationMonitoringActive;
-    v2g_ctx->evse_v2g_data.evse_status_code[PHASE_PRECHARGE] = iso2_DC_EVSEStatusCodeType_EVSE_Ready;
-    v2g_ctx->evse_v2g_data.evse_status_code[PHASE_CHARGE] = iso2_DC_EVSEStatusCodeType_EVSE_Ready;
-    v2g_ctx->evse_v2g_data.evse_status_code[PHASE_WELDING] = iso2_DC_EVSEStatusCodeType_EVSE_NotReady;
-    v2g_ctx->evse_v2g_data.evse_status_code[PHASE_STOP] = iso2_DC_EVSEStatusCodeType_EVSE_NotReady;
+    v2g_ctx_init_dc_evse_status_codes(v2g_ctx);
 
     // Todo(sl): check if emergency should be cleared here?
 }

--- a/modules/EVSE/EvseV2G/tests/v2g_ctx_test.cpp
+++ b/modules/EVSE/EvseV2G/tests/v2g_ctx_test.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
+#include <cstring>
 #include <memory>
 #include <v2g_ctx.hpp>
 
@@ -58,6 +59,23 @@ protected:
         // many items in session not reset
         EXPECT_FALSE(ctx->session.renegotiation_required);
         EXPECT_FALSE(ctx->session.is_charging);
+
+        // a stopped DC session must not leak EVSE_Shutdown into the next one
+        EXPECT_EQ(ctx->evse_v2g_data.evse_status_code[PHASE_INIT], iso2_DC_EVSEStatusCodeType_EVSE_NotReady);
+        EXPECT_EQ(ctx->evse_v2g_data.evse_status_code[PHASE_AUTH], iso2_DC_EVSEStatusCodeType_EVSE_NotReady);
+        EXPECT_EQ(ctx->evse_v2g_data.evse_status_code[PHASE_PARAMETER], iso2_DC_EVSEStatusCodeType_EVSE_Ready);
+        EXPECT_EQ(ctx->evse_v2g_data.evse_status_code[PHASE_ISOLATION],
+                  iso2_DC_EVSEStatusCodeType_EVSE_IsolationMonitoringActive);
+        EXPECT_EQ(ctx->evse_v2g_data.evse_status_code[PHASE_PRECHARGE], iso2_DC_EVSEStatusCodeType_EVSE_Ready);
+        EXPECT_EQ(ctx->evse_v2g_data.evse_status_code[PHASE_CHARGE], iso2_DC_EVSEStatusCodeType_EVSE_Ready);
+        EXPECT_EQ(ctx->evse_v2g_data.evse_status_code[PHASE_WELDING], iso2_DC_EVSEStatusCodeType_EVSE_NotReady);
+        EXPECT_EQ(ctx->evse_v2g_data.evse_status_code[PHASE_STOP], iso2_DC_EVSEStatusCodeType_EVSE_NotReady);
+    }
+
+    void set_dc_status_codes_shutdown() {
+        // what handle_stop_charging() and a PowerDeliveryReq(Stop) leave behind
+        memset(ctx->evse_v2g_data.evse_status_code, iso2_DC_EVSEStatusCodeType_EVSE_Shutdown,
+               sizeof(ctx->evse_v2g_data.evse_status_code));
     }
 
     void SetUp() override {
@@ -104,6 +122,7 @@ TEST_F(V2gCtxTest, v2g_ctx_init_charging_stateTrue) {
     ctx->stop_hlc = true;
     ctx->session.renegotiation_required = true;
     ctx->session.is_charging = true;
+    set_dc_status_codes_shutdown();
 
     v2g_ctx_init_charging_state(ctx.get(), true);
 
@@ -122,6 +141,7 @@ TEST_F(V2gCtxTest, v2g_ctx_init_charging_stateFalse) {
     ctx->stop_hlc = true;
     ctx->session.renegotiation_required = true;
     ctx->session.is_charging = true;
+    set_dc_status_codes_shutdown();
 
     v2g_ctx_init_charging_state(ctx.get(), false);
 

--- a/modules/EVSE/EvseV2G/v2g_ctx.cpp
+++ b/modules/EVSE/EvseV2G/v2g_ctx.cpp
@@ -96,6 +96,17 @@ void v2g_ctx_init_charging_session(struct v2g_context* const ctx, bool is_connec
     v2g_ctx_init_charging_values(ctx);                          // Loads the internal default config
 }
 
+void v2g_ctx_init_dc_evse_status_codes(struct v2g_context* const ctx) {
+    ctx->evse_v2g_data.evse_status_code[PHASE_INIT] = iso2_DC_EVSEStatusCodeType_EVSE_NotReady;
+    ctx->evse_v2g_data.evse_status_code[PHASE_AUTH] = iso2_DC_EVSEStatusCodeType_EVSE_NotReady;
+    ctx->evse_v2g_data.evse_status_code[PHASE_PARAMETER] = iso2_DC_EVSEStatusCodeType_EVSE_Ready; // [V2G-DC-453]
+    ctx->evse_v2g_data.evse_status_code[PHASE_ISOLATION] = iso2_DC_EVSEStatusCodeType_EVSE_IsolationMonitoringActive;
+    ctx->evse_v2g_data.evse_status_code[PHASE_PRECHARGE] = iso2_DC_EVSEStatusCodeType_EVSE_Ready;
+    ctx->evse_v2g_data.evse_status_code[PHASE_CHARGE] = iso2_DC_EVSEStatusCodeType_EVSE_Ready;
+    ctx->evse_v2g_data.evse_status_code[PHASE_WELDING] = iso2_DC_EVSEStatusCodeType_EVSE_NotReady;
+    ctx->evse_v2g_data.evse_status_code[PHASE_STOP] = iso2_DC_EVSEStatusCodeType_EVSE_NotReady;
+}
+
 void v2g_ctx_init_charging_state(struct v2g_context* const ctx, bool is_connection_terminated) {
     ctx->stop_hlc = false;
     ctx->intl_emergency_shutdown = false;
@@ -107,6 +118,9 @@ void v2g_ctx_init_charging_state(struct v2g_context* const ctx, bool is_connecti
     ctx->session.renegotiation_required = false;
     ctx->session.is_charging = false;
     ctx->evse_v2g_data.evse_notification = (uint8_t)0;
+    /* A stopped DC session writes EVSE_Shutdown into every phase [IEC 61851-23:2023 CC.7.5.19]. It must not outlive
+     * the connection, or the next PowerDeliveryRes is refused with FAILED_PowerDeliveryNotApplied [V2G2-480]. */
+    v2g_ctx_init_dc_evse_status_codes(ctx);
 }
 
 void v2g_ctx_init_charging_values(struct v2g_context* const ctx) {
@@ -120,14 +134,7 @@ void v2g_ctx_init_charging_values(struct v2g_context* const ctx) {
     ctx->evse_v2g_data.evse_isolation_status = (uint8_t)iso2_isolationLevelType_Invalid;
     ctx->evse_v2g_data.evse_isolation_status_is_used = (unsigned int)1; // Shall be used in DIN
     ctx->evse_v2g_data.evse_notification = (uint8_t)0;
-    ctx->evse_v2g_data.evse_status_code[PHASE_INIT] = iso2_DC_EVSEStatusCodeType_EVSE_NotReady;
-    ctx->evse_v2g_data.evse_status_code[PHASE_AUTH] = iso2_DC_EVSEStatusCodeType_EVSE_NotReady;
-    ctx->evse_v2g_data.evse_status_code[PHASE_PARAMETER] = iso2_DC_EVSEStatusCodeType_EVSE_Ready; // [V2G-DC-453]
-    ctx->evse_v2g_data.evse_status_code[PHASE_ISOLATION] = iso2_DC_EVSEStatusCodeType_EVSE_IsolationMonitoringActive;
-    ctx->evse_v2g_data.evse_status_code[PHASE_PRECHARGE] = iso2_DC_EVSEStatusCodeType_EVSE_Ready;
-    ctx->evse_v2g_data.evse_status_code[PHASE_CHARGE] = iso2_DC_EVSEStatusCodeType_EVSE_Ready;
-    ctx->evse_v2g_data.evse_status_code[PHASE_WELDING] = iso2_DC_EVSEStatusCodeType_EVSE_NotReady;
-    ctx->evse_v2g_data.evse_status_code[PHASE_STOP] = iso2_DC_EVSEStatusCodeType_EVSE_NotReady;
+    v2g_ctx_init_dc_evse_status_codes(ctx);
     memset(ctx->evse_v2g_data.evse_processing, iso2_EVSEProcessingType_Ongoing, PHASE_LENGTH);
     ctx->evse_v2g_data.evse_processing[PHASE_PARAMETER] = iso2_EVSEProcessingType_Finished; // Skip parameter phase
 

--- a/modules/EVSE/EvseV2G/v2g_ctx.hpp
+++ b/modules/EVSE/EvseV2G/v2g_ctx.hpp
@@ -65,6 +65,13 @@ void populate_physical_value_float(struct iso2_PhysicalValueType* pv, float valu
 void v2g_ctx_init_charging_state(struct v2g_context* const ctx, bool is_connection_terminated);
 
 /*!
+ * \brief v2g_ctx_init_dc_evse_status_codes This function sets the DC status code of every charging phase back to its
+ * default.
+ * \param ctx is a pointer of type \c v2g_context. It holds the charging values.
+ */
+void v2g_ctx_init_dc_evse_status_codes(struct v2g_context* const ctx);
+
+/*!
  * \brief init_charging_values This function inits all charge-values (din/iso). This should be called after starting the
  * charging session.
  * \param ctx is a pointer of type \c v2g_context. It holds the charging values.


### PR DESCRIPTION
## Describe your changes

A stopped DC session leaves `EVSE_Shutdown` set in every phase of `evse_v2g_data.evse_status_code`. `connection_teardown()` does reset the defaults, but it loses a race: the detached thread spawned by `handle_stop_charging()` memsets all phases back to `EVSE_Shutdown` roughly 0.6 s *after* that reset has already run. The next session then reads `EVSE_Shutdown` for the charge phase and its `PowerDeliveryRes` is refused with `FAILED_PowerDeliveryNotApplied` [V2G2-480] for the lifetime of the module, so any ISO 15118 DC charger that pauses cannot resume.

Because the wipe lands after teardown, resetting at teardown provably cannot fix it. Reset in `v2g_ctx_init_charging_state()` instead, which runs at connection start, after any asynchronous write from the previous session. The defaults now have a single definition; the shutdown write itself is untouched, so a session that is genuinely ending still reports `EVSE_Shutdown` in every later `PowerDeliveryRes` and `WeldingDetectionRes` [IEC 61851-23:2023 CC.7.5.19].

Verified by the added `v2g_ctx_test` case: red before the change, green after, against stock upstream Josev, so no EV-side change is masking the result.

## Issue ticket number and link

None.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
