### PR TITLE
Restart Charging Without Disconnecting

### DIFF
--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -2207,8 +2207,9 @@ void ChargePointImpl::handleRemoteStartTransactionRequest(ocpp::Call<RemoteStart
             continue;
         }
 
-        if (this->transaction_handler->get_transaction(connector) != nullptr ||
-            this->status->get_state(connector) == ChargePointStatus::Finishing) {
+        // Finishing is not rejected: a remote start may begin a new transaction while the cable
+        // is still plugged in after the previous transaction (F2: Finishing -> Preparing)
+        if (this->transaction_handler->get_transaction(connector) != nullptr) {
             obtainable = false;
             continue;
         }
@@ -4424,7 +4425,9 @@ void ChargePointImpl::on_transaction_started(const std::int32_t& connector, cons
                                              std::optional<std::int32_t> reservation_id,
                                              const ocpp::DateTime& timestamp,
                                              std::optional<std::string> signed_meter_value) {
-    if (this->status->get_state(connector) == ChargePointStatus::Reserved) {
+    // Finishing: F2 transition, the user starts a new transaction while the cable is still plugged in
+    if (this->status->get_state(connector) == ChargePointStatus::Reserved ||
+        this->status->get_state(connector) == ChargePointStatus::Finishing) {
         this->status->submit_event(connector, FSMEvent::UsageInitiated, ocpp::DateTime());
     }
 

--- a/modules/EVSE/Auth/lib/Connector.cpp
+++ b/modules/EVSE/Auth/lib/Connector.cpp
@@ -52,7 +52,9 @@ bool EVSEContext::is_available() {
     bool occupied = false;
     bool available = false;
     for (const auto& connector : this->connectors) {
-        if (connector.get_state() == ConnectorState::OCCUPIED ||
+        // OCCUPIED without an active transaction means the previous transaction has finished but the cable
+        // is still plugged in (OCPP 1.6 Finishing); a new authorization may start a new transaction (F2)
+        if ((connector.get_state() == ConnectorState::OCCUPIED && this->transaction_active) ||
             connector.get_state() == ConnectorState::FAULTED_OCCUPIED) {
             occupied = true;
         }

--- a/modules/EVSE/Auth/tests/auth_tests.cpp
+++ b/modules/EVSE/Auth/tests/auth_tests.cpp
@@ -959,6 +959,60 @@ TEST_F(AuthTest, test_transaction_finish) {
     ASSERT_FALSE(this->auth_receiver->get_authorization(1));
 }
 
+/// \brief Test that a new authorization is possible after TransactionFinished while the cable is still
+/// plugged in (no SessionFinished yet, OCPP 1.6 Finishing state), supporting the F2 restart
+TEST_F(AuthTest, test_new_authorization_after_transaction_finished_while_plugged_in) {
+
+    TokenHandlingResult result;
+
+    std::vector<int32_t> connectors{1};
+    ProvidedIdToken provided_token_1 = get_provided_token(VALID_TOKEN_2, connectors);
+    ProvidedIdToken provided_token_2 = get_provided_token(VALID_TOKEN_1, connectors);
+
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token), TokenValidationStatus::Processing));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token), TokenValidationStatus::Accepted));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token), TokenValidationStatus::UsedToStart));
+
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_2.id_token), TokenValidationStatus::Processing))
+        .Times(2);
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_2.id_token), TokenValidationStatus::Rejected));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_2.id_token), TokenValidationStatus::Accepted));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_2.id_token), TokenValidationStatus::UsedToStart));
+
+    // start a transaction with the first token
+    SessionEvent session_started_event =
+        get_session_started_event(types::evse_manager::StartSessionReason::EVConnected);
+    this->auth_handler->handle_session_event(1, session_started_event);
+
+    result = this->auth_handler->on_token(provided_token_1);
+    ASSERT_TRUE(result == TokenHandlingResult::USED_TO_START_TRANSACTION);
+
+    SessionEvent transaction_started_event = get_transaction_started_event(provided_token_1);
+    this->auth_handler->handle_session_event(1, transaction_started_event);
+
+    // while the transaction is active, a new token must not be authorized
+    result = this->auth_handler->on_token(provided_token_2);
+    ASSERT_TRUE(result == TokenHandlingResult::NO_CONNECTOR_AVAILABLE);
+
+    // transaction ends, but cable stays plugged in: no SessionFinished
+    SessionEvent transaction_finished_event;
+    transaction_finished_event.event = SessionEventEnum::TransactionFinished;
+    transaction_finished_event.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
+    this->auth_handler->handle_session_event(1, transaction_finished_event);
+
+    // a new authorization can now start a new transaction (F2: Finishing -> Preparing)
+    result = this->auth_handler->on_token(provided_token_2);
+    ASSERT_TRUE(result == TokenHandlingResult::USED_TO_START_TRANSACTION);
+    ASSERT_TRUE(this->auth_receiver->get_authorization(0));
+}
+
 /// \brief Test if transaction can be finished with parent_id when prioritize_authorization_over_stopping_transaction is
 /// false
 TEST_F(AuthTest, test_parent_id_finish) {

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -1096,8 +1096,8 @@ void Charger::run_state_machine() {
             }
             break;
 
-        // Final state that may only wait for unplug, but does not allow session restart.
-        // Cleans the session up.
+        // Final state that waits for unplug and cleans the session up. A new authorization
+        // may restart a new transaction while the cable is still plugged in (OCPP 1.6 F2).
         case EvseState::Finished:
 
             if (initialize_state) {
@@ -1120,6 +1120,16 @@ void Charger::run_state_machine() {
             if (not shared_context.flag_ev_plugged_in or shared_context.flag_disable_requested) {
                 stop_session();
                 set_state(shared_context.flag_disable_requested ? EvseState::Disabled : EvseState::Idle);
+                break;
+            }
+
+            // A new authorization was received (RFID swipe or RemoteStartTransaction):
+            // restart a new transaction within the still active session. Do not restart
+            // while a fatal error is active, WaitingForAuthentication would bail out
+            // right back to Finished (ping-pong).
+            if (shared_context.flag_authorized and shared_context.shutdown_type == ShutdownType::None) {
+                restart_from_finished();
+                set_state(EvseState::WaitingForAuthentication);
             }
             break;
         }
@@ -1550,6 +1560,30 @@ void Charger::stop_transaction() {
                                       shared_context.stop_transaction_id_token);
 }
 
+void Charger::restart_from_finished() {
+    session_log.evse(false, "Restarting a new transaction while still plugged in (Finishing -> Preparing)");
+
+    // The session stays active, but the new transaction needs its own id since the previous
+    // transaction of this session was billed with the current one (transaction id == session uuid)
+    shared_context.session_uuid = utils::generate_session_id(config_context.session_id_type);
+
+    // Re-initialize everything that is normally reset in Idle on a replug cycle,
+    // since Idle is skipped when going back to WaitingForAuthentication directly
+    bcb_toggle_reset();
+    shared_context.iec_allow_close_contactor = false;
+    shared_context.hlc_charging_active = config_context.charge_mode == ChargeMode::DC;
+    shared_context.hlc_allow_close_contactor = false;
+    shared_context.hlc_charging_terminate_pause = HlcTerminatePause::Unknown;
+    shared_context.legacy_wakeup_done = false;
+    shared_context.hlc_d20_active = false;
+    shared_context.matching_started = false;
+    internal_context.dc_statistics_printed = false;
+
+    // The previous ISO session was terminated, so SLAC needs a fresh matching cycle
+    signal_slac_reset();
+    signal_slac_start();
+}
+
 void Charger::cleanup_transactions_on_startup() {
     // See if we have an open transaction in persistent storage
     auto session_uuid = store->get_session();
@@ -1757,7 +1791,14 @@ void Charger::authorize(bool a, const types::authorization::ProvidedIdToken& tok
                         const types::authorization::ValidationResult& result) {
     Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_authorize);
     if (a) {
-        if (shared_context.flag_externally_cancelled || shared_context.flag_disable_requested) {
+        // In Finished with the cable still plugged in, a new authorization starts a new transaction
+        // (OCPP 1.6 F2: Finishing -> Preparing), even if the previous one was externally cancelled
+        const bool restart_from_finished_allowed =
+            shared_context.current_state == EvseState::Finished and shared_context.flag_ev_plugged_in and
+            not shared_context.flag_transaction_active and not shared_context.flag_disable_requested;
+
+        if ((shared_context.flag_externally_cancelled and not restart_from_finished_allowed) ||
+            shared_context.flag_disable_requested) {
             EVLOG_warning
                 << "Received an authorization after the session was externally cancelled. Ignoring this authorization.";
             // Ignore (delayed) authorization responses after an external cancellation or while EVSE is disabled.
@@ -1765,6 +1806,7 @@ void Charger::authorize(bool a, const types::authorization::ProvidedIdToken& tok
             // from routing to EvseState::Finished
             return;
         }
+        shared_context.flag_externally_cancelled = false;
         shared_context.id_token = token;
         shared_context.validation_result = result;
         // First user interaction was auth? Then start session already here and not at plug in

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -286,6 +286,7 @@ private:
 
     bool start_transaction();
     void stop_transaction();
+    void restart_from_finished();
 
     void process_event(CPEvent event);
 

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -768,6 +768,95 @@ TEST_F(ChargerTest, DisableDuringIdle) {
 }
 
 // ----------------------------------------------------------------------------
+// tests for restarting a new transaction from Finished (OCPP 1.6 F2:
+// Finishing -> Preparing). A new authorization while the cable is still plugged
+// in restarts a new transaction within the still active session.
+
+// helper: bring the charger into Finished with the cable still plugged in after an
+// externally cancelled transaction (e.g. OCPP RemoteStopTransaction)
+template <typename SharedContextT> void enter_finished_plugged_in(SharedContextT& ctx) {
+    ctx.current_state = Charger::EvseState::Finished;
+    ctx.session_active = true;
+    ctx.flag_ev_plugged_in = true;
+    ctx.flag_transaction_active = false;
+    ctx.flag_authorized = false;
+    ctx.flag_externally_cancelled = true;
+    ctx.session_uuid = "OLD_SESSION_UUID";
+}
+
+static types::authorization::ProvidedIdToken make_rfid_token() {
+    types::authorization::ProvidedIdToken token;
+    token.id_token.value = "NEW_TOKEN";
+    token.id_token.type = types::authorization::IdTokenType::ISO14443;
+    token.authorization_type = types::authorization::AuthorizationType::RFID;
+    return token;
+}
+
+TEST_F(ChargerTest, RestartFromFinishedWithNewAuthorization) {
+    auto& ctx = charger->get_shared_context();
+    enter_finished_plugged_in(ctx);
+    const auto old_uuid = ctx.session_uuid;
+
+    types::authorization::ValidationResult validation_result;
+    validation_result.authorization_status = types::authorization::AuthorizationStatus::Accepted;
+
+    charger->authorize(true, make_rfid_token(), validation_result);
+
+    // The new authorization is accepted even though the previous transaction was externally cancelled
+    EXPECT_TRUE(ctx.flag_authorized);
+    EXPECT_FALSE(ctx.flag_externally_cancelled);
+
+    reset_last_event();
+    charger->run_state_machine();
+
+    // Restarted: back in WaitingForAuthentication with a fresh transaction id, session still active
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::WaitingForAuthentication);
+    EXPECT_TRUE(ctx.session_active);
+    EXPECT_NE(ctx.session_uuid, old_uuid);
+    EXPECT_FALSE(ctx.session_uuid.empty());
+    EXPECT_EQ(last_event, SessionEventEnum::AuthRequired);
+}
+
+// No restart from Finished without a new authorization: wait for unplug
+TEST_F(ChargerTest, NoRestartFromFinishedWithoutAuthorization) {
+    auto& ctx = charger->get_shared_context();
+    enter_finished_plugged_in(ctx);
+
+    charger->run_state_machine();
+
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::Finished);
+    EXPECT_TRUE(ctx.session_active);
+}
+
+// No restart from Finished while a fatal error is active
+TEST_F(ChargerTest, NoRestartFromFinishedWithFatalError) {
+    auto& ctx = charger->get_shared_context();
+    enter_finished_plugged_in(ctx);
+    ctx.shutdown_type = ShutdownType::ErrorShutdown;
+
+    types::authorization::ValidationResult validation_result;
+    validation_result.authorization_status = types::authorization::AuthorizationStatus::Accepted;
+    charger->authorize(true, make_rfid_token(), validation_result);
+
+    charger->run_state_machine();
+
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::Finished);
+}
+
+// Unplugging in Finished still ends the session even if an authorization sneaked in
+TEST_F(ChargerTest, UnplugInFinishedEndsSession) {
+    auto& ctx = charger->get_shared_context();
+    enter_finished_plugged_in(ctx);
+    ctx.flag_ev_plugged_in = false;
+
+    reset_last_event();
+    charger->run_state_machine();
+
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::Idle);
+    EXPECT_FALSE(ctx.session_active);
+}
+
+// ----------------------------------------------------------------------------
 // tests for dlink_error()
 // A D-LINK_ERROR normally restarts SLAC matching according to the ISO 15118-3
 // error recovery sequence ([V2G3-M07-05]). For an HLC session, CP is first
@@ -898,90 +987,6 @@ TEST_F(ChargerDlinkErrorTest, NoMatchingRestartWithNominalPwm) {
     charger->dlink_error();
 
     EXPECT_EQ(charger->current_state(), Charger::EvseState::Charging);
-// helper: bring the charger into Finished with the cable still plugged in after an
-// externally cancelled transaction (e.g. OCPP RemoteStopTransaction)
-template <typename SharedContextT> void enter_finished_plugged_in(SharedContextT& ctx) {
-    ctx.current_state = Charger::EvseState::Finished;
-    ctx.session_active = true;
-    ctx.flag_ev_plugged_in = true;
-    ctx.flag_transaction_active = false;
-    ctx.flag_authorized = false;
-    ctx.flag_externally_cancelled = true;
-    ctx.session_uuid = "OLD_SESSION_UUID";
-}
-
-static types::authorization::ProvidedIdToken make_rfid_token() {
-    types::authorization::ProvidedIdToken token;
-    token.id_token.value = "NEW_TOKEN";
-    token.id_token.type = types::authorization::IdTokenType::ISO14443;
-    token.authorization_type = types::authorization::AuthorizationType::RFID;
-    return token;
-}
-
-// F2 (OCPP 1.6): a new authorization while in Finished with the cable still plugged in
-// restarts a new transaction within the still active session
-TEST_F(ChargerTest, RestartFromFinishedWithNewAuthorization) {
-    auto& ctx = charger->get_shared_context();
-    enter_finished_plugged_in(ctx);
-    const auto old_uuid = ctx.session_uuid;
-
-    types::authorization::ValidationResult validation_result;
-    validation_result.authorization_status = types::authorization::AuthorizationStatus::Accepted;
-
-    charger->authorize(true, make_rfid_token(), validation_result);
-
-    // The new authorization is accepted even though the previous transaction was externally cancelled
-    EXPECT_TRUE(ctx.flag_authorized);
-    EXPECT_FALSE(ctx.flag_externally_cancelled);
-
-    reset_last_event();
-    charger->run_state_machine();
-
-    // Restarted: back in WaitingForAuthentication with a fresh transaction id, session still active
-    EXPECT_EQ(ctx.current_state, Charger::EvseState::WaitingForAuthentication);
-    EXPECT_TRUE(ctx.session_active);
-    EXPECT_NE(ctx.session_uuid, old_uuid);
-    EXPECT_FALSE(ctx.session_uuid.empty());
-    EXPECT_EQ(last_event, SessionEventEnum::AuthRequired);
-}
-
-// No restart from Finished without a new authorization: wait for unplug
-TEST_F(ChargerTest, NoRestartFromFinishedWithoutAuthorization) {
-    auto& ctx = charger->get_shared_context();
-    enter_finished_plugged_in(ctx);
-
-    charger->run_state_machine();
-
-    EXPECT_EQ(ctx.current_state, Charger::EvseState::Finished);
-    EXPECT_TRUE(ctx.session_active);
-}
-
-// No restart from Finished while a fatal error is active
-TEST_F(ChargerTest, NoRestartFromFinishedWithFatalError) {
-    auto& ctx = charger->get_shared_context();
-    enter_finished_plugged_in(ctx);
-    ctx.shutdown_type = ShutdownType::ErrorShutdown;
-
-    types::authorization::ValidationResult validation_result;
-    validation_result.authorization_status = types::authorization::AuthorizationStatus::Accepted;
-    charger->authorize(true, make_rfid_token(), validation_result);
-
-    charger->run_state_machine();
-
-    EXPECT_EQ(ctx.current_state, Charger::EvseState::Finished);
-}
-
-// Unplugging in Finished still ends the session even if an authorization sneaked in
-TEST_F(ChargerTest, UnplugInFinishedEndsSession) {
-    auto& ctx = charger->get_shared_context();
-    enter_finished_plugged_in(ctx);
-    ctx.flag_ev_plugged_in = false;
-
-    reset_last_event();
-    charger->run_state_machine();
-
-    EXPECT_EQ(ctx.current_state, Charger::EvseState::Idle);
-    EXPECT_FALSE(ctx.session_active);
 }
 
 } // namespace

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -898,6 +898,90 @@ TEST_F(ChargerDlinkErrorTest, NoMatchingRestartWithNominalPwm) {
     charger->dlink_error();
 
     EXPECT_EQ(charger->current_state(), Charger::EvseState::Charging);
+// helper: bring the charger into Finished with the cable still plugged in after an
+// externally cancelled transaction (e.g. OCPP RemoteStopTransaction)
+template <typename SharedContextT> void enter_finished_plugged_in(SharedContextT& ctx) {
+    ctx.current_state = Charger::EvseState::Finished;
+    ctx.session_active = true;
+    ctx.flag_ev_plugged_in = true;
+    ctx.flag_transaction_active = false;
+    ctx.flag_authorized = false;
+    ctx.flag_externally_cancelled = true;
+    ctx.session_uuid = "OLD_SESSION_UUID";
+}
+
+static types::authorization::ProvidedIdToken make_rfid_token() {
+    types::authorization::ProvidedIdToken token;
+    token.id_token.value = "NEW_TOKEN";
+    token.id_token.type = types::authorization::IdTokenType::ISO14443;
+    token.authorization_type = types::authorization::AuthorizationType::RFID;
+    return token;
+}
+
+// F2 (OCPP 1.6): a new authorization while in Finished with the cable still plugged in
+// restarts a new transaction within the still active session
+TEST_F(ChargerTest, RestartFromFinishedWithNewAuthorization) {
+    auto& ctx = charger->get_shared_context();
+    enter_finished_plugged_in(ctx);
+    const auto old_uuid = ctx.session_uuid;
+
+    types::authorization::ValidationResult validation_result;
+    validation_result.authorization_status = types::authorization::AuthorizationStatus::Accepted;
+
+    charger->authorize(true, make_rfid_token(), validation_result);
+
+    // The new authorization is accepted even though the previous transaction was externally cancelled
+    EXPECT_TRUE(ctx.flag_authorized);
+    EXPECT_FALSE(ctx.flag_externally_cancelled);
+
+    reset_last_event();
+    charger->run_state_machine();
+
+    // Restarted: back in WaitingForAuthentication with a fresh transaction id, session still active
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::WaitingForAuthentication);
+    EXPECT_TRUE(ctx.session_active);
+    EXPECT_NE(ctx.session_uuid, old_uuid);
+    EXPECT_FALSE(ctx.session_uuid.empty());
+    EXPECT_EQ(last_event, SessionEventEnum::AuthRequired);
+}
+
+// No restart from Finished without a new authorization: wait for unplug
+TEST_F(ChargerTest, NoRestartFromFinishedWithoutAuthorization) {
+    auto& ctx = charger->get_shared_context();
+    enter_finished_plugged_in(ctx);
+
+    charger->run_state_machine();
+
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::Finished);
+    EXPECT_TRUE(ctx.session_active);
+}
+
+// No restart from Finished while a fatal error is active
+TEST_F(ChargerTest, NoRestartFromFinishedWithFatalError) {
+    auto& ctx = charger->get_shared_context();
+    enter_finished_plugged_in(ctx);
+    ctx.shutdown_type = ShutdownType::ErrorShutdown;
+
+    types::authorization::ValidationResult validation_result;
+    validation_result.authorization_status = types::authorization::AuthorizationStatus::Accepted;
+    charger->authorize(true, make_rfid_token(), validation_result);
+
+    charger->run_state_machine();
+
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::Finished);
+}
+
+// Unplugging in Finished still ends the session even if an authorization sneaked in
+TEST_F(ChargerTest, UnplugInFinishedEndsSession) {
+    auto& ctx = charger->get_shared_context();
+    enter_finished_plugged_in(ctx);
+    ctx.flag_ev_plugged_in = false;
+
+    reset_last_event();
+    charger->run_state_machine();
+
+    EXPECT_EQ(ctx.current_state, Charger::EvseState::Idle);
+    EXPECT_FALSE(ctx.session_active);
 }
 
 } // namespace

--- a/modules/EVSE/OCPP201/OCPP201.cpp
+++ b/modules/EVSE/OCPP201/OCPP201.cpp
@@ -1568,9 +1568,37 @@ void OCPP201::process_transaction_started(const int32_t evse_id, const int32_t c
 
     auto transaction_data = this->transaction_handler->get_transaction_data(evse_id);
     if (transaction_data == nullptr) {
-        EVLOG_warning << "Could not update transaction data because no transaction data is present. This might happen "
-                         "in case a TxStopPoint is already active when a TransactionStarted event occurs (e.g. "
-                         "TxStopPoint is EnergyTransfer or ParkingBayOccupied)";
+        // No SessionStarted preceded this TransactionStarted: either a TxStopPoint already ended the previous
+        // transaction early, or a new transaction is started while the EV stayed plugged in after the previous
+        // transaction finished (restart from Finishing). Recreate the transaction data from this event so a
+        // new OCPP transaction can be started.
+        EVLOG_info << "Received TransactionStarted without transaction data present. Creating new transaction "
+                      "data to start a new transaction within the ongoing session on evse "
+                   << evse_id;
+        const auto transaction_started = session_event.transaction_started.value();
+        const auto timestamp = ocpp_conversions::to_ocpp_datetime_or_now(session_event.timestamp);
+        auto trigger_reason = ocpp::v2::TriggerReasonEnum::Authorized;
+        if (transaction_started.id_tag.authorization_type == types::authorization::AuthorizationType::OCPP) {
+            trigger_reason = ocpp::v2::TriggerReasonEnum::RemoteStart;
+        }
+        transaction_data = std::make_shared<TransactionData>(connector_id, session_event.uuid, timestamp,
+                                                             trigger_reason, ocpp::v2::ChargingStateEnum::EVConnected);
+        auto restart_id_token = conversions::to_ocpp_id_token(transaction_started.id_tag.id_token);
+        {
+            auto evse_evcc_id_handle = this->evse_evcc_id.handle();
+            if (!evse_evcc_id_handle->at(evse_id).empty()) {
+                update_evcc_id_token(restart_id_token, evse_evcc_id_handle->at(evse_id), ocpp_protocol_version);
+            }
+        }
+        transaction_data->id_token = restart_id_token;
+        if (transaction_started.id_tag.parent_id_token.has_value()) {
+            transaction_data->group_id_token =
+                conversions::to_ocpp_id_token(transaction_started.id_tag.parent_id_token.value());
+        }
+        transaction_data->remote_start_id = transaction_started.id_tag.request_id;
+        transaction_data->reservation_id = transaction_started.reservation_id;
+        this->transaction_handler->add_transaction_data(evse_id, transaction_data);
+
         this->charge_point->on_session_started(evse_id, connector_id);
         auto tx_event_effect = this->transaction_handler->submit_event(evse_id, TxEvent::AUTHORIZED);
         this->process_tx_event_effect(evse_id, tx_event_effect, session_event);

--- a/modules/EVSE/OCPPmulti/tests/v2_chargepoint_tests.cpp
+++ b/modules/EVSE/OCPPmulti/tests/v2_chargepoint_tests.cpp
@@ -109,6 +109,35 @@ TEST_F(ChargePointV2Test, transactionStartedReportsTokenData) {
     m_chargepoint.on_event_transaction_started(EVSE_ID, CONNECTOR_ID, session_event);
 }
 
+// Restart from Finishing: a TransactionStarted event without preceding transaction data (previous
+// transaction already finished, cable stayed plugged in) creates fresh transaction data and starts a new
+// transaction instead of only warning
+TEST_F(ChargePointV2Test, transactionStartedWithoutTransactionDataRestartsTransaction) {
+    ON_CALL(m_callbacks, transaction_data(EVSE_ID)).WillByDefault(Return(nullptr));
+
+    types::evse_manager::SessionEvent session_event;
+    session_event.uuid = SESSION_ID;
+    session_event.timestamp = TIMESTAMP;
+    session_event.event = types::evse_manager::SessionEventEnum::TransactionStarted;
+    session_event.connector_id = CONNECTOR_ID;
+    types::evse_manager::TransactionStarted transaction_started;
+    transaction_started.id_tag = provided_id_token("TOKEN123");
+    transaction_started.id_tag.authorization_type = types::authorization::AuthorizationType::OCPP;
+    transaction_started.meter_value = meter_value_wh(0.0F);
+    session_event.transaction_started = transaction_started;
+
+    EXPECT_CALL(m_callbacks, transaction_add(EVSE_ID, _));
+    EXPECT_CALL(*m_libocpp, on_session_started(EVSE_ID, CONNECTOR_ID));
+    EXPECT_CALL(m_callbacks, transaction_event(EVSE_ID, module::TxEvent::AUTHORIZED))
+        .WillOnce(Return(module::TxEventEffect::NONE));
+    EXPECT_CALL(m_callbacks, transaction_event(EVSE_ID, module::TxEvent::EV_CONNECTED))
+        .WillOnce(Return(module::TxEventEffect::NONE));
+
+    const auto result = m_chargepoint.on_event_transaction_started(EVSE_ID, CONNECTOR_ID, session_event);
+
+    EXPECT_TRUE(result);
+}
+
 // TransactionEvent(Ended) reports the stop reason accumulated by the event handlers
 TEST_F(ChargePointV2Test, transactionStopReportsAccumulatedStopReason) {
     make_transaction_data(ocpp::v2::TriggerReasonEnum::ChargingStateChanged, ocpp::v2::ChargingStateEnum::Charging);

--- a/modules/EVSE/OCPPmulti/v2_chargepoint.cpp
+++ b/modules/EVSE/OCPPmulti/v2_chargepoint.cpp
@@ -845,10 +845,31 @@ ChargePointV2::on_event_transaction_started(std::int32_t evse_id, std::int32_t c
     if (session_event.transaction_started.has_value()) {
         auto transaction_data = m_callbacks_ptr->transaction_data(evse_id);
         if (transaction_data == nullptr) {
-            EVLOG_warning
-                << "Could not update transaction data because no transaction data is present. This might happen "
-                   "in case a TxStopPoint is already active when a TransactionStarted event occurs (e.g. "
-                   "TxStopPoint is EnergyTransfer or ParkingBayOccupied)";
+            // No SessionStarted preceded this TransactionStarted: either a TxStopPoint already ended the
+            // previous transaction early, or a new transaction is started while the EV stayed plugged in after
+            // the previous transaction finished (restart from Finishing). Recreate the transaction data from
+            // this event so a new OCPP transaction can be started.
+            EVLOG_info << "Received TransactionStarted without transaction data present. Creating new "
+                          "transaction data to start a new transaction within the ongoing session on evse "
+                       << evse_id;
+            const auto transaction_started = session_event.transaction_started.value();
+            const auto timestamp = ocpp_conversions::to_ocpp_datetime_or_now(session_event.timestamp);
+            auto trigger_reason = ocpp::v2::TriggerReasonEnum::Authorized;
+            if (transaction_started.id_tag.authorization_type == types::authorization::AuthorizationType::OCPP) {
+                trigger_reason = ocpp::v2::TriggerReasonEnum::RemoteStart;
+            }
+            transaction_data = std::make_shared<module::TransactionData>(
+                connector_id, session_event.uuid, timestamp, trigger_reason, ocpp::v2::ChargingStateEnum::EVConnected);
+            auto restart_id_token = to_ocpp_id_token(transaction_started.id_tag.id_token);
+            m_callbacks_ptr->update_evcc_id_token(evse_id, restart_id_token);
+            transaction_data->id_token = restart_id_token;
+            if (transaction_started.id_tag.parent_id_token.has_value()) {
+                transaction_data->group_id_token = to_ocpp_id_token(transaction_started.id_tag.parent_id_token.value());
+            }
+            transaction_data->remote_start_id = transaction_started.id_tag.request_id;
+            transaction_data->reservation_id = transaction_started.reservation_id;
+            m_callbacks_ptr->transaction_add(evse_id, transaction_data);
+
             m_charge_point->on_session_started(evse_id, connector_id);
             auto tx_event_effect = m_callbacks_ptr->transaction_event(evse_id, module::TxEvent::AUTHORIZED);
             process_tx_event_effect(evse_id, tx_event_effect, session_event);


### PR DESCRIPTION
## Describe your changes
After a charging session ends, if a vehicle remains plugged in, users should be able to start a new session immediately by re-authenticating. This theme implements smooth session transitions in EVerest so vehicles can charge multiple times without unplugging the connector.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

