### PR TITLE
fix(EvseManager): dlink_pause/terminate must respect the armed CP oscillator retain timer

### DIFF
--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -2120,7 +2120,15 @@ void Charger::dlink_pause() {
         return;
     }
     shared_context.hlc_allow_close_contactor = false;
-    cp_state_X1();
+    if (not internal_context.session_stop_pwm_off_deadline.has_value()) {
+        // [V2G-DC-968]: while the CP oscillator retain timer is armed the PWM must stay on -- the
+        // -2/-20 TCP teardown can deliver this signal milliseconds after SessionStopRes, long
+        // before the EV has left state C. Applying X1 here anyway opened S S3 under the EV's
+        // still-closed S V3 on MCS (CE state EC, an EVSE-initiated emergency per Table CC.103)
+        // and latched the EV's CC.114 C-exit fault on every clean session end. The global retain
+        // check applies X1 when the timer expires.
+        cp_state_X1();
+    }
     shared_context.hlc_charging_terminate_pause = HlcTerminatePause::Pause;
 }
 
@@ -2132,7 +2140,10 @@ void Charger::dlink_terminate() {
         return;
     }
     shared_context.hlc_allow_close_contactor = false;
-    cp_state_X1();
+    if (not internal_context.session_stop_pwm_off_deadline.has_value()) {
+        // Same retain-timer guard as dlink_pause() above.
+        cp_state_X1();
+    }
     shared_context.hlc_charging_terminate_pause = HlcTerminatePause::Terminate;
 }
 


### PR DESCRIPTION
Against `feat/cpp_iso2_din_ev_evse` (#2485), because the CP oscillator retain timer this fix guards only exists there. One commit, 13 lines in `Charger.cpp`. Meant to be merged into the #2485 branch (or folded into it) so it lands together.

## Describe your changes

**`dlink_pause` / `dlink_terminate` must respect the armed CP oscillator retain timer.**

#2485 arms the [V2G-DC-968] retain window (`session_stop_pwm_off_deadline`, 1550 ms) at SessionStopRes so the EV can finish its shutdown under a live oscillator, and the Charger state machine applies X1 when it expires. But the -2/-20 TCP teardown delivers `dlink_terminate` (or `dlink_pause`) milliseconds after SessionStopRes, and both handlers call `cp_state_X1()` unconditionally, so the PWM is switched off while the retain window is still armed and the EV, conformant per IEC 61851-23-3 Table CC.111, still holds its readiness switch closed.

On MCS (ISO 15118-10, `McsDataLink`, #2696) that line state is CE state EC, an EVSE-initiated emergency per Table CC.103: the EV firmware latched its C-exit fault on every clean session end and every second session died in DC_CableCheck (EV never left B). On CCS the same early X1 is a softer violation of V2G-DC-968.

Fix: both handlers skip the immediate X1 while the retain deadline is armed; the state machine's existing retain check applies X1 at expiry, as designed. `dlink_error` (the CC.5.2.3.2 restart path) is untouched.

**Tests:** Charger unit tests 25/25. Bench on the MCS boards: clean session ends no longer latch the EV fault, wake-cycle soak passes. CCS EVAL hardware (DIN, ISO 15118-2, ISO 15118-20 incl. pause/resume, 2026-09-10): session ends clean; on -20 the PWM now visibly stays on from SessionStopRes until the retain window or the unplug, whichever comes first.

## Issue ticket number and link

—

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (n/a)
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)
