### PR TITLE
Suppress Initialization Errors Until Startup is Complete

### DIFF
--- a/docs/source/reference/EVerest_API/evse_manager_consumer_API.yaml
+++ b/docs/source/reference/EVerest_API/evse_manager_consumer_API.yaml
@@ -254,6 +254,11 @@ channels:
     messages:
       receive_reply_get_supported_energy_transfer_modes:
         $ref: '#/components/messages/receive_reply_get_supported_energy_transfer_modes'
+  receive_all_errors_cleared:
+    address: 'e2m/all_errors_cleared'
+    messages:
+      receive_all_errors_cleared:
+        $ref: '#/components/messages/receive_all_errors_cleared'
 
   ########## evse_board_support
   receive_ac_nr_of_phases_available:
@@ -791,6 +796,11 @@ operations:
     action: receive
     channel:
       $ref: '#/channels/receive_reply_get_supported_energy_transfer_modes'
+  receive_all_errors_cleared:
+    title: 'Receive all errors cleared event'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_all_errors_cleared'
 
   ########## evse_board_support
   receive_ac_nr_of_phases_available:
@@ -1658,6 +1668,15 @@ components:
         oneOf:
           - $ref: '#/components/schemas/SupportedEnergyTransferModeList'
           - type: 'null'
+    receive_all_errors_cleared:
+      name: receive_all_errors_cleared
+      title: 'Receive all errors cleared event'
+      summary: >-
+        Emits true whenever the active error count of this EVSE and all hardware modules
+        it depends on reaches zero. May be published repeatedly.
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/AllErrorsCleared'
 
     ########## evse_board_support
     receive_ac_nr_of_phases_available:
@@ -2034,6 +2053,12 @@ components:
 
 
   schemas:
+    AllErrorsCleared:
+      description: >-
+        Signals that no errors (including ones that do not prevent charging) are currently
+        active on this EVSE or any of the hardware modules it depends on. Published every
+        time the active error count reaches zero, which can happen repeatedly.
+      type: boolean
     AuthorizationEvent:
       description: Context for authorization event (Authorized or Deauthorized)
       type: object

--- a/interfaces/evse_manager.yaml
+++ b/interfaces/evse_manager.yaml
@@ -211,6 +211,12 @@ vars:
   ready:
     description: Signals that the EVSE Manager is ready to start charging
     type: boolean
+  all_errors_cleared:
+    description: >-
+      Signals that no errors (including ones that do not prevent charging) are currently active on this EVSE
+      or any of the hardware modules it depends on (BSP, powermeter, etc.). Published every time the active
+      error count reaches zero, which can happen repeatedly over the module's lifetime.
+    type: boolean
   selected_protocol:
     description: >-
       Contains the selected protocol used for charging for informative purposes

--- a/modules/API/EVerestAPI/evse_manager_consumer_API/evse_manager_consumer_API.cpp
+++ b/modules/API/EVerestAPI/evse_manager_consumer_API/evse_manager_consumer_API.cpp
@@ -77,6 +77,7 @@ void evse_manager_consumer_API::init() {
     generate_api_var_selected_protocol();
     generate_api_var_powermeter_public_key_ocmf();
     generate_api_var_supported_energy_transfer_modes();
+    generate_api_var_all_errors_cleared();
 
     generate_api_var_ac_nr_of_phases_available();
     generate_api_var_ac_pp_ampacity();
@@ -282,6 +283,10 @@ void evse_manager_consumer_API::generate_api_var_supported_energy_transfer_modes
 
 void evse_manager_consumer_API::generate_api_var_powermeter_public_key_ocmf() {
     r_evse_manager->subscribe_powermeter_public_key_ocmf(forward_and_cache_api_var("powermeter_public_key_ocmf"));
+}
+
+void evse_manager_consumer_API::generate_api_var_all_errors_cleared() {
+    r_evse_manager->subscribe_all_errors_cleared(forward_api_var("all_errors_cleared"));
 }
 
 void evse_manager_consumer_API::generate_api_var_ac_nr_of_phases_available() {

--- a/modules/API/EVerestAPI/evse_manager_consumer_API/evse_manager_consumer_API.hpp
+++ b/modules/API/EVerestAPI/evse_manager_consumer_API/evse_manager_consumer_API.hpp
@@ -118,6 +118,7 @@ private:
     void generate_api_var_selected_protocol();
     void generate_api_var_powermeter_public_key_ocmf();
     void generate_api_var_supported_energy_transfer_modes();
+    void generate_api_var_all_errors_cleared();
 
     void generate_api_var_ac_nr_of_phases_available();
     void generate_api_var_ac_pp_ampacity();

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -316,7 +316,10 @@ void EvseManager::ready() {
 
     // expose the aggregated error state so other modules (e.g. OCPP) can delay startup reporting
     error_handling->signal_all_errors_cleared.connect(
-        [this]() { this->p_evse->publish_all_errors_cleared(true); });
+        [this]() {
+            EVLOG_warning << "All errors cleared, charging can continue"; 
+            this->p_evse->publish_all_errors_cleared(true);
+        });
 
     internal_over_voltage_monitor = std::make_unique<OverVoltageMonitor>(
         [this](OverVoltageMonitor::FaultType type, const std::string& description) {

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -314,6 +314,10 @@ void EvseManager::ready() {
                           config.fail_on_powermeter_errors ? r_powermeter_billing() : EMPTY_POWERMETER_VECTOR, r_slac,
                           r_over_voltage_monitor, config.inoperative_error_use_vendor_id));
 
+    // expose the aggregated error state so other modules (e.g. OCPP) can delay startup reporting
+    error_handling->signal_all_errors_cleared.connect(
+        [this]() { this->p_evse->publish_all_errors_cleared(true); });
+
     internal_over_voltage_monitor = std::make_unique<OverVoltageMonitor>(
         [this](OverVoltageMonitor::FaultType type, const std::string& description) {
             if (this->error_handling) {

--- a/modules/EVSE/OCPP/OCPP.cpp
+++ b/modules/EVSE/OCPP/OCPP.cpp
@@ -4,6 +4,7 @@
 
 #include "charge_point_config_factory.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <memory>
 #include <optional>
@@ -411,6 +412,12 @@ void OCPP::init_evse_maps() {
         }
     }
     {
+        auto errors_cleared_handle = this->evse_errors_cleared_map.handle();
+        for (size_t evse_id = 1; evse_id <= this->r_evse_manager.size(); evse_id++) {
+            (*errors_cleared_handle)[evse_id] = false;
+        }
+    }
+    {
         auto soc_handle = this->evse_soc_map.handle();
         for (size_t evse_id = 1; evse_id <= this->r_evse_manager.size(); evse_id++) {
             (*soc_handle)[evse_id] = std::nullopt;
@@ -544,6 +551,13 @@ void OCPP::init() {
                     ready_handle->at(evse_id) = true;
                 }
                 this->evse_ready_map.notify_one();
+            }
+        });
+
+        this->r_evse_manager.at(evse_id - 1)->subscribe_all_errors_cleared([this, evse_id](bool cleared) {
+            if (cleared) {
+                this->evse_errors_cleared_map.handle()->at(evse_id) = true;
+                this->evse_errors_cleared_map.notify_one();
             }
         });
     }
@@ -1098,6 +1112,38 @@ void OCPP::ready() {
     // wait for potential events from the evses in order to start OCPP with the
     // correct initial state (e.g. EV might be plugged in at startup)
     std::this_thread::sleep_for(std::chrono::milliseconds(this->config.DelayOcppStart));
+
+    // optional grace period: delay connecting to the CSMS so transient startup errors (e.g. hardware
+    // self-tests) can clear before OCPP starts reporting them
+    if (this->config.ErrorGracePeriodS > 0) {
+        // always wait out the minimum: right after startup, "no errors yet" can simply mean slow-initializing
+        // hardware (BSP, powermeter, ...) hasn't run its self-test yet, not that everything is fine
+        const auto min_period_s = std::max(0, std::min(this->config.ErrorGraceMinPeriodS, this->config.ErrorGracePeriodS));
+        if (min_period_s > 0) {
+            std::this_thread::sleep_for(std::chrono::seconds(min_period_s));
+        }
+
+        const auto remaining = std::chrono::seconds(this->config.ErrorGracePeriodS - min_period_s);
+        if (remaining.count() > 0) {
+            auto errors_cleared_handle = this->evse_errors_cleared_map.handle();
+            const auto all_cleared = errors_cleared_handle.wait_for(
+                [&errors_cleared_handle]() {
+                    for (const auto& [evse, cleared] : *errors_cleared_handle) {
+                        if (!cleared) {
+                            return false;
+                        }
+                    }
+                    return true;
+                },
+                remaining);
+            if (all_cleared) {
+                EVLOG_info << "All EVSE errors cleared, connecting to CSMS.";
+            } else {
+                EVLOG_info << "Error grace period elapsed, connecting to CSMS with current error state.";
+            }
+        }
+    }
+
     const auto boot_reason = conversions::to_ocpp_boot_reason_enum(this->r_system->call_get_boot_reason());
 
     // we can now start the OCPP connection and process any queued events. We lock

--- a/modules/EVSE/OCPP/OCPP.cpp
+++ b/modules/EVSE/OCPP/OCPP.cpp
@@ -1137,9 +1137,9 @@ void OCPP::ready() {
                 },
                 remaining);
             if (all_cleared) {
-                EVLOG_info << "All EVSE errors cleared, connecting to CSMS.";
+                EVLOG_warning << "All EVSE errors cleared, connecting to CSMS.";
             } else {
-                EVLOG_info << "Error grace period elapsed, connecting to CSMS with current error state.";
+                EVLOG_warning << "Error grace period elapsed, connecting to CSMS with current error state.";
             }
         }
     }

--- a/modules/EVSE/OCPP/OCPP.hpp
+++ b/modules/EVSE/OCPP/OCPP.hpp
@@ -94,6 +94,8 @@ struct Conf {
     int MessageQueueResumeDelay;
     std::string RequestCompositeScheduleUnit;
     int DelayOcppStart;
+    int ErrorGracePeriodS;
+    int ErrorGraceMinPeriodS;
     int ResetStopDelay;
     int Ocpp16NetworkConfigSlot;
 };
@@ -194,6 +196,7 @@ private:
     std::map<int32_t, int32_t> connector_evse_index_map; // provides access to r_evse_manager index by
                                                          // using OCPP connector id
     everest::lib::util::monitor<std::map<int32_t, bool>> evse_ready_map;
+    everest::lib::util::monitor<std::map<int32_t, bool>> evse_errors_cleared_map;
     everest::lib::util::monitor<std::map<int32_t, std::optional<float>>> evse_soc_map;
     std::set<std::string> resuming_session_ids;
 

--- a/modules/EVSE/OCPP/manifest.yaml
+++ b/modules/EVSE/OCPP/manifest.yaml
@@ -104,6 +104,22 @@ config:
       This is only used to prevent issues from passing by availlable before preparing on a restart.
     type: integer
     default: 0
+  ErrorGracePeriodS:
+    description: >-
+      Maximum time (seconds) to delay connecting to the CSMS after startup, to allow transient startup errors
+      (e.g. hardware self-tests) to clear before they are reported. The wait ends early once EvseManager reports
+      that all its errors have cleared (see ErrorGraceMinPeriodS), or once this period elapses, whichever is
+      first. Set to 0 to disable (connect immediately, previous behavior).
+    type: integer
+    default: 0
+  ErrorGraceMinPeriodS:
+    description: >-
+      Minimum time (seconds) within ErrorGracePeriodS to always wait, ignoring EvseManager's all_errors_cleared
+      signal. Needed because slow-initializing hardware (BSP, powermeter, etc.) may not have raised its first
+      error yet immediately after startup, which would otherwise cause a premature "all clear". Only relevant
+      if ErrorGracePeriodS is greater than 0.
+    type: integer
+    default: 0
   ResetStopDelay:
     description: >-
       Time (seconds) to delay the stopping of the charge point so that the CSMS has enough time to respond


### PR DESCRIPTION
## Describe your changes
During EVerest's initialization phase, transient errors occur because drivers and components are still loading—these errors disappear once initialization finishes. Currently, all these errors are reported to the OCPP backend immediately, cluttering the logs. This theme implements a startup timeout mechanism that suppresses error reporting until initialization is complete, then only reports errors that persist.

## Issue ticket number and link
#2699 

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

