### PR TITLE
fix(tests): ignore stale startup connection-status payloads

### DIFF
--- a/tests/async_api_tests/test_ocpp_consumer.py
+++ b/tests/async_api_tests/test_ocpp_consumer.py
@@ -80,15 +80,18 @@ def _subscribe_to_queue(handler: AsyncApiMqttHandler, topic: str) -> Queue:
     return queue
 
 
-async def _get_from_queue(queue: Queue, deadline: float = 10.0):
+async def _get_from_queue(queue: Queue, deadline: float = 10.0, *, ignore_values=()):
+    """Return the next payload other than an explicitly allowed stale value."""
     loop = asyncio.get_event_loop()
     end = loop.time() + deadline
     while loop.time() < end:
         try:
-            return await loop.run_in_executor(None, lambda: queue.get(timeout=0.5))
+            value = await loop.run_in_executor(None, lambda: queue.get(timeout=0.5))
+            if value not in ignore_values:
+                return value
         except Empty:
             continue
-    raise TimeoutError("no value received on the external topic")
+    raise TimeoutError("no new value received on the external topic")
 
 
 async def _publish_status_until_received(probe_module: ProbeModule, queues, status: dict,
@@ -141,8 +144,10 @@ async def test_connection_status_is_forwarded_with_legacy_is_connected(
     disconnected_status = dict(CONNECTED_STATUS, connected=False)
     probe_module.publish_variable(
         "ProbeModuleOcpp", "connection_status", disconnected_status)
-    assert await _get_from_queue(status_queue) == disconnected_status
-    assert await _get_from_queue(is_connected_queue) is False
+    # Startup retries can still be queued or in flight. Skip only the previously
+    # validated connected payloads, so unexpected changed payloads still fail.
+    assert await _get_from_queue(status_queue, ignore_values=(CONNECTED_STATUS,)) == disconnected_status
+    assert await _get_from_queue(is_connected_queue, ignore_values=(True,)) is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Describe your changes

`test_connection_status_is_forwarded_with_legacy_is_connected` republishes the connected status until both external topics respond. Responses to those startup publications can remain queued or in flight when the test publishes the disconnect. The disconnect assertion then compares a stale connected payload with the expected disconnected payload and fails depending on delivery timing.

Allow the queue reader to skip explicitly supplied stale values, and skip only the exact connected payloads already validated by this test when checking the disconnect. The first changed payload must still match the complete disconnected status or the legacy `False` value. The existing deadline remains in force if no transition arrives. This also covers startup responses delivered after waiting for the disconnect has begun.

Validation:
- Both tests in `tests/async_api_tests/test_ocpp_consumer.py` pass against the local EVerest installation: **2 passed in 2.93s**.
- A deterministic bridge-delivery harness invokes the actual test coroutine, forces a startup retry and queued plus in-flight connected responses: the original test fails and the revised test passes.
- The same harness verifies that an incorrect changed status payload or legacy value still fails, even if the correct payload follows, and that a missing disconnect still times out.
- `git diff --check` passes.

## Issue ticket number and link

Observed failure: https://github.com/EVerest/EVerest/actions/runs/32976906771/job/98206963494

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (queue-reader docstring and synchronization comment)
- [ ] Human review and verification before requesting review
