### PR TITLE
fix(slac_API): Fix slac api mismatch and missing types

### DIFF
--- a/docs/source/reference/EVerest_API/slac_API.yaml
+++ b/docs/source/reference/EVerest_API/slac_API.yaml
@@ -229,7 +229,7 @@ components:
       summary: Provides the state enum.
       contentType: application/json
       payload:
-        $ref: '#/components/schemas/SLACState'
+        $ref: '#/components/schemas/State'
       examples:
         - summary: "Example state MATCHED"
           payload: "MATCHED"
@@ -322,7 +322,7 @@ components:
     Enabled:
       type: boolean
       description: 'true: start SLAC after reset, false: stop SLAC'
-    SLACState:
+    State:
       description: Provides the state enum.
       type: string
       enum:


### PR DESCRIPTION
## Describe your changes

The slac_API documentation and the implementation did not match up completely.
To not change the actual API I renamed the SLACState type in the slac_API documentation.
Also I added the ErrorEnum and Error type in the same way it's used in all the other APIs instead of using the generic error type here.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

