### PR TITLE
docs: link the federated testing status page from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ![Alt text](docs/images/everest_horizontal-color.svg)
 
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/6739/badge)](https://bestpractices.coreinfrastructure.org/projects/6739)
+[![Self-reported results](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Feverest.github.io%2FHimalayas%2Fsummary.json&query=%24.generated&label=self-reported%20results&color=informational&prefix=updated%20)](https://everest.github.io/Himalayas/)
 
 # EVerest
 


### PR DESCRIPTION
Adds one badge to the README linking to the [Himalayas](https://github.com/EVerest/Himalayas) status page:

[![Self-reported results](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Feverest.github.io%2FHimalayas%2Fsummary.json&query=%24.generated&label=self-reported%20results&color=informational&prefix=updated%20)](https://everest.github.io/Himalayas/)

Opening as a **draft for discussion**, because a badge here touches a decision Himalayas appears to have made deliberately.

## What it deliberately does not do

`scripts/build_status.py` in Himalayas says:

> The README carries no badge, so this page is the only place the self-reported caveat and the staleness date appear. It is load-bearing for honesty, not just presentation.

and, among its honesty rules:

> Verdict and freshness are ORTHOGONAL and get separate slots. A stale result that is also failing must show both; one must never suppress the other.

A conventional green/red badge would break both: it collapses verdict and freshness into a single colour, and it would put a pass/fail signal on this README without the "self-reported, not verified by EVerest" caveat that the status page leads with. Given that this README already states *"The EVerest project does not run, reproduce or verify them"*, a green **conformance: passing** badge here would imply exactly the verification the project disclaims.

So this badge reports **no verdict and uses no pass/fail colour**. It is a signpost: it says when the federated results were last generated, and links to the page where the caveat, the per-integrator verdicts and the staleness dates live. It reads:

```
self-reported results | updated 2026-09-12 19:42 UTC
```

## How it works

It is a shields.io dynamic-JSON badge reading `$.generated` from the already-published `https://everest.github.io/Himalayas/summary.json`. **No change to Himalayas is required** — it consumes what `build_status.py` already deploys to Pages.

## If maintainers would prefer something richer

A badge showing a *count* of reporting integrators is not expressible this way: shields' dynamic-JSON backend cannot count object keys (`integrators.length` returns no result — verified). Per-integrator numbers such as `integrators.pionix.passed` do work, but naming one integrator on the project README seems wrong.

Conditional colour would need Himalayas to emit a shields *endpoint* document (`{schemaVersion, label, message, color}`) from `build_status.py`. That is a small change and I am happy to open it — but it should be a deliberate choice there, since it reverses the "no badge" reasoning quoted above, and if it is done the colour ought to keep verdict and freshness separate rather than collapsing them.

Happy to close this if the maintainers would rather the README stay badge-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
