### PR TITLE
fix(iso15118): tear down session on EV disconnect

### DIFF
--- a/lib/everest/iso15118/include/iso15118/detail/io/socket_helper.hpp
+++ b/lib/everest/iso15118/include/iso15118/detail/io/socket_helper.hpp
@@ -14,4 +14,6 @@ bool check_and_update_interface(std::string& interface_name);
 bool get_first_sockaddr_in6_for_interface(const std::string& interface_name, sockaddr_in6& address);
 
 std::unique_ptr<char[]> sockaddr_in6_to_name(const sockaddr_in6&);
+
+bool set_tcp_keepalive(int fd);
 } // namespace iso15118::io

--- a/lib/everest/iso15118/include/iso15118/io/connection_abstract.hpp
+++ b/lib/everest/iso15118/include/iso15118/io/connection_abstract.hpp
@@ -24,6 +24,8 @@ using ConnectionEventCallback = std::function<void(ConnectionEvent)>;
 struct ReadResult {
     bool would_block{true};
     size_t bytes_read{0};
+    bool connection_closed{false}; //!< connection ended during this read (EOF / TLS close_notify, or a fatal
+                                   //!< socket error such as ECONNRESET / keepalive ETIMEDOUT)
 };
 
 struct IConnection {

--- a/lib/everest/iso15118/src/iso15118/io/connection_plain.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_plain.cpp
@@ -3,6 +3,7 @@
 #include <iso15118/io/connection_plain.hpp>
 
 #include <cassert>
+#include <cerrno>
 #include <chrono>
 #include <cinttypes>
 #include <cstring>
@@ -91,17 +92,26 @@ ReadResult ConnectionPlain::read(uint8_t* buf, size_t len) {
     const auto read_result = ::read(fd, buf, len);
     const auto did_block = (len > 0) and (not cmp_equal(read_result, len));
 
+    if (read_result == 0 && len > 0) {
+        return {false, 0, true}; // peer closed (EOF)
+    }
+
     if (read_result >= 0) {
         return {did_block, static_cast<size_t>(read_result)};
     }
 
-    // should be an error
-    if (errno != EAGAIN) {
-        // in case the error is not due to blocking, log it
-        logf_error("ConnectionPlain::read failed with error code: %d", errno);
+    // read_result < 0: distinguish a genuine would-block from a fatal error.
+    // EAGAIN/EWOULDBLOCK/EINTR mean "retry"; anything else (ECONNRESET, or
+    // ETIMEDOUT from the TCP keepalive, ...) is terminal, so report it as a
+    // closed connection. Otherwise the level-triggered poll would spin on the
+    // dead socket until the 60 s sequence timeout instead of tearing the
+    // session down within one tick.
+    if (errno == EAGAIN or errno == EWOULDBLOCK or errno == EINTR) {
+        return {true, 0, false};
     }
 
-    return {did_block, 0};
+    logf_warning("ConnectionPlain::read failed with error code: %d", errno);
+    return {false, 0, true};
 }
 
 void ConnectionPlain::handle_connect() {
@@ -112,6 +122,10 @@ void ConnectionPlain::handle_connect() {
     const auto accept_fd = accept4(fd, reinterpret_cast<struct sockaddr*>(&address), &address_len, SOCK_NONBLOCK);
     if (accept_fd == -1) {
         log_and_throw("Failed to accept4");
+    }
+
+    if (not set_tcp_keepalive(accept_fd)) {
+        logf_warning("Failed to configure TCP keepalive on accepted connection");
     }
 
     const auto address_name = sockaddr_in6_to_name(address);

--- a/lib/everest/iso15118/src/iso15118/io/socket_helper.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/socket_helper.cpp
@@ -9,6 +9,8 @@
 #include <net/if.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
 
 #include <iso15118/detail/helper.hpp>
 
@@ -106,6 +108,38 @@ bool get_first_sockaddr_in6_for_interface(const std::string& interface_name, soc
 
     // Todo(sl): What to do if interface was not found?
     return found_interface;
+}
+
+bool set_tcp_keepalive(int fd) {
+    constexpr int TCP_KEEPALIVE_IDLE_S = 10;
+    constexpr int TCP_KEEPALIVE_INTERVAL_S = 3;
+    constexpr int TCP_KEEPALIVE_PROBE_COUNT = 3;
+
+    int enable = 1;
+    if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &enable, sizeof(enable)) == -1) {
+        logf_error("Failed to enable SO_KEEPALIVE");
+        return false;
+    }
+
+    int idle = TCP_KEEPALIVE_IDLE_S;
+    if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle)) == -1) {
+        logf_error("Failed to set TCP_KEEPIDLE");
+        return false;
+    }
+
+    int interval = TCP_KEEPALIVE_INTERVAL_S;
+    if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &interval, sizeof(interval)) == -1) {
+        logf_error("Failed to set TCP_KEEPINTVL");
+        return false;
+    }
+
+    int count = TCP_KEEPALIVE_PROBE_COUNT;
+    if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &count, sizeof(count)) == -1) {
+        logf_error("Failed to set TCP_KEEPCNT");
+        return false;
+    }
+
+    return true;
 }
 
 std::unique_ptr<char[]> sockaddr_in6_to_name(const sockaddr_in6& address) {

--- a/lib/everest/iso15118/src/iso15118/session/iso.cpp
+++ b/lib/everest/iso15118/src/iso15118/session/iso.cpp
@@ -58,9 +58,19 @@ void raise_invalid_packet_state(const io::SdpPacket& sdp_packet) {
     log_and_throw(error.c_str());
 }
 
-// NOTE (aw): this function return true, if it would block to read a complete packet
-//            if it returns false, the packet is complete
-bool read_single_sdp_packet(io::IConnection& connection, io::SdpPacket& sdp_packet) {
+namespace {
+enum class V2GTPReadResult {
+    complete,          //!< a full packet was read
+    would_block,       //!< more data is needed to complete the packet
+    connection_closed, //!< the peer closed the connection mid-read
+};
+} // namespace
+
+// NOTE (aw): this function reports a tri-state result:
+//            - would_block: it would block to read a complete packet
+//            - complete: the packet is complete
+//            - connection_closed: the peer closed the connection during the read
+V2GTPReadResult read_single_v2gtp_packet(io::IConnection& connection, io::SdpPacket& sdp_packet) {
     // NOTE (aw): not happy with this function
     //            main problem is, that it combines too much logic of the sdp packet and io related stuff
     using PacketState = io::SdpPacket::State;
@@ -70,16 +80,20 @@ bool read_single_sdp_packet(io::IConnection& connection, io::SdpPacket& sdp_pack
     const auto first_try =
         connection.read(sdp_packet.get_current_buffer_pos(), sdp_packet.get_remaining_bytes_to_read());
 
+    if (first_try.connection_closed) {
+        return V2GTPReadResult::connection_closed;
+    }
+
     sdp_packet.update_read_bytes(first_try.bytes_read);
 
     if (first_try.would_block) {
         // need more data for at least the header
-        return true;
+        return V2GTPReadResult::would_block;
     }
 
     if (sdp_packet.get_state() == PacketState::COMPLETE) {
         // done
-        return false;
+        return V2GTPReadResult::complete;
     }
 
     // packet not finished
@@ -91,11 +105,15 @@ bool read_single_sdp_packet(io::IConnection& connection, io::SdpPacket& sdp_pack
     const auto second_try =
         connection.read(sdp_packet.get_current_buffer_pos(), sdp_packet.get_remaining_bytes_to_read());
 
+    if (second_try.connection_closed) {
+        return V2GTPReadResult::connection_closed;
+    }
+
     sdp_packet.update_read_bytes(second_try.bytes_read);
 
     if (second_try.would_block) {
         // need more data for the rest of the packet!
-        return true;
+        return V2GTPReadResult::would_block;
     }
 
     // assert finished packet
@@ -103,7 +121,7 @@ bool read_single_sdp_packet(io::IConnection& connection, io::SdpPacket& sdp_pack
         raise_invalid_packet_state(sdp_packet);
     }
 
-    return false;
+    return V2GTPReadResult::complete;
 }
 
 static size_t setup_response_header(uint8_t* buffer, iso15118::io::v2gtp::PayloadType payload_type, size_t size) {
@@ -151,10 +169,16 @@ TimePoint const& Session::poll() {
 
     // check for new data to read
     if (state.new_data) {
-        const bool would_block = read_single_sdp_packet(*connection, packet);
-
-        if (would_block) {
+        switch (read_single_v2gtp_packet(*connection, packet)) {
+        case V2GTPReadResult::connection_closed:
+            logf_info("Peer closed the connection");
+            close();
+            return next_session_event;
+        case V2GTPReadResult::would_block:
             state.new_data = false;
+            break;
+        case V2GTPReadResult::complete:
+            break;
         }
     }
 
@@ -191,7 +215,7 @@ TimePoint const& Session::poll() {
 
         for (const auto& timeout : reached) {
             if (timeout == d20::TimeoutType::SEQUENCE) {
-                logf_error("Sequence Timeout 40secs is reached. Stopping the session");
+                logf_error("Sequence timeout (60s) reached. Stopping the session");
                 ctx.session_stopped = true;
                 break;
             } else {
@@ -314,6 +338,9 @@ void Session::handle_connection_event(io::ConnectionEvent event) {
 
     case Event::CLOSED:
         state.connected = false;
+        // Terminal: trip is_finished() so the controller reaps this session.
+        // Re-entry from Session::close() (which already set the flag) is a no-op.
+        ctx.session_stopped = true;
         logf_info("Connection is closed");
         return;
     }
@@ -321,6 +348,8 @@ void Session::handle_connection_event(io::ConnectionEvent event) {
 
 void Session::close() {
     connection->close();
+    // transport gone; a rate-limiter-deferred response is undeliverable
+    [[maybe_unused]] auto res = message_exchange.check_and_clear_response();
     ctx.feedback.signal(session::feedback::Signal::DLINK_TERMINATE);
     ctx.session_stopped = true;
 }

--- a/lib/everest/iso15118/test/iso15118/io/CMakeLists.txt
+++ b/lib/everest/iso15118/test/iso15118/io/CMakeLists.txt
@@ -10,6 +10,16 @@ target_link_libraries(test_logging
 
 catch_discover_tests(test_logging)
 
+add_executable(test_socket_keepalive socket_keepalive.cpp)
+target_link_libraries(test_socket_keepalive PRIVATE iso15118 Catch2::Catch2WithMain)
+catch_discover_tests(test_socket_keepalive)
+
+add_executable(test_connection_plain connection_plain.cpp)
+target_link_libraries(test_connection_plain PRIVATE iso15118 Catch2::Catch2WithMain)
+catch_discover_tests(test_connection_plain
+    PROPERTIES RESOURCE_LOCK iso15118_tls_port_50000
+)
+
 add_executable(connection_openssl_test)
 add_custom_command(
     TARGET connection_openssl_test POST_BUILD

--- a/lib/everest/iso15118/test/iso15118/io/connection_plain.cpp
+++ b/lib/everest/iso15118/test/iso15118/io/connection_plain.cpp
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <future>
+#include <thread>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <iso15118/io/connection_plain.hpp>
+#include <iso15118/io/logging.hpp>
+#include <iso15118/io/poll_manager.hpp>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+constexpr auto LOOPBACK_IFACE = "lo";
+constexpr auto SERVER_PORT = 50000;
+
+// Drive poll_manager until predicate returns true or the deadline expires.
+template <typename Predicate>
+bool poll_until(iso15118::io::PollManager& pm, Predicate done, std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        pm.poll(50);
+        if (done()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Connect to the server on loopback, send data the server will NOT read, then
+// abort with SO_LINGER {1,0}. Because unread data is still queued at the peer,
+// the close sends a RST, so the server's next read() fails with ECONNRESET
+// rather than a clean EOF. Signals `reset_done` once the abort has been issued.
+bool run_resetting_client(std::atomic<bool>& reset_done) {
+    sockaddr_in6 addr{};
+    addr.sin6_family = AF_INET6;
+    addr.sin6_port = htons(SERVER_PORT);
+    if (inet_pton(AF_INET6, "::1", &addr.sin6_addr) != 1) {
+        return false;
+    }
+
+    const int fd = ::socket(AF_INET6, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return false;
+    }
+
+    int connected = -1;
+    for (int i = 0; i < 50; ++i) {
+        connected = ::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+        if (connected == 0) {
+            break;
+        }
+        std::this_thread::sleep_for(20ms);
+    }
+    if (connected != 0) {
+        ::close(fd);
+        return false;
+    }
+
+    const std::array<uint8_t, 8> payload{};
+    [[maybe_unused]] auto res = ::write(fd, payload.data(), payload.size());
+    // Give the server kernel time to buffer the bytes so they are still unread
+    // when the abortive close arrives.
+    std::this_thread::sleep_for(100ms);
+
+    struct linger lin {};
+    lin.l_onoff = 1;
+    lin.l_linger = 0;
+    ::setsockopt(fd, SOL_SOCKET, SO_LINGER, &lin, sizeof(lin));
+
+    ::close(fd);
+    reset_done.store(true);
+    return true;
+}
+
+} // namespace
+
+SCENARIO("ConnectionPlain::read reports a fatal errno as a closed connection") {
+
+    GIVEN("A ConnectionPlain listening on loopback") {
+        iso15118::io::set_logging_callback([](iso15118::LogLevel, const std::string&) {});
+
+        iso15118::io::PollManager poll_manager;
+        iso15118::io::ConnectionPlain connection(poll_manager, LOOPBACK_IFACE);
+
+        std::atomic<bool> connection_open{false};
+        std::atomic<bool> reset_done{false};
+        std::atomic<bool> saw_reset_read{false};
+        std::atomic<bool> reset_read_reported_closed{false};
+        connection.set_event_callback([&](iso15118::io::ConnectionEvent event) {
+            if (event == iso15118::io::ConnectionEvent::OPEN) {
+                connection_open.store(true);
+            } else if (event == iso15118::io::ConnectionEvent::NEW_DATA) {
+                // Withhold the read until the peer has aborted, so that unread
+                // data is still queued when the abortive close fires and the
+                // peer therefore sends a RST rather than a clean FIN.
+                if (not reset_done.load()) {
+                    return;
+                }
+                std::array<uint8_t, 64> buf{};
+                errno = 0;
+                const auto r = connection.read(buf.data(), buf.size());
+                if (errno == ECONNRESET) {
+                    // The read that hits the reset must be surfaced as a closed
+                    // connection, not masked as would_block.
+                    reset_read_reported_closed.store(r.connection_closed);
+                    saw_reset_read.store(true);
+                }
+            }
+        });
+
+        WHEN("the peer aborts the connection with a RST and the server reads") {
+            auto client_future = std::async(std::launch::async, [&]() { return run_resetting_client(reset_done); });
+
+            const bool got_open = poll_until(
+                poll_manager, [&]() { return connection_open.load(); }, 5s);
+
+            const bool got_reset = poll_until(
+                poll_manager, [&]() { return saw_reset_read.load(); }, 5s);
+
+            const auto client_connected = client_future.get();
+
+            THEN("read() surfaces connection_closed instead of would_block") {
+                REQUIRE(client_connected);
+                REQUIRE(got_open);
+                REQUIRE(got_reset);
+                REQUIRE(reset_read_reported_closed.load());
+            }
+        }
+
+        if (connection_open.load()) {
+            connection.close();
+        }
+    }
+}

--- a/lib/everest/iso15118/test/iso15118/io/socket_keepalive.cpp
+++ b/lib/everest/iso15118/test/iso15118/io/socket_keepalive.cpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#include <catch2/catch_test_macros.hpp>
+
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <iso15118/detail/io/socket_helper.hpp>
+
+SCENARIO("set_tcp_keepalive configures the socket") {
+
+    GIVEN("An open TCP/IPv6 socket") {
+        const int fd = ::socket(AF_INET6, SOCK_STREAM, 0);
+        REQUIRE(fd >= 0);
+
+        WHEN("set_tcp_keepalive is called") {
+            const auto ok = iso15118::io::set_tcp_keepalive(fd);
+
+            THEN("keepalive is enabled with the configured idle/interval/count") {
+                REQUIRE(ok);
+
+                int value = 0;
+                socklen_t len = sizeof(value);
+
+                REQUIRE(::getsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &value, &len) == 0);
+                REQUIRE(value == 1);
+
+                REQUIRE(::getsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &value, &len) == 0);
+                REQUIRE(value == 10);
+
+                REQUIRE(::getsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &value, &len) == 0);
+                REQUIRE(value == 3);
+
+                REQUIRE(::getsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &value, &len) == 0);
+                REQUIRE(value == 3);
+            }
+        }
+
+        ::close(fd);
+    }
+}

--- a/lib/everest/iso15118/test/iso15118/session/CMakeLists.txt
+++ b/lib/everest/iso15118/test/iso15118/session/CMakeLists.txt
@@ -9,3 +9,13 @@ target_link_libraries(test_feedback
 )
 
 catch_discover_tests(test_feedback)
+
+add_executable(test_session_teardown session_teardown.cpp)
+
+target_link_libraries(test_session_teardown
+    PRIVATE
+        iso15118
+        Catch2::Catch2WithMain
+)
+
+catch_discover_tests(test_session_teardown)

--- a/lib/everest/iso15118/test/iso15118/session/mock_connection.hpp
+++ b/lib/everest/iso15118/test/iso15118/session/mock_connection.hpp
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <optional>
+#include <vector>
+
+#include <arpa/inet.h>
+
+#include <iso15118/io/connection_abstract.hpp>
+#include <iso15118/io/sdp.hpp>
+#include <iso15118/io/sdp_packet.hpp>
+
+namespace iso15118::test {
+
+// Test double for io::IConnection. Records close() and lets the test drive
+// connection events and read results without any real socket or sleep.
+class MockConnection final : public io::IConnection {
+public:
+    void set_event_callback(const io::ConnectionEventCallback& callback) override {
+        event_callback = callback;
+    }
+
+    io::Ipv6EndPoint get_public_endpoint() const override {
+        return {};
+    }
+
+    void write(const uint8_t*, size_t) override {
+    }
+
+    io::ReadResult read(uint8_t* buf, size_t len) override {
+        if (read_pos < read_buffer.size()) {
+            const auto available = read_buffer.size() - read_pos;
+            const auto count = std::min(len, available);
+            std::memcpy(buf, read_buffer.data() + read_pos, count);
+            read_pos += count;
+            return {false, count, false};
+        }
+        return next_read_result;
+    }
+
+    void close() override {
+        closed = true;
+        fire(io::ConnectionEvent::CLOSED);
+    }
+
+    std::optional<io::sha512_hash_t> get_vehicle_cert_hash() const override {
+        return std::nullopt;
+    }
+
+    // Inject a connection event through the stored callback.
+    void fire(io::ConnectionEvent event) {
+        if (event_callback) {
+            event_callback(event);
+        }
+    }
+
+    // Queue a full V2GTP frame (8-byte header + payload) for read() to deliver.
+    void queue_v2gtp_packet(io::v2gtp::PayloadType payload_type, const uint8_t* payload, std::size_t payload_len) {
+        read_buffer.resize(io::SdpPacket::V2GTP_HEADER_SIZE + payload_len);
+        read_buffer[0] = io::SDP_PROTOCOL_VERSION;
+        read_buffer[1] = io::SDP_INVERSE_PROTOCOL_VERSION;
+
+        const uint16_t type = htons(static_cast<uint16_t>(payload_type));
+        std::memcpy(read_buffer.data() + 2, &type, sizeof(type));
+
+        const uint32_t len = htonl(static_cast<uint32_t>(payload_len));
+        std::memcpy(read_buffer.data() + 4, &len, sizeof(len));
+
+        std::memcpy(read_buffer.data() + io::SdpPacket::V2GTP_HEADER_SIZE, payload, payload_len);
+        read_pos = 0;
+    }
+
+    io::ReadResult next_read_result{};
+    bool closed{false};
+
+private:
+    io::ConnectionEventCallback event_callback;
+    std::vector<uint8_t> read_buffer;
+    std::size_t read_pos{0};
+};
+
+} // namespace iso15118::test

--- a/lib/everest/iso15118/test/iso15118/session/session_teardown.cpp
+++ b/lib/everest/iso15118/test/iso15118/session/session_teardown.cpp
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#include <memory>
+#include <optional>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <iso15118/d20/config.hpp>
+#include <iso15118/d20/context.hpp>
+#include <iso15118/session/feedback.hpp>
+#include <iso15118/session/iso.hpp>
+#include <iso15118/session/logger.hpp>
+
+#include "mock_connection.hpp"
+
+using iso15118::test::MockConnection;
+
+namespace {
+
+// Captured SupportedAppProtocolReq offering the -20:AC namespace.
+constexpr uint8_t sap_req[] = {0x80, 0x00, 0xf3, 0xab, 0x93, 0x71, 0xd3, 0x4b, 0x9b, 0x79, 0xd3, 0x9b, 0xa3,
+                               0x21, 0xd3, 0x4b, 0x9b, 0x79, 0xd1, 0x89, 0xa9, 0x89, 0x89, 0xc1, 0xd1, 0x69,
+                               0x91, 0x81, 0xd2, 0x0a, 0x18, 0x01, 0x00, 0x00, 0x04, 0x00, 0x40};
+
+// Captured SessionSetupReq with a zeroed session id (starts a new session).
+constexpr uint8_t session_setup_req[] = {0x80, 0x8c, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0c, 0x9f,
+                                         0x9c, 0x2b, 0xd0, 0x62, 0x0b, 0x2b, 0xa6, 0xa4, 0xab, 0x18, 0x99, 0x19, 0x9a,
+                                         0x1a, 0x9b, 0x1b, 0x9c, 0x1c, 0x98, 0x20, 0xa1, 0x21, 0xa2, 0x22, 0xac, 0x00};
+
+} // namespace
+
+SCENARIO("Session teardown primitives") {
+    // The Session FSM logs a state transition on construction through the
+    // process-global session log callback, which starts null.
+    iso15118::session::logging::set_session_log_callback([](std::size_t, const auto&) {});
+
+    iso15118::session::feedback::Callbacks callbacks;
+    callbacks.signal = [](auto) {};
+
+    const iso15118::d20::SessionConfig session_config{iso15118::d20::EvseSetupConfig{}};
+    std::optional<iso15118::d20::PauseContext> pause_ctx{std::nullopt};
+
+    auto connection = std::make_unique<MockConnection>();
+    auto* conn = connection.get();
+
+    iso15118::Session session{std::move(connection), session_config, callbacks, pause_ctx};
+
+    GIVEN("a never-connected session") {
+        WHEN("close() is called") {
+            session.close();
+
+            THEN("the session is finished") {
+                REQUIRE(session.is_finished());
+            }
+        }
+    }
+
+    GIVEN("a connected session with a peer-closed read") {
+        conn->fire(iso15118::io::ConnectionEvent::ACCEPTED);
+        conn->next_read_result = {false, 0, true};
+        conn->fire(iso15118::io::ConnectionEvent::NEW_DATA);
+
+        WHEN("poll() reads the closed connection") {
+            session.poll();
+
+            THEN("the session is finished") {
+                REQUIRE(session.is_finished());
+            }
+        }
+    }
+
+    GIVEN("a connected session with a rate-limiter-deferred response") {
+        conn->fire(iso15118::io::ConnectionEvent::ACCEPTED);
+
+        // First response goes out immediately and latches the tx timestamp.
+        conn->queue_v2gtp_packet(iso15118::io::v2gtp::PayloadType::SAP, sap_req, sizeof(sap_req));
+        conn->fire(iso15118::io::ConnectionEvent::NEW_DATA);
+        session.poll();
+
+        // Second response is generated but held back by the 100 ms rate limiter.
+        conn->queue_v2gtp_packet(iso15118::io::v2gtp::PayloadType::Part20Main, session_setup_req,
+                                 sizeof(session_setup_req));
+        conn->fire(iso15118::io::ConnectionEvent::NEW_DATA);
+        session.poll();
+
+        REQUIRE_FALSE(session.is_finished());
+
+        WHEN("close() is called with a response still pending") {
+            session.close();
+
+            THEN("the session is finished") {
+                REQUIRE(session.is_finished());
+            }
+        }
+    }
+}

--- a/modules/EVSE/IsoMux/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/IsoMux/charger/ISO15118_chargerImpl.cpp
@@ -562,6 +562,13 @@ void ISO15118_chargerImpl::handle_ac_contactor_closed(bool& status) {
 }
 
 void ISO15118_chargerImpl::handle_dlink_ready(bool& value) {
+    if (not value) {
+        // Data-link loss is a broadcast teardown: forward to both children so the
+        // active session's owner tears down regardless of the current selection.
+        mod->r_iso20->call_dlink_ready(value);
+        mod->r_iso2->call_dlink_ready(value);
+        return;
+    }
     if (mod->selected_iso20()) {
         mod->r_iso20->call_dlink_ready(value);
     } else {


### PR DESCRIPTION
**Manual backport.** This is a hand-assembled equivalent of #2393, not a cherry-pick
of it. Review it as new code on this branch.

Without it, a 2026.02 SECC whose EV vanishes without a clean shutdown keeps the
session alive: the poll loop spins on the dead socket and SDP refuses the next
session until the 60 s sequence timeout. In the TLS handshake-drop case the listener
is never released and the connector stops accepting ISO-20 sessions until restart.
ISO 15118-2 is unaffected.

#2393 was stacked on #2225 and also assumes #1983 and #2300, none of which are on
this branch. Cherry-picking it conflicts in 6 files and 12 hunks, and two of them
address a `tls::Server` API that does not exist here. The decisive problem is a hunk
that does **not** conflict: `ConnectionPlain::read` merges cleanly because #2393 only
rewrites the errno branch there, while the EOF branch it depends on came from #2225.
Clean disconnect and FIN would stay broken while the commit claimed they were fixed.

Nine product hunks, four from #2225 and five from #2393, each attributed by file and
line in the commit message. The four test files are verbatim from `027c4966a`.

**Deliberately not carried:** the `set_dlink_ready` trigger path, whose entry point
belongs to #1983 and does not exist here. Detection is therefore transport-driven -
a silent vanish is caught by keepalive after ~19 s rather than immediately, while
RST, FIN and clean close are torn down within one poll tick. Picking #1983 separately
would close that gap; it applies clean.

Verified on this branch: builds clean under `-Werror`, 41/41 of the libiso15118
suite, and each of the three fix components goes red when removed. The IsoMux hunk
was compiled in a full everest-core tree.
