### PR TITLE
fix(manager): don't require default.yaml when

### DIFF
--- a/docs/source/explanation/configuration-service.rst
+++ b/docs/source/explanation/configuration-service.rst
@@ -98,6 +98,11 @@ options. There are three cases.
   ``user-config/<config-name>.yaml`` merge, and seeded into a process-private
   **in-memory** database on every start. Nothing is persisted to disk except
   runtime configuration writes, which go to the user-config YAML.
+  The default config file ``<prefix>/etc/everest/default.yaml`` is optional: if
+  neither ``--config`` is given nor that file exists, the manager starts with an
+  empty configuration on built-in defaults (and exits with no modules unless
+  ``--into-idle`` or ``--idle-on-failure`` is given). Runtime writes are then
+  kept in memory only.
 
 ``--db`` **only**
   The database file is the only configuration source; manager settings come from

--- a/lib/everest/framework/docs/ConfigService.md
+++ b/lib/everest/framework/docs/ConfigService.md
@@ -118,7 +118,10 @@ These orderings are load-bearing and cheap to break; each has test coverage.
    this layer.
 2. **Mirror before database.** Without `--db` the user-config YAML mirror is written *before* the
    in-memory database, and a failed mirror write rejects the update, because the mirror is the
-   only persistence that survives a restart (`config_service_core.cpp`).
+   only persistence that survives a restart (`config_service_core.cpp`). The mirror exists only
+   when a YAML config file was actually loaded; with no config file at all (no `--config` and no
+   `<prefix>/etc/everest/default.yaml`, or `--db` only) there is no mirror and runtime writes
+   without `--db` are lost on restart.
 3. **Persist before consulting the module.** A successful database write sets
    `WillApplyOnRestart`; only then is the runtime path entered, and only when mutability is
    `ReadWrite` and the modules are running. With no forwarder registered the value is

--- a/lib/everest/framework/include/framework/runtime.hpp
+++ b/lib/everest/framework/include/framework/runtime.hpp
@@ -63,7 +63,8 @@ namespace defaults {
 //   schemas_dir: ${DATAROOT_DIR}${EVEREST_NAMESPACE}/schemas
 //   configs_dir: ${SYSCONF_DIR}${EVEREST_NAMESPACE}
 //
-//   config_path: ${SYSCONF_DIR}${EVEREST_NAMESPACE}/default.yaml
+//   config_path: ${SYSCONF_DIR}${EVEREST_NAMESPACE}/default.yaml (optional: if absent and no --config is
+//                given, the manager runs with an empty config on built-in defaults)
 //   logging_config_path: ${SYSCONF_DIR}${EVEREST_NAMESPACE}/default_logging.cfg
 
 const std::string& prefix();

--- a/lib/everest/framework/include/utils/config/settings.hpp
+++ b/lib/everest/framework/include/utils/config/settings.hpp
@@ -82,14 +82,17 @@ struct ManagerSettings : public ConfigParseSettings {
     ManagerSettings(const std::string& prefix, const std::string& config, const std::string& db_path);
 
     /// \brief Constructor that initializes the ManagerSettings without any config file: config_file stays empty,
-    /// config is an empty object and all settings come from compiled-in defaults (no default.yaml fallback).
-    /// An empty \p db_path falls back to an in-memory database.
+    /// config is an empty object and all settings come from compiled-in defaults. Unlike the other constructors
+    /// this one never looks for default.yaml, even if it exists. An empty \p db_path falls back to an in-memory
+    /// database.
     ManagerSettings(WithoutConfig, const std::string& prefix, const std::string& db_path);
 
     /// \brief Initializes the ManagerSettings with the given settings and prefix.
     void init_settings(const everest::config::Settings& settings);
 
-    /// \brief Initializes the ManagerSettings based on the user provided \p config file or fallback options
+    /// \brief Initializes the ManagerSettings based on the user provided \p config file or fallback options.
+    /// A user provided \p config (full path or short name) must exist. With an empty \p config the default
+    /// config file is looked up; if it is absent this is not an error and init_no_config() is used instead.
     void init_config_file(const std::string& config);
 
     /// \brief Initializes the ManagerSettings for the no-config case: config_file = "", config = empty object.
@@ -104,7 +107,8 @@ struct ManagerSettings : public ConfigParseSettings {
 enum class BootMode {
     /// No --db given (--config or the default config lookup): the YAML config is authoritative and
     /// seeds a process-private in-memory database on every start; runtime configuration writes are
-    /// persisted to the user-config YAML.
+    /// persisted to the user-config YAML. If no --config is given and the default config file does
+    /// not exist, the manager runs with an empty config on built-in defaults and nothing is persisted.
     YamlWithInMemoryDb,
     /// --db only: the database file is the only configuration source.
     DatabaseOnly,
@@ -116,7 +120,7 @@ enum class BootMode {
 /// \brief Resolved configuration boot source, see resolve_boot_source().
 struct BootSource {
     BootMode mode = BootMode::YamlWithInMemoryDb;
-    /// Config file option as given; empty in DatabaseOnly mode, or to request the default config lookup.
+    /// Config file option as given; empty in DatabaseOnly mode, or to request the (optional) default config lookup.
     std::string config_path;
     /// Database path as given; empty means "use an in-memory database" (only in YamlWithInMemoryDb mode).
     std::string db_path;

--- a/lib/everest/framework/lib/runtime.cpp
+++ b/lib/everest/framework/lib/runtime.cpp
@@ -81,7 +81,8 @@ BootSource resolve_boot_source(const std::string& config_path, const std::string
     src.db_path = db_path;
     src.reset_from_yaml = reset_from_yaml;
     if (db_path.empty()) {
-        // Also covers "neither --config nor --db": init_config_file("") resolves the default config file.
+        // Also covers "neither --config nor --db": init_config_file("") resolves the default config file if
+        // it exists, otherwise the manager boots without a config on built-in defaults.
         src.mode = BootMode::YamlWithInMemoryDb;
     } else if (config_path.empty()) {
         src.mode = BootMode::DatabaseOnly;
@@ -488,9 +489,9 @@ void ManagerSettings::init_config_file(const std::string& config_) {
 
     if (config_.length() != 0) {
         try {
-            config_file = assert_file(config_, "User profided config");
+            config_file = assert_file(config_, "User provided config");
         } catch (const BootException& e) {
-            if (has_extension(config_file, ".yaml")) {
+            if (has_extension(config_, ".yaml")) {
                 throw;
             }
 
@@ -519,10 +520,18 @@ void ManagerSettings::init_config_file(const std::string& config_) {
 
             config_file = assert_file(user_config_file, short_form_alias);
         } else {
-            // default
-            config_file =
-                assert_file(config_file_prefix / defaults::SYSCONF_DIR / defaults::NAMESPACE / defaults::CONFIG_NAME,
-                            "Default config");
+            // default lookup: the default config file is optional. Only its absence is tolerated; a
+            // present but unusable file (directory, dangling symlink) still fails via assert_file below.
+            const auto default_config =
+                config_file_prefix / defaults::SYSCONF_DIR / defaults::NAMESPACE / defaults::CONFIG_NAME;
+            if (!fs::exists(default_config)) {
+                EVLOG_warning << "No --config given and the default config file '" << default_config.string()
+                              << "' does not exist; starting without a configuration on built-in defaults. The "
+                                 "manager will exit with no modules unless --into-idle or --idle-on-failure is given.";
+                init_no_config();
+                return;
+            }
+            config_file = assert_file(default_config, "Default config");
         }
     }
 

--- a/lib/everest/framework/src/manager.cpp
+++ b/lib/everest/framework/src/manager.cpp
@@ -913,8 +913,9 @@ int Manager::run() {
     const bool have_config = not config_path.empty();
     const auto boot_source = resolve_boot_source(config_path, db_opt, reset_from_yaml, m_vm.count("db-init") != 0);
 
-    // DatabaseOnly runs on built-in defaults (no default.yaml fallback); the other modes resolve
-    // the config file, falling back to the default config lookup when no --config was given.
+    // DatabaseOnly runs on built-in defaults and never looks for default.yaml; the other modes resolve
+    // the config file. Without --config the default config is looked up and, if it is absent, the
+    // manager also runs on built-in defaults with an empty config (ms.config_file is then empty).
     ManagerSettings ms = boot_source.mode == BootMode::DatabaseOnly
                              ? ManagerSettings(ManagerSettings::WithoutConfig{}, prefix_opt, boot_source.db_path)
                              : ManagerSettings(prefix_opt, boot_source.config_path, boot_source.db_path);
@@ -1036,8 +1037,15 @@ int Manager::run() {
     // merges back into the config on the next start (the pre-database write behavior).
     std::unique_ptr<everest::config::StorageInterface> persistence_mirror;
     if (boot_source.mode == BootMode::YamlWithInMemoryDb) {
-        const auto user_config_path = ms.config_file.parent_path() / "user-config" / ms.config_file.filename();
-        persistence_mirror = std::make_unique<everest::config::UserConfigStorage>(user_config_path);
+        if (not ms.config_file.empty()) {
+            const auto user_config_path = ms.config_file.parent_path() / "user-config" / ms.config_file.filename();
+            persistence_mirror = std::make_unique<everest::config::UserConfigStorage>(user_config_path);
+        } else {
+            // No --config and no default.yaml: there is no YAML to mirror into, and the loader would not read
+            // a user-config back without a main config file anyway.
+            EVLOG_warning << "No config file loaded and no --db given: runtime configuration changes are kept in "
+                             "memory only and are lost on restart. Use --db <path> for persistence.";
+        }
     }
     m_config_service_core =
         std::make_unique<config::ConfigServiceCore>(ms, m_db_connection, std::move(persistence_mirror));
@@ -2103,8 +2111,10 @@ int main(int argc, char* argv[]) {
     desc.add_options()("dontvalidateschema", "Don't validate json schema on every message");
     desc.add_options()("config", po::value<std::string>(),
                        "Full path to a config file.  If the file does not exist and has no extension, it will be "
-                       "looked up in the default config directory. Optional: defaults to the default config file in "
-                       "the default config directory. Without --db, the config is loaded from YAML on every start "
+                       "looked up in the default config directory. Optional: defaults to "
+                       "<prefix>/etc/everest/default.yaml if it exists; otherwise the manager starts with an empty "
+                       "configuration on built-in defaults (and exits with no modules unless --into-idle or "
+                       "--idle-on-failure is given). Without --db, the config is loaded from YAML on every start "
                        "and runtime configuration changes are persisted to user-config/<config-name>.yaml.");
     desc.add_options()("conf", po::value<std::string>(), "Deprecated: Same as --config. Do not use both.");
     desc.add_options()("configuration-api", po::value<std::string>()->implicit_value("ro"),

--- a/lib/everest/framework/tests/CMakeLists.txt
+++ b/lib/everest/framework/tests/CMakeLists.txt
@@ -75,6 +75,11 @@ setup_test_directory(empty_yaml_object USE_FILESYSTEM_HIERARCHY_STANDARD)
 setup_test_directory(empty_yaml USE_FILESYSTEM_HIERARCHY_STANDARD)
 setup_test_directory(null_yaml USE_FILESYSTEM_HIERARCHY_STANDARD)
 setup_test_directory(string_yaml USE_FILESYSTEM_HIERARCHY_STANDARD)
+# FHS prefix that actually contains etc/everest/default.yaml (all other FHS fixtures do not)
+setup_test_directory(default_yaml USE_FILESYSTEM_HIERARCHY_STANDARD
+    CONFIG empty_yaml_object_config.yaml
+    DEFAULT_CONFIG empty_yaml_object_config.yaml
+)
 
 setup_test_directory(missing_module)
 setup_test_directory(broken_manifest_1 TESTBrokenManifest1 test_interface)

--- a/lib/everest/framework/tests/test_config.cpp
+++ b/lib/everest/framework/tests/test_config.cpp
@@ -19,9 +19,11 @@ SCENARIO("Check ManagerSettings Constructor", "[!throws]") {
         }
     }
     GIVEN("A valid prefix, but a non existing config file") {
-        THEN("It should throw BootException") {
+        THEN("It should throw BootException about the user provided path (not the short-form lookup)") {
             CHECK_THROWS_AS(Everest::ManagerSettings(bin_dir + "valid_config/", bin_dir + "non-existing-config.yaml"),
                             Everest::BootException);
+            CHECK_THROWS_WITH(Everest::ManagerSettings(bin_dir + "valid_config/", bin_dir + "non-existing-config.yaml"),
+                              Catch::Matchers::ContainsSubstring("User provided config"));
         }
     }
     GIVEN("A valid prefix and a valid config file") {
@@ -80,12 +82,49 @@ SCENARIO("Check ManagerSettings without a config file", "[!throws]") {
     auto prefix = bin_dir + "empty_yaml/";
 
     GIVEN("A valid prefix without any config file and without a default.yaml") {
-        THEN("Construction should not throw (proves there is no default.yaml fallback) and use built-in defaults") {
+        THEN("The WithoutConfig constructor never looks for default.yaml and uses built-in defaults") {
             auto ms = Everest::ManagerSettings(Everest::ManagerSettings::WithoutConfig{}, prefix, "");
             CHECK(ms.config_file.empty());
             CHECK(ms.config.is_object());
             CHECK(ms.config.empty());
             CHECK(ms.db_dir == fs::path(Everest::defaults::IN_MEMORY_DB_URI));
+        }
+        THEN("The default config lookup (no --config) tolerates the missing default.yaml") {
+            CHECK_NOTHROW(Everest::ManagerSettings(prefix, ""));
+            auto ms = Everest::ManagerSettings(prefix, "");
+            CHECK(ms.config_file.empty());
+            CHECK(ms.config.is_object());
+            CHECK(ms.config.empty());
+        }
+        THEN("The three-argument constructor without --config and --db falls back to an in-memory database") {
+            auto ms = Everest::ManagerSettings(prefix, "", "");
+            CHECK(ms.config_file.empty());
+            CHECK(ms.db_dir == fs::path(Everest::defaults::IN_MEMORY_DB_URI));
+        }
+        THEN("An explicitly given short-form config name that does not exist still throws") {
+            CHECK_THROWS_AS(Everest::ManagerSettings(prefix, "does-not-exist"), Everest::BootException);
+        }
+        THEN("An explicitly given config path that does not exist still throws") {
+            CHECK_THROWS_AS(Everest::ManagerSettings(prefix, prefix + "does-not-exist.yaml"), Everest::BootException);
+        }
+    }
+    GIVEN("A valid prefix without default.yaml, no --config and an explicit database path") {
+        auto db_path = bin_dir + "empty_yaml/no_default_config.db";
+        if (fs::exists(db_path)) {
+            fs::remove(db_path);
+        }
+        Everest::ManagerSettings ms(prefix, "", db_path);
+        CHECK(ms.config_file.empty());
+        CHECK(ms.db_dir == fs::path(db_path));
+
+        THEN("Bootstrap on a fresh database should seed an empty config slot without a config file path") {
+            auto bs = Everest::init_database_bootstrap(ms);
+            CHECK(bs.module_configs_initialized == true);
+
+            everest::config::SqliteConfigSlotManager slot_mgr(bs.db_connection);
+            const auto slots = slot_mgr.list_slots();
+            REQUIRE(slots.size() == 1);
+            CHECK_FALSE(slots.front().config_file_path.has_value());
         }
     }
     GIVEN("A valid prefix without a config file and an explicit database path") {
@@ -125,10 +164,29 @@ SCENARIO("Check ManagerSettings without a config file", "[!throws]") {
     }
 }
 
+SCENARIO("Check ManagerSettings default config lookup", "[!throws]") {
+    auto bin_dir = Everest::tests::get_bin_dir().string() + "/";
+    // The default_yaml fixture is the only FHS fixture that contains etc/everest/default.yaml.
+    auto prefix = bin_dir + "default_yaml/";
+    const auto default_config = fs::canonical(bin_dir + "default_yaml/etc/everest/default.yaml");
+
+    GIVEN("A valid prefix that contains etc/everest/default.yaml") {
+        THEN("No --config resolves to the default config file") {
+            auto ms = Everest::ManagerSettings(prefix, "");
+            CHECK(ms.config_file == default_config);
+            CHECK(ms.config.is_object());
+        }
+        THEN("The short form 'default' resolves to the same file") {
+            auto ms = Everest::ManagerSettings(prefix, "default");
+            CHECK(ms.config_file == default_config);
+        }
+    }
+}
+
 SCENARIO("Check resolve_boot_source", "[!throws]") {
     using Everest::BootMode;
     GIVEN("Neither --config nor --db") {
-        THEN("The YAML mode with an in-memory database is selected (default config lookup)") {
+        THEN("The YAML mode with an in-memory database is selected (optional default config lookup)") {
             const auto src = Everest::resolve_boot_source("", "", false, false);
             CHECK(src.mode == BootMode::YamlWithInMemoryDb);
             CHECK(src.config_path.empty());

--- a/lib/everest/framework/tests/test_utilities.cmake
+++ b/lib/everest/framework/tests/test_utilities.cmake
@@ -9,6 +9,7 @@ function (setup_test_directory)
     set(one_value_args
         CONFIG
         USER_CONFIG
+        DEFAULT_CONFIG
     )
     set(multi_value_args
         TYPE_FILES
@@ -109,6 +110,12 @@ function (setup_test_directory)
 
     if (arg_USER_CONFIG)
         configure_file(test_configs/${arg_USER_CONFIG} ${DIR}/user-config/config.yaml COPYONLY)
+    endif()
+
+    # installs the given config as the default config file that the manager looks up when no
+    # --config is given (etc/everest/default.yaml in the FHS layout)
+    if (arg_DEFAULT_CONFIG)
+        configure_file(test_configs/${arg_DEFAULT_CONFIG} ${CONFIG_DIR}/default.yaml COPYONLY)
     endif()
 
     if (MODULE)


### PR DESCRIPTION
## Describe your changes
When using the manager without --db and --config it would require default.yaml.
This change allows the manager to start without --db and --config and to only read default.yaml if it exists and otherwise fallback to the manager settings defaults (+empty module configuration).

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

